### PR TITLE
Mark AbstractHamiltonian::FindConn as const

### DIFF
--- a/NetKet/Hamiltonian/abstract_hamiltonian.hpp
+++ b/NetKet/Hamiltonian/abstract_hamiltonian.hpp
@@ -48,7 +48,7 @@ class AbstractHamiltonian {
   virtual void FindConn(const Eigen::VectorXd &v,
                         std::vector<std::complex<double>> &mel,
                         std::vector<std::vector<int>> &connectors,
-                        std::vector<std::vector<double>> &newconfs) = 0;
+                        std::vector<std::vector<double>> &newconfs) const = 0;
 
   /**
   Member function returning the hilbert space associated with this Hamiltonian.

--- a/NetKet/Hamiltonian/bosonhubbard.hpp
+++ b/NetKet/Hamiltonian/bosonhubbard.hpp
@@ -130,7 +130,7 @@ class BoseHubbard : public AbstractHamiltonian {
   void FindConn(const Eigen::VectorXd &v,
                 std::vector<std::complex<double>> &mel,
                 std::vector<std::vector<int>> &connectors,
-                std::vector<std::vector<double>> &newconfs) override {
+                std::vector<std::vector<double>> &newconfs) const override {
     connectors.clear();
     connectors.resize(1);
     newconfs.clear();

--- a/NetKet/Hamiltonian/custom_hamiltonian.hpp
+++ b/NetKet/Hamiltonian/custom_hamiltonian.hpp
@@ -69,7 +69,7 @@ class CustomHamiltonian : public AbstractHamiltonian {
   void FindConn(const Eigen::VectorXd &v,
                 std::vector<std::complex<double>> &mel,
                 std::vector<std::vector<int>> &connectors,
-                std::vector<std::vector<double>> &newconfs) override {
+                std::vector<std::vector<double>> &newconfs) const override {
     connectors.clear();
     newconfs.clear();
     mel.resize(0);

--- a/NetKet/Hamiltonian/hamiltonian.hpp
+++ b/NetKet/Hamiltonian/hamiltonian.hpp
@@ -54,7 +54,7 @@ class Hamiltonian : public AbstractHamiltonian {
   void FindConn(const Eigen::VectorXd &v,
                 std::vector<std::complex<double>> &mel,
                 std::vector<std::vector<int>> &connectors,
-                std::vector<std::vector<double>> &newconfs) override {
+                std::vector<std::vector<double>> &newconfs) const override {
     return h_->FindConn(v, mel, connectors, newconfs);
   }
 

--- a/NetKet/Hamiltonian/heisenberg.hpp
+++ b/NetKet/Hamiltonian/heisenberg.hpp
@@ -108,7 +108,7 @@ class Heisenberg : public AbstractHamiltonian {
   void FindConn(const Eigen::VectorXd &v,
                 std::vector<std::complex<double>> &mel,
                 std::vector<std::vector<int>> &connectors,
-                std::vector<std::vector<double>> &newconfs) override {
+                std::vector<std::vector<double>> &newconfs) const override {
     connectors.clear();
     connectors.resize(1);
     newconfs.clear();

--- a/NetKet/Hamiltonian/ising.hpp
+++ b/NetKet/Hamiltonian/ising.hpp
@@ -119,7 +119,7 @@ class Ising : public AbstractHamiltonian {
   void FindConn(const Eigen::VectorXd &v,
                 std::vector<std::complex<double>> &mel,
                 std::vector<std::vector<int>> &connectors,
-                std::vector<std::vector<double>> &newconfs) override {
+                std::vector<std::vector<double>> &newconfs) const override {
     connectors.clear();
     connectors.resize(nspins_ + 1);
     newconfs.clear();

--- a/NetKet/Hilbert/hilbert_index.hpp
+++ b/NetKet/Hilbert/hilbert_index.hpp
@@ -94,7 +94,7 @@ class HilbertIndex {
 
   std::size_t NStates() const { return nstates_; }
 
-  constexpr static int MaxStates = (std::numeric_limits<int>::max() - 1.);
+  constexpr static int MaxStates = std::numeric_limits<int>::max() - 1;
 };
 
 }  // namespace netket


### PR DESCRIPTION
`AbstractHamiltonian::FindConn` does not changes the internal state of the Hamiltonian (and judging from the documentation it is not meant to), so it should be marked as const.

(This pull request also contains a tiny unrelated change in a second commit. I could split this up if you want.)