### PR TITLE
Simplify graph code in conv layer

### DIFF
--- a/NetKet/Graph/abstract_graph.hpp
+++ b/NetKet/Graph/abstract_graph.hpp
@@ -22,7 +22,7 @@
 
 namespace netket {
 /**
-    Abstract class for Graphs.
+    Abstract class for undirected Graphs.
     This class prototypes the methods needed
     by a class satisfying the Graph concept.
     These include lattices and non-regular graphs.
@@ -57,6 +57,13 @@ class AbstractGraph {
   @return true if lattice is bipartite.
   */
   virtual bool IsBipartite() const = 0;
+
+  /**
+   * Checks whether the graph is connected, i.e., there exists a path between
+   * every pair of nodes.
+   * @return true, if the graph is connected
+   */
+  virtual bool IsConnected() const = 0;
 
   /**
    * Perform a breadth-first search (BFS) through the graph, calling

--- a/NetKet/Graph/custom_graph.hpp
+++ b/NetKet/Graph/custom_graph.hpp
@@ -40,6 +40,7 @@ class CustomGraph : public AbstractGraph {
   std::vector<std::vector<int>> automorphisms_;
 
   bool isbipartite_;
+  bool is_connected_;
 
  public:
   // Json constructor
@@ -81,6 +82,7 @@ class CustomGraph : public AbstractGraph {
     }
 
     isbipartite_ = false;
+    is_connected_ = ComputeConnected();
 
     // Other graph properties
     if (FieldExists(pars, "Graph")) {
@@ -157,6 +159,8 @@ class CustomGraph : public AbstractGraph {
 
   bool IsBipartite() const { return isbipartite_; }
 
+  bool IsConnected() const override { return is_connected_; }
+
   // returns the distances of each point from the others
   std::vector<std::vector<int>> Distances() const {
     std::vector<std::vector<int>> distances;
@@ -166,6 +170,16 @@ class CustomGraph : public AbstractGraph {
     }
 
     return distances;
+  }
+
+ private:
+  bool ComputeConnected() const {
+    const int start = 0; // arbitrary node
+    int nvisited = 0;
+    BreadthFirstSearch(start, [&nvisited](int, int) {
+      ++nvisited;
+    });
+    return nvisited == Nsites();
   }
 };
 

--- a/NetKet/Graph/graph.hpp
+++ b/NetKet/Graph/graph.hpp
@@ -70,6 +70,33 @@ class Graph : public AbstractGraph {
     return g_->Distances();
   }
 
+  /**
+   * Perform a breadth-first search (BFS) through the graph, calling
+   * visitor_func exactly once for each visited node. The search will visit
+   * all nodes reachable from start.
+   * @param start The starting node for the BFS.
+   * @param visitor_func Function void visitor_func(int node, int depth) which is
+   *    called once for each visited node and where depth is the distance of node from start.
+   */
+  template<typename Func>
+  void BreadthFirstSearch(int start, Func visitor_func) const {
+    g_->BreadthFirstSearch(start, visitor_func);
+  }
+
+  /**
+   * Perform a breadth-first search (BFS) through the graph, calling
+   * visitor_func exactly once for each visited node. The search will visit
+   * all nodes reachable from start in at most max_depth steps.
+   * @param start The starting node for the BFS.
+   * @param max_depth The maximum distance from start for nodes to be visited.
+   * @param visitor_func Function void visitor_func(int node, int depth) which is
+   *    called once for each visited node and where depth is the distance of node from start.
+   */
+  template<typename Func>
+  void BreadthFirstSearch(int start, int max_depth, Func visitor_func) const {
+    g_->BreadthFirstSearch(start, max_depth, visitor_func);
+  }
+
   bool IsBipartite() const override { return g_->IsBipartite(); }
 };
 }  // namespace netket

--- a/NetKet/Graph/graph.hpp
+++ b/NetKet/Graph/graph.hpp
@@ -98,6 +98,9 @@ class Graph : public AbstractGraph {
   }
 
   bool IsBipartite() const override { return g_->IsBipartite(); }
+
+  bool IsConnected() const override { return g_->IsConnected(); }
+
 };
 }  // namespace netket
 

