### PR TITLE
Adding cholesky decomposition as possible choice for exact solver

### DIFF
--- a/NetKet/GroundState/variational_montecarlo.hpp
+++ b/NetKet/GroundState/variational_montecarlo.hpp
@@ -159,7 +159,7 @@ class VariationalMonteCarlo {
       bool use_iterative =
           FieldOrDefaultVal(pars["GroundState"], "UseIterative", false);
       use_cholesky_ =
-          FieldOrDefaultVal(pars["GroundState"], "UseCholesky", false);
+          FieldOrDefaultVal(pars["GroundState"], "UseCholesky", true);
       setSrParameters(diagshift, rescale_shift, use_iterative);
     }
 


### PR DESCRIPTION
In the Stochastic Reconfiguration part of the variational Monte Carlo, this PR adds the possibility to use Cholesky decomposition in lieu of QR by adding UseCholesky = True in the input parameters.
In my tests, this considerably speeds up computations when using the exact solver.
Currently UseCholesky = False by default, one could set it to True after more tests if you agree.

Ideally, one would like to speed up the iterative solver part too, but I did not manage to do so yet.  