### PR TITLE
Fix segmentation fault in machine test

### DIFF
--- a/Test/Machine/test_machine.py
+++ b/Test/Machine/test_machine.py
@@ -10,17 +10,17 @@ machines = {}
 g = nk.graph.Hypercube(length=20, ndim=1)
 
 # Hilbert space of spins from given graph
-hi = nk.hilbert.Spin(s=0.5, graph=g)
+hi1 = nk.hilbert.Spin(s=0.5, graph=g)
 
-machines["RbmSpin 1d Hypercube spin"] = nk.machine.RbmSpin(hilbert=hi, alpha=1)
+machines["RbmSpin 1d Hypercube spin"] = nk.machine.RbmSpin(hilbert=hi1, alpha=1)
 
 machines["RbmSpinSymm 1d Hypercube spin"] = nk.machine.RbmSpinSymm(
-    hilbert=hi, alpha=2)
+    hilbert=hi1, alpha=2)
 
-machines["Jastrow 1d Hypercube spin"] = nk.machine.Jastrow(hilbert=hi)
+machines["Jastrow 1d Hypercube spin"] = nk.machine.Jastrow(hilbert=hi1)
 
-hi = nk.hilbert.Spin(s=0.5, graph=g, total_sz=0)
-machines["Jastrow 1d Hypercube spin"] = nk.machine.JastrowSymm(hilbert=hi)
+hi2 = nk.hilbert.Spin(s=0.5, graph=g, total_sz=0)
+machines["Jastrow 1d Hypercube spin"] = nk.machine.JastrowSymm(hilbert=hi2)
 
 # Layers
 layers = [
@@ -31,26 +31,26 @@ layers = [
 ]
 
 # FFNN Machine
-machines["FFFN 1d Hypercube spin"] = nk.machine.FFNN(hi, layers)
+machines["FFFN 1d Hypercube spin"] = nk.machine.FFNN(hi2, layers)
 
 machines["MPS Diagonal 1d spin"] = nk.machine.MPSPeriodicDiagonal(
-    hi, bond_dim=8)
-machines["MPS 1d spin"] = nk.machine.MPSPeriodic(hi, bond_dim=8)
+    hi2, bond_dim=8)
+machines["MPS 1d spin"] = nk.machine.MPSPeriodic(hi2, bond_dim=8)
 
 
 # BOSONS
-hi = nk.hilbert.Boson(graph=g, n_max=4)
+hi3 = nk.hilbert.Boson(graph=g, n_max=4)
 machines["RbmSpin 1d Hypercube boson"] = nk.machine.RbmSpin(
-    hilbert=hi, alpha=1)
+    hilbert=hi3, alpha=1)
 
 machines["RbmSpinSymm 1d Hypercube boson"] = nk.machine.RbmSpinSymm(
-    hilbert=hi, alpha=2)
+    hilbert=hi3, alpha=2)
 machines["RbmMultival 1d Hypercube boson"] = nk.machine.RbmMultival(
-    hilbert=hi, n_hidden=10)
-machines["Jastrow 1d Hypercube boson"] = nk.machine.Jastrow(hilbert=hi)
+    hilbert=hi3, n_hidden=10)
+machines["Jastrow 1d Hypercube boson"] = nk.machine.Jastrow(hilbert=hi3)
 
-machines["JastrowSymm 1d Hypercube boson"] = nk.machine.JastrowSymm(hilbert=hi)
-machines["MPS 1d boson"] = nk.machine.MPSPeriodic(hi, bond_dim=5)
+machines["JastrowSymm 1d Hypercube boson"] = nk.machine.JastrowSymm(hilbert=hi3)
+machines["MPS 1d boson"] = nk.machine.MPSPeriodic(hi3, bond_dim=5)
 
 
 def log_val(par, machine, v):
@@ -78,14 +78,12 @@ def test_log_derivative():
         randpars = np.random.randn(npar) + 1.0j * np.random.randn(npar)
 
         # random visibile state
-        # TODO GetHilbert is broken because we return a reference and not a pointer
-        # hi = ma.get_hilbert()
-        # rg = nk.RandomEngine(seed=1234)
-        # v = np.zeros(hi.size())
-        # hi.random_vals(v, rg)
-        #
-        # grad = (nd.Gradient(log_val))
-        #
+        hi = ma.get_hilbert()
+        rg = nk.RandomEngine(seed=1234)
+        v = np.zeros(hi.size())
+        hi.random_vals(v, rg)
+        # grad = nk.Gradient(log_val)
+
         # ma.SetParameters(randpars)
         # assert(np.linalg.norm(ma.DerLog(v) -
         #                       grad(randpars, ma, v), ord=np.inf) < 1.0e-6)
@@ -94,6 +92,5 @@ def test_log_derivative():
 def test_nvisible():
     for name, ma in machines.items():
         print("Machine test: %s" % name)
-        # TODO GetHilbert is broken because we return a reference and not a pointer
-        # hh=ma.get_hilbert()
-        # assert(ma.Nvisible()==ma.GetHilbert().Size())
+        hh=ma.get_hilbert()
+        assert(ma.n_visible()==ma.get_hilbert().size())


### PR DESCRIPTION
The reason for the segfault seems to have been that the Machine
instances only store references to the Hilbert instances.
Since these were created from Python and stores in the variable `hi`,
they were deleted when `hi` was assigned another Hilbert instance,
in the test code and the machines then contained dangling references.

The return value policy for `Machine.get_hilbert` is `py::return_value_policy::reference`, which I think is correct (and this policy should also be specified for `Operator.get_hilbert`).

The part using `Gradient` in one of the tests is still commented out because `Gradient` does not seem to be exported right now (unless I missed something).