### PR TITLE
Make samplers deterministically seedable

### DIFF
--- a/NetKet/Sampler/abstract_sampler.hpp
+++ b/NetKet/Sampler/abstract_sampler.hpp
@@ -39,20 +39,17 @@ class AbstractSampler {
   virtual const AbstractHilbert& GetHilbert() const noexcept = 0;
 
   virtual ~AbstractSampler() {}
-};
 
-template <class WfType>
-class SeedableSampler : public AbstractSampler<WfType> {
-  DistributedRandomEngine engine_;
-
- public:
   void Seed(DistributedRandomEngine::ResultType base_seed) {
     engine_.Seed(base_seed);
     this->Reset(true);
   }
 
  protected:
-  default_random_engine &GetRandomEngine() { return engine_.Get(); }
+  default_random_engine& GetRandomEngine() { return engine_.Get(); }
+
+ private:
+  DistributedRandomEngine engine_;
 };
 
 }  // namespace netket

--- a/NetKet/Sampler/abstract_sampler.hpp
+++ b/NetKet/Sampler/abstract_sampler.hpp
@@ -41,5 +41,19 @@ class AbstractSampler {
   virtual ~AbstractSampler() {}
 };
 
+template <class WfType>
+class SeedableSampler : public AbstractSampler<WfType> {
+  DistributedRandomEngine engine_;
+
+ public:
+  void Seed(DistributedRandomEngine::ResultType base_seed) {
+    engine_.Seed(base_seed);
+    this->Reset(true);
+  }
+
+ protected:
+  default_random_engine &GetRandomEngine() { return engine_.Get(); }
+};
+
 }  // namespace netket
 #endif