--- a/NetKet/Graph/hypercube.hpp
+++ b/NetKet/Graph/hypercube.hpp
@@ -162,6 +162,8 @@ class Hypercube : public AbstractGraph {
 
   bool IsBipartite() const override { return true; }
 
+  bool IsConnected() const override { return true; }
+
   // returns the distances of each point from the others
   std::vector<std::vector<int>> Distances() const override {
     std::vector<std::vector<int>> distances;

--- a/NetKet/Machine/conv_layer.hpp
+++ b/NetKet/Machine/conv_layer.hpp
@@ -22,6 +22,8 @@
 #include <fstream>
 #include <random>
 #include <vector>
+
+#include "Graph/graph.hpp"
 #include "Lookup/lookup.hpp"
 #include "Utils/all_utils.hpp"
 #include "abstract_layer.hpp"
@@ -110,28 +112,13 @@ class Convolutional : public AbstractLayer<T> {
   }
 
   void Init(const Graph &graph) {
-    // Construct neighbours_ kernel(k) will act on neighbours_[i][k]
-    std::vector<std::vector<int>> adjlist;
-    adjlist = graph.AdjacencyList();
-    for (int i = 0; i < nv_; ++i) {
+    // Construct neighbourhood of all nodes with distance of at most dist_ from each node i
+    // kernel(k) will act on neighbours_[i][k]
+    for(int i = 0; i < nv_; ++i) {
       std::vector<int> neigh;
-      neigh.push_back(i);
-      for (int d = 0; d < dist_; ++d) {
-        std::size_t current = neigh.size();
-        for (std::size_t n = 0; n < current; ++n) {
-          for (auto m : adjlist[neigh[n]]) {
-            bool isin = false;
-            for (std::size_t k = 0; k < neigh.size(); ++k) {
-              if (neigh[k] == m) {
-                isin = true;
-              }
-            }
-            if (!isin) {
-              neigh.push_back(m);
-            }
-          }
-        }
-      }
+      graph.BreadthFirstSearch(i, dist_, [&neigh](int node, int /*depth*/) {
+        neigh.push_back(node);
+      });
       neighbours_.push_back(neigh);
     }
 

--- a/NetKet/Machine/conv_layer.hpp
+++ b/NetKet/Machine/conv_layer.hpp
@@ -177,7 +177,6 @@ class Convolutional : public AbstractLayer<T> {
     flipped_kernels_.resize(kernel_size_ * out_channels_, in_channels_);
 
     npar_ = in_channels_ * kernel_size_ * out_channels_;
-    kernelpar_ = in_channels_ * kernel_size_ * out_channels_;
 
     if (usebias_) {
       npar_ += out_channels_;

--- a/Test/Graph/graph_input_tests.hpp
+++ b/Test/Graph/graph_input_tests.hpp
@@ -11,31 +11,36 @@ std::vector<netket::json> GetGraphInputs() {
   // Small 1d graph
   pars = {
       {"Graph",
-       {{"Name", "Hypercube"}, {"L", 3}, {"Dimension", 1}, {"Pbc", true}}}};
+       {{"Name", "Hypercube"}, {"L", 3}, {"Dimension", 1}, {"Pbc", true}}},
+      {"Test:IsConnected", true}};
   input_tests.push_back(pars);
 
   // Hypercube 1d
   pars = {
       {"Graph",
-       {{"Name", "Hypercube"}, {"L", 20}, {"Dimension", 1}, {"Pbc", true}}}};
+       {{"Name", "Hypercube"}, {"L", 20}, {"Dimension", 1}, {"Pbc", true}}},
+      {"Test:IsConnected", true}};
   input_tests.push_back(pars);
 
   // Hypercube 2d
   pars = {
       {"Graph",
-       {{"Name", "Hypercube"}, {"L", 20}, {"Dimension", 2}, {"Pbc", true}}}};
+       {{"Name", "Hypercube"}, {"L", 20}, {"Dimension", 2}, {"Pbc", true}}},
+      {"Test:IsConnected", true}};
   input_tests.push_back(pars);
 
   // Hypercube 3d
   pars = {
       {"Graph",
-       {{"Name", "Hypercube"}, {"L", 10}, {"Dimension", 3}, {"Pbc", true}}}};
+       {{"Name", "Hypercube"}, {"L", 10}, {"Dimension", 3}, {"Pbc", true}}},
+      {"Test:IsConnected", true}};
   input_tests.push_back(pars);
 
   // Graph from hilbert space
   pars.clear();
   pars["Hilbert"]["QuantumNumbers"] = {1, -1};
   pars["Hilbert"]["Size"] = 10;
