### PR TITLE
Speedup in sparse matrix wrapper 

### DIFF
--- a/NetKet/GroundState/ground_state.hpp
+++ b/NetKet/GroundState/ground_state.hpp
@@ -17,7 +17,7 @@
 
 #include <memory>
 
-#include "Hamiltonian/MatrixWrapper/dense_matrix_wrapper.hpp"
+#include "Hamiltonian/MatrixWrapper/sparse_matrix_wrapper.hpp"
 #include "Optimizer/optimizer.hpp"
 #include "variational_montecarlo.hpp"
 
@@ -60,7 +60,7 @@ class GroundState {
       Graph graph(pars);
 
       Hamiltonian hamiltonian(graph, pars);
-      std::string file_base = FieldVal(pars["Learning"], "OutputFile");
+      std::string file_base = FieldVal(pars["GroundState"], "OutputFile");
 
       SaveEigenValues(hamiltonian, file_base + std::string(".log"));
 
@@ -75,7 +75,8 @@ class GroundState {
                        const std::string &filename, int first_n = 1) {
     std::ofstream file_ed(filename);
 
-    auto matrix = DenseMatrixWrapper<Hamiltonian>(hamiltonian);
+    auto matrix = SparseMatrixWrapper<Hamiltonian>(hamiltonian);
+
     auto ed = matrix.ComputeEigendecomposition(Eigen::EigenvaluesOnly);
 
     auto eigs = ed.eigenvalues();

--- a/NetKet/Hamiltonian/MatrixWrapper/sparse_matrix_wrapper.hpp
+++ b/NetKet/Hamiltonian/MatrixWrapper/sparse_matrix_wrapper.hpp
@@ -63,14 +63,13 @@ class SparseMatrixWrapper : public AbstractMatrixWrapper<Operator, WfType> {
     dim_ = hilbert_index.NStates();
 
     using Triplet = Eigen::Triplet<std::complex<double>>;
-    Triplet triplet;
+    
     std::vector<Triplet> tripletList;
     tripletList.reserve(dim_);
 
     matrix_.resize(dim_, dim_);
     matrix_.setZero();
 
-    std::vector<std::vector<int>> ind(dim_);
 
     for (int i = 0; i < dim_; ++i) {
       auto v = hilbert_index.NumberToState(i);
@@ -84,7 +83,6 @@ class SparseMatrixWrapper : public AbstractMatrixWrapper<Operator, WfType> {
         auto vk = v;
         hilbert.UpdateConf(vk, connectors[k], newconfs[k]);
         auto j = hilbert_index.StateToNumber(vk);
-        ind[i].push_back(j);
         tripletList.push_back(Triplet(i, j, matrix_elements[k]));
       }
     }

--- a/NetKet/Hamiltonian/MatrixWrapper/sparse_matrix_wrapper.hpp
+++ b/NetKet/Hamiltonian/MatrixWrapper/sparse_matrix_wrapper.hpp
@@ -17,86 +17,82 @@
 
 #include <Eigen/SparseCore>
 
-#include "abstract_matrix_wrapper.hpp"
 #include "Hilbert/hilbert_index.hpp"
+#include "abstract_matrix_wrapper.hpp"
 
-namespace netket
-{
+namespace netket {
 
 /**
- * This class stores the matrix elements of a given Operator (AbstractHamiltonian
- * or AbstractObservable) as an Eigen dense matrix.
+ * This class stores the matrix elements of a given Operator
+ * (AbstractHamiltonian or AbstractObservable) as an Eigen dense matrix.
  */
-template<class Operator, class WfType = Eigen::VectorXcd>
-class SparseMatrixWrapper : public AbstractMatrixWrapper<Operator, WfType>
-{
-    using Matrix = Eigen::SparseMatrix<std::complex<double>>;
+template <class Operator, class WfType = Eigen::VectorXcd>
+class SparseMatrixWrapper : public AbstractMatrixWrapper<Operator, WfType> {
+  using Matrix = Eigen::SparseMatrix<std::complex<double>>;
 
-    Matrix matrix_;
-    int dim_;
+  Matrix matrix_;
+  int dim_;
 
-public:
-    explicit SparseMatrixWrapper(const Operator& the_operator)
-    {
-        InitializeMatrix(the_operator);
+ public:
+  explicit SparseMatrixWrapper(const Operator& the_operator) {
+    InitializeMatrix(the_operator);
+  }
+
+  WfType Apply(const WfType& state) const override { return matrix_ * state; }
+
+  int GetDimension() const override { return dim_; }
+
+  const Matrix& GetMatrix() const { return matrix_; }
+
+  /**
+   * Computes the eigendecomposition of the given matrix.
+   * @param options The options are passed directly to the constructor of
+   * SelfAdjointEigenSolver.
+   * @return An instance of Eigen::SelfAdjointEigenSolver initialized with the
+   * wrapped operator and options.
+   */
+  Eigen::SelfAdjointEigenSolver<Matrix> ComputeEigendecomposition(
+      int options = Eigen::ComputeEigenvectors) const {
+    return Eigen::SelfAdjointEigenSolver<Matrix>(matrix_, options);
+  }
+
+ private:
+  void InitializeMatrix(const Operator& the_operator) {
+    const auto& hilbert = the_operator.GetHilbert();
+    const HilbertIndex hilbert_index(hilbert);
+    dim_ = hilbert_index.NStates();
+
+    using Triplet = Eigen::Triplet<std::complex<double>>;
+    Triplet triplet;
+    std::vector<Triplet> tripletList;
+    tripletList.reserve(dim_);
+
+    matrix_.resize(dim_, dim_);
+    matrix_.setZero();
+
+    std::vector<std::vector<int>> ind(dim_);
+
+    for (int i = 0; i < dim_; ++i) {
+      auto v = hilbert_index.NumberToState(i);
+
+      std::vector<std::complex<double>> matrix_elements;
+      std::vector<std::vector<int>> connectors;
+      std::vector<std::vector<double>> newconfs;
+      the_operator.FindConn(v, matrix_elements, connectors, newconfs);
+
+      for (size_t k = 0; k < connectors.size(); ++k) {
+        auto vk = v;
+        hilbert.UpdateConf(vk, connectors[k], newconfs[k]);
+        auto j = hilbert_index.StateToNumber(vk);
+        ind[i].push_back(j);
+        tripletList.push_back(Triplet(i, j, matrix_elements[k]));
+      }
     }
-
-    WfType Apply(const WfType& state) const override
-    {
-        return matrix_ * state;
-    }
-
-    int GetDimension() const override
-    {
-        return dim_;
-    }
-
-    const Matrix& GetMatrix() const
-    {
-        return matrix_;
-    }
-
-    /**
-     * Computes the eigendecomposition of the given matrix.
-     * @param options The options are passed directly to the constructor of SelfAdjointEigenSolver.
-     * @return An instance of Eigen::SelfAdjointEigenSolver initialized with the wrapped operator and options.
-     */
-    Eigen::SelfAdjointEigenSolver<Matrix> ComputeEigendecomposition(int options = Eigen::ComputeEigenvectors) const
-    {
-        return Eigen::SelfAdjointEigenSolver<Matrix>(matrix_, options);
-    }
-
-private:
-    void InitializeMatrix(const Operator &the_operator)
-    {
-        const auto& hilbert = the_operator.GetHilbert();
-        const HilbertIndex hilbert_index(hilbert);
-        dim_ = hilbert_index.NStates();
-
-        matrix_.resize(dim_, dim_);
-        matrix_.setZero();
-
-        for(int i = 0; i < dim_; ++i)
-        {
-            auto v = hilbert_index.NumberToState(i);
-
-            std::vector<std::complex<double>> matrix_elements;
-            std::vector<std::vector<int>> connectors;
-            std::vector<std::vector<double>> newconfs;
-            the_operator.FindConn(v, matrix_elements, connectors, newconfs);
-
-            for(size_t k = 0; k < connectors.size(); ++k)
-            {
-                auto vk = v;
-                hilbert.UpdateConf(vk, connectors[k], newconfs[k]);
-                auto j = hilbert_index.StateToNumber(vk);
-                matrix_.coeffRef(i, j) += matrix_elements[k];
-            }
-        }
-        matrix_.makeCompressed();
-    }
+    matrix_.setFromTriplets(tripletList.begin(), tripletList.end());
+    matrix_.makeCompressed();
+  }
 };
 
-}
+}  // namespace netket
 
-#endif //NETKET_SPARSE_HAMILTONIAN_OPERATOR_HH
+#endif  // NETKET_SPARSE_HAMILTONIAN_OPERATOR_HH


### PR DESCRIPTION
The way the Eigen sparse matrix was constructed was very inefficient, because it involved accessing a map every time a new element was inserted in the sparse matrix. Using triplets substantially speeds up the matrix construction (maybe a couple of orders of magnitude faster on large systems). 