### PR TITLE
travis: Remove deprecated Xcode images from build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,12 +33,6 @@ matrix:
     osx_image: xcode8
 
   - os: osx
-    osx_image: xcode8.1
-
-  - os: osx
-    osx_image: xcode8.2
-
-  - os: osx
     osx_image: xcode8.3
 
   - os: osx


### PR DESCRIPTION
The Travis CI images for Xcode 8.1 and 8.2 have been retired [1].
According to a message in the Travis web interface, they are now routed
to the Xcode 8.3 image [2]. Therefore this commit removes them from the
build configuration.

[1] https://blog.travis-ci.com/2017-11-21-xcode8-3-default-image-announce
[2] "This job was configured to run on an OS X image that was retired on
November 28, 2017. It was routed to our Xcode 8.3 image."