### PR TITLE
Compile Travis tests without -DNDEBUG to trigger assertion errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -104,6 +104,6 @@ script:
 
   # compile and execute unit tests
   - mkdir -p build && cd build
-  - cmake .. ${CMAKE_OPTIONS} && cmake --build . --config Release
+  - cmake .. ${CMAKE_OPTIONS} -DCMAKE_CXX_FLAGS_RELEASE=-O3 && cmake --build . --config Release
   - ctest -C Release -V -j
   - cd ..


### PR DESCRIPTION
By passing `-DCMAKE_CXX_FLAGS_RELEASE=-O3` we leave the optimization level high but remove the `-DNDEBUG` flag that cmake sets by default for release builds.