### PR TITLE
Prevent duplicate connectors in Hamiltonian

### DIFF
--- a/NetKet/Graph/hypercube.hpp
+++ b/NetKet/Graph/hypercube.hpp
@@ -54,6 +54,11 @@ class Hypercube : public AbstractGraph {
       : L_(FieldVal(pars["Graph"], "L")),
         ndim_(FieldVal(pars["Graph"], "Dimension")),
         pbc_(FieldOrDefaultVal(pars["Graph"], "Pbc", true)) {
+    if(pbc_ && L_ <= 2)
+    {
+        std::cout << "L<=2 hypercubes should not have periodic boundary conditions" << std::endl;
+        std::abort();
+    }
     Init();
   }
 

--- a/Test/Hamiltonian/unit-hamiltonian.cc
+++ b/Test/Hamiltonian/unit-hamiltonian.cc
@@ -69,7 +69,7 @@ TEST_CASE("hamiltonians produce elements in the hilbert space",
   }
 }
 
-TEST_CASE("hamiltonians do not have duplicate newconfs", "[hamiltonian]") {
+TEST_CASE("hamiltonians do not have duplicate connections or newconfs", "[hamiltonian]") {
 
   auto input_tests = GetHamiltonianInputs();
   std::size_t ntests = input_tests.size();
@@ -106,6 +106,10 @@ TEST_CASE("hamiltonians do not have duplicate newconfs", "[hamiltonian]") {
             REQUIRE(isUniqueConnector);
           }
         }
+
+        auto itu = std::unique(connectors.begin(), connectors.end());
+        bool noDuplicateConnectors = (itu == connectors.end());
+        REQUIRE(noDuplicateConnectors);
       }
     }
   }

--- a/Test/Hamiltonian/unit-matrixwrapper.cc
+++ b/Test/Hamiltonian/unit-matrixwrapper.cc
@@ -44,7 +44,7 @@ std::vector<netket::json> GetHamiltonianInputs() {
     // Bose Hubbard
     pars = {
             {"Graph",
-                    {{"Name", "Hypercube"}, {"L", 2}, {"Dimension", 2}, {"Pbc", true}}},
+                    {{"Name", "Hypercube"}, {"L", 2}, {"Dimension", 2}, {"Pbc", false}}},
             {"Hamiltonian",
                     {{"Name", "BoseHubbard"}, {"U", 4.0}, {"Nmax", 2}, {"Nbosons", 2}}}};
 

--- a/Test/Hilbert/hilbert_input_tests.hpp
+++ b/Test/Hilbert/hilbert_input_tests.hpp
@@ -81,7 +81,7 @@ std::vector<netket::json> GetHilbertInputs() {
 
   // Bose Hubbard
   pars = {{"Graph",
-           {{"Name", "Hypercube"}, {"L", 2}, {"Dimension", 1}, {"Pbc", true}}},
+           {{"Name", "Hypercube"}, {"L", 2}, {"Dimension", 1}, {"Pbc", false}}},
           {"Hamiltonian", {{"Name", "BoseHubbard"}, {"U", 4.0}, {"Nmax", 4}}}};
   input_tests.push_back(pars);
 


### PR DESCRIPTION
Continuing the discussion from #27:

> But it is also because FindConn is not supposed to return duplicate terms (this is also checked for in one of the unit tests).

If I am not mistaken, the test you refer to currently checks for a different kind of duplication, namely, for duplicate target quantum numbers within each connector. Whether the `connectors` vector has duplicate entries, i.e., there exist `k != j` such that `connectors[k] == connectors[j]`, is not checked. That case happens for the 2x2 PBC cube example, as there e.g. site `(0,0)` has two connectors to `(0,1)` (one "direct" and one "through the boundary").

This pull request adds a check for this scenario and disallows periodic boundaries for L<=2 hypercubes to prevent duplicate connectors there.

The case of merging local operators in `CustomHamiltonian` is still open for now.