### PR TITLE
Throw exceptions for invalid user input

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,13 @@ Main differences with respect to Google standards include:
 
 1. Header files should end in `.hpp` (not in `.h` as per [this](https://google.github.io/styleguide/cppguide.html#Self_contained_Headers))
 2. Use of non-const reference arguments is allowed (exception to [this](https://google.github.io/styleguide/cppguide.html#Reference_Arguments))
+3. The use of exceptions is permitted but should be limited to invalid
+  user input, IO errors, and similar cases. The arguments against using
+  exceptions from the [Google guide](https://google.github.io/styleguide/cppguide.html#Exceptions)
+  are specific to Google's situation and do not apply to netket.
+  See also [NR.3](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#nr3-dont-dont-use-exceptions)
+  and [E.2 and following](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#e2-throw-an-exception-to-signal-that-a-function-cant-perform-its-assigned-task)
+  from the C++ Core Guidelines.
 
 The Google C++ Style Guide also includes useful guidelines to format the code.
 Those can be conveniently enforced by means of automatic reformatting tools.

--- a/NetKet/Graph/custom_graph.hpp
+++ b/NetKet/Graph/custom_graph.hpp
@@ -71,12 +71,8 @@ class CustomGraph : public AbstractGraph {
       assert(nsites_ > 0);
       adjlist_.resize(nsites_);
     } else {
-      if (mynode_ == 0) {
-        std::cerr << "Graph: one among Size, AdjacencyList, Edges, or Hilbert "
-                     "Space Size must be specified"
-                  << std::endl;
-      }
-      std::abort();
+      throw InvalidInputError("Graph: one among Size, AdjacencyList, Edges, or Hilbert "
+                              "Space Size must be specified");
     }
 
     nsites_ = adjlist_.size();
@@ -114,12 +110,11 @@ class CustomGraph : public AbstractGraph {
 
     for (auto edge : edges) {
       if (edge.size() != 2) {
-        std::cerr << "# The edge list is invalid" << std::endl;
-        std::abort();
+        throw InvalidInputError("The edge list is invalid (edges need "
+                                "to connect exactly two sites)");
       }
       if (edge[0] < 0 || edge[1] < 0) {
-        std::cerr << "# The edge list is invalid" << std::endl;
-        std::abort();
+        throw InvalidInputError("The edge list is invalid");
       }
 
       nsites_ = std::max(std::max(edge[0], edge[1]), nsites_);
@@ -139,29 +134,19 @@ class CustomGraph : public AbstractGraph {
       for (auto s : adjlist_[i]) {
         // Checking if the referenced nodes are within the expected range
         if (s >= nsites_ || s < 0) {
-          if (mynode_ == 0) {
-            std::cerr << "# The graph is invalid" << std::endl;
-          }
-          std::abort();
+          throw InvalidInputError("The graph is invalid");
         }
         // Checking if the adjacency list is symmetric
         // i.e. if site s is declared neihgbor of site i
         // when site i is declared neighbor of site s
         if (std::count(adjlist_[s].begin(), adjlist_[s].end(), i) != 1) {
-          if (mynode_ == 0) {
-            std::cerr << "# The graph adjacencylist is not symmetric"
-                      << std::endl;
-          }
-          std::abort();
+          throw InvalidInputError("The graph adjacencylist is not symmetric");
         }
       }
     }
     for (std::size_t i = 0; i < automorphisms_.size(); i++) {
       if (int(automorphisms_[i].size()) != nsites_) {
-        if (mynode_ == 0) {
-          std::cerr << "# The automorphism list is invalid" << std::endl;
-        }
-        std::abort();
+        throw InvalidInputError("The automorphism list is invalid");
       }
     }
   }

--- a/NetKet/Graph/graph.hpp
+++ b/NetKet/Graph/graph.hpp
@@ -36,11 +36,13 @@ class Graph : public AbstractGraph {
     if (FieldExists(pars, "Graph")) {
       // Checking if we are using a graph in the hard-coded library
       if (FieldExists(pars["Graph"], "Name")) {
-        if (pars["Graph"]["Name"] == "Hypercube") {
+        std::string graph_name = pars["Graph"]["Name"];
+        if (graph_name == "Hypercube") {
           g_ = Ptype(new Hypercube(pars));
         } else {
-          std::cout << "Graph not found" << std::endl;
-          std::abort();
+          std::stringstream s;
+          s << "Unknown Graph type: " << graph_name;
+          throw InvalidInputError(s.str());
         }
       }
       // Otherwise using a user-defined graph

--- a/NetKet/Graph/hypercube.hpp
+++ b/NetKet/Graph/hypercube.hpp
@@ -51,13 +51,12 @@ class Hypercube : public AbstractGraph {
  public:
   // Json constructor
   explicit Hypercube(const json &pars)
-      : L_(FieldVal(pars["Graph"], "L")),
-        ndim_(FieldVal(pars["Graph"], "Dimension")),
+      : L_(FieldVal(pars["Graph"], "L", "Graph")),
+        ndim_(FieldVal(pars["Graph"], "Dimension", "Graph")),
         pbc_(FieldOrDefaultVal(pars["Graph"], "Pbc", true)) {
     if(pbc_ && L_ <= 2)
     {
-        std::cout << "L<=2 hypercubes should not have periodic boundary conditions" << std::endl;
-        std::abort();
+        throw InvalidInputError("L<=2 hypercubes cannot have periodic boundary conditions");
     }
     Init();
   }
@@ -121,10 +120,8 @@ class Hypercube : public AbstractGraph {
   // translation symmetry
   std::vector<std::vector<int>> SymmetryTable() const override {
     if (!pbc_) {
-      std::cerr << "Cannot generate translation symmetries in the hypercube "
-                   "without PBC"
-                << std::endl;
-      std::abort();
+      throw InvalidInputError("Cannot generate translation symmetries "
+                              "in the hypercube without PBC");
     }
 
     std::vector<std::vector<int>> permtable;

--- a/NetKet/Hamiltonian/bosonhubbard.hpp
+++ b/NetKet/Hamiltonian/bosonhubbard.hpp
@@ -19,6 +19,10 @@
 #include <cmath>
 #include <iostream>
 #include <vector>
+
+#include "Utils/exceptions.hpp"
+#include "Utils/json_helper.hpp"
+
 #include "abstract_hamiltonian.hpp"
 
 namespace netket {
@@ -50,32 +54,13 @@ class BoseHubbard : public AbstractHamiltonian {
  public:
   // Json constructor
   explicit BoseHubbard(const G &graph, const json &pars)
-      : nsites_(graph.Nsites()), graph_(graph) {
-    if (FieldExists(pars["Hamiltonian"], "Nmax")) {
-      nmax_ = pars["Hamiltonian"]["Nmax"];
-    } else {
-      std::cerr << "Nmax is not specified for bosons" << std::endl;
-      std::abort();
-    }
+      : nsites_(graph.Nsites()), graph_(graph)
+  {
+    nmax_ = FieldVal(pars["Hamiltonian"], "Nmax", "Hamiltonian");
+    U_ = FieldVal(pars["Hamiltonian"], "U", "Hamiltonian");
 
-    if (FieldExists(pars["Hamiltonian"], "U")) {
-      U_ = pars["Hamiltonian"]["U"];
-    } else {
-      std::cerr << "U interaction is not specified" << std::endl;
-      std::abort();
-    }
-
-    if (FieldExists(pars["Hamiltonian"], "V")) {
-      V_ = pars["Hamiltonian"]["V"];
-    } else {
-      V_ = 0;
-    }
-
-    if (FieldExists(pars["Hamiltonian"], "Mu")) {
-      mu_ = pars["Hamiltonian"]["Mu"];
-    } else {
-      mu_ = 0;
-    }
+    V_ = FieldOrDefaultVal(pars["Hamiltonian"], "V", .0);
+    mu_ = FieldOrDefaultVal(pars["Hamiltonian"], "Mu", .0);
 
     Init();
 

--- a/NetKet/Hamiltonian/hamiltonian.hpp
+++ b/NetKet/Hamiltonian/hamiltonian.hpp
@@ -31,8 +31,7 @@ class Hamiltonian : public AbstractHamiltonian {
  public:
   explicit Hamiltonian(const Graph &graph, const json &pars) {
     if (!FieldExists(pars, "Hamiltonian")) {
-      std::cerr << "Hamiltonian is not defined in the input" << std::endl;
-      std::abort();
+      throw InvalidInputError("Hamiltonian is not defined in the input");
     }
 
     if (FieldExists(pars["Hamiltonian"], "Name")) {
@@ -43,8 +42,7 @@ class Hamiltonian : public AbstractHamiltonian {
       } else if (pars["Hamiltonian"]["Name"] == "BoseHubbard") {
         h_ = std::make_shared<BoseHubbard<Graph>>(graph, pars);
       } else {
-        std::cout << "Hamiltonian name not found" << std::endl;
-        std::abort();
+        throw InvalidInputError("Hamiltonian name not found");
       }
     } else {
       h_ = std::make_shared<CustomHamiltonian>(pars);

--- a/NetKet/Hamiltonian/local_operator.hpp
+++ b/NetKet/Hamiltonian/local_operator.hpp
@@ -57,15 +57,12 @@ class LocalOperator {
 
   void Init() {
     if (!hilbert_.IsDiscrete()) {
-      std::cerr << "Cannot construct operators on infinite local hilbert spaces"
-                << std::endl;
-      std::abort();
+      throw InvalidInputError("Cannot construct operators on infinite local hilbert spaces");
     }
 
     if (*std::max_element(sites_.begin(), sites_.end()) >= hilbert_.Size() ||
         *std::min_element(sites_.begin(), sites_.end()) < 0) {
-      std::cerr << "Operator acts on an invalid set of sites" << std::endl;
-      std::abort();
+      throw InvalidInputError("Operator acts on an invalid set of sites");
     }
 
     auto localstates = hilbert_.LocalStates();
@@ -77,18 +74,13 @@ class LocalOperator {
     connected_.resize(mat_.size());
 
     if (mat_.size() != std::pow(localsize_, sites_.size())) {
-      std::cerr << "Matrix size in operator is inconsistent with Hilbert space"
-                << std::endl;
-      std::abort();
+      throw InvalidInputError("Matrix size in operator is inconsistent with Hilbert space");
     }
 
     for (std::size_t i = 0; i < mat_.size(); i++) {
       for (std::size_t j = 0; j < mat_[i].size(); j++) {
         if (mat_.size() != mat_[i].size()) {
-          std::cerr
-              << "Matrix size in operator is inconsistent with Hilbert space"
-              << std::endl;
-          std::abort();
+          throw InvalidInputError("Matrix size in operator is inconsistent with Hilbert space");
         }
 
         if (i != j && std::abs(mat_[i][j]) > epsilon) {

--- a/NetKet/Hilbert/bosons.hpp
+++ b/NetKet/Hilbert/bosons.hpp
@@ -72,13 +72,11 @@ class Boson : public AbstractHilbert {
 
   void Init() {
     if (nsites_ <= 0) {
-      std::cerr << "Invalid number of sites" << std::endl;
-      std::abort();
+      throw InvalidInputError("Invalid number of sites");
     }
 
     if (nmax_ <= 0) {
-      std::cerr << "Invalid maximum occupation number" << std::endl;
-      std::abort();
+      throw InvalidInputError("Invalid maximum occupation number");
     }
 
     nstates_ = nmax_ + 1;
@@ -95,8 +93,7 @@ class Boson : public AbstractHilbert {
     nbosons_ = nbosons;
 
     if (nbosons_ > nsites_ * nmax_) {
-      std::cerr << "Cannot set the desired number of bosons" << std::endl;
-      std::abort();
+      throw InvalidInputError("Cannot set the desired number of bosons");
     }
   }
 

--- a/NetKet/Hilbert/custom_hilbert.hpp
+++ b/NetKet/Hilbert/custom_hilbert.hpp
@@ -41,22 +41,20 @@ class CustomHilbert : public AbstractHilbert {
   explicit CustomHilbert(const json &pars) {
     if (FieldExists(pars["Hilbert"], "QuantumNumbers")) {
       if (!pars["Hilbert"]["QuantumNumbers"].is_array()) {
-        std::cerr << "QuantumNumbers is not an array" << std::endl;
-        std::abort();
+        throw InvalidInputError("QuantumNumbers is not an array");
       }
       local_ = pars["Hilbert"]["QuantumNumbers"].get<std::vector<double>>();
     } else {
-      std::cerr << "QuantumNumbers are not defined" << std::endl;
+      throw InvalidInputError("QuantumNumbers are not defined");
     }
 
     if (FieldExists(pars["Hilbert"], "Size")) {
       size_ = pars["Hilbert"]["Size"];
       if (size_ <= 0) {
-        std::cerr << "Hilbert Size parameter must be positive" << std::endl;
-        std::abort();
+        throw InvalidInputError("Hilbert Size parameter must be positive");
       }
     } else {
-      std::cerr << "Hilbert space extent is not defined" << std::endl;
+      throw InvalidInputError("Hilbert space extent is not defined");
     }
 
     nstates_ = local_.size();

--- a/NetKet/Hilbert/hilbert.hpp
+++ b/NetKet/Hilbert/hilbert.hpp
@@ -54,22 +54,14 @@ class Hilbert : public AbstractHilbert {
     }
   }
 
-  void CheckInput(const json &pars) {
-    int mynode;
-    MPI_Comm_rank(MPI_COMM_WORLD, &mynode);
-
+  void CheckInput(const json &pars)
+  {
     if (!FieldExists(pars, "Hilbert")) {
       if (!FieldExists(pars, "Hamiltonian")) {
-        if (mynode == 0)
-          std::cerr << "Not enough information to construct Hilbert space"
-                    << std::endl;
-        std::abort();
+        throw InvalidInputError("Not enough information to construct Hilbert space");
       } else {
         if (!FieldExists(pars["Hamiltonian"], "Name")) {
-          if (mynode == 0)
-            std::cerr << "Not enough information to construct Hilbert space"
-                      << std::endl;
-          std::abort();
+          throw InvalidInputError("Not enough information to construct Hilbert space");
         }
       }
     }
@@ -80,8 +72,9 @@ class Hilbert : public AbstractHilbert {
       const auto name = pars["Hilbert"]["Name"];
 
       if (hilberts.count(name) == 0) {
-        std::cerr << "Hilbert " << name << " not found." << std::endl;
-        std::abort();
+        std::stringstream s;
+        s << "Hilbert space type " << name << " not found.";
+        throw InvalidInputError(s.str());
       }
     }
   }

--- a/NetKet/Hilbert/hilbert_index.hpp
+++ b/NetKet/Hilbert/hilbert_index.hpp
@@ -48,8 +48,7 @@ class HilbertIndex {
 
   void Init() {
     if (size_ * std::log(localsize_) > std::log(MaxStates)) {
-      std::cerr << "Hilbert space is too large to be indexed" << std::endl;
-      std::abort();
+      throw InvalidInputError("Hilbert space is too large to be indexed");
     }
 
     nstates_ = std::pow(localsize_, size_);

--- a/NetKet/Hilbert/qubits.hpp
+++ b/NetKet/Hilbert/qubits.hpp
@@ -37,14 +37,7 @@ class Qubit : public AbstractHilbert {
 
  public:
   explicit Qubit(const json &pars) {
-    int nqubits;
-
-    if (!FieldExists(pars["Hilbert"], "Nqubits")) {
-      std::cerr << "Nqubits is not defined" << std::endl;
-    }
-
-    nqubits = pars["Hilbert"]["Nqubits"];
-
+    const int nqubits = FieldVal(pars["Hilbert"], "Nqubits", "Hilbert");
     Init(nqubits);
   }
 

--- a/NetKet/Hilbert/spins.hpp
+++ b/NetKet/Hilbert/spins.hpp
@@ -46,20 +46,8 @@ class Spin : public AbstractHilbert {
 
  public:
   explicit Spin(const json &pars) {
-    int nspins;
-    double S;
-
-    if (!FieldExists(pars["Hilbert"], "Nspins")) {
-      std::cerr << "Nspins is not defined" << std::endl;
-    }
-
-    nspins = pars["Hilbert"]["Nspins"];
-
-    if (!FieldExists(pars["Hilbert"], "S")) {
-      std::cerr << "S is not defined" << std::endl;
-    }
-
-    S = pars["Hilbert"]["S"];
+    const int nspins = FieldVal(pars["Hilbert"], "Nspins", "Hilbert");
+    const double S = FieldVal(pars["Hilbert"], "S", "Hilbert");
 
     Init(nspins, S);
 
@@ -75,13 +63,11 @@ class Spin : public AbstractHilbert {
     nspins_ = nspins;
 
     if (S <= 0) {
-      std::cerr << "Invalid spin value" << std::endl;
-      std::abort();
+      throw InvalidInputError("Invalid spin value");
     }
 
     if (std::floor(2. * S) != 2. * S) {
-      std::cerr << "Spin value is hot integer or half integer" << std::endl;
-      std::abort();
+      throw InvalidInputError("Spin value is hot integer or half integer");
     }
 
     nstates_ = std::floor(2. * S) + 1;
@@ -125,8 +111,7 @@ class Spin : public AbstractHilbert {
         int ndown = nspins_ - nup;
 
         if ((nup - ndown) != int(2 * totalS_)) {
-          std::cerr << "#Cannot fix the total magnetization " << std::endl;
-          std::abort();
+          throw InvalidInputError("Cannot fix the total magnetization");
         }
 
         std::vector<double> vect(nspins_);

--- a/NetKet/Learning/ground_state.hpp
+++ b/NetKet/Learning/ground_state.hpp
@@ -100,10 +100,10 @@ class GroundState {
         obs_(ham.GetHilbert(), pars) {
     Init();
 
-    int nsamples = FieldVal(pars["Learning"], "Nsamples");
-    int niter_opt = FieldVal(pars["Learning"], "NiterOpt");
+    int nsamples = FieldVal(pars["Learning"], "Nsamples", "Learning");
+    int niter_opt = FieldVal(pars["Learning"], "NiterOpt", "Learning");
 
-    std::string file_base = FieldVal(pars["Learning"], "OutputFile");
+    std::string file_base = FieldVal(pars["Learning"], "OutputFile", "Learning");
     double freqbackup = FieldOrDefaultVal(pars["Learning"], "SaveEvery", 100.);
     SetOutName(file_base, freqbackup);
 

--- a/NetKet/Learning/learning.hpp
+++ b/NetKet/Learning/learning.hpp
@@ -26,18 +26,11 @@ namespace netket {
 class Learning {
  public:
   explicit Learning(const json &pars) {
-    if (!FieldExists(pars, "Learning")) {
-      std::cerr << "Learning field is not defined in the input" << std::endl;
-      std::abort();
-    }
+    CheckFieldExists(pars, "Learning");
+    const std::string method_name = FieldVal(pars["Learning"], "Method", "Learning");
 
-    if (!FieldExists(pars["Learning"], "Method")) {
-      std::cerr << "Learning Method is not defined in the input" << std::endl;
-      std::abort();
-    }
-
-    if (pars["Learning"]["Method"] == "Gd" ||
-        pars["Learning"]["Method"] == "Sr") {
+    if (method_name == "Gd" ||
+        method_name == "Sr") {
       Graph graph(pars);
 
       Hamiltonian hamiltonian(graph, pars);
@@ -50,7 +43,7 @@ class Learning {
       Stepper stepper(pars);
 
       GroundState le(hamiltonian, sampler, stepper, pars);
-    } else if (pars["Learning"]["Method"] == "Ed") {
+    } else if (method_name == "Ed") {
       Graph graph(pars);
 
       Hamiltonian hamiltonian(graph, pars);
@@ -59,9 +52,9 @@ class Learning {
       SaveEigenValues(hamiltonian, file_base + std::string(".log"));
 
     } else {
-      std::cout << "Learning method not found" << std::endl;
-      std::cout << pars["Learning"]["Method"] << std::endl;
-      std::abort();
+      std::stringstream s;
+      s << "Unknown Learning method: " << method_name;
+      throw InvalidInputError(s.str());
     }
   }
 

--- a/NetKet/Learning/stepper.hpp
+++ b/NetKet/Learning/stepper.hpp
@@ -34,33 +34,27 @@ class Stepper : public AbstractStepper {
 
  public:
   explicit Stepper(const json &pars) {
-    if (!FieldExists(pars, "Learning")) {
-      std::cerr << "Learning is not defined in the input" << std::endl;
-      std::abort();
-    }
+    CheckFieldExists(pars, "Learning");
+    const std::string stepper_name = FieldVal(pars["Learning"], "StepperType", "Learning");
 
-    if (!FieldExists(pars["Learning"], "StepperType")) {
-      std::cerr << "Stepper Type is not defined in the input" << std::endl;
-      std::abort();
-    }
-
-    if (pars["Learning"]["StepperType"] == "Sgd") {
+    if (stepper_name == "Sgd") {
       s_ = Ptype(new Sgd(pars));
-    } else if (pars["Learning"]["StepperType"] == "AdaMax") {
+    } else if (stepper_name == "AdaMax") {
       s_ = Ptype(new AdaMax(pars));
-    } else if (pars["Learning"]["StepperType"] == "AdaDelta") {
+    } else if (stepper_name == "AdaDelta") {
       s_ = Ptype(new AdaDelta(pars));
-    } else if (pars["Learning"]["StepperType"] == "Momentum") {
+    } else if (stepper_name == "Momentum") {
       s_ = Ptype(new Momentum(pars));
-    } else if (pars["Learning"]["StepperType"] == "AMSGrad") {
+    } else if (stepper_name == "AMSGrad") {
       s_ = Ptype(new AMSGrad(pars));
-    } else if (pars["Learning"]["StepperType"] == "AdaGrad") {
+    } else if (stepper_name == "AdaGrad") {
       s_ = Ptype(new AdaGrad(pars));
-    } else if (pars["Learning"]["StepperType"] == "RMSProp") {
+    } else if (stepper_name == "RMSProp") {
       s_ = Ptype(new RMSProp(pars));
     } else {
-      std::cout << "StepperType not found" << std::endl;
-      std::abort();
+      std::stringstream s;
+      s << "Unknown StepperType: " << stepper_name;
+      throw InvalidInputError(s.str());
     }
   }
 

--- a/NetKet/Machine/machine.hpp
+++ b/NetKet/Machine/machine.hpp
@@ -108,9 +108,9 @@ class Machine : public AbstractMachine<T> {
         ifs >> jmachine;
         m_->from_json(jmachine);
       } else {
-        if (mynode == 0)
-          std::cerr << "Error opening file : " << filename << std::endl;
-        std::abort();
+        std::stringstream s;
+        s << "Error opening file: " << filename;
+        throw InvalidInputError(s.str());
       }
 
       if (mynode == 0)
@@ -123,25 +123,15 @@ class Machine : public AbstractMachine<T> {
     int mynode;
     MPI_Comm_rank(MPI_COMM_WORLD, &mynode);
 
-    if (!FieldExists(pars, "Machine")) {
-      if (mynode == 0)
-        std::cerr << "Machine is not defined in the input" << std::endl;
-      std::abort();
-    }
-
-    if (!FieldExists(pars["Machine"], "Name")) {
-      if (mynode == 0)
-        std::cerr << "Machine Name is not defined in the input" << std::endl;
-      std::abort();
-    }
+    CheckFieldExists(pars, "Machine");
+    const std::string name = FieldVal(pars["Machine"], "Name", "Machine");
 
     std::set<std::string> machines = {"RbmSpin", "RbmSpinSymm", "RbmMultival"};
 
-    const auto name = pars["Machine"]["Name"];
-
     if (machines.count(name) == 0) {
-      std::cerr << "Machine " << name << " not found." << std::endl;
-      std::abort();
+      std::stringstream s;
+      s << "Unknown Machine: " << name;
+      throw InvalidInputError(s.str());
     }
   }
 

--- a/NetKet/Machine/rbm_multival.hpp
+++ b/NetKet/Machine/rbm_multival.hpp
@@ -374,33 +374,22 @@ class RbmMultival : public AbstractMachine<T> {
 
   void from_json(const json &pars) override {
     if (pars.at("Machine").at("Name") != "RbmMultival") {
-      if (mynode_ == 0) {
-        std::cerr << "# Error while constructing RbmMultival from Json input"
-                  << std::endl;
-      }
-      std::abort();
+      throw InvalidInputError("Error while constructing RbmMultival from Json input");
     }
 
     if (FieldExists(pars["Machine"], "Nvisible")) {
       nv_ = pars["Machine"]["Nvisible"];
     }
+
     if (nv_ != hilbert_.Size()) {
-      if (mynode_ == 0) {
-        std::cerr << "# Loaded wave-function has incompatible Hilbert space"
-                  << std::endl;
-      }
-      std::abort();
+      throw InvalidInputError("Loaded wave-function has incompatible Hilbert space");
     }
 
     if (FieldExists(pars["Machine"], "LocalSize")) {
       ls_ = pars["Machine"]["LocalSize"];
     }
     if (ls_ != hilbert_.LocalSize()) {
-      if (mynode_ == 0) {
-        std::cerr << "# Loaded wave-function has incompatible Hilbert space"
-                  << std::endl;
-      }
-      std::abort();
+      throw InvalidInputError("Loaded wave-function has incompatible Hilbert space");
     }
 
     if (FieldExists(pars["Machine"], "Nhidden")) {

--- a/NetKet/Machine/rbm_spin.hpp
+++ b/NetKet/Machine/rbm_spin.hpp
@@ -347,23 +347,15 @@ class RbmSpin : public AbstractMachine<T> {
 
   void from_json(const json &pars) override {
     if (pars.at("Machine").at("Name") != "RbmSpin") {
-      if (mynode_ == 0) {
-        std::cerr << "# Error while constructing RbmSpin from Json input"
-                  << std::endl;
-      }
-      std::abort();
+      throw InvalidInputError("Error while constructing RbmSpin from Json input");
     }
 
     if (FieldExists(pars["Machine"], "Nvisible")) {
       nv_ = pars["Machine"]["Nvisible"];
     }
     if (nv_ != hilbert_.Size()) {
-      if (mynode_ == 0) {
-        std::cerr << "# Number of visible units is incompatible with given "
-                     "Hilbert space"
-                  << std::endl;
-      }
-      std::abort();
+      throw InvalidInputError("Number of visible units is incompatible with given "
+                              "Hilbert space");
     }
 
     if (FieldExists(pars["Machine"], "Nhidden")) {

--- a/NetKet/Machine/rbm_spin_symm.hpp
+++ b/NetKet/Machine/rbm_spin_symm.hpp
@@ -413,26 +413,18 @@ class RbmSpinSymm : public AbstractMachine<T> {
 
   void from_json(const json &pars) override {
     if (pars.at("Machine").at("Name") != "RbmSpinSymm") {
-      if (mynode_ == 0) {
-        std::cerr << "# Error while constructing RbmSpinSymm from Json input"
-                  << std::endl;
-      }
-      std::abort();
+      throw InvalidInputError("Error while constructing RbmSpinSymm from Json input");
     }
 
     if (FieldExists(pars["Machine"], "Nvisible")) {
       nv_ = pars["Machine"]["Nvisible"];
     }
     if (nv_ != hilbert_.Size()) {
-      if (mynode_ == 0) {
-        std::cerr << "# Number of visible units is incompatible with given "
-                     "Hilbert space"
-                  << std::endl;
-      }
-      std::abort();
+      throw InvalidInputError("Number of visible units is incompatible with given "
+                              "Hilbert space");
     }
 
-    alpha_ = FieldVal(pars["Machine"], "Alpha");
+    alpha_ = FieldVal(pars["Machine"], "Alpha", "Machine");
 
     usea_ = FieldOrDefaultVal(pars["Machine"], "UseVisibleBias", true);
     useb_ = FieldOrDefaultVal(pars["Machine"], "UseHiddenBias", true);

--- a/NetKet/Observable/custom_observable.hpp
+++ b/NetKet/Observable/custom_observable.hpp
@@ -34,10 +34,8 @@ class CustomObservable : public AbstractObservable {
                    const std::string &name)
       : hilbert_(hilbert), name_(name) {
     if (sites.size() != jop.size()) {
-      std::cerr << "The custom Observable definition is inconsistent:"
-                << std::endl;
-      std::cerr << "Check that ActingOn is defined" << std::endl;
-      std::abort();
+      throw InvalidInputError("The custom Observable definition is inconsistent: "
+                              "Check that ActingOn is defined");
     }
 
     for (std::size_t i = 0; i < jop.size(); i++) {

--- a/NetKet/Observable/observable.hpp
+++ b/NetKet/Observable/observable.hpp
@@ -30,19 +30,11 @@ class Observable : public AbstractObservable {
  public:
   using MatType = LocalOperator::MatType;
 
-  Observable(const Hilbert &hilbert, const json &obspars) {
-    if (!FieldExists(obspars, "Operators")) {
-      std::cerr << "Observable's Operators not defined" << std::endl;
-      std::abort();
-    }
-    if (!FieldExists(obspars, "ActingOn")) {
-      std::cerr << "Observable's ActingOn not defined" << std::endl;
-      std::abort();
-    }
-    if (!FieldExists(obspars, "Name")) {
-      std::cerr << "Observable's Name not defined" << std::endl;
-      std::abort();
-    }
+  Observable(const Hilbert &hilbert, const json &obspars)
+  {
+    CheckFieldExists(obspars, "Operators", "Observables");
+    CheckFieldExists(obspars, "ActingOn", "Observables");
+    CheckFieldExists(obspars, "Name", "Observables");
 
     auto jop = obspars.at("Operators").get<std::vector<MatType>>();
     auto sites = obspars.at("ActingOn").get<std::vector<std::vector<int>>>();

--- a/NetKet/Sampler/metropolis_hamiltonian.hpp
+++ b/NetKet/Sampler/metropolis_hamiltonian.hpp
@@ -76,12 +76,8 @@ class MetropolisHamiltonian : public AbstractSampler<WfType> {
     MPI_Comm_rank(MPI_COMM_WORLD, &mynode_);
 
     if (!hilbert_.IsDiscrete()) {
-      if (mynode_ == 0) {
-        std::cerr << "# Hamiltonian Metropolis sampler works only for discrete "
-                     "Hilbert spaces"
-                  << std::endl;
-      }
-      std::abort();
+        throw InvalidInputError("Hamiltonian Metropolis sampler works only for discrete "
+                                "Hilbert spaces");
     }
 
     accept_.resize(1);

--- a/NetKet/Sampler/metropolis_hamiltonian_pt.hpp
+++ b/NetKet/Sampler/metropolis_hamiltonian_pt.hpp
@@ -87,12 +87,8 @@ class MetropolisHamiltonianPt : public AbstractSampler<WfType> {
     MPI_Comm_rank(MPI_COMM_WORLD, &mynode_);
 
     if (!hilbert_.IsDiscrete()) {
-      if (mynode_ == 0) {
-        std::cerr << "# Hamiltonian Metropolis sampler works only for discrete "
-                     "Hilbert spaces"
-                  << std::endl;
-      }
-      std::abort();
+        throw InvalidInputError("Hamiltonian Metropolis sampler works only for discrete "
+                                "Hilbert spaces");
     }
 
     v_.resize(nrep_);

--- a/NetKet/Sampler/metropolis_local.hpp
+++ b/NetKet/Sampler/metropolis_local.hpp
@@ -65,12 +65,8 @@ class MetropolisLocal : public AbstractSampler<WfType> {
     MPI_Comm_rank(MPI_COMM_WORLD, &mynode_);
 
     if (!hilbert_.IsDiscrete()) {
-      if (mynode_ == 0) {
-        std::cerr << "# Local Metropolis sampler works only for discrete "
-                     "Hilbert spaces"
-                  << std::endl;
-      }
-      std::abort();
+        throw InvalidInputError("Hamiltonian Metropolis sampler works only for discrete "
+                                "Hilbert spaces");
     }
 
     accept_.resize(1);

--- a/NetKet/Sampler/sampler.hpp
+++ b/NetKet/Sampler/sampler.hpp
@@ -92,17 +92,8 @@ class Sampler : public AbstractSampler<WfType> {
     int mynode;
     MPI_Comm_rank(MPI_COMM_WORLD, &mynode);
 
-    if (!FieldExists(pars, "Sampler")) {
-      if (mynode == 0)
-        std::cerr << "Sampler is not defined in the input" << std::endl;
-      std::abort();
-    }
-
-    if (!FieldExists(pars["Sampler"], "Name")) {
-      if (mynode == 0)
-        std::cerr << "Sampler Name is not defined in the input" << std::endl;
-      std::abort();
-    }
+    CheckFieldExists(pars, "Sampler");
+    CheckFieldExists(pars["Sampler"], "Name");
 
     std::set<std::string> samplers = {
         "MetropolisLocal",       "MetropolisLocalPt",
@@ -113,8 +104,9 @@ class Sampler : public AbstractSampler<WfType> {
     const auto name = pars["Sampler"]["Name"];
 
     if (samplers.count(name) == 0) {
-      std::cerr << "Sampler " << name << " not found." << std::endl;
-      std::abort();
+      std::stringstream s;
+      s << "Unknown Sampler.Name: " << name;
+      throw InvalidInputError(s.str());
     }
   }
 

--- a/NetKet/Utils/all_utils.hpp
+++ b/NetKet/Utils/all_utils.hpp
@@ -15,6 +15,7 @@
 #ifndef NETKET_ALLUTILS_HPP
 #define NETKET_ALLUTILS_HPP
 
+#include "exceptions.hpp"
 #include "json_utils.hpp"
 #include "parallel_utils.hpp"
 #include "random_utils.hpp"

--- a/NetKet/Utils/exceptions.hpp
+++ b/NetKet/Utils/exceptions.hpp
@@ -12,30 +12,39 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "netket.hpp"
-#include <mpi.h>
+#ifndef NETKET_EXCEPTIONS_HPP
+#define NETKET_EXCEPTIONS_HPP
 
-int main(int argc, char *argv[]) {
-  MPI_Init(&argc, &argv);
+#include <exception>
+#include <string>
 
-  netket::Welcome(argc);
+namespace netket {
 
-  try
-  {
-    auto pars = netket::ReadJsonFromFile(argv[1]);
-    netket::Learning learning(pars);
-  }
-  catch(const netket::InvalidInputError& e)
-  {
-    int rank;
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-    if(rank == 0) {
-      std::cerr << "Error: " << e.what() << "\nExiting." << std::endl;
+class NetketBaseException : public std::exception
+{
+    std::string message_;
+
+public:
+    explicit NetketBaseException(const std::string& message)
+        : message_(message)
+    {
     }
-  }
 
-  MPI_Barrier(MPI_COMM_WORLD);
-  MPI_Finalize();
+    const char* what() const noexcept override
+    {
+        return message_.c_str();
+    }
+};
 
-  return 0;
+class InvalidInputError : public NetketBaseException
+{
+public:
+    explicit InvalidInputError(const std::string& message)
+        : NetketBaseException(message)
+    {
+    }
+};
+
 }
+
+#endif // NETKET_EXCEPTIONS_HPP

--- a/NetKet/Utils/json_dumps.hpp
+++ b/NetKet/Utils/json_dumps.hpp
@@ -21,6 +21,8 @@
 #include <json.hpp>
 #include <vector>
 
+#include "exceptions.hpp"
+
 namespace Eigen {
 
 template <class T>
@@ -60,16 +62,14 @@ void from_json(const nlohmann::json &js,
   std::vector<std::vector<T>> temp = js.get<std::vector<std::vector<T>>>();
 
   if (temp[0].size() == 0) {
-    std::cerr << "Error while loading Eigen Matrix from Json" << std::endl;
-    std::abort();
+    throw netket::InvalidInputError("Error while loading Eigen Matrix from Json");
   }
 
   v.resize(temp.size(), temp[0].size());
   for (std::size_t i = 0; i < temp.size(); i++) {
     for (std::size_t j = 0; j < temp[i].size(); j++) {
       if (temp[i].size() != temp[0].size()) {
-        std::cerr << "Error while loading Eigen Matrix from Json" << std::endl;
-        std::abort();
+        throw netket::InvalidInputError("Error while loading Eigen Matrix from Json");
       }
       v(i, j) = temp[i][j];
     }

--- a/Test/CMakeLists.txt
+++ b/Test/CMakeLists.txt
@@ -54,8 +54,15 @@ add_library(catch_main OBJECT
 )
 
 
-file(GLOB TEST_SOURCES Graph/*.cc Hamiltonian/*.cc Hilbert/*.cc Machine/*.cc)
-file(GLOB TEST_SOURCES ${TEST_SOURCES} Observable/*.cc Sampler/*.cc Stats/*.cc)
+file(GLOB TEST_SOURCES
+    Graph/*.cc
+    Hamiltonian/*.cc
+    Hilbert/*.cc
+    Machine/*.cc
+    Observable/*.cc
+    Sampler/*.cc
+    Stats/*.cc
+    Utils/*.cpp)
 
 foreach(file ${TEST_SOURCES})
    get_filename_component(file_basename ${file} NAME_WE)

--- a/Test/Utils/unit-utils.cpp
+++ b/Test/Utils/unit-utils.cpp
@@ -1,0 +1,76 @@
+// Copyright 2018 The Simons Foundation, Inc. - All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <catch.hpp>
+
+#include "netket.hpp"
+
+using namespace netket;
+
+/**
+ * Matcher class for checking an exeption message.
+ */
+template<class Exception>
+class HasMessage : public Catch::MatcherBase<Exception>
+{
+    std::string message_;
+
+public:
+    explicit HasMessage(const std::string& message)
+        : message_(message)
+    {}
+
+    bool match(const Exception& e) const override {
+        return message_ == e.what();
+    }
+
+    std::string describe() const override {
+        std::ostringstream s;
+        s << "has error message \"" << message_ << "\"";
+        return s.str();
+    }
+};
+
+TEST_CASE("JSON helper functions throw errors", "[stats]")
+{
+    SECTION("CheckFieldExists")
+    {
+        auto pars = json();
+
+        REQUIRE_THROWS_AS(CheckFieldExists(pars, "Key"), InvalidInputError);
+        REQUIRE_THROWS_MATCHES(
+                    CheckFieldExists(pars, "Key"),
+                    InvalidInputError,
+                    HasMessage<InvalidInputError>("Field 'Key' is not defined in the input"));
+
+        pars["Key"] = {{"SubKey1", 0}, {"SubKey2", 1}};
+
+        REQUIRE_NOTHROW(CheckFieldExists(pars["Key"], "SubKey1"));
+        REQUIRE_NOTHROW(CheckFieldExists(pars["Key"], "SubKey2"));
+
+        REQUIRE_THROWS_MATCHES(
+                    CheckFieldExists(pars["Key"], "NoSuchKey", "Context"),
+                    InvalidInputError,
+                    HasMessage<InvalidInputError>("Field 'NoSuchKey' (below 'Context') is not defined in the input"));
+    }
+
+    SECTION("FieldVal")
+    {
+        auto pars = json();
+        REQUIRE_THROWS_AS(FieldVal(pars, "Key"), InvalidInputError);
+
+        pars["Key"] = 0;
+        REQUIRE_NOTHROW(FieldVal(pars, "Key"));
+    }
+}


### PR DESCRIPTION
This pull request adds a custom exception class and replaces all calls to `std::abort` for invalid user input with throwing this exception.

This makes the code easier to read in most parts and allows us to handle invalid input in a single place (currently in `main` by printing an error message and exiting).

This PR also adds a point to the list of exceptions from the Google C++ Guide in `CONTRIBUTING.md` because the Google guide does not permit the use of exceptions (for reasons that in my opinion do not apply to netket).