### PR TITLE
 Allow duplicate connections when initializing matrix wrappers

### DIFF
--- a/NetKet/Hamiltonian/MatrixWrapper/dense_matrix_wrapper.hpp
+++ b/NetKet/Hamiltonian/MatrixWrapper/dense_matrix_wrapper.hpp
@@ -93,7 +93,7 @@ private:
                 auto vk = v;
                 hilbert.UpdateConf(vk, connectors[k], newconfs[k]);
                 auto j = hilbert_index.StateToNumber(vk);
-                matrix_(i, j) = matrix_elements[k];
+                matrix_(i, j) += matrix_elements[k];
             }
         }
     }

--- a/NetKet/Hamiltonian/MatrixWrapper/sparse_matrix_wrapper.hpp
+++ b/NetKet/Hamiltonian/MatrixWrapper/sparse_matrix_wrapper.hpp
@@ -93,6 +93,7 @@ private:
                 matrix_.coeffRef(i, j) += matrix_elements[k];
             }
         }
+        matrix_.makeCompressed();
     }
 };
 

--- a/NetKet/Hamiltonian/MatrixWrapper/sparse_matrix_wrapper.hpp
+++ b/NetKet/Hamiltonian/MatrixWrapper/sparse_matrix_wrapper.hpp
@@ -90,7 +90,7 @@ private:
                 auto vk = v;
                 hilbert.UpdateConf(vk, connectors[k], newconfs[k]);
                 auto j = hilbert_index.StateToNumber(vk);
-                matrix_.insert(i, j) = matrix_elements[k];
+                matrix_.coeffRef(i, j) += matrix_elements[k];
             }
         }
     }


### PR DESCRIPTION
The current matrix wrapper implementation assumes that each pair of indices (i,j) occurs only once when collecting the results of `Hamiltonian::FindConn` over all states using `HilbertIndex`.

This is not true in some cases, e.g., for a 2x2 cubic lattice with periodic boundary conditions, where `FindConn` currently returns two edges between each pair of adjacent nodes. With this commit, matrix elements for multiple edges are now added together. (We could alternatively disallow duplicate connections in the Hamiltonian as these might indicate an error in the model. Still, I think this case should either be prevented more thoroughly in the Hamiltonian implementation or the matrix wrappers should handle it.)

(This PR also includes a second commit, 19c668e, which compresses the sparse matrix after setting up the coefficients. This should save memory.)