### PR TITLE
Custom sampling

### DIFF
--- a/NetKet/Sampler/custom_sampler.hpp
+++ b/NetKet/Sampler/custom_sampler.hpp
@@ -1,0 +1,287 @@
+// Copyright 2018 The Simons Foundation, Inc. - All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// authors: Hugo Théveniaut and Fabien Alet
+
+#ifndef NETKET_CUSTOMSAMPLER_HPP
+#define NETKET_CUSTOMSAMPLER_HPP
+
+#include <mpi.h>
+#include <Eigen/Dense>
+#include <iostream>
+#include <limits>
+#include "../Hamiltonian/local_operator.hpp"
+#include "Utils/parallel_utils.hpp"
+#include "Utils/random_utils.hpp"
+#include "abstract_sampler.hpp"
+
+namespace netket {
+
+// Metropolis sampling using custom moves provided by user
+template <class WfType>
+class CustomSampler : public AbstractSampler<WfType> {
+  WfType &psi_;
+  const Hilbert &hilbert_;
+  std::vector<LocalOperator> move_operators_;
+  std::vector<double> operatorsweights_;
+
+  // number of visible units
+  const int nv_;
+
+  netket::default_random_engine rgen_;
+
+  // states of visible units
+  Eigen::VectorXd v_;
+
+  Eigen::VectorXd accept_;
+  Eigen::VectorXd moves_;
+
+  int mynode_;
+  int totalnodes_;
+
+  // Look-up tables
+  typename WfType::LookupType lt_;
+
+  std::vector<std::vector<int>> tochange_;
+  std::vector<std::vector<double>> newconfs_;
+  std::vector<std::complex<double>> mel_;
+
+  int nstates_;
+  std::vector<double> localstates_;
+
+ public:
+  using MatType = std::vector<std::vector<std::complex<double>>>;
+
+  explicit CustomSampler(WfType &psi, const json &pars)
+      : psi_(psi), hilbert_(psi.GetHilbert()), nv_(hilbert_.Size()) {
+    CheckFieldExists(pars["Sampler"], "MoveOperators");
+
+    if (!pars["Sampler"]["MoveOperators"].is_array()) {
+      throw InvalidInputError("MoveOperators is not an array");
+    }
+    CheckFieldExists(pars["Sampler"], "ActingOn");
+
+    if (!pars["Sampler"]["ActingOn"].is_array()) {
+      throw InvalidInputError("ActingOn is not an array");
+    }
+
+    auto jop = pars["Sampler"]["MoveOperators"].get<std::vector<MatType>>();
+    auto sites =
+        pars["Sampler"]["ActingOn"].get<std::vector<std::vector<int>>>();
+
+    if (sites.size() != jop.size()) {
+      throw InvalidInputError(
+          "The custom sampler definition is inconsistent (between "
+          "MoveOperators and ActingOn sizes); Check that ActingOn is defined");
+    }
+
+    std::set<int> touched_sites;
+    for (std::size_t c = 0; c < jop.size(); c++) {
+      // check if matrix of this operator is stochastic
+      bool is_stochastic = true;
+      bool is_complex = false;
+      bool is_definite_positive = true;
+      bool is_symmetric = true;
+      const double epsilon = 1.0e-6;
+      for (std::size_t i = 0; i < jop[c].size(); i++) {
+        double sum_column = 0.;
+        for (std::size_t j = 0; j < jop[c].size(); j++) {
+          if (std::abs(jop[c][i][j].imag()) > epsilon) {
+            is_complex = true;
+            is_stochastic = false;
+            break;
+          }
+          if (jop[c][i][j].real() < 0) {
+            is_definite_positive = false;
+            is_stochastic = false;
+            break;
+          }
+          if (std::abs(jop[c][i][j].real() - jop[c][j][i].real()) > epsilon) {
+            is_symmetric = false;
+            is_stochastic = false;
+            break;
+          }
+          sum_column += jop[c][i][j].real();
+        }
+        if (std::abs(sum_column - 1.) > epsilon) {
+          is_stochastic = false;
+        }
+      }
+      if (is_complex == true) {
+        InfoMessage() << "Warning: MoveOperators " << c
+                      << " has complex matrix elements" << std::endl;
+      }
+      if (is_definite_positive == false) {
+        InfoMessage() << "Warning: MoveOperators " << c
+                      << " has negative matrix elements" << std::endl;
+      }
+      if (is_symmetric == false) {
+        InfoMessage() << "Warning: MoveOperators " << c << " is not symmetric"
+                      << std::endl;
+      }
+      if (is_stochastic == false) {
+        InfoMessage() << "Warning: MoveOperators " << c << " is not stochastic"
+                      << std::endl;
+        InfoMessage() << "MoveOperators " << c << " is discarded" << std::endl;
+      }
+
+      else {
+        move_operators_.push_back(LocalOperator(hilbert_, jop[c], sites[c]));
+        for (std::size_t i = 0; i < sites[c].size(); i++) {
+          touched_sites.insert(sites[c][i]);
+        }
+      }
+    }
+
+    if (move_operators_.size() == 0) {
+      throw InvalidInputError("No valid MoveOperators provided");
+    }
+
+    if (static_cast<int>(touched_sites.size()) != hilbert_.Size()) {
+      InfoMessage() << "Warning: MoveOperators appear not to act on "
+                       "all sites of the sample:"
+                    << std::endl;
+      InfoMessage() << "Check ergodicity" << std::endl;
+    }
+
+    if (FieldExists(pars["Sampler"], "MoveWeights")) {
+      if (!pars["Sampler"]["MoveWeights"].is_array()) {
+        throw InvalidInputError("MoveWeights is not an array");
+      }
+      operatorsweights_ =
+          pars["Sampler"]["MoveWeights"].get<std::vector<double>>();
+
+      if (operatorsweights_.size() != jop.size()) {
+        throw InvalidInputError(
+            "The custom sampler definition is inconsistent (between "
+            "MoveWeights and MoveOperators sizes)");
+      }
+
+    } else {  // By default the stochastic operators are drawn uniformly
+      operatorsweights_.resize(move_operators_.size(), 1.0);
+    }
+
+    Init();
+  }
+
+  void Init() {
+    v_.resize(nv_);
+
+    MPI_Comm_size(MPI_COMM_WORLD, &totalnodes_);
+    MPI_Comm_rank(MPI_COMM_WORLD, &mynode_);
+
+    if (!hilbert_.IsDiscrete()) {
+      throw InvalidInputError(
+          "Custom Metropolis sampler works only for discrete Hilbert spaces");
+    }
+
+    accept_.resize(1);
+    moves_.resize(1);
+
+    nstates_ = hilbert_.LocalSize();
+    localstates_ = hilbert_.LocalStates();
+
+    Seed();
+
+    Reset(true);
+
+    InfoMessage() << "Custom Metropolis sampler is ready " << std::endl;
+  }
+
+  void Seed(int baseseed = 0) {
+    std::random_device rd;
+    std::vector<int> seeds(totalnodes_);
+
+    if (mynode_ == 0) {
+      for (int i = 0; i < totalnodes_; i++) {
+        seeds[i] = rd() + baseseed;
+      }
+    }
+
+    SendToAll(seeds);
+
+    rgen_.seed(seeds[mynode_]);
+  }
+
+  void Reset(bool initrandom = false) override {
+    if (initrandom) {
+      hilbert_.RandomVals(v_, rgen_);
+    }
+
+    psi_.InitLookup(v_, lt_);
+
+    accept_ = Eigen::VectorXd::Zero(1);
+    moves_ = Eigen::VectorXd::Zero(1);
+  }
+
+  void Sweep() override {
+    std::discrete_distribution<int> disc_dist(operatorsweights_.begin(),
+                                              operatorsweights_.end());
+    std::uniform_real_distribution<double> distu;
+
+    for (int i = 0; i < nv_; i++) {
+      // pick a random operator in possible ones according to the provided
+      // weights
+      int op = disc_dist(rgen_);
+      move_operators_[op].FindConn(v_, mel_, tochange_, newconfs_);
+
+      double p = distu(rgen_);
+      std::size_t exit_state = 0;
+      double cumulative_prob = mel_[0].real();
+      while (p > cumulative_prob) {
+        exit_state++;
+        cumulative_prob += mel_[exit_state].real();
+      }
+
+      double ratio = std::norm(std::exp(psi_.LogValDiff(
+          v_, tochange_[exit_state], newconfs_[exit_state], lt_)));
+
+#ifndef NDEBUG
+      const auto psival1 = psi_.LogVal(v_);
+      if (std::abs(std::exp(psi_.LogVal(v_) - psi_.LogVal(v_, lt_)) - 1.) >
+          1.0e-8) {
+        std::cerr << psi_.LogVal(v_) << "  and LogVal with Lt is "
+                  << psi_.LogVal(v_, lt_) << std::endl;
+        std::abort();
+      }
+#endif
+
+      // Metropolis acceptance test
+      if (ratio > distu(rgen_)) {
+        accept_[0] += 1;
+        psi_.UpdateLookup(v_, tochange_[exit_state], newconfs_[exit_state],
+                          lt_);
+        hilbert_.UpdateConf(v_, tochange_[exit_state], newconfs_[exit_state]);
+      }
+      moves_[0] += 1;
+    }
+  }
+
+  Eigen::VectorXd Visible() override { return v_; }
+
+  void SetVisible(const Eigen::VectorXd &v) override { v_ = v; }
+
+  WfType &Psi() override { return psi_; }
+
+  Eigen::VectorXd Acceptance() const override {
+    Eigen::VectorXd acc = accept_;
+    for (int i = 0; i < 1; i++) {
+      acc(i) /= moves_(i);
+    }
+    return acc;
+  }
+};
+}  // namespace netket
+
+#endif