+  pars["Test:IsConnected"] = false;
 
   input_tests.push_back(pars);
 

--- a/Test/Graph/graph_input_tests.hpp
+++ b/Test/Graph/graph_input_tests.hpp
@@ -8,6 +8,12 @@ std::vector<netket::json> GetGraphInputs() {
   std::vector<netket::json> input_tests;
   netket::json pars;
 
+  // Small 1d graph
+  pars = {
+      {"Graph",
+       {{"Name", "Hypercube"}, {"L", 3}, {"Dimension", 1}, {"Pbc", true}}}};
+  input_tests.push_back(pars);
+
   // Hypercube 1d
   pars = {
       {"Graph",
@@ -23,7 +29,7 @@ std::vector<netket::json> GetGraphInputs() {
   // Hypercube 3d
   pars = {
       {"Graph",
-       {{"Name", "Hypercube"}, {"L", 20}, {"Dimension", 3}, {"Pbc", true}}}};
+       {{"Name", "Hypercube"}, {"L", 10}, {"Dimension", 3}, {"Pbc", true}}}};
   input_tests.push_back(pars);
 
   // Graph from hilbert space

--- a/Test/Graph/unit-graph.cc
+++ b/Test/Graph/unit-graph.cc
@@ -43,7 +43,7 @@ TEST_CASE("Breadth-first search", "[graph]") {
 
   for(const auto input : input_tests) {
     const auto data = input.dump();
-    SECTION("each node is visited at most once on " + data) {
+    SECTION("each node is visited at most once (and exactly once if the graph is connected) on " + data) {
       netket::Graph graph(input);
       for(int start = 0; start < graph.Nsites(); ++start) {
         std::unordered_set<int> visited;
@@ -54,25 +54,25 @@ TEST_CASE("Breadth-first search", "[graph]") {
           visited.insert(v);
           ncall++;
         });
+
+        if(graph.IsConnected()) {
+          for(int v = 0; v < graph.Nsites(); ++v) {
+            INFO("v: " << v);
+            REQUIRE(visited.count(v) == 1);
+          }
+        }
       }
     }
   }
+}
 
-  SECTION("each node is visited at least once on connected graph") {
-    netket::json pars;
-    pars = {
-        {"Graph",
-         {{"Name", "Hypercube"}, {"L", 20}, {"Dimension", 1}, {"Pbc", false}}}};
-    netket::Graph graph(pars);
-    for(int i = 0; i < graph.Nsites(); ++i) {
-      std::unordered_set<int> visited;
-      graph.BreadthFirstSearch(i, [&visited](int v, int /*depth*/) {
-        visited.insert(v);
-      });
-      for(int v = 0; v < graph.Nsites(); ++v) {
-        INFO("v: " << v);
-        REQUIRE(visited.count(v) == 1);
-      }
+TEST_CASE("Graph::IsConnected is correct", "[graph]") {
+  const auto input_tests = GetGraphInputs();
+  for(const auto input : input_tests) {
+    const auto data = input.dump();
+    SECTION("on " + data) {
+      netket::Graph graph(input);
+      CHECK(graph.IsConnected() == input["Test:IsConnected"]);
     }
   }
 }


### PR DESCRIPTION
As far as I understand, the following part of the code in the `Convolutional` class is supposed to store, for each node `i`, all nodes with distance of at most `dist_` to `i` in `neighbours_[i]`:
https://github.com/netket/netket/blob/67fe7e62c93abf4280d85c16023563868b3e41bd/NetKet/Machine/conv_layer.hpp#L115-L137

I found the logic there a bit hard to read an rewrote it in terms of a [breadth-first search](https://en.wikipedia.org/wiki/Breadth-first_search) started from each node, which I find easier to understand. (It could also be a bit faster, but I did not check this.)
The BFS code can potentially also be useful elsewhere.

If this looks good to you, accepting this PR will merge the changes into the branch for the feedforward PR #46 (so this is a PR on a PR, essentially).