### PR TITLE
Fixes #22. At least on my local machine.

### DIFF
--- a/NetKet/Learning/matrix_replacement.hpp
+++ b/NetKet/Learning/matrix_replacement.hpp
@@ -68,7 +68,7 @@ class MatrixReplacement : public Eigen::EigenBase<netket::MatrixReplacement> {
   void attachMatrix(const Eigen::MatrixXcd &mat) { mp_mat_ = mat; }
   void attachMatrix(const Eigen::MatrixXd &mat) { mp_mat_ = mat; }
   void setShift(double shift) { shift_ = shift; }
-  Eigen::MatrixXcd my_matrix() const { return mp_mat_; }
+  Eigen::MatrixXcd const& my_matrix() const { return mp_mat_; }
   double shift() const { return shift_; }
   void setScale(double scale) { scale_ = scale; }
   double getScale() const { return scale_; }


### PR DESCRIPTION
The reason for segfaults in `general_product_impl` is this line:
```
    auto vtilde = lhs.my_matrix() * rhs;
```
`my_matrix()` member function returned a temporary which was destructed
after the assignment (see Eigen's docs page about the use of `auto`).
You were then trying to access an already destructed matrix in line 101
which, obviously, didn't go well.
There are numerous solutions to this issue, but the simplest one that as
a by-product should also increase the performance, is to let `my_matrix`
return a reference to the stored matrix rather than a copy.