--- a/NetKet/Sampler/custom_sampler.hpp
+++ b/NetKet/Sampler/custom_sampler.hpp
@@ -247,16 +247,6 @@ class CustomSampler : public AbstractSampler<WfType> {
       double ratio = std::norm(std::exp(psi_.LogValDiff(
           v_, tochange_[exit_state], newconfs_[exit_state], lt_)));
 
-#ifndef NDEBUG
-      const auto psival1 = psi_.LogVal(v_);
-      if (std::abs(std::exp(psi_.LogVal(v_) - psi_.LogVal(v_, lt_)) - 1.) >
-          1.0e-8) {
-        std::cerr << psi_.LogVal(v_) << "  and LogVal with Lt is "
-                  << psi_.LogVal(v_, lt_) << std::endl;
-        std::abort();
-      }
-#endif
-
       // Metropolis acceptance test
       if (ratio > distu(rgen_)) {
         accept_[0] += 1;

--- a/NetKet/Sampler/custom_sampler_pt.hpp
+++ b/NetKet/Sampler/custom_sampler_pt.hpp
@@ -269,17 +269,6 @@ class CustomSamplerPt : public AbstractSampler<WfType> {
           beta_[rep] * psi_.LogValDiff(v_[rep], tochange_[exit_state],
                                        newconfs_[exit_state], lt_[rep])));
 
-#ifndef NDEBUG
-      const auto psival1 = psi_.LogVal(v_[rep]);
-      if (std::abs(
-              std::exp(psi_.LogVal(v_[rep]) - psi_.LogVal(v_[rep], lt_[rep])) -
-              1.) > 1.0e-8) {
-        std::cerr << psi_.LogVal(v_[rep]) << "  and LogVal with Lt is "
-                  << psi_.LogVal(v_[rep], lt_[rep]) << std::endl;
-        std::abort();
-      }
-#endif
-
       // Metropolis acceptance test
       if (ratio > distu(rgen_)) {
         accept_(rep) += 1;
@@ -287,17 +276,6 @@ class CustomSamplerPt : public AbstractSampler<WfType> {
                           lt_[rep]);
         hilbert_.UpdateConf(v_[rep], tochange_[exit_state],
                             newconfs_[exit_state]);
-
-#ifndef NDEBUG
-        const auto psival2 = psi_.LogVal(v_[rep]);
-        if (std::abs(std::exp(psival2 - psival1 - lvd) - 1.) > 1.0e-8) {
-          std::cerr << psival2 - psival1 << " and logvaldiff is " << lvd
-                    << std::endl;
-          std::cerr << psival2 << " and LogVal with Lt is "
-                    << psi_.LogVal(v_[rep], lt_[rep]) << std::endl;
-          std::abort();
-        }
-#endif
       }
       moves_(rep) += 1;
     }