--- a/NetKet/Sampler/custom_sampler.hpp
+++ b/NetKet/Sampler/custom_sampler.hpp
@@ -30,7 +30,7 @@ namespace netket {
 
 // Metropolis sampling using custom moves provided by user
 template <class WfType>
-class CustomSampler : public SeedableSampler<WfType> {
+class CustomSampler: public AbstractSampler<WfType> {
   WfType &psi_;
   const AbstractHilbert &hilbert_;
   LocalOperator move_operators_;

--- a/NetKet/Sampler/custom_sampler_pt.hpp
+++ b/NetKet/Sampler/custom_sampler_pt.hpp
@@ -38,7 +38,7 @@ class CustomSamplerPt : public AbstractSampler<WfType> {
   // number of visible units
   const int nv_;
 
-  netket::default_random_engine rgen_;
+  DistributedRandomEngine rgen_;
 
   // states of visible units
   // for each sampled temperature
@@ -64,18 +64,34 @@ class CustomSamplerPt : public AbstractSampler<WfType> {
   std::vector<double> beta_;
 
  public:
-  explicit CustomSamplerPt(
-      WfType& psi, const LocalOperator& move_operators,
-      std::vector<double> move_weights = std::vector<double>(),
-      int nreplicas = 1)
+  CustomSamplerPt(WfType& psi, const LocalOperator& move_operators,
+                  const std::vector<double>& move_weights = {},
+                  int nreplicas = 1)
       : psi_(psi),
         hilbert_(psi.GetHilbert()),
         move_operators_(move_operators),
         nv_(hilbert_.Size()),
         nrep_(nreplicas) {
+    Init(move_weights);
+  }
+
+  CustomSamplerPt(WfType& psi, const LocalOperator& move_operators,
+                  DistributedRandomEngine::ResultType seed,
+                  const std::vector<double>& move_weights = {},
+                  int nreplicas = 1)
+      : psi_(psi),
+        hilbert_(psi.GetHilbert()),
+        move_operators_(move_operators),
+        nv_(hilbert_.Size()),
+        rgen_(seed),
+        nrep_(nreplicas) {
+    Init(move_weights);
+  }
+
+  void Init(const std::vector<double>& move_weights) {
     CustomSampler<WfType>::CheckMoveOperators(move_operators_);
 
-    if (hilbert_.Size() != move_operators.GetHilbert().Size()) {
+    if (hilbert_.Size() != move_operators_.GetHilbert().Size()) {
       throw InvalidInputError(
           "Move operators in CustomSampler act on a different hilbert space "
           "than the Machine");
@@ -84,7 +100,7 @@ class CustomSamplerPt : public AbstractSampler<WfType> {
     if (move_weights.size()) {
       operatorsweights_ = move_weights;
 
-      if (operatorsweights_.size() != move_operators.Size()) {
+      if (operatorsweights_.size() != move_operators_.Size()) {
         throw InvalidInputError(
             "The custom sampler definition is inconsistent (between "
             "MoveWeights and MoveOperators sizes)");
@@ -94,10 +110,6 @@ class CustomSamplerPt : public AbstractSampler<WfType> {
       operatorsweights_.resize(move_operators_.Size(), 1.0);
     }
 
-    Init();
-  }
-
-  void Init() {
     MPI_Comm_size(MPI_COMM_WORLD, &totalnodes_);
     MPI_Comm_rank(MPI_COMM_WORLD, &mynode_);
 
@@ -123,8 +135,6 @@ class CustomSamplerPt : public AbstractSampler<WfType> {
     accept_.resize(2 * nrep_);
     moves_.resize(2 * nrep_);
 
-    Seed();
-
     Reset(true);
 
     InfoMessage() << "Custom Metropolis sampler with parallel tempering "
@@ -133,25 +143,10 @@ class CustomSamplerPt : public AbstractSampler<WfType> {
     InfoMessage() << nrep_ << " replicas are being used" << std::endl;
   }
 
-  void Seed(int baseseed = 0) {
-    std::random_device rd;
-    std::vector<int> seeds(totalnodes_);
-
-    if (mynode_ == 0) {
-      for (int i = 0; i < totalnodes_; i++) {
-        seeds[i] = rd() + baseseed;
-      }
-    }
-
-    SendToAll(seeds);
-
-    rgen_.seed(seeds[mynode_]);
-  }
-
   void Reset(bool initrandom = false) override {
     if (initrandom) {
       for (int i = 0; i < nrep_; i++) {
-        hilbert_.RandomVals(v_[i], rgen_);
+        hilbert_.RandomVals(v_[i], rgen_.Get());
       }
     }
 
@@ -170,10 +165,10 @@ class CustomSamplerPt : public AbstractSampler<WfType> {
     for (int i = 0; i < nv_; i++) {
       // pick a random operator in possible ones according to the provided
       // weights
-      int op = disc_dist(rgen_);
+      int op = disc_dist(rgen_.Get());
       move_operators_.FindConn(op, v_[rep], mel_, tochange_, newconfs_);
 
-      double p = distu(rgen_);
+      double p = distu(rgen_.Get());
       std::size_t exit_state = 0;
       double cumulative_prob = std::real(mel_[0]);
       while (p > cumulative_prob) {
@@ -186,7 +181,7 @@ class CustomSamplerPt : public AbstractSampler<WfType> {
                                        newconfs_[exit_state], lt_[rep])));
 
       // Metropolis acceptance test
-      if (ratio > distu(rgen_)) {
+      if (ratio > distu(rgen_.Get())) {
         accept_(rep) += 1;
         psi_.UpdateLookup(v_[rep], tochange_[exit_state], newconfs_[exit_state],
                           lt_[rep]);
@@ -207,7 +202,7 @@ class CustomSamplerPt : public AbstractSampler<WfType> {
     std::uniform_real_distribution<double> distribution(0, 1);
 
     for (int r = 1; r < nrep_; r += 2) {
-      if (ExchangeProb(r, r - 1) > distribution(rgen_)) {
+      if (ExchangeProb(r, r - 1) > distribution(rgen_.Get())) {
         Exchange(r, r - 1);
         accept_(nrep_ + r) += 1.;
         accept_(nrep_ + r - 1) += 1;
@@ -217,7 +212,7 @@ class CustomSamplerPt : public AbstractSampler<WfType> {
     }
 
     for (int r = 2; r < nrep_; r += 2) {
-      if (ExchangeProb(r, r - 1) > distribution(rgen_)) {
+      if (ExchangeProb(r, r - 1) > distribution(rgen_.Get())) {
         Exchange(r, r - 1);
         accept_(nrep_ + r) += 1.;
         accept_(nrep_ + r - 1) += 1;

--- a/NetKet/Sampler/custom_sampler_pt.hpp
+++ b/NetKet/Sampler/custom_sampler_pt.hpp
@@ -30,7 +30,7 @@ namespace netket {
 
 // Metropolis sampling using custom moves provided by user
 template <class WfType>
-class CustomSamplerPt : public SeedableSampler<WfType> {
+class CustomSamplerPt: public AbstractSampler<WfType> {
   WfType& psi_;
   const AbstractHilbert& hilbert_;
   LocalOperator move_operators_;

--- a/NetKet/Sampler/exact_sampler.hpp
+++ b/NetKet/Sampler/exact_sampler.hpp
@@ -27,15 +27,13 @@ namespace netket {
 
 // Exact sampling using heat bath, mostly for testing purposes on small systems
 template <class WfType>
-class ExactSampler : public AbstractSampler<WfType> {
+class ExactSampler : public SeedableSampler<WfType> {
   WfType& psi_;
 
   const AbstractHilbert& hilbert_;
 
   // number of visible units
   const int nv_;
-
-  DistributedRandomEngine rgen_;
 
   // states of visible units
   Eigen::VectorXd v_;
@@ -65,16 +63,6 @@ class ExactSampler : public AbstractSampler<WfType> {
     Init();
   }
 
-  explicit ExactSampler(WfType& psi, DistributedRandomEngine::ResultType seed)
-      : psi_(psi),
-        hilbert_(psi.GetHilbert()),
-        nv_(hilbert_.Size()),
-        rgen_(seed),
-        hilbert_index_(hilbert_),
-        dim_(hilbert_index_.NStates()) {
-    Init();
-  }
-
   void Init() {
     v_.resize(nv_);
 
@@ -97,7 +85,7 @@ class ExactSampler : public AbstractSampler<WfType> {
 
   void Reset(bool initrandom) override {
     if (initrandom) {
-      hilbert_.RandomVals(v_, rgen_.Get());
+      hilbert_.RandomVals(v_, this->GetRandomEngine());
     }
 
     double logmax = -std::numeric_limits<double>::infinity();
@@ -122,7 +110,7 @@ class ExactSampler : public AbstractSampler<WfType> {
   }
 
   void Sweep() override {
-    int newstate = dist_(rgen_.Get());
+    int newstate = dist_(this->GetRandomEngine());
     v_ = hilbert_index_.NumberToState(newstate);
 
     accept_(0) += 1;

--- a/NetKet/Sampler/exact_sampler.hpp
+++ b/NetKet/Sampler/exact_sampler.hpp
@@ -27,7 +27,7 @@ namespace netket {
 
 // Exact sampling using heat bath, mostly for testing purposes on small systems
 template <class WfType>
-class ExactSampler : public SeedableSampler<WfType> {
+class ExactSampler: public AbstractSampler<WfType> {
   WfType& psi_;
 
   const AbstractHilbert& hilbert_;

--- a/NetKet/Sampler/metropolis_exchange.hpp
+++ b/NetKet/Sampler/metropolis_exchange.hpp
@@ -26,7 +26,7 @@ namespace netket {
 
 // Metropolis sampling generating local exchanges
 template <class WfType>
-class MetropolisExchange : public SeedableSampler<WfType> {
+class MetropolisExchange: public AbstractSampler<WfType> {
   WfType &psi_;
 
   const AbstractHilbert &hilbert_;

--- a/NetKet/Sampler/metropolis_exchange_pt.hpp
+++ b/NetKet/Sampler/metropolis_exchange_pt.hpp
@@ -34,7 +34,10 @@ class MetropolisExchangePt : public AbstractSampler<WfType> {
   // number of visible units
   const int nv_;
 
-  netket::default_random_engine rgen_;
+  const int nrep_;
+  std::vector<double> beta_;
+
+  DistributedRandomEngine rgen_;
 
   // states of visible units
   // for each sampled temperature
@@ -52,17 +55,24 @@ class MetropolisExchangePt : public AbstractSampler<WfType> {
   // Look-up tables
   std::vector<typename WfType::LookupType> lt_;
 
-  const int nrep_;
-
-  std::vector<double> beta_;
-
  public:
-  explicit MetropolisExchangePt(const AbstractGraph &graph, WfType &psi,
-                                int dmax = 1, int nreplicas = 1)
+  MetropolisExchangePt(const AbstractGraph &graph, WfType &psi, int dmax = 1,
+                       int nreplicas = 1)
       : psi_(psi),
         hilbert_(psi.GetHilbert()),
         nv_(hilbert_.Size()),
         nrep_(nreplicas) {
+    Init(graph, dmax);
+  }
+
+  MetropolisExchangePt(const AbstractGraph &graph, WfType &psi,
+                       DistributedRandomEngine::ResultType seed, int dmax = 1,
+                       int nreplicas = 1)
+      : psi_(psi),
+        hilbert_(psi.GetHilbert()),
+        nv_(hilbert_.Size()),
+        nrep_(nreplicas),
+        rgen_(seed) {
     Init(graph, dmax);
   }
 
@@ -85,8 +95,6 @@ class MetropolisExchangePt : public AbstractSampler<WfType> {
     moves_.resize(2 * nrep_);
 
     GenerateClusters(graph, dmax);
-
-    Seed();
 
     Reset(true);
 
@@ -112,25 +120,10 @@ class MetropolisExchangePt : public AbstractSampler<WfType> {
     }
   }
 
-  void Seed(int baseseed = 0) {
-    std::random_device rd;
-    std::vector<int> seeds(totalnodes_);
-
-    if (mynode_ == 0) {
-      for (int i = 0; i < totalnodes_; i++) {
-        seeds[i] = rd() + baseseed;
-      }
-    }
-
-    SendToAll(seeds);
-
-    rgen_.seed(seeds[mynode_]);
-  }
-
   void Reset(bool initrandom = false) override {
     if (initrandom) {
       for (int i = 0; i < nrep_; i++) {
-        hilbert_.RandomVals(v_[i], rgen_);
+        hilbert_.RandomVals(v_[i], rgen_.Get());
       }
     }
 
@@ -151,7 +144,7 @@ class MetropolisExchangePt : public AbstractSampler<WfType> {
     std::vector<double> newconf(2);
 
     for (int i = 0; i < nv_; i++) {
-      int rcl = distcl(rgen_);
+      int rcl = distcl(rgen_.Get());
       assert(rcl < int(clusters_.size()));
       int si = clusters_[rcl][0];
       int sj = clusters_[rcl][1];
@@ -168,7 +161,7 @@ class MetropolisExchangePt : public AbstractSampler<WfType> {
             std::exp(beta_[rep] *
                      psi_.LogValDiff(v_[rep], tochange, newconf, lt_[rep])));
 
-        if (ratio > distu(rgen_)) {
+        if (ratio > distu(rgen_.Get())) {
           accept_(rep) += 1;
           psi_.UpdateLookup(v_[rep], tochange, newconf, lt_[rep]);
           hilbert_.UpdateConf(v_[rep], tochange, newconf);
@@ -189,7 +182,7 @@ class MetropolisExchangePt : public AbstractSampler<WfType> {
     std::uniform_real_distribution<double> distribution(0, 1);
 
     for (int r = 1; r < nrep_; r += 2) {
-      if (ExchangeProb(r, r - 1) > distribution(rgen_)) {
+      if (ExchangeProb(r, r - 1) > distribution(rgen_.Get())) {
         Exchange(r, r - 1);
         accept_(nrep_ + r) += 1.;
         accept_(nrep_ + r - 1) += 1;
@@ -199,7 +192,7 @@ class MetropolisExchangePt : public AbstractSampler<WfType> {
     }
 
     for (int r = 2; r < nrep_; r += 2) {
-      if (ExchangeProb(r, r - 1) > distribution(rgen_)) {
+      if (ExchangeProb(r, r - 1) > distribution(rgen_.Get())) {
         Exchange(r, r - 1);
         accept_(nrep_ + r) += 1.;
         accept_(nrep_ + r - 1) += 1;

--- a/NetKet/Sampler/metropolis_exchange_pt.hpp
+++ b/NetKet/Sampler/metropolis_exchange_pt.hpp
@@ -27,7 +27,7 @@ namespace netket {
 // Metropolis sampling generating local exchanges
 // Parallel tempering is also used
 template <class WfType>
-class MetropolisExchangePt : public SeedableSampler<WfType> {
+class MetropolisExchangePt: public AbstractSampler<WfType> {
   WfType &psi_;
   const AbstractHilbert &hilbert_;
 

--- a/NetKet/Sampler/metropolis_hamiltonian.hpp
+++ b/NetKet/Sampler/metropolis_hamiltonian.hpp
@@ -26,7 +26,7 @@ namespace netket {
 
 // Metropolis sampling generating transitions using the Hamiltonian
 template <class WfType, class H>
-class MetropolisHamiltonian : public SeedableSampler<WfType> {
+class MetropolisHamiltonian: public AbstractSampler<WfType> {
   WfType &psi_;
 
   const AbstractHilbert &hilbert_;

--- a/NetKet/Sampler/metropolis_hamiltonian_pt.hpp
+++ b/NetKet/Sampler/metropolis_hamiltonian_pt.hpp
@@ -26,7 +26,7 @@ namespace netket {
 
 // Metropolis sampling generating transitions using the Hamiltonian
 template <class WfType, class H>
-class MetropolisHamiltonianPt : public SeedableSampler<WfType> {
+class MetropolisHamiltonianPt: public AbstractSampler<WfType> {
   WfType &psi_;
 
   const AbstractHilbert &hilbert_;

--- a/NetKet/Sampler/metropolis_hamiltonian_pt.hpp
+++ b/NetKet/Sampler/metropolis_hamiltonian_pt.hpp
@@ -36,7 +36,10 @@ class MetropolisHamiltonianPt : public AbstractSampler<WfType> {
   // number of visible units
   const int nv_;
 
-  netket::default_random_engine rgen_;
+  const int nrep_;
+  std::vector<double> beta_;
+
+  DistributedRandomEngine rgen_;
 
   // states of visible units
   std::vector<Eigen::VectorXd> v_;
@@ -59,9 +62,6 @@ class MetropolisHamiltonianPt : public AbstractSampler<WfType> {
   std::vector<std::vector<double>> newconfs1_;
   std::vector<std::complex<double>> mel1_;
 
-  const int nrep_;
-  std::vector<double> beta_;
-
  public:
   MetropolisHamiltonianPt(WfType &psi, H &hamiltonian, int nrep)
       : psi_(psi),
@@ -69,6 +69,17 @@ class MetropolisHamiltonianPt : public AbstractSampler<WfType> {
         hamiltonian_(hamiltonian),
         nv_(hilbert_.Size()),
         nrep_(nrep) {
+    Init();
+  }
+
+  MetropolisHamiltonianPt(WfType &psi, H &hamiltonian, int nrep,
+                          DistributedRandomEngine::ResultType seed)
+      : psi_(psi),
+        hilbert_(psi.GetHilbert()),
+        hamiltonian_(hamiltonian),
+        nv_(hilbert_.Size()),
+        nrep_(nrep),
+        rgen_(seed) {
     Init();
   }
 
@@ -96,8 +107,6 @@ class MetropolisHamiltonianPt : public AbstractSampler<WfType> {
 
     lt_.resize(nrep_);
 
-    Seed();
-
     Reset(true);
 
     InfoMessage() << "Hamiltonian Metropolis sampler with parallel tempering "
@@ -106,25 +115,10 @@ class MetropolisHamiltonianPt : public AbstractSampler<WfType> {
     InfoMessage() << nrep_ << " replicas are being used" << std::endl;
   }
 
-  void Seed(int baseseed = 0) {
-    std::random_device rd;
-    std::vector<int> seeds(totalnodes_);
-
-    if (mynode_ == 0) {
-      for (int i = 0; i < totalnodes_; i++) {
-        seeds[i] = rd() + baseseed;
-      }
-    }
-
-    SendToAll(seeds);
-
-    rgen_.seed(seeds[mynode_]);
-  }
-
   void Reset(bool initrandom = false) override {
     if (initrandom) {
       for (int i = 0; i < nrep_; i++) {
-        hilbert_.RandomVals(v_[i], rgen_);
+        hilbert_.RandomVals(v_[i], rgen_.Get());
       }
     }
 
@@ -146,7 +140,7 @@ class MetropolisHamiltonianPt : public AbstractSampler<WfType> {
       std::uniform_real_distribution<double> distu(0, 1);
 
       // picking a random state to transit to
-      int si = distrs(rgen_);
+      int si = distrs(rgen_.Get());
 
       // Inverse transition
       v1_ = v_[rep];
@@ -172,7 +166,7 @@ class MetropolisHamiltonianPt : public AbstractSampler<WfType> {
 #endif
 
       // Metropolis acceptance test
-      if (ratio > distu(rgen_)) {
+      if (ratio > distu(rgen_.Get())) {
         accept_(rep) += 1;
         psi_.UpdateLookup(v_[rep], tochange_[si], newconfs_[si], lt_[rep]);
         v_[rep] = v1_;
@@ -202,7 +196,7 @@ class MetropolisHamiltonianPt : public AbstractSampler<WfType> {
     std::uniform_real_distribution<double> distribution(0, 1);
 
     for (int r = 1; r < nrep_; r += 2) {
-      if (ExchangeProb(r, r - 1) > distribution(rgen_)) {
+      if (ExchangeProb(r, r - 1) > distribution(rgen_.Get())) {
         Exchange(r, r - 1);
         accept_(nrep_ + r) += 1.;
         accept_(nrep_ + r - 1) += 1;
@@ -212,7 +206,7 @@ class MetropolisHamiltonianPt : public AbstractSampler<WfType> {
     }
 
     for (int r = 2; r < nrep_; r += 2) {
-      if (ExchangeProb(r, r - 1) > distribution(rgen_)) {
+      if (ExchangeProb(r, r - 1) > distribution(rgen_.Get())) {
         Exchange(r, r - 1);
         accept_(nrep_ + r) += 1.;
         accept_(nrep_ + r - 1) += 1;

--- a/NetKet/Sampler/metropolis_hop.hpp
+++ b/NetKet/Sampler/metropolis_hop.hpp
@@ -25,7 +25,7 @@ namespace netket {
 
 // Metropolis sampling generating local hoppings
 template <class WfType>
-class MetropolisHop : public SeedableSampler<WfType> {
+class MetropolisHop: public AbstractSampler<WfType> {
   WfType &psi_;
 
   const AbstractHilbert &hilbert_;

--- a/NetKet/Sampler/metropolis_local.hpp
+++ b/NetKet/Sampler/metropolis_local.hpp
@@ -35,7 +35,7 @@ class MetropolisLocal : public AbstractSampler<WfType> {
   // number of visible units
   const int nv_;
 
-  netket::default_random_engine rgen_;
+  DistributedRandomEngine rgen_;
 
   // states of visible units
   Eigen::VectorXd v_;
@@ -58,6 +58,14 @@ class MetropolisLocal : public AbstractSampler<WfType> {
     Init();
   }
 
+  MetropolisLocal(WfType& psi, DistributedRandomEngine::ResultType seed)
+      : psi_(psi),
+        hilbert_(psi.GetHilbert()),
+        nv_(hilbert_.Size()),
+        rgen_(seed) {
+    Init();
+  }
+
   void Init() {
     v_.resize(nv_);
 
@@ -76,31 +84,14 @@ class MetropolisLocal : public AbstractSampler<WfType> {
     nstates_ = hilbert_.LocalSize();
     localstates_ = hilbert_.LocalStates();
 
-    Seed();
-
     Reset(true);
 
     InfoMessage() << "Local Metropolis sampler is ready " << std::endl;
   }
 
-  void Seed(int baseseed = 0) {
-    std::random_device rd;
-    std::vector<int> seeds(totalnodes_);
-
-    if (mynode_ == 0) {
-      for (int i = 0; i < totalnodes_; i++) {
-        seeds[i] = rd() + baseseed;
-      }
-    }
-
-    SendToAll(seeds);
-
-    rgen_.seed(seeds[mynode_]);
-  }
-
-  void Reset(bool initrandom = false) override {
+  void Reset(bool initrandom) override {
     if (initrandom) {
-      hilbert_.RandomVals(v_, rgen_);
+      hilbert_.RandomVals(v_, rgen_.Get());
     }
 
     psi_.InitLookup(v_, lt_);
@@ -119,18 +110,18 @@ class MetropolisLocal : public AbstractSampler<WfType> {
 
     for (int i = 0; i < nv_; i++) {
       // picking a random site to be changed
-      int si = distrs(rgen_);
+      int si = distrs(rgen_.Get());
       assert(si < nv_);
       tochange[0] = si;
 
       // picking a random state
-      int newstate = diststate(rgen_);
+      int newstate = diststate(rgen_.Get());
       newconf[0] = localstates_[newstate];
 
       // make sure that the new state is not equal to the current one
       while (std::abs(newconf[0] - v_(si)) <
              std::numeric_limits<double>::epsilon()) {
-        newstate = diststate(rgen_);
+        newstate = diststate(rgen_.Get());
         newconf[0] = localstates_[newstate];
       }
 
@@ -148,7 +139,7 @@ class MetropolisLocal : public AbstractSampler<WfType> {
 #endif
 
       // Metropolis acceptance test
-      if (ratio > distu(rgen_)) {
+      if (ratio > distu(rgen_.Get())) {
         accept_[0] += 1;
         psi_.UpdateLookup(v_, tochange, newconf, lt_);
         hilbert_.UpdateConf(v_, tochange, newconf);

--- a/NetKet/Sampler/metropolis_local.hpp
+++ b/NetKet/Sampler/metropolis_local.hpp
@@ -27,7 +27,7 @@ namespace netket {
 
 // Metropolis sampling generating local moves in hilbert space
 template <class WfType>
-class MetropolisLocal : public SeedableSampler<WfType> {
+class MetropolisLocal: public AbstractSampler<WfType> {
   WfType& psi_;
 
   const AbstractHilbert& hilbert_;

--- a/NetKet/Sampler/metropolis_local_pt.hpp
+++ b/NetKet/Sampler/metropolis_local_pt.hpp
@@ -27,7 +27,7 @@ namespace netket {
 // Metropolis sampling generating local changes
 // Parallel tempering is also used
 template <class WfType>
-class MetropolisLocalPt : public SeedableSampler<WfType> {
+class MetropolisLocalPt: public AbstractSampler<WfType> {
   WfType& psi_;
 
   const AbstractHilbert& hilbert_;

--- a/NetKet/Sampler/metropolis_local_pt.hpp
+++ b/NetKet/Sampler/metropolis_local_pt.hpp
@@ -27,15 +27,13 @@ namespace netket {
 // Metropolis sampling generating local changes
 // Parallel tempering is also used
 template <class WfType>
-class MetropolisLocalPt : public AbstractSampler<WfType> {
+class MetropolisLocalPt : public SeedableSampler<WfType> {
   WfType& psi_;
 
   const AbstractHilbert& hilbert_;
 
   // number of visible units
   const int nv_;
-
-  DistributedRandomEngine rgen_;
 
   // states of visible units
   // for each sampled temperature
@@ -66,16 +64,6 @@ class MetropolisLocalPt : public AbstractSampler<WfType> {
       : psi_(psi),
         hilbert_(psi.GetHilbert()),
         nv_(hilbert_.Size()),
-        nrep_(nreplicas) {
-    Init();
-  }
-
-  MetropolisLocalPt(WfType& psi, int nreplicas,
-                    DistributedRandomEngine::ResultType seed)
-      : psi_(psi),
-        hilbert_(psi.GetHilbert()),
-        nv_(hilbert_.Size()),
-        rgen_(seed),
         nrep_(nreplicas) {
     Init();
   }
@@ -116,7 +104,7 @@ class MetropolisLocalPt : public AbstractSampler<WfType> {
   void Reset(bool initrandom = false) override {
     if (initrandom) {
       for (int i = 0; i < nrep_; i++) {
-        hilbert_.RandomVals(v_[i], rgen_.Get());
+        hilbert_.RandomVals(v_[i], this->GetRandomEngine());
       }
     }
 
@@ -139,18 +127,18 @@ class MetropolisLocalPt : public AbstractSampler<WfType> {
 
     for (int i = 0; i < nv_; i++) {
       // picking a random site to be changed
-      int si = distrs(rgen_.Get());
+      int si = distrs(this->GetRandomEngine());
       assert(si < nv_);
       tochange[0] = si;
 
       // picking a random state
-      int newstate = diststate(rgen_.Get());
+      int newstate = diststate(this->GetRandomEngine());
       newconf[0] = localstates_[newstate];
 
       // make sure that the new state is not equal to the current one
       while (std::abs(newconf[0] - v_[rep](si)) <
              std::numeric_limits<double>::epsilon()) {
-        newstate = diststate(rgen_.Get());
+        newstate = diststate(this->GetRandomEngine());
         newconf[0] = localstates_[newstate];
       }
 
@@ -168,7 +156,7 @@ class MetropolisLocalPt : public AbstractSampler<WfType> {
       }
 #endif
       // Metropolis acceptance test
-      if (ratio > distu(rgen_.Get())) {
+      if (ratio > distu(this->GetRandomEngine())) {
         accept_(rep) += 1;
 
         psi_.UpdateLookup(v_[rep], tochange, newconf, lt_[rep]);
@@ -199,7 +187,7 @@ class MetropolisLocalPt : public AbstractSampler<WfType> {
     std::uniform_real_distribution<double> distribution(0, 1);
 
     for (int r = 1; r < nrep_; r += 2) {
-      if (ExchangeProb(r, r - 1) > distribution(rgen_.Get())) {
+      if (ExchangeProb(r, r - 1) > distribution(this->GetRandomEngine())) {
         Exchange(r, r - 1);
         accept_(nrep_ + r) += 1.;
         accept_(nrep_ + r - 1) += 1;
@@ -209,7 +197,7 @@ class MetropolisLocalPt : public AbstractSampler<WfType> {
     }
 
     for (int r = 2; r < nrep_; r += 2) {
-      if (ExchangeProb(r, r - 1) > distribution(rgen_.Get())) {
+      if (ExchangeProb(r, r - 1) > distribution(this->GetRandomEngine())) {
         Exchange(r, r - 1);
         accept_(nrep_ + r) += 1.;
         accept_(nrep_ + r - 1) += 1;

--- a/NetKet/Sampler/pysampler.hpp
+++ b/NetKet/Sampler/pysampler.hpp
@@ -55,20 +55,26 @@ namespace netket {
 void AddSamplerModule(py::module &m) {
   auto subm = m.def_submodule("sampler");
 
+  using Seed = DistributedRandomEngine::ResultType;
+
   py::class_<SamplerType>(subm, "Sampler") ADDSAMPLERMETHODS(SamplerType);
 
   {
     using DerSampler = MetropolisLocal<MachineType>;
     py::class_<DerSampler, SamplerType>(subm, "MetropolisLocal")
         .def(py::init<MachineType &>(), py::keep_alive<1, 2>(),
-             py::arg("machine")) ADDSAMPLERMETHODS(DerSampler);
+             py::arg("machine"))
+        .def(py::init<MachineType &, Seed>(), py::keep_alive<1, 2>(),
+             py::arg("machine"), py::arg("seed")) ADDSAMPLERMETHODS(DerSampler);
   }
 
   {
     using DerSampler = MetropolisLocalPt<MachineType>;
     py::class_<DerSampler, SamplerType>(subm, "MetropolisLocalPt")
         .def(py::init<MachineType &, int>(), py::keep_alive<1, 2>(),
-             py::arg("machine"), py::arg("n_replicas"))
+             py::arg("machine"), py::arg("n_replicas") = 1)
+        .def(py::init<MachineType &, int, Seed>(), py::keep_alive<1, 2>(),
+             py::arg("machine"), py::arg("n_replicas"), py::arg("seed"))
             ADDSAMPLERMETHODS(DerSampler);
   }
 
@@ -76,7 +82,9 @@ void AddSamplerModule(py::module &m) {
     using DerSampler = MetropolisHop<MachineType>;
     py::class_<DerSampler, SamplerType>(subm, "MetropolisHop")
         .def(py::init<MachineType &, int>(), py::keep_alive<1, 3>(),
-             py::arg("machine"), py::arg("d_max"))
+             py::arg("machine"), py::arg("d_max") = 1)
+        .def(py::init<MachineType &, int, Seed>(), py::keep_alive<1, 3>(),
+             py::arg("machine"), py::arg("d_max"), py::arg("seed"))
             ADDSAMPLERMETHODS(DerSampler);
   }
 
@@ -85,7 +93,11 @@ void AddSamplerModule(py::module &m) {
     py::class_<DerSampler, SamplerType>(subm, "MetropolisHamiltonian")
         .def(py::init<MachineType &, AbstractOperator &>(),
              py::keep_alive<1, 2>(), py::keep_alive<1, 3>(), py::arg("machine"),
-             py::arg("hamiltonian")) ADDSAMPLERMETHODS(DerSampler);
+             py::arg("hamiltonian"))
+        .def(py::init<MachineType &, AbstractOperator &, Seed>(),
+             py::keep_alive<1, 2>(), py::keep_alive<1, 3>(), py::arg("machine"),
+             py::arg("hamiltonian"), py::arg("seed"))
+            ADDSAMPLERMETHODS(DerSampler);
   }
 
   {
@@ -94,6 +106,9 @@ void AddSamplerModule(py::module &m) {
         .def(py::init<MachineType &, AbstractOperator &, int>(),
              py::keep_alive<1, 2>(), py::keep_alive<1, 3>(), py::arg("machine"),
              py::arg("hamiltonian"), py::arg("n_replicas"))
+        .def(py::init<MachineType &, AbstractOperator &, int, Seed>(),
+             py::keep_alive<1, 2>(), py::keep_alive<1, 3>(), py::arg("machine"),
+             py::arg("hamiltonian"), py::arg("n_replicas"), py::arg("seed"))
             ADDSAMPLERMETHODS(DerSampler);
   }
 
@@ -101,46 +116,66 @@ void AddSamplerModule(py::module &m) {
     using DerSampler = MetropolisExchange<MachineType>;
     py::class_<DerSampler, SamplerType>(subm, "MetropolisExchange")
         .def(py::init<const AbstractGraph &, MachineType &, int>(),
-             py::keep_alive<1, 3>(), py::arg("graph"), py::arg("machine"),
-             py::arg("d_max") = 1) ADDSAMPLERMETHODS(DerSampler);
+             py::keep_alive<1, 2>(), py::keep_alive<1, 3>(), py::arg("graph"),
+             py::arg("machine"), py::arg("d_max") = 1)
+        .def(py::init<const AbstractGraph &, MachineType &, Seed, int>(),
+             py::keep_alive<1, 2>(), py::keep_alive<1, 3>(), py::arg("graph"),
+             py::arg("machine"), py::arg("seed"), py::arg("d_max") = 1)
+            ADDSAMPLERMETHODS(DerSampler);
   }
 
   {
     using DerSampler = MetropolisExchangePt<MachineType>;
     py::class_<DerSampler, SamplerType>(subm, "MetropolisExchangePt")
         .def(py::init<const AbstractGraph &, MachineType &, int, int>(),
-             py::keep_alive<1, 3>(), py::arg("graph"), py::arg("machine"),
-             py::arg("d_max") = 1, py::arg("n_replicas") = 1)
-            ADDSAMPLERMETHODS(DerSampler);
+             py::keep_alive<1, 2>(), py::keep_alive<1, 3>(), py::arg("graph"),
+             py::arg("machine"), py::arg("d_max") = 1,
+             py::arg("n_replicas") = 1)
+        .def(py::init<const AbstractGraph &, MachineType &, Seed, int, int>(),
+             py::keep_alive<1, 2>(), py::keep_alive<1, 3>(), py::arg("graph"),
+             py::arg("machine"), py::arg("seed"), py::arg("d_max") = 1,
+             py::arg("n_replicas") = 1) ADDSAMPLERMETHODS(DerSampler);
   }
 
   {
     using DerSampler = ExactSampler<MachineType>;
     py::class_<DerSampler, SamplerType>(subm, "ExactSampler")
         .def(py::init<MachineType &>(), py::keep_alive<1, 2>(),
-             py::arg("machine")) ADDSAMPLERMETHODS(DerSampler);
+             py::arg("machine"))
+        .def(py::init<MachineType &, Seed>(), py::keep_alive<1, 2>(),
+             py::arg("machine"), py::arg("seed")) ADDSAMPLERMETHODS(DerSampler);
   }
 
   {
     using DerSampler = CustomSampler<MachineType>;
     py::class_<DerSampler, SamplerType>(subm, "CustomSampler")
         .def(py::init<MachineType &, const LocalOperator &,
-                      std::vector<double>>(),
+                      const std::vector<double> &>(),
              py::keep_alive<1, 2>(), py::arg("machine"),
              py::arg("move_operators"),
              py::arg("move_weights") = std::vector<double>())
-            ADDSAMPLERMETHODS(DerSampler);
+        .def(py::init<MachineType &, const LocalOperator &, Seed,
+                      const std::vector<double> &>(),
+             py::keep_alive<1, 2>(), py::arg("machine"),
+             py::arg("move_operators"), py::arg("seed"),
+             py::arg("move_weights")) ADDSAMPLERMETHODS(DerSampler);
   }
 
   {
     using DerSampler = CustomSamplerPt<MachineType>;
     py::class_<DerSampler, SamplerType>(subm, "CustomSamplerPt")
-        .def(py::init<MachineType &, const LocalOperator &, std::vector<double>,
-                      int>(),
+        .def(py::init<MachineType &, const LocalOperator &,
+                      const std::vector<double> &, int>(),
              py::keep_alive<1, 2>(), py::arg("machine"),
              py::arg("move_operators"),
              py::arg("move_weights") = std::vector<double>(),
-             py::arg("n_replicas")) ADDSAMPLERMETHODS(DerSampler);
+             py::arg("n_replicas") = 1)
+        .def(py::init<MachineType &, const LocalOperator &, Seed,
+                      const std::vector<double> &, int>(),
+             py::keep_alive<1, 2>(), py::arg("machine"),
+             py::arg("move_operators"), py::arg("seed"),
+             py::arg("move_weights"), py::arg("n_replicas") = 1)
+            ADDSAMPLERMETHODS(DerSampler);
   }
 }
 

--- a/NetKet/Sampler/pysampler.hpp
+++ b/NetKet/Sampler/pysampler.hpp
@@ -55,127 +55,97 @@ namespace netket {
 void AddSamplerModule(py::module &m) {
   auto subm = m.def_submodule("sampler");
 
-  using Seed = DistributedRandomEngine::ResultType;
-
   py::class_<SamplerType>(subm, "Sampler") ADDSAMPLERMETHODS(SamplerType);
+
+  using SeedableSamplerType = SeedableSampler<MachineType>;
+  py::class_<SeedableSamplerType, SamplerType>(subm, "SeedableSampler")
+      .def("seed", &SeedableSamplerType::Seed, py::arg("base_seed"));
 
   {
     using DerSampler = MetropolisLocal<MachineType>;
-    py::class_<DerSampler, SamplerType>(subm, "MetropolisLocal")
+    py::class_<DerSampler, SeedableSamplerType>(subm, "MetropolisLocal")
         .def(py::init<MachineType &>(), py::keep_alive<1, 2>(),
-             py::arg("machine"))
-        .def(py::init<MachineType &, Seed>(), py::keep_alive<1, 2>(),
-             py::arg("machine"), py::arg("seed")) ADDSAMPLERMETHODS(DerSampler);
+             py::arg("machine")) ADDSAMPLERMETHODS(DerSampler);
   }
 
   {
     using DerSampler = MetropolisLocalPt<MachineType>;
-    py::class_<DerSampler, SamplerType>(subm, "MetropolisLocalPt")
+    py::class_<DerSampler, SeedableSamplerType>(subm, "MetropolisLocalPt")
         .def(py::init<MachineType &, int>(), py::keep_alive<1, 2>(),
              py::arg("machine"), py::arg("n_replicas") = 1)
-        .def(py::init<MachineType &, int, Seed>(), py::keep_alive<1, 2>(),
-             py::arg("machine"), py::arg("n_replicas"), py::arg("seed"))
             ADDSAMPLERMETHODS(DerSampler);
   }
 
   {
     using DerSampler = MetropolisHop<MachineType>;
-    py::class_<DerSampler, SamplerType>(subm, "MetropolisHop")
+    py::class_<DerSampler, SeedableSamplerType>(subm, "MetropolisHop")
         .def(py::init<MachineType &, int>(), py::keep_alive<1, 3>(),
              py::arg("machine"), py::arg("d_max") = 1)
-        .def(py::init<MachineType &, int, Seed>(), py::keep_alive<1, 3>(),
-             py::arg("machine"), py::arg("d_max"), py::arg("seed"))
             ADDSAMPLERMETHODS(DerSampler);
   }
 
   {
     using DerSampler = MetropolisHamiltonian<MachineType, AbstractOperator>;
-    py::class_<DerSampler, SamplerType>(subm, "MetropolisHamiltonian")
+    py::class_<DerSampler, SeedableSamplerType>(subm, "MetropolisHamiltonian")
         .def(py::init<MachineType &, AbstractOperator &>(),
              py::keep_alive<1, 2>(), py::keep_alive<1, 3>(), py::arg("machine"),
-             py::arg("hamiltonian"))
-        .def(py::init<MachineType &, AbstractOperator &, Seed>(),
-             py::keep_alive<1, 2>(), py::keep_alive<1, 3>(), py::arg("machine"),
-             py::arg("hamiltonian"), py::arg("seed"))
-            ADDSAMPLERMETHODS(DerSampler);
+             py::arg("hamiltonian")) ADDSAMPLERMETHODS(DerSampler);
   }
 
   {
     using DerSampler = MetropolisHamiltonianPt<MachineType, AbstractOperator>;
-    py::class_<DerSampler, SamplerType>(subm, "MetropolisHamiltonianPt")
+    py::class_<DerSampler, SeedableSamplerType>(subm, "MetropolisHamiltonianPt")
         .def(py::init<MachineType &, AbstractOperator &, int>(),
              py::keep_alive<1, 2>(), py::keep_alive<1, 3>(), py::arg("machine"),
              py::arg("hamiltonian"), py::arg("n_replicas"))
-        .def(py::init<MachineType &, AbstractOperator &, int, Seed>(),
-             py::keep_alive<1, 2>(), py::keep_alive<1, 3>(), py::arg("machine"),
-             py::arg("hamiltonian"), py::arg("n_replicas"), py::arg("seed"))
             ADDSAMPLERMETHODS(DerSampler);
   }
 
   {
     using DerSampler = MetropolisExchange<MachineType>;
-    py::class_<DerSampler, SamplerType>(subm, "MetropolisExchange")
+    py::class_<DerSampler, SeedableSamplerType>(subm, "MetropolisExchange")
         .def(py::init<const AbstractGraph &, MachineType &, int>(),
              py::keep_alive<1, 2>(), py::keep_alive<1, 3>(), py::arg("graph"),
              py::arg("machine"), py::arg("d_max") = 1)
-        .def(py::init<const AbstractGraph &, MachineType &, Seed, int>(),
-             py::keep_alive<1, 2>(), py::keep_alive<1, 3>(), py::arg("graph"),
-             py::arg("machine"), py::arg("seed"), py::arg("d_max") = 1)
             ADDSAMPLERMETHODS(DerSampler);
   }
 
   {
     using DerSampler = MetropolisExchangePt<MachineType>;
-    py::class_<DerSampler, SamplerType>(subm, "MetropolisExchangePt")
+    py::class_<DerSampler, SeedableSamplerType>(subm, "MetropolisExchangePt")
         .def(py::init<const AbstractGraph &, MachineType &, int, int>(),
              py::keep_alive<1, 2>(), py::keep_alive<1, 3>(), py::arg("graph"),
              py::arg("machine"), py::arg("d_max") = 1,
-             py::arg("n_replicas") = 1)
-        .def(py::init<const AbstractGraph &, MachineType &, Seed, int, int>(),
-             py::keep_alive<1, 2>(), py::keep_alive<1, 3>(), py::arg("graph"),
-             py::arg("machine"), py::arg("seed"), py::arg("d_max") = 1,
              py::arg("n_replicas") = 1) ADDSAMPLERMETHODS(DerSampler);
   }
 
   {
     using DerSampler = ExactSampler<MachineType>;
-    py::class_<DerSampler, SamplerType>(subm, "ExactSampler")
+    py::class_<DerSampler, SeedableSamplerType>(subm, "ExactSampler")
         .def(py::init<MachineType &>(), py::keep_alive<1, 2>(),
-             py::arg("machine"))
-        .def(py::init<MachineType &, Seed>(), py::keep_alive<1, 2>(),
-             py::arg("machine"), py::arg("seed")) ADDSAMPLERMETHODS(DerSampler);
+             py::arg("machine")) ADDSAMPLERMETHODS(DerSampler);
   }
 
   {
     using DerSampler = CustomSampler<MachineType>;
-    py::class_<DerSampler, SamplerType>(subm, "CustomSampler")
+    py::class_<DerSampler, SeedableSamplerType>(subm, "CustomSampler")
         .def(py::init<MachineType &, const LocalOperator &,
                       const std::vector<double> &>(),
              py::keep_alive<1, 2>(), py::arg("machine"),
              py::arg("move_operators"),
              py::arg("move_weights") = std::vector<double>())
-        .def(py::init<MachineType &, const LocalOperator &, Seed,
-                      const std::vector<double> &>(),
-             py::keep_alive<1, 2>(), py::arg("machine"),
-             py::arg("move_operators"), py::arg("seed"),
-             py::arg("move_weights")) ADDSAMPLERMETHODS(DerSampler);
+            ADDSAMPLERMETHODS(DerSampler);
   }
 
   {
     using DerSampler = CustomSamplerPt<MachineType>;
-    py::class_<DerSampler, SamplerType>(subm, "CustomSamplerPt")
+    py::class_<DerSampler, SeedableSamplerType>(subm, "CustomSamplerPt")
         .def(py::init<MachineType &, const LocalOperator &,
                       const std::vector<double> &, int>(),
              py::keep_alive<1, 2>(), py::arg("machine"),
              py::arg("move_operators"),
              py::arg("move_weights") = std::vector<double>(),
-             py::arg("n_replicas") = 1)
-        .def(py::init<MachineType &, const LocalOperator &, Seed,
-                      const std::vector<double> &, int>(),
-             py::keep_alive<1, 2>(), py::arg("machine"),
-             py::arg("move_operators"), py::arg("seed"),
-             py::arg("move_weights"), py::arg("n_replicas") = 1)
-            ADDSAMPLERMETHODS(DerSampler);
+             py::arg("n_replicas") = 1) ADDSAMPLERMETHODS(DerSampler);
   }
 }
 

--- a/NetKet/Sampler/pysampler.hpp
+++ b/NetKet/Sampler/pysampler.hpp
@@ -55,22 +55,20 @@ namespace netket {
 void AddSamplerModule(py::module &m) {
   auto subm = m.def_submodule("sampler");
 
-  py::class_<SamplerType>(subm, "Sampler") ADDSAMPLERMETHODS(SamplerType);
-
-  using SeedableSamplerType = SeedableSampler<MachineType>;
-  py::class_<SeedableSamplerType, SamplerType>(subm, "SeedableSampler")
-      .def("seed", &SeedableSamplerType::Seed, py::arg("base_seed"));
+  py::class_<SamplerType>(subm, "Sampler")
+      .def("seed", &SamplerType::Seed, py::arg("base_seed"))
+          ADDSAMPLERMETHODS(SamplerType);
 
   {
     using DerSampler = MetropolisLocal<MachineType>;
-    py::class_<DerSampler, SeedableSamplerType>(subm, "MetropolisLocal")
+    py::class_<DerSampler, SamplerType>(subm, "MetropolisLocal")
         .def(py::init<MachineType &>(), py::keep_alive<1, 2>(),
              py::arg("machine")) ADDSAMPLERMETHODS(DerSampler);
   }
 
   {
     using DerSampler = MetropolisLocalPt<MachineType>;
-    py::class_<DerSampler, SeedableSamplerType>(subm, "MetropolisLocalPt")
+    py::class_<DerSampler, SamplerType>(subm, "MetropolisLocalPt")
         .def(py::init<MachineType &, int>(), py::keep_alive<1, 2>(),
              py::arg("machine"), py::arg("n_replicas") = 1)
             ADDSAMPLERMETHODS(DerSampler);
@@ -78,7 +76,7 @@ void AddSamplerModule(py::module &m) {
 
   {
     using DerSampler = MetropolisHop<MachineType>;
-    py::class_<DerSampler, SeedableSamplerType>(subm, "MetropolisHop")
+    py::class_<DerSampler, SamplerType>(subm, "MetropolisHop")
         .def(py::init<MachineType &, int>(), py::keep_alive<1, 3>(),
              py::arg("machine"), py::arg("d_max") = 1)
             ADDSAMPLERMETHODS(DerSampler);
@@ -86,7 +84,7 @@ void AddSamplerModule(py::module &m) {
 
   {
     using DerSampler = MetropolisHamiltonian<MachineType, AbstractOperator>;
-    py::class_<DerSampler, SeedableSamplerType>(subm, "MetropolisHamiltonian")
+    py::class_<DerSampler, SamplerType>(subm, "MetropolisHamiltonian")
         .def(py::init<MachineType &, AbstractOperator &>(),
              py::keep_alive<1, 2>(), py::keep_alive<1, 3>(), py::arg("machine"),
              py::arg("hamiltonian")) ADDSAMPLERMETHODS(DerSampler);
@@ -94,7 +92,7 @@ void AddSamplerModule(py::module &m) {
 
   {
     using DerSampler = MetropolisHamiltonianPt<MachineType, AbstractOperator>;
-    py::class_<DerSampler, SeedableSamplerType>(subm, "MetropolisHamiltonianPt")
+    py::class_<DerSampler, SamplerType>(subm, "MetropolisHamiltonianPt")
         .def(py::init<MachineType &, AbstractOperator &, int>(),
              py::keep_alive<1, 2>(), py::keep_alive<1, 3>(), py::arg("machine"),
              py::arg("hamiltonian"), py::arg("n_replicas"))
@@ -103,7 +101,7 @@ void AddSamplerModule(py::module &m) {
 
   {
     using DerSampler = MetropolisExchange<MachineType>;
-    py::class_<DerSampler, SeedableSamplerType>(subm, "MetropolisExchange")
+    py::class_<DerSampler, SamplerType>(subm, "MetropolisExchange")
         .def(py::init<const AbstractGraph &, MachineType &, int>(),
              py::keep_alive<1, 2>(), py::keep_alive<1, 3>(), py::arg("graph"),
              py::arg("machine"), py::arg("d_max") = 1)
@@ -112,7 +110,7 @@ void AddSamplerModule(py::module &m) {
 
   {
     using DerSampler = MetropolisExchangePt<MachineType>;
-    py::class_<DerSampler, SeedableSamplerType>(subm, "MetropolisExchangePt")
+    py::class_<DerSampler, SamplerType>(subm, "MetropolisExchangePt")
         .def(py::init<const AbstractGraph &, MachineType &, int, int>(),
              py::keep_alive<1, 2>(), py::keep_alive<1, 3>(), py::arg("graph"),
              py::arg("machine"), py::arg("d_max") = 1,
@@ -121,14 +119,14 @@ void AddSamplerModule(py::module &m) {
 
   {
     using DerSampler = ExactSampler<MachineType>;
-    py::class_<DerSampler, SeedableSamplerType>(subm, "ExactSampler")
+    py::class_<DerSampler, SamplerType>(subm, "ExactSampler")
         .def(py::init<MachineType &>(), py::keep_alive<1, 2>(),
              py::arg("machine")) ADDSAMPLERMETHODS(DerSampler);
   }
 
   {
     using DerSampler = CustomSampler<MachineType>;
-    py::class_<DerSampler, SeedableSamplerType>(subm, "CustomSampler")
+    py::class_<DerSampler, SamplerType>(subm, "CustomSampler")
         .def(py::init<MachineType &, const LocalOperator &,
                       const std::vector<double> &>(),
              py::keep_alive<1, 2>(), py::arg("machine"),
@@ -139,7 +137,7 @@ void AddSamplerModule(py::module &m) {
 
   {
     using DerSampler = CustomSamplerPt<MachineType>;
-    py::class_<DerSampler, SeedableSamplerType>(subm, "CustomSamplerPt")
+    py::class_<DerSampler, SamplerType>(subm, "CustomSamplerPt")
         .def(py::init<MachineType &, const LocalOperator &,
                       const std::vector<double> &, int>(),
              py::keep_alive<1, 2>(), py::arg("machine"),

--- a/NetKet/Utils/mpi_interface.hpp
+++ b/NetKet/Utils/mpi_interface.hpp
@@ -41,6 +41,14 @@ void SendToAll(std::vector<int> &value, int root = 0,
                const MPI_Comm comm = MPI_COMM_WORLD) {
   MPI_Bcast(&value[0], value.size(), MPI_INT, root, comm);
 }
+void SendToAll(std::vector<unsigned int> &value, int root = 0,
+               const MPI_Comm comm = MPI_COMM_WORLD) {
+  MPI_Bcast(&value[0], value.size(), MPI_UNSIGNED, root, comm);
+}
+void SendToAll(std::vector<unsigned long> &value, int root = 0,
+               const MPI_Comm comm = MPI_COMM_WORLD) {
+  MPI_Bcast(&value[0], value.size(), MPI_UNSIGNED_LONG, root, comm);
+}
 void SendToAll(std::vector<double> &value, int root = 0,
                const MPI_Comm comm = MPI_COMM_WORLD) {
   MPI_Bcast(&value[0], value.size(), MPI_DOUBLE, root, comm);

--- a/Tutorials/PyNetKet/ground_state.py
+++ b/Tutorials/PyNetKet/ground_state.py
@@ -31,6 +31,7 @@ ma.init_random_parameters(seed=1234, sigma=0.01)
 
 # Sampler
 sa = nk.sampler.MetropolisLocal(machine=ma)
+sa.seed(1234)
 
 # Optimizer
 op = nk.optimizer.Sgd(learning_rate=0.1)


### PR DESCRIPTION
This PR makes the sampler classes seedable so that simulation results are deterministic when a fixed seed is provided. It also extracts the corresponding code to a reusable class, since it was the same for all samplers.