--- a/NetKet/Sampler/custom_sampler_pt.hpp
+++ b/NetKet/Sampler/custom_sampler_pt.hpp
@@ -1,0 +1,365 @@
+// Copyright 2018 The Simons Foundation, Inc. - All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// authors: Hugo Théveniaut and Fabien Alet
+
+#ifndef NETKET_CUSTOMSAMPLERPT_HPP
+#define NETKET_CUSTOMSAMPLERPT_HPP
+
+#include <mpi.h>
+#include <Eigen/Dense>
+#include <iostream>
+#include <limits>
+#include "../Hamiltonian/local_operator.hpp"
+#include "Utils/parallel_utils.hpp"
+#include "Utils/random_utils.hpp"
+#include "abstract_sampler.hpp"
+
+namespace netket {
+
+// Metropolis sampling using custom moves provided by user
+template <class WfType>
+class CustomSamplerPt : public AbstractSampler<WfType> {
+  WfType &psi_;
+  const Hilbert &hilbert_;
+  std::vector<LocalOperator> move_operators_;
+  std::vector<double> operatorsweights_;
+  // number of visible units
+  const int nv_;
+
+  netket::default_random_engine rgen_;
+
+  // states of visible units
+  // for each sampled temperature
+  std::vector<Eigen::VectorXd> v_;
+
+  Eigen::VectorXd accept_;
+  Eigen::VectorXd moves_;
+
+  int mynode_;
+  int totalnodes_;
+
+  // Look-up tables
+  std::vector<typename WfType::LookupType> lt_;
+
+  std::vector<std::vector<int>> tochange_;
+  std::vector<std::vector<double>> newconfs_;
+  std::vector<std::complex<double>> mel_;
+
+  int nstates_;
+  std::vector<double> localstates_;
+
+  int nrep_;
+  std::vector<double> beta_;
+
+ public:
+  using MatType = std::vector<std::vector<std::complex<double>>>;
+
+  explicit CustomSamplerPt(WfType &psi, const json &pars)
+      : psi_(psi), hilbert_(psi.GetHilbert()), nv_(hilbert_.Size()) {
+    CheckFieldExists(pars["Sampler"], "Nreplicas");
+    nrep_ = FieldVal(pars["Sampler"], "Nreplicas");
+
+    CheckFieldExists(pars["Sampler"], "MoveOperators");
+
+    if (!pars["Sampler"]["MoveOperators"].is_array()) {
+      throw InvalidInputError("MoveOperators is not an array");
+    }
+    CheckFieldExists(pars["Sampler"], "ActingOn");
+
+    if (!pars["Sampler"]["ActingOn"].is_array()) {
+      throw InvalidInputError("ActingOn is not an array");
+    }
+
+    auto jop = pars["Sampler"]["MoveOperators"].get<std::vector<MatType>>();
+    auto sites =
+        pars["Sampler"]["ActingOn"].get<std::vector<std::vector<int>>>();
+
+    if (sites.size() != jop.size()) {
+      throw InvalidInputError(
+          "The custom sampler definition is inconsistent (between "
+          "MoveOperators and ActingOn sizes); Check that ActingOn is defined");
+    }
+
+    std::set<int> touched_sites;
+    for (std::size_t c = 0; c < jop.size(); c++) {
+      // check if matrix of this operator is stochastic
+      bool is_stochastic = true;
+      bool is_complex = false;
+      bool is_definite_positive = true;
+      bool is_symmetric = true;
+      const double epsilon = 1.0e-6;
+      for (std::size_t i = 0; i < jop[c].size(); i++) {
+        double sum_column = 0.;
+        for (std::size_t j = 0; j < jop[c].size(); j++) {
+          if (std::abs(jop[c][i][j].imag()) > epsilon) {
+            is_complex = true;
+            is_stochastic = false;
+            break;
+          }
+          if (jop[c][i][j].real() < 0) {
+            is_definite_positive = false;
+            is_stochastic = false;
+            break;
+          }
+          if (std::abs(jop[c][i][j].real() - jop[c][j][i].real()) > epsilon) {
+            is_symmetric = false;
+            is_stochastic = false;
+            break;
+          }
+          sum_column += jop[c][i][j].real();
+        }
+        if (std::abs(sum_column - 1.) > epsilon) {
+          is_stochastic = false;
+        }
+      }
+      if (is_complex == true) {
+        InfoMessage() << "Warning: MoveOperators " << c
+                      << " has complex matrix elements" << std::endl;
+      }
+      if (is_definite_positive == false) {
+        InfoMessage() << "Warning: MoveOperators " << c
+                      << " has negative matrix elements" << std::endl;
+      }
+      if (is_symmetric == false) {
+        InfoMessage() << "Warning: MoveOperators " << c << " is not symmetric"
+                      << std::endl;
+      }
+      if (is_stochastic == false) {
+        InfoMessage() << "Warning: MoveOperators " << c << " is not stochastic"
+                      << std::endl;
+        InfoMessage() << "MoveOperators " << c << " is discarded" << std::endl;
+      }
+
+      else {
+        move_operators_.push_back(LocalOperator(hilbert_, jop[c], sites[c]));
+        for (std::size_t i = 0; i < sites[c].size(); i++) {
+          touched_sites.insert(sites[c][i]);
+        }
+      }
+    }
+
+    if (move_operators_.size() == 0) {
+      throw InvalidInputError("No valid MoveOperators provided");
+    }
+
+    if (static_cast<int>(touched_sites.size()) != hilbert_.Size()) {
+      InfoMessage() << "Warning: MoveOperators appear not to act on "
+                       "all sites of the sample:"
+                    << std::endl;
+      InfoMessage() << "Check ergodicity" << std::endl;
+    }
+
+    if (FieldExists(pars["Sampler"], "MoveWeights")) {
+      if (!pars["Sampler"]["MoveWeights"].is_array()) {
+        throw InvalidInputError("MoveWeights is not an array");
+      }
+      operatorsweights_ =
+          pars["Sampler"]["MoveWeights"].get<std::vector<double>>();
+
+      if (operatorsweights_.size() != jop.size()) {
+        throw InvalidInputError(
+            "The custom sampler definition is inconsistent (between "
+            "MoveWeights and MoveOperators sizes)");
+      }
+
+    } else {  // By default the stochastic operators are drawn uniformly
+      operatorsweights_.resize(move_operators_.size(), 1.0);
+    }
+
+    Init();
+  }
+
+  void Init() {
+    MPI_Comm_size(MPI_COMM_WORLD, &totalnodes_);
+    MPI_Comm_rank(MPI_COMM_WORLD, &mynode_);
+
+    if (!hilbert_.IsDiscrete()) {
+      throw InvalidInputError(
+          "Custom Metropolis sampler works only for discrete Hilbert spaces");
+    }
+
+    nstates_ = hilbert_.LocalSize();
+    localstates_ = hilbert_.LocalStates();
+
+    v_.resize(nrep_);
+    for (int i = 0; i < nrep_; i++) {
+      v_[i].resize(nv_);
+    }
+
+    for (int i = 0; i < nrep_; i++) {
+      beta_.push_back(1. - double(i) / double(nrep_));
+    }
+
+    lt_.resize(nrep_);
+
+    accept_.resize(2 * nrep_);
+    moves_.resize(2 * nrep_);
+
+    Seed();
+
+    Reset(true);
+
+    InfoMessage() << "Custom Metropolis sampler with parallel tempering "
+                     "is ready "
+                  << std::endl;
+    InfoMessage() << nrep_ << " replicas are being used" << std::endl;
+  }
+
+  void Seed(int baseseed = 0) {
+    std::random_device rd;
+    std::vector<int> seeds(totalnodes_);
+
+    if (mynode_ == 0) {
+      for (int i = 0; i < totalnodes_; i++) {
+        seeds[i] = rd() + baseseed;
+      }
+    }
+
+    SendToAll(seeds);
+
+    rgen_.seed(seeds[mynode_]);
+  }
+
+  void Reset(bool initrandom = false) override {
+    if (initrandom) {
+      for (int i = 0; i < nrep_; i++) {
+        hilbert_.RandomVals(v_[i], rgen_);
+      }
+    }
+
+    for (int i = 0; i < nrep_; i++) {
+      psi_.InitLookup(v_[i], lt_[i]);
+    }
+
+    accept_ = Eigen::VectorXd::Zero(2 * nrep_);
+    moves_ = Eigen::VectorXd::Zero(2 * nrep_);
+  }
+
+  void LocalSweep(int rep) {
+    std::discrete_distribution<int> disc_dist(operatorsweights_.begin(),
+                                              operatorsweights_.end());
+    std::uniform_real_distribution<double> distu;
+    for (int i = 0; i < nv_; i++) {
+      // pick a random operator in possible ones according to the provided
+      // weights
+      int op = disc_dist(rgen_);
+      move_operators_[op].FindConn(v_[rep], mel_, tochange_, newconfs_);
+
+      double p = distu(rgen_);
+      std::size_t exit_state = 0;
+      double cumulative_prob = mel_[0].real();
+      while (p > cumulative_prob) {
+        exit_state++;
+        cumulative_prob += mel_[exit_state].real();
+      }
+
+      double ratio = std::norm(std::exp(
+          beta_[rep] * psi_.LogValDiff(v_[rep], tochange_[exit_state],
+                                       newconfs_[exit_state], lt_[rep])));
+
+#ifndef NDEBUG
+      const auto psival1 = psi_.LogVal(v_[rep]);
+      if (std::abs(
+              std::exp(psi_.LogVal(v_[rep]) - psi_.LogVal(v_[rep], lt_[rep])) -
+              1.) > 1.0e-8) {
+        std::cerr << psi_.LogVal(v_[rep]) << "  and LogVal with Lt is "
+                  << psi_.LogVal(v_[rep], lt_[rep]) << std::endl;
+        std::abort();
+      }
+#endif
+
+      // Metropolis acceptance test
+      if (ratio > distu(rgen_)) {
+        accept_(rep) += 1;
+        psi_.UpdateLookup(v_[rep], tochange_[exit_state], newconfs_[exit_state],
+                          lt_[rep]);
+        hilbert_.UpdateConf(v_[rep], tochange_[exit_state],
+                            newconfs_[exit_state]);
+
+#ifndef NDEBUG
+        const auto psival2 = psi_.LogVal(v_[rep]);
+        if (std::abs(std::exp(psival2 - psival1 - lvd) - 1.) > 1.0e-8) {
+          std::cerr << psival2 - psival1 << " and logvaldiff is " << lvd
+                    << std::endl;
+          std::cerr << psival2 << " and LogVal with Lt is "
+                    << psi_.LogVal(v_[rep], lt_[rep]) << std::endl;
+          std::abort();
+        }
+#endif
+      }
+      moves_(rep) += 1;
+    }
+  }
+
+  void Sweep() override {
+    // First we do local sweeps
+    for (int i = 0; i < nrep_; i++) {
+      LocalSweep(i);
+    }
+
+    // Temperature exchanges
+    std::uniform_real_distribution<double> distribution(0, 1);
+
+    for (int r = 1; r < nrep_; r += 2) {
+      if (ExchangeProb(r, r - 1) > distribution(rgen_)) {
+        Exchange(r, r - 1);
+        accept_(nrep_ + r) += 1.;
+        accept_(nrep_ + r - 1) += 1;
+      }
+      moves_(nrep_ + r) += 1.;
+      moves_(nrep_ + r - 1) += 1;
+    }
+
+    for (int r = 2; r < nrep_; r += 2) {
+      if (ExchangeProb(r, r - 1) > distribution(rgen_)) {
+        Exchange(r, r - 1);
+        accept_(nrep_ + r) += 1.;
+        accept_(nrep_ + r - 1) += 1;
+      }
+      moves_(nrep_ + r) += 1.;
+      moves_(nrep_ + r - 1) += 1;
+    }
+  }
+
+  // computes the probability to exchange two replicas
+  double ExchangeProb(int r1, int r2) {
+    const double lf1 = 2 * std::real(psi_.LogVal(v_[r1], lt_[r1]));
+    const double lf2 = 2 * std::real(psi_.LogVal(v_[r2], lt_[r2]));
+
+    return std::exp((beta_[r1] - beta_[r2]) * (lf2 - lf1));
+  }
+
+  void Exchange(int r1, int r2) {
+    std::swap(v_[r1], v_[r2]);
+    std::swap(lt_[r1], lt_[r2]);
+  }
+
+  Eigen::VectorXd Visible() override { return v_[0]; }
+
+  void SetVisible(const Eigen::VectorXd &v) override { v_[0] = v; }
+
+  WfType &Psi() override { return psi_; }
+
+  Eigen::VectorXd Acceptance() const override {
+    Eigen::VectorXd acc = accept_;
+    for (int i = 0; i < acc.size(); i++) {
+      acc(i) /= moves_(i);
+    }
+    return acc;
+  }
+};
+}  // namespace netket
+
+#endif

--- a/NetKet/Sampler/sampler.hpp
+++ b/NetKet/Sampler/sampler.hpp
@@ -63,11 +63,13 @@ class Sampler : public AbstractSampler<WfType> {
   }
 
   void Init(WfType &psi, const json &pars) {
-    if (pars["Sampler"]["Name"] == "MetropolisLocal") {
-      s_ = Ptype(new MetropolisLocal<WfType>(psi));
-    } else if (pars["Sampler"]["Name"] == "MetropolisLocalPt") {
-      s_ = Ptype(new MetropolisLocalPt<WfType>(psi, pars));
-    } else if (!FieldExists(pars["Sampler"], "Name")) {
+    if (FieldExists(pars["Sampler"], "Name")) {
+      if (pars["Sampler"]["Name"] == "MetropolisLocal") {
+        s_ = Ptype(new MetropolisLocal<WfType>(psi));
+      } else if (pars["Sampler"]["Name"] == "MetropolisLocalPt") {
+        s_ = Ptype(new MetropolisLocalPt<WfType>(psi, pars));
+      }
+    } else {
       if (FieldExists(pars["Sampler"], "Nreplicas")) {
         s_ = Ptype(new CustomSamplerPt<WfType>(psi, pars));
       } else {
@@ -77,22 +79,26 @@ class Sampler : public AbstractSampler<WfType> {
   }
 
   void Init(Graph &graph, WfType &psi, const json &pars) {
-    if (pars["Sampler"]["Name"] == "MetropolisExchange") {
-      s_ = Ptype(new MetropolisExchange<WfType>(graph, psi, pars));
-    } else if (pars["Sampler"]["Name"] == "MetropolisExchangePt") {
-      s_ = Ptype(new MetropolisExchangePt<WfType>(graph, psi, pars));
-    } else if (pars["Sampler"]["Name"] == "MetropolisHop") {
-      s_ = Ptype(new MetropolisHop<WfType>(graph, psi, pars));
+    if (FieldExists(pars["Sampler"], "Name")) {
+      if (pars["Sampler"]["Name"] == "MetropolisExchange") {
+        s_ = Ptype(new MetropolisExchange<WfType>(graph, psi, pars));
+      } else if (pars["Sampler"]["Name"] == "MetropolisExchangePt") {
+        s_ = Ptype(new MetropolisExchangePt<WfType>(graph, psi, pars));
+      } else if (pars["Sampler"]["Name"] == "MetropolisHop") {
+        s_ = Ptype(new MetropolisHop<WfType>(graph, psi, pars));
+      }
     }
   }
 
   void Init(Hamiltonian &hamiltonian, WfType &psi, const json &pars) {
-    if (pars["Sampler"]["Name"] == "MetropolisHamiltonian") {
-      s_ = Ptype(
-          new MetropolisHamiltonian<WfType, Hamiltonian>(psi, hamiltonian));
-    } else if (pars["Sampler"]["Name"] == "MetropolisHamiltonianPt") {
-      s_ = Ptype(new MetropolisHamiltonianPt<WfType, Hamiltonian>(
-          psi, hamiltonian, pars));
+    if (FieldExists(pars["Sampler"], "Name")) {
+      if (pars["Sampler"]["Name"] == "MetropolisHamiltonian") {
+        s_ = Ptype(
+            new MetropolisHamiltonian<WfType, Hamiltonian>(psi, hamiltonian));
+      } else if (pars["Sampler"]["Name"] == "MetropolisHamiltonianPt") {
+        s_ = Ptype(new MetropolisHamiltonianPt<WfType, Hamiltonian>(
+            psi, hamiltonian, pars));
+      }
     }
   }
 

--- a/Test/Sampler/sampler_input_tests.hpp
+++ b/Test/Sampler/sampler_input_tests.hpp
@@ -78,23 +78,21 @@ std::vector<netket::json> GetSamplerInputs() {
   std::vector<std::vector<double>> spsm = {
       {1, 0, 0, 0}, {0, 0, 1, 0}, {0, 1, 0, 0}, {0, 0, 0, 1}};
   pars = {{"Graph",
-           {{"Name", "Hypercube"}, {"L", 6}, {"Dimension", 1}, {"Pbc", true}}},
+           {{"Name", "Hypercube"}, {"L", 4}, {"Dimension", 1}, {"Pbc", true}}},
           {"Machine", {{"Name", "RbmSpin"}, {"Alpha", 1.0}}},
           {"Hamiltonian", {{"Name", "Ising"}, {"h", 1.0}}}};
-  pars["Sampler"]["MoveOperators"] = {sx,   sx,   sx,   sx,   sx,   sx,
-                                      spsm, spsm, spsm, spsm, spsm, spsm};
+  pars["Sampler"]["MoveOperators"] = {sx, sx, sx, sx, spsm, spsm, spsm, spsm};
   pars["Sampler"]["ActingOn"] = {{0},    {1},    {2},    {3},
-                                 {4},    {5},    {0, 1}, {1, 2},
-                                 {2, 3}, {3, 4}, {4, 5}, {5, 0}};
+                                 {0, 1}, {1, 2}, {2, 3}, {3, 0}};
   input_tests.push_back(pars);
 
   // Ising 1d with Custom Sampler and replicas
   pars = {{"Graph",
-           {{"Name", "Hypercube"}, {"L", 6}, {"Dimension", 1}, {"Pbc", true}}},
+           {{"Name", "Hypercube"}, {"L", 4}, {"Dimension", 1}, {"Pbc", true}}},
           {"Machine", {{"Name", "RbmSpin"}, {"Alpha", 1.0}}},
           {"Hamiltonian", {{"Name", "Ising"}, {"h", 1.0}}}};
-  pars["Sampler"]["MoveOperators"] = {sx, sx, sx, sx, sx, sx};
-  pars["Sampler"]["ActingOn"] = {{0}, {1}, {2}, {3}, {4}, {5}};
+  pars["Sampler"]["MoveOperators"] = {sx, sx, sx, sx};
+  pars["Sampler"]["ActingOn"] = {{0}, {1}, {2}, {3}};
   pars["Sampler"]["Nreplicas"] = 4;
   input_tests.push_back(pars);
 

--- a/Test/Sampler/sampler_input_tests.hpp
+++ b/Test/Sampler/sampler_input_tests.hpp
@@ -64,5 +64,39 @@ std::vector<netket::json> GetSamplerInputs() {
           {"Sampler", {{"Name", "MetropolisLocalPt"}, {"Nreplicas", 4}}}};
   input_tests.push_back(pars);
 
+  // Ising 1d with Custom Sampler
+  std::vector<std::vector<double>> sx = {{0, 1}, {1, 0}};
+  pars = {{"Graph",
+           {{"Name", "Hypercube"}, {"L", 6}, {"Dimension", 1}, {"Pbc", true}}},
+          {"Machine", {{"Name", "RbmSpin"}, {"Alpha", 1.0}}},
+          {"Hamiltonian", {{"Name", "Ising"}, {"h", 1.0}}}};
+  pars["Sampler"]["MoveOperators"] = {sx, sx, sx, sx, sx, sx};
+  pars["Sampler"]["ActingOn"] = {{0}, {1}, {2}, {3}, {4}, {5}};
+  input_tests.push_back(pars);
+
+  // Ising 1D with CustomSampler two types of updates
+  std::vector<std::vector<double>> spsm = {
+      {1, 0, 0, 0}, {0, 0, 1, 0}, {0, 1, 0, 0}, {0, 0, 0, 1}};
+  pars = {{"Graph",
+           {{"Name", "Hypercube"}, {"L", 6}, {"Dimension", 1}, {"Pbc", true}}},
+          {"Machine", {{"Name", "RbmSpin"}, {"Alpha", 1.0}}},
+          {"Hamiltonian", {{"Name", "Ising"}, {"h", 1.0}}}};
+  pars["Sampler"]["MoveOperators"] = {sx,   sx,   sx,   sx,   sx,   sx,
+                                      spsm, spsm, spsm, spsm, spsm, spsm};
+  pars["Sampler"]["ActingOn"] = {{0},    {1},    {2},    {3},
+                                 {4},    {5},    {0, 1}, {1, 2},
+                                 {2, 3}, {3, 4}, {4, 5}, {5, 0}};
+  input_tests.push_back(pars);
+
+  // Ising 1d with Custom Sampler and replicas
+  pars = {{"Graph",
+           {{"Name", "Hypercube"}, {"L", 6}, {"Dimension", 1}, {"Pbc", true}}},
+          {"Machine", {{"Name", "RbmSpin"}, {"Alpha", 1.0}}},
+          {"Hamiltonian", {{"Name", "Ising"}, {"h", 1.0}}}};
+  pars["Sampler"]["MoveOperators"] = {sx, sx, sx, sx, sx, sx};
+  pars["Sampler"]["ActingOn"] = {{0}, {1}, {2}, {3}, {4}, {5}};
+  pars["Sampler"]["Nreplicas"] = 4;
+  input_tests.push_back(pars);
+
   return input_tests;
 }

--- a/Tutorials/CustomSampler/customsampler_heisenberg1d.py
+++ b/Tutorials/CustomSampler/customsampler_heisenberg1d.py
@@ -59,20 +59,20 @@ operators = []
 sites = []
 weights = []
 for i in range(L):
-        operators.append(exchange_flip)
-        sites.append([i, (i + 1) % L])
-        weights.append(weight_exchange_flip)
-        operators.append(spin_flip)
-        sites.append([i])
-        weights.append(weight_spin_flip)
+     operators.append(exchange_flip)
+     sites.append([i, (i + 1) % L])
+     weights.append(weight_exchange_flip)
+     operators.append(spin_flip)
+     sites.append([i])
+     weights.append(weight_spin_flip)
 
 # now we define the custom sampler accordingly
 pars['Sampler'] = {
-'MoveOperators' : operators,
-'ActingOn' : sites,
-'MoveWeights' : weights,
-# parallel tempering is also possible with custom sampler (uncomment the following line)
-#'Nreplicas' : 12,
+    'MoveOperators' : operators,
+    'ActingOn' : sites,
+    'MoveWeights' : weights,
+    # parallel tempering is also possible with custom sampler (uncomment the following line)
+    #'Nreplicas' : 12,
 }
 
 # defining the Optimizer

--- a/Tutorials/CustomSampler/customsampler_heisenberg1d.py
+++ b/Tutorials/CustomSampler/customsampler_heisenberg1d.py
@@ -1,0 +1,103 @@
+# Copyright 2018 The Simons Foundation, Inc. - All Rights Reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#    http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from __future__ import print_function
+import json
+import numpy as np
+
+pars = {}
+
+# Tutorial for defining a custom sampler
+# taking L=20 Heisenberg spin chain as example
+# (adapted from Heisenberg1d tutorial)
+# (you can use plot_heis.py from Heisenberg1d folder identically here to plot results)
+
+L=20
+
+# defining the lattice
+pars['Graph'] = {
+    'Name': 'Hypercube',
+    'L': L,
+    'Dimension': 1,
+    'Pbc': True,
+}
+
+# defining the hamiltonian
+pars['Hamiltonian'] = {
+    'Name': 'Heisenberg',
+    'TotalSz': 0,
+}
+
+# defining the wave function
+pars['Machine'] = {
+    'Name': 'RbmSpinSymm',
+    'Alpha': 1.0,
+}
+
+# defining the custom sampler
+# here we use two types of moves : local spin flip, and exchange flip between two sites
+# note that each line and column have to add up to 1.0 (stochastic matrices)
+# we also choose a relative frequency of 2 for local-spin flips with respect to exchange flips
+spin_flip = [[0, 1], [1, 0]]
+exchange_flip = [[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 1]]
+weight_spin_flip = 2.0
+weight_exchange_flip = 1.0
+
+# adding both types of flip for all sites in the chain
+operators = []
+sites = []
+weights = []
+for i in range(L):
+        operators.append(exchange_flip)
+        sites.append([i, (i + 1) % L])
+        weights.append(weight_exchange_flip)
+        operators.append(spin_flip)
+        sites.append([i])
+        weights.append(weight_spin_flip)
+
+# now we define the custom sampler accordingly
+pars['Sampler'] = {
+'MoveOperators' : operators,
+'ActingOn' : sites,
+'MoveWeights' : weights,
+# parallel tempering is also possible with custom sampler (uncomment the following line)
+#'Nreplicas' : 12,
+}
+
+# defining the Optimizer
+# here we use AdaMax
+pars['Optimizer'] = {
+    'Name': 'AdaMax',
+}
+
+# defining the learning method
+# here we use the Stochastic Reconfiguration Method
+pars['Learning'] = {
+    'Method': 'Sr',
+    'Nsamples': 1.0e3,
+    'NiterOpt': 4000,
+    'Diagshift': 0.1,
+    'UseIterative': False,
+    'OutputFile': 'test',
+}
+
+json_file = "customsampler_heisenberg1d.json"
+with open(json_file, 'w') as outfile:
+    json.dump(pars, outfile)
+
+print("\nGenerated Json input file: ", json_file)
+print("\nNow you have two options to run NetKet: ")
+print("\n1) Serial mode: netket " + json_file)
+print("\n2) Parallel mode: mpirun -n N_proc netket " + json_file)

--- a/Tutorials/CustomSampler/customsampler_heisenberg1d.py
+++ b/Tutorials/CustomSampler/customsampler_heisenberg1d.py
@@ -15,7 +15,6 @@
 
 from __future__ import print_function
 import json
-import numpy as np
 
 pars = {}
 


### PR DESCRIPTION
This PR allows to define a custom sampler, so that user can define which flips are performed in the sampling.

- Add custom Metropolis sampler, and custom Metropolis parallel tempering sampler
- Include tests for various custom samplers
- Adding a new tutorial for custom sampling