### PR TITLE
Docs

### DIFF
--- a/Docs/Graph/CustomGraph.md
+++ b/Docs/Graph/CustomGraph.md
@@ -1,0 +1,36 @@
+# CustomGraph
+In addition to built-in graphs, NetKet provides the freedom to define custom graphs, specifying a list of edges.
+## Constructor
+Constructs a new graph given a list of edges.
+
+|    Field    |       Type       |                                                                                                                                                                                                                                     Description                                                                                                                                                                                                                                     |
+|-------------|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|edges        |iterable          |If `edges` has elements of type `Tuple[int, int]` it is treated as a list of edges. Then each element `(i, j)` means a connection between sites `i` and `j`. It is assumed that `0 <= i <= j`. Also, `edges` should contain no duplicates. If `edges` has elements of type `Tuple[int, int, int]` each element `(i, j, c)` represents an edge between sites `i` and `j` colored into `c`. It is again assumed that `0 <= i <= j` and that there are no duplicate elements in `edges`.|
+|automorphisms|List[List[int]]=[]|The automorphisms of the graph, i.e. a List[List[int]] where the inner List[int] is a unique permutation of the graph sites.                                                                                                                                                                                                                                                                                                                                                         |
+|is_bipartite |bool=False        |Wheter the custom graph is bipartite. Notice that this is not deduced from the edge list and it is left to the user to specify whether the graph is bipartite or not.                                                                                                                                                                                                                                                                                                                |
+
+### Examples
+A 10-site one-dimensional lattice with periodic boundary conditions can be
+constructed specifying the edges as follows:
+
+```python
+>>> from netket.graph import CustomGraph
+>>> g=CustomGraph([[i, (i + 1) % 10] for i in range(10)])
+>>> print(g.n_sites)
+10
+
+```
+
+
+## Properties
+|   Property   |      Type       |                                                        Description                                                        |
+|--------------|-----------------|---------------------------------------------------------------------------------------------------------------------------|
+|adjacency_list|       list      | The adjacency list of the graph where each node is           represented by an integer in `[0, n_sites)`                  |
+|automorphisms |       list[list]| The automorphisms of the graph,           including translation symmetries only.                                          |
+|distances     |       list[list]| The distances between the nodes. The fact that some node           may not be reachable from another is represented by -1.|
+|edges         |       list      | The graph edges.                                                                                                          |
+|is_bipartite  |       bool      | Whether the graph is bipartite.                                                                                           |
+|is_connected  |       bool      | Whether the graph is connected.                                                                                           |
+|n_sites       |       int       | The number of vertices in the graph.                                                                                      |
+
+

--- a/Docs/Graph/Hypercube.md
+++ b/Docs/Graph/Hypercube.md
@@ -1,0 +1,43 @@
+# Hypercube
+A hypercube lattice of side L in d dimensions. Periodic boundary conditions can also be imposed.
+## Constructor [1]
+Constructs a new ``Hypercube`` given its side length and dimension.
+
+|Field |  Type   |                                                           Description                                                            |
+|------|---------|----------------------------------------------------------------------------------------------------------------------------------|
+|length|int      |Side length of the hypercube. It must always be >=1, but if ``pbc==True`` then the minimal valid length is 3.                     |
+|n_dim |int=1    |Dimension of the hypercube. It must be at least 1.                                                                                |
+|pbc   |bool=True|If ``True`` then the constructed hypercube will have periodic boundary conditions, otherwise open boundary conditions are imposed.|
+
+### Examples
+A 10x10 square lattice with periodic boundary conditions can be
+constructed as follows:
+
+```python
+>>> from netket.graph import Hypercube
+>>> g=Hypercube(length=10,n_dim=2,pbc=True)
+>>> print(g.n_sites)
+100
+
+```
+
+## Constructor [2]
+Constructs a new `Hypercube` given its side length and edge coloring.
+
+|Field |  Type  |                                                                                 Description                                                                                 |
+|------|--------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|length|int     |Side length of the hypercube. It must always be >=3 if the hypercube has periodic boundary conditions and >=1 otherwise.                                                     |
+|colors|iterable|Edge colors, must be an iterable of `Tuple[int, int, int]` where each element `(i, j, c) represents an edge `i <-> j` of color `c`. Colors must be assigned to **all** edges.|
+
+## Properties
+|   Property   |      Type       |                                                        Description                                                        |
+|--------------|-----------------|---------------------------------------------------------------------------------------------------------------------------|
+|adjacency_list|       list      | The adjacency list of the graph where each node is           represented by an integer in `[0, n_sites)`                  |
+|automorphisms |       list[list]| The automorphisms of the graph,           including translation symmetries only.                                          |
+|distances     |       list[list]| The distances between the nodes. The fact that some node           may not be reachable from another is represented by -1.|
+|edges         |       list      | The graph edges.                                                                                                          |
+|is_bipartite  |       bool      | Whether the graph is bipartite.                                                                                           |
+|is_connected  |       bool      | Whether the graph is connected.                                                                                           |
+|n_sites       |       int       | The number of vertices in the graph.                                                                                      |
+
+

--- a/Docs/extract.py
+++ b/Docs/extract.py
@@ -1,0 +1,457 @@
+"""
+MIT License
+
+Copyright (c) 2018 Ossian O'Reilly
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+"""
+This module is used to extract a docstring from source.
+"""
+import re
+
+class Extract(object):
+    """
+    Base class for extracting docstrings.
+
+    Attributes:
+        txt : A string that contains the source code that has been read from
+            `source`.
+        query : A copy of the most recent docstring searched. The search is
+            specified in the form of `Class.method`, or `function`, or `.` to
+            search for the module docstring.
+        classname : Holds the class name of the query.
+        funcname : Holds the function or method name of the query.
+        dtype : Holds the type of the query `module`, `class`, `method`, or
+            `function`.
+
+    """
+
+    def __init__(self, txt):
+        """
+        Initializer for Extract.
+
+        Arguments:
+            txt: A string containing the text to extract docstrings from.
+
+        """
+        self.txt = txt
+        self.query = ''
+        self.classname = ''
+        self.funcname = ''
+        self.dtype = ''
+        #This dictionary contains the ids of the different attributes that can
+        #be captured. The value specifies the order in which attribute is
+        #captured.
+        self.ids = {'class' : 0, 'function' : 1, 'signature' : 2,
+                'indent' : 3, 'docstring' : 4, 'body' : 5, 'return_type' : 100}
+        # This dictionary contains keywords that describe if a function should
+        # start with 'def', and if the docstring that comes after the function
+        # should be enclosed with """.
+        self.keywords = {'function' : 'def ', 
+                         'docstring' : '"""', 
+                         'signature_end' : ':',
+                         'token_split' : 'def '}
+        self.function_keyword = 'def '
+        self.docstring_keyword = '"""'
+        # Handle multiple functions (typically function overloads) by splitting
+        # text for each function. The key `token_split` in `self.keywords`.
+        # determines the regex for the splitting.
+        self.split = 1
+
+    def get_matches(self, pattern):
+        """
+        Apply regex pattern for finding functions, classes, etc. 
+
+        Args:
+            pattern: The pattern to search for.
+
+        Raises:
+            NameError: if no matches are found. 
+
+        Returns:
+            The matches found.
+            
+
+        """
+        matches = re.compile(pattern, re.M).findall(self.txt)
+        if not matches:
+            raise NameError(r'Unable to extract docstring for `%s`' %
+                            self.query)
+        return matches
+
+
+    def extract(self, query):
+        """
+        Extracts the docstring.
+
+        Arguments:
+            query : The docstring to search for. The search is specified in the
+                form of `Class.method`, or `function`, or `.` to search for the
+                module docstring.
+
+        Returns:
+            A dictionary that matches the description given by `Extract.find`.
+
+        """
+
+        self.query = query
+        self.classname, self.funcname, self.dtype = get_names(query)
+        types = {'class' : self.extract_class,
+                 'method' : self.extract_method,
+                 'function' : self.extract_function,
+                 'module' : self.extract_module}
+
+        return types[self.dtype]()
+
+    def extract_function(self):
+        """
+        Override this method to extract function docstrings for the specific
+        language. The functions extracted are module functions. Lamba functions
+        are not extracted.
+
+        Returns:
+            A dictionary that matches the description given by `Extract.find`.
+        """
+        pass
+
+    def extract_class(self):
+        """
+        Override this method to extract class docstrings for the specific
+        language.
+
+        Returns:
+            A dictionary that matches the description given by `Extract.find`.
+        """
+        pass
+
+    def extract_method(self):
+        """
+        Override this method to extract method docstrings for the specific
+        language.
+
+        Returns:
+            A dictionary that matches the description given by `Extract.find`.
+        """
+        pass
+
+    def extract_module(self):
+        """
+        Override this method to extract module docstrings for the specific
+        language. Module docstrings are defined at the start of a file and are
+        not attached to any block of code.
+
+        Returns:
+            A dictionary that matches the description given by `Extract.find`.
+        """
+        pass
+
+    def findall(self, pattern, ids=None):
+        """
+        Splits the input text into multiple strings and performs a search for
+        each string. The idea is to handle text that contains multiple
+        functions/methods and search each such function for a specific pattern.
+
+        """
+        import re
+
+        out = []
+        input_txt = self.txt
+        if self.split:
+            matches = re.split(self.keywords['token_split'], self.txt,
+                    flags=re.M) 
+            for match in matches:
+                self.txt = match
+                try:
+                    out.append(self.find(pattern, ids))
+                except:
+                    continue
+            self.txt = input_txt
+            if not out:
+                raise NameError(r'Unable to extract docstring for `%s`' %
+                                self.query)
+            if len(out) == 1:
+                return out[0]
+            else:
+                return out
+        else:
+            return self.find(pattern, ids)
+
+    def find(self, pattern, ids=None):
+        """
+        Performs a search for a docstring that matches a specific pattern.
+
+        Returns:
+            dict: The return type is a dictionary with the following keys:
+                 * `class` :  The name of the class.
+                 * `function` : The name of the function/method.
+                 * `signature` : The signature of the function/method.
+                 * `docstring` : The docstring itself.
+                 * `type` : What type of construct the docstring is attached to.
+                      This can be either `'module'`, `'class'`, `'method'`, or
+                      `'function'`.
+                 * `label` : The search query string.
+                 * `source` : The source code if the query is a function/method.
+
+        Raises:
+            NameError: This is exception is raised if the docstring cannot be
+                extracted.
+        """
+        import textwrap
+        matches = self.get_matches(pattern)
+
+        if not ids:
+            ids = self.ids
+
+        out_list = []
+
+        for match in matches:
+            cls = get_match(match, ids['class'])
+            function = get_match(match, ids['function'])
+            signature = format_txt(get_match(match, ids['signature']))
+            indent = len(get_match(match, ids['indent']))
+            return_type = get_match(match, ids['return_type'])
+            docstring = remove_indent(get_match(match, ids['docstring']),
+                                      indent)
+            if self.dtype == 'function' or self.dtype == 'method': 
+                source = textwrap.dedent(self.function_keyword + function +
+                                         signature + ':' + return_type + '\n'
+                                         +
+                                         get_match(match, ids['body'])) 
+            else: 
+                source = ''
+
+            out = {}
+            out['class'] = cls
+            out['function'] = function
+            out['signature'] = signature
+            out['docstring'] = docstring
+            out['return_type'] = return_type
+            out['source'] = source
+            out['type'] = self.dtype
+            out['label'] = self.query
+            out_list.append(out)
+
+        if len(out_list) == 1:
+            return out_list[0]
+        else:
+            return out_list
+
+class PyExtract(Extract):
+    """
+    Base class for extracting docstrings from python source code.
+    """
+
+    def extract_function(self):
+        pattern = (r'^\s*(%s)(\([\w\W]*?\))' % self.funcname
+                   + r'\s*(?:->\s*(\w+))?%s\n+' % self.keywords['signature_end']
+                   + r'(\s+)%s([\w\W]*)?%s\n((\4.*\n+)+)?' %
+                   (self.keywords['docstring'], self.keywords['docstring']))
+
+        ids = {'class' : 100, 'function' : 0, 'signature' : 1,
+                'return_type' : 2, 'indent' : 3, 'docstring' : 4, 'body' : 5}
+        return self.findall(pattern, ids)
+
+    def extract_class(self):
+        pattern = (r'^\s*class\s+(%s)()(\(\w*\))?:\n(\s+)"""([\w\W]*?)"""()' %
+                   self.classname)
+        return self.find(pattern)
+
+    def extract_method(self):
+        pattern = (r'class\s+(%s)\(?\w*\)?:[\n\s]+[\w\W]*?' % self.classname +
+                   r'[\n\s]+def\s+(%s)(\(self[\w\W]*?\)):.*\n' % self.funcname +
+                   r'(\s+)"""([\w\W]*?)"""\n((?:\4.*\n+)+)?')
+        return self.find(pattern)
+
+    def extract_module(self):
+        pattern = r'()()()()^"""([\w\W]*?)"""'
+        return self.find(pattern)
+
+class PyBindExtract(PyExtract):
+    """
+    Extract function header, signature, and documentation from PyBind-generated
+    docstrings.
+    """
+
+    def __init__(self, query):
+        PyExtract.__init__(self, query)
+        self.function_keyword = ""
+        self.docstring_symbol = ""
+        self.keywords = {'function' : '', 
+                         'docstring' : '', 
+                         'self' : 'self',
+                         'signature_end' : '', 
+                         'token_split' : '^\s*\d+\.'}
+        self.split = 1
+
+    def extract_function(self):
+        pattern = (r'^\s*(%s)(\([\w\W]*?\))' %
+                  (self.funcname)
+                   + r'\s*(?:->\s*(\w+))%s\n+' % self.keywords['signature_end']
+                   + r'(\s*)%s([\w\W]*)?%s((\4.*\n+)+)?' %
+                   (self.keywords['docstring'], self.keywords['docstring']))
+        ids = {'class' : 100, 'function' : 0, 'signature' : 1,
+                'return_type' : 2, 'indent' : 3, 'docstring' : 4, 'body' : 5}
+        return self.findall(pattern, ids)
+
+    def extract_method(self):
+        out = self.extract_function()
+        pattern = r'self:.*(%s)\s*,+' % (self.classname)
+        match = re.compile(pattern, re.M).findall(out['signature'])
+        if not match:
+            raise NameError('Class name in query string does not match class ' \
+                            'name in docstring.') 
+        out['class'] = self.classname
+        return out
+
+
+    def extract_class(self):
+        pattern = (r'^\s*class\s+(%s)' % self.classname +
+                   r'(\(\w+\))?\n+' + 
+                   r'(\s+)([\w\W]+)*')
+        ids = {'class' : 0, 'function' : 100, 'signature' : 1,
+                'return_type' : 100,
+                'indent' : 2, 'docstring' : 3, 'body' : 4}
+        return self.find(pattern, ids)
+
+    def extract_overloaded_function(self):
+        pattern = r'\s*Overloaded function.\n+\s*((\d+\.)[\w\W]+)'
+        matches = self.get_matches(pattern)
+        functions = matches[0][0]
+        lines = self.txt.split('\n')
+        pattern = r'\s*\d+\.\s+(%s\(.*\)\s*(?:->\s+\w+))'%(self.funcname)
+        search = re.compile(pattern, re.M)
+        first = 0
+        function = []
+        begin = 1
+
+        functions = []
+        # Look for function header: 1. function_name(..) -> ..
+        # capture text following it, and then parse each one individually
+        for line in lines:
+            matches = search.findall(line)
+
+            if matches:
+                function_header = matches[0]
+                # Done parsing function
+                if not begin:
+                    self.txt = '\n'.join(function)
+                    functions.append(self.extract_function())
+                # Start parsing next function
+                function = []
+                function.append(function_header)
+                if begin:
+                    begin = 0
+            elif not begin:
+                function.append(line)
+
+        self.txt = '\n'.join(function)
+        functions.append(self.extract_function())
+        return functions
+    
+def extract(filestr, query):
+    """
+    Extracts a docstring from source.
+
+    Arguments:
+        filestr: A string that specifies filename of the source code to extract
+            from.
+        query: A string that specifies what type of docstring to extract.
+
+    """
+    import os
+
+    filename = os.path.splitext(filestr)
+    ext = filename[1]
+
+    options = {'.py' : PyExtract}
+
+    if ext in options:
+        extractor = options[ext](open(filestr).read())
+
+    return extractor.extract(query)
+
+def get_names(query):
+    """
+    Extracts the function and class name from a query string.
+    The query string is in the format `Class.function`.
+    Functions starts with a lower case letter and classes starts
+    with an upper case letter.
+
+    Arguments:
+        query: The string to process.
+
+    Returns:
+        tuple: A tuple containing the class name, function name,
+               and type. The class name or function name can be empty.
+
+    """
+    funcname = ''
+    classname = ''
+    dtype = ''
+
+    members = query.split('.')
+    if len(members) == 1:
+        # If no class, or function is specified, then it is a module docstring
+        if members[0] == '':
+            dtype = 'module'
+        # Identify class by checking if first letter is upper case
+        elif members[0][0].isupper():
+            classname = query
+            dtype = 'class'
+        else:
+            funcname = query
+            dtype = 'function'
+    elif len(members) == 2:
+        # Parse method
+        classname = members[0]
+        funcname = members[1]
+        dtype = 'method'
+    else:
+        raise ValueError('Unable to parse: `%s`' % query)
+
+    return (classname, funcname, dtype)
+
+def remove_indent(txt, indent):
+    """
+    Dedents a string by a certain amount.
+    """
+    lines = txt.split('\n')
+    if lines[0] != '\n':
+        header = '\n' + lines[0]
+    else:
+        header = ''
+    return '\n'.join([header] + [line[indent:] for line in lines[1:]])
+
+def get_match(match, index, default=''):
+    """
+    Returns a value from match list for a given index. In the list is out of
+    bounds `default` is returned.
+
+    """
+    if index >= len(match):
+        return default
+    else:
+        return match[index]
+
+def format_txt(signature):
+    """
+    Remove excess spaces and newline characters.
+    """
+    return ' '.join(' '.join(signature.split('\n')).split())

--- a/Docs/format.py
+++ b/Docs/format.py
@@ -1,0 +1,100 @@
+import pytablewriter
+import parse as pa
+import extract as ext
+import re
+import inspect
+import io
+
+
+def format_class(cl):
+    f = io.StringIO("")
+    docs = cl.__doc__
+
+    # skip undocumented classes
+    if(docs == None):
+        return f.getvalue()
+
+    # # remove excess spaces
+    docs = " ".join(docs.split())
+
+    # General hig-level class docs
+    f.write('# ' + cl.__name__ + '\n')
+    f.write(docs + '\n')
+
+    # Docs for __init__
+    docs = (cl.__init__).__doc__
+    clex = ext.PyBindExtract(docs)
+
+    match = clex.extract("__init__")
+
+    if(isinstance(match, list)):
+        for ima, ma in enumerate(match):
+            f.write(format_function(ma, 'Constructor [' + str(ima + 1) + ']'))
+    else:
+        f.write(format_function(match, 'Constructor'))
+
+    # properties
+    properties = inspect.getmembers(cl, lambda o: isinstance(o, property))
+    f.write(format_properties(properties))
+    return f.getvalue()
+
+
+def format_function(ma, name):
+    f = io.StringIO("")
+    f.write('## ' + name)
+    value_matrix = []
+    signature = ma["signature"]
+
+    sigp = pa.parse_signature(signature)
+    gds = pa.GoogleDocString(ma["docstring"], args=sigp).parse()
+
+    has_example = False
+    for gd in gds:
+        if(gd['header'] == 'Args'):
+
+            for arg in gd['args']:
+                field = arg['field']
+                sig = arg['signature']
+                # # remove excess spaces
+                descr = " ".join(arg['description'].split())
+
+                value_matrix.append([field, sig, descr])
+        elif(gd['header'].startswith("Example")):
+            examples = (gd['text'])
+            has_example = True
+        else:
+            f.write(gd['text'] + '\n')
+
+    writer = pytablewriter.MarkdownTableWriter()
+    writer.header_list = ["Field", "Type", "Description"]
+    writer.value_matrix = value_matrix
+    writer.stream = f
+    writer.write_table()
+    if(has_example):
+        f.write('### Examples' + '\n')
+        f.write(examples + '\n')
+    return f.getvalue()
+
+
+def format_properties(properties):
+    writer = pytablewriter.MarkdownTableWriter()
+    value_matrix = []
+
+    for prop in properties:
+        docs = prop[1].__doc__
+        semic = docs.find(":")
+        type_name = ''
+        if(semic != -1):
+            type_name = docs[: semic]
+            docs = docs[semic + 1:]
+
+        value_matrix.append([prop[0], type_name, docs])
+
+    f = io.StringIO("")
+    writer.header_list = ["Property", "Type", "Description"]
+    writer.value_matrix = value_matrix
+    writer.stream = f
+
+    f.write('## Properties' + '\n')
+    writer.write_table()
+    return f.getvalue()

--- a/Docs/make_class_docs.py
+++ b/Docs/make_class_docs.py
@@ -1,0 +1,14 @@
+import netket
+import format
+import inspect
+import sys
+
+if(len(sys.argv) != 2):
+    print("Insert class name,for example: ")
+    print("python3 make_class_docs.py netket.graph.Hypercube")
+    exit()
+
+assert("netket" in sys.argv[1])
+class_name = eval(sys.argv[1])
+markdown = format.format_class(class_name)
+print(markdown)

--- a/Docs/parse.py
+++ b/Docs/parse.py
@@ -1,0 +1,633 @@
+"""
+MIT License
+
+Copyright (c) 2018 Ossian O'Reilly
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+"""
+This module provides parsers for parsing different docstring formats.  The
+parsers work on docstring data objects that are constructed using the `extract`
+module. After parsing, the data of docstring is stored in a dictionary. This
+data can for instance be serialized using JSON, or rendered to markdown.
+"""
+import re
+import warnings
+
+class DocString(object):
+    """
+    This is the base class for parsing docstrings.
+
+    Default behavior of the parser can be modified by passing a dict called
+    `config` during initialization. This dict does only have to contain the
+    key-value pairs for the configuration settings to change. Possible options
+    are listed and explained below.
+
+    Attributes:
+        delimiter: A string that is used to identify a section and is placed
+            after the section name (e.g., `Arguments:`). Defaults to `': '`.
+        arg_delimiter: A string that specifies how to separate arguments in a
+            argument list. Defaults to `':'`.
+        indent: An int that specifies the minimum number of spaces to use for
+            indentation. Defaults to `4`.
+        code: Convert code blocks to Markdown. Defaults to `'python'`. Use
+            `None` to disable. Use `''` (empty string) to convert code blocks to
+            markdown, but disable syntax highlighting.
+        ignore_args_for_undefined_headers: A flag that if set to `True` treats
+            argument lists as text if the header is unknown, or does not exist. 
+        check_args: A flag that if set to `True` checks if all arguments are
+            documented in a docstring, and if their types are correct. For this
+            option to work, the optional input `args` must be passed upon
+            initialization.
+        override_annotations: A flag that if set to `True` sets the argument
+            annotation field in a docstring (optional) to the value specified by
+            the optional input `args`. 
+        warn_if_no_arg_doc: Issue a warning if an argument does not have any
+            documentation. For this option to work, `args` must be passed.
+            Defaults to `True`.
+        exclude_warn_if_no_arg_doc: Do no issue warnings for args missing
+            documentation if they are part of this list. Defaults to `['self']`.
+
+    """
+
+    def __init__(self, docstring, args=None, returns=None, config=None):
+        """
+
+        Initialize a new parser.
+
+        Args:
+            args(dict, optional): A dict containing arguments and types. See
+                the function `parse_signature' to construct this dict from a
+                PEP484 annotated signature. When this argument is specified, the
+                parser will assign types to arguments using this dict instead of
+                obtaining them from the docstrings.
+            returns(string, optional) : Optional return type. When this argument
+                is specified, the parser will assign the return type using this
+                string instead of obtaining it from the docstring.
+            config(dict, optional): A dict containing optional configuration
+                settings that modify default behavior.
+
+        """
+        self.header = {}
+        self.docstring = docstring
+        self.data = []
+        self.args = args
+        self.returns = returns
+
+        default_config = {}
+        default_config['delimiter'] = ':'
+        default_config['arg_delimiter'] = ': '
+        default_config['indent'] = 4
+        default_config['check_args'] = True
+        default_config['override_annotations'] = True
+        default_config['warn_if_no_arg_doc'] = True
+        default_config['exclude_warn_if_no_arg_doc'] = ['self']
+        default_config['code'] = 'python'
+        default_config['warn_if_undefined_header'] = True
+        default_config['ignore_args_for_undefined_headers'] = True
+
+        default_config['headers'] = ''
+        default_config['extra_headers'] = ''
+        default_config['args'] = ''
+        default_config['returns'] = ''
+
+        self._config = get_config(default_config, config)
+
+        # Internals for parsing
+        # _section : This variable will hold the contents of each unparsed section
+        # _sections : A list that will hold all unparsed sections.
+        # _linenum : line number relative to the current section being
+        # parsed.
+        # _re .. : Regex functions.
+        # _indent : This variable will hold the current indentation (number of spaces).
+
+        self._parsing = {'indent' : 0, 'linenum' : 0, 'sections' : [],
+                         'section' : []}
+        self._re = {}
+
+    def parse(self, mark_code_blocks=False):
+        """
+        This method should be overloaded and perform the parsing of all
+        sections.
+
+        Args:
+            mark_code_blocks: Format code blocks using markdown. Defaults to
+                `False`.
+        """
+        self.data = []
+        self.extract_sections()
+        for section in self._parsing['sections']:
+            self.data.append(self.parse_section(section))
+
+        for i, di in enumerate(self.data):
+            self.check_args(di)
+            self.override_annotations(self.data[i],
+                                      self.args,
+                                      self._config['args'].split('|'))
+            self.override_annotations(self.data[i], 
+                                      {'' : self.returns},
+                                      self._config['returns'].split('|'))
+            if mark_code_blocks:
+                self.mark_code_blocks(self.data[i])
+            
+        return self.data
+
+    def extract_sections(self):
+        """
+        This method should be overloaded to specify how to extract sections.
+        """
+        pass
+
+    def parse_section(self, section):
+        """
+        This method should be overloaded to specify how to parse a section.
+        """
+        pass
+
+    def __json__(self):
+        """
+        Output docstring as JSON data.
+        """
+        import json
+
+        data = self.data
+        data.append(self.header)
+        return json.dumps(self.data, sort_keys=True,
+                          indent=4, separators=(',', ': '))
+
+    def __str__(self):
+        """
+        This method should be overloaded to specify how to output to plain-text.
+        """
+        return self.docstring
+
+    def markdown(self):
+        """
+        Output data relevant data needed for markdown rendering.
+
+        Args:
+            filename (str, optional) : select template to use for markdown
+                rendering.
+        """
+        data = self.data
+        headers = self._config['headers'].split('|')
+        return headers, data
+
+    def check_args(self, section):
+        """
+        Check if all args have been documented in the docstring and if, they
+        have annotations, annotations matches the ones in the function
+        signature. This method only works when `args` have been specified. 
+
+        """
+        if not self.args or not self._config['check_args']:
+            return
+
+        docstring_args = {}
+
+        if section['header'] in self._config['args'].split('|'):
+            for arg in section['args']:
+                docstring_args[arg['field']] = arg
+
+            for arg in self.args:
+                # Skip checks if signature does not contain any annotations
+                # or if the argument should not have documentation.
+                if not self.args[arg] or                                       \
+                   arg in self._config['exclude_warn_if_no_arg_doc']:
+                    continue
+                if arg not in docstring_args and                               \
+                        self._config['warn_if_no_arg_doc']: 
+                    warnings.warn('Missing documentation for `%s` in docstring.'
+                            % arg, UserWarning)   
+                elif docstring_args[arg]['signature'] != self.args[arg] and    \
+                     docstring_args[arg]['signature'] != '':
+                    warnings.warn('Annotation mismatch for `%s` in docstring.' %
+                            arg, UserWarning)   
+            for arg in docstring_args:
+                if arg not in self.args:
+                    warnings.warn(' Found argument `%s` in docstring that does'\
+                    ' not exist in function signature.' % arg, UserWarning)   
+
+    def override_annotations(self, section, parsed_args, headers):
+        """
+
+        Override argument annotations in docstrings with annotations found in
+        `args`. 
+
+        """
+        if not parsed_args or not self._config['override_annotations']:
+            return
+
+        if not section['header'] in headers:
+            return
+
+        args = section['args']
+        section['args'] = []
+        for arg in args:
+            out = arg
+            if arg['field'] in parsed_args and parsed_args[arg['field']]:
+                out['signature'] = parsed_args[arg['field']]
+            section['args'].append(out)
+
+    def mark_code_blocks(self, section):
+        """
+
+        Enclose code blocks in formatting tags if option `config['code']` is
+        not None.
+
+        """
+        if not self._config['code']: 
+            return
+
+        section['text'] = mark_code_blocks(section['text'], 
+                                           lang=self._config['code'])
+
+class GoogleDocString(DocString):
+    """
+    This is the base class for parsing docstrings that are formatted according
+    to the Google style guide.
+
+    Google docstrings are treated as sections that begin with a header (say,
+    Args) and are then followed by either an argument list or some text.
+
+    The headers are identified based on a keyword search. 
+
+    In addition to the configuration settings provided by the baseclass, the
+    GoogleDocString class introduces some additional configurable parameters,
+    listed and explained below.
+
+    Attributes:
+        headers: A string of header keywords, each separated by `|`. 
+        extra_headers: Modify this argument to include additional header
+            keywords.
+        args: A string that specifies the name of the `Args` section. This value
+            is used to assign types to the argument list by passing the argument
+            `args` upon initialization (see baseclass for further details).
+        returns: A string that specifies the name of the `Returns` section. The
+            use of this argument is the same as for `args`.
+        
+
+    """
+
+    def __init__(self, docstring, args=None, returns=None, config=None):
+        import os
+
+        default_config = {}
+        default_config['headers'] = \
+         ('Args|Arguments|Returns|Yields|Raises|Note|' +
+          'Notes|Example|Examples|Attributes|Todo')
+        default_config['extra_headers'] = ''
+        default_config['args'] = 'Args|Arguments'
+        default_config['returns'] = 'Returns|'
+
+        config = get_config(default_config, config, warn=0)
+
+        if config['extra_headers']:
+            config['headers'] += '|' + config['extra_headers']
+
+        super(GoogleDocString, self).__init__(docstring, args, returns, config)
+
+        self._re = {'header' : self._compile_header(),
+                    'indent' : self._compile_indent(),
+                    'arg' : self._compile_arg()}
+
+
+    def parse_section(self, section):
+        """
+        Parses blocks in a section by searching for an argument list, and
+        regular notes. The argument list must be the first block in the section.
+        A section is broken up into multiple blocks by having empty lines.
+
+        Returns:
+            A dictionary that contains the key `args` for holding the argument
+            list (`None`) if not found and the key `text` for holding regular
+            notes.
+
+        Example:
+            ```
+            Section:
+                This is block 1 and may or not contain an argument list (see
+                `args` for details).
+
+                This is block 2 and any should not contain any argument list.
+            ```
+
+        """
+
+        # Get header
+        lines = section.split('\n')
+        header = self._compile_header().findall(lines[0])
+
+
+        # Skip the first line if it is a header
+        header = self._get_header(lines[0])
+        self._parsing['linenum'] = int(bool(header))
+        text = []
+
+        args = []
+        while self._parsing['linenum'] < len(lines):
+
+            arg_data = self._parse_arglist(lines)
+            if not header and arg_data and                                    \
+            self._config['warn_if_undefined_header']:
+                warnings.warn("Undefined header: '%s'" %header                 \
+                              + ' followed by an argument list.')
+            if (arg_data and header) or                                        \
+               (arg_data and not header and not                                \
+               self._config['ignore_args_for_undefined_headers']):
+                args.append(arg_data)
+            else:
+                text.append(lines[self._parsing['linenum']])
+            self._parsing['linenum'] += 1
+
+        out = {}
+        out['header'] = header
+        out['text'] = '\n'.join(text)
+        out['args'] = args
+        return out
+
+    def extract_sections(self):
+        """
+        Extracts sections from the docstring. Sections are identified by an
+        additional header which is a recognized Keyword such as `Args` or
+        `Returns`. All text within  a section is indented and the section ends
+        after the indention.
+        """
+
+        lines = self.docstring.split('\n')
+        new_section = True
+
+        for linenumber, line in enumerate(lines):
+            # Compute amount of indentation
+            current_indent = self._get_indent(line)
+
+            # Capture indent to be able to remove it from the text and also
+            # to determine when a section ends.
+            # The indent is reset when a new section begins.
+            if new_section and self._is_indent(line):
+                self._parsing['indent'] = current_indent
+                new_section = False
+
+            if self._is_header(line):
+                self._err_if_missing_indent(lines, linenumber)
+                self._end_section()
+                self._begin_section()
+                new_section = True
+            # Section ends because of a change in indent that is not caused
+            # by a line break
+            elif line  and current_indent < self._parsing['indent']:
+                self._end_section()
+                self._begin_section()
+
+            self._parsing['section'].append(line[self._parsing['indent']:])
+
+        self._end_section()
+        self._begin_section()
+
+    def _parse_arglist(self, lines, require=False):
+        arg_data = self._get_arg(lines[self._parsing['linenum']])
+
+        if not arg_data:
+            if require:
+                raise ValueError('Failed to parse argument list:\n `%s` ' %
+                                 (self._parsing['section']))
+            return None
+
+        # Take into account that the description can be multi-line
+        # the next line has to be indented
+        description = [arg_data[0][2]]
+        next_line = _get_next_line(lines, self._parsing['linenum'])
+        while self._is_indent(next_line):
+            self._parsing['linenum'] += 1
+            description.append(lines[self._parsing['linenum']])
+            next_line = _get_next_line(lines, self._parsing['linenum'])
+
+        return {'field' : arg_data[0][0],
+                'signature' : arg_data[0][1],
+                'description' : '\n'.join(description)}
+
+    def _compile_header(self):
+        return re.compile(r'^\s*(%s)%s\s*'%(self._config['headers'],
+                                            self._config['delimiter']))
+
+    def _compile_indent(self):
+        return re.compile(r'(^\s{%s,})'%self._config['indent'])
+
+    def _compile_arg(self):
+        return re.compile(r'(\w*)\s*(\(.*\))?\s*%s(.*)' %
+                          self._config['arg_delimiter'])
+
+
+    def _err_if_missing_indent(self, lines, linenumber):
+        next_line = _get_next_line(lines, linenumber)
+        is_next_indent = self._is_indent(next_line)
+        if not is_next_indent:
+            raise SyntaxError("Missing indent after `%s`" %
+                              next_line)
+
+    def _begin_section(self):
+        self._parsing['section'] = []
+        self._parsing['indent'] = 0
+
+    def _end_section(self):
+        section_text = '\n'.join(self._parsing['section'])
+        if section_text.strip():
+            self._parsing['sections'].append(section_text)
+
+    def _get_indent(self, line):
+        """
+        Returns the indentation size.
+        """
+        indent_size = self._re['indent'].findall(line)
+        if indent_size:
+            return len(indent_size[0])
+        else:
+            return 0
+
+    def _is_indent(self, line):
+        """
+        Returns if the line is indented or not.
+        """
+        indent = self._get_indent(line)
+        return bool(indent > 0)
+
+    def _is_header(self, line):
+        return bool(self._re['header'].findall(line))
+
+    def _get_header(self, line):
+        header = self._re['header'].findall(line)
+        if header:
+            return header[0]
+        else:
+            return ''
+    def _get_arg(self, line):
+        return self._re['arg'].findall(line)
+
+    def _is_arg(self, line):
+        return bool(self._re['arg'].findall(line))
+
+def _get_next_line(lines, linenumber):
+    """
+    Returns the next line but skips over any empty lines.
+    An empty line is returned if read past the last line.
+    """
+    inc = linenumber + 1
+    num_lines = len(lines)
+    while True:
+        if inc == num_lines:
+            return ''
+        if lines[inc]:
+            return lines[inc]
+        inc += 1
+
+def parser(obj, choice='Google', args=None, returns=None, config=None):
+    """
+    Returns a new docstring parser based on selection. Currently, only the
+    Google docstring syntax is supported.
+
+    Args:
+        obj : A dictionary that contains the docstring and other properties.
+            This object is typically obtained by calling the `extract` function.
+        choice: Keyword that determines the parser to use. Defaults to
+            `'Google'`.
+
+
+    Returns:
+        A parser for the selected docstring syntax.
+
+    Raises:
+        NotImplementedError : This exception is raised when no parser is found.
+
+    """
+    parsers = {'Google' : GoogleDocString}
+
+    if choice in parsers:
+        return parsers[choice](obj, args, returns, config)
+    else:
+        NotImplementedError('The docstring parser `%s` is not implemented' %
+                            choice)
+
+def summary(txt):
+    """
+    Returns the first line of a string.
+    """
+    lines = txt.split('\n')
+    return lines[0]
+
+def parse_signature(args):
+        """
+        Parse the signature e.g., `(int: a, int: b)` and put into a dict 
+        {'a' : 'int', 'b' : 'int'}
+        """
+        # Remove () 
+        substr = args[1:-1]
+        substr = substr.split(',')
+        args_out = {}
+        for si in substr:
+            # PEP 484 strings separate name and type by : 
+            try:
+                name, type_ = si.split(':')
+            # No PEP484 string (':' does not exist)
+            except:
+                name = si
+                type_ = ''
+                if '=' in name:
+                    name, _ = name.split('=')
+            name = name.strip()
+            args_out[name] = type_.strip()
+        return args_out
+
+def get_config(default, config=None, warn=1):
+    """
+    Return a dictionary containing default configuration settings and any
+    settings that the user has specified. The user settings will override the
+    default settings.
+
+    Args:
+        default(dict) : A dictionary of default configuration settings.
+        config(dict) : A dictionary of user-specified configuration settings. 
+        warn: Issue a warning if `config` contains an unknown key (not found in
+            `default`).
+
+    Returns:
+        dict : User-specified configuration supplemented with default settings
+            for field the user has not specified.
+
+    """
+
+    config_out = {}
+    # Set defaults
+    for key in default:
+        config_out[key] = default[key]
+
+    if not config:
+        return config_out
+
+    for key in config:
+        if key not in default and warn:
+            warnings.warn('Unknown option: %s in `config`' % key)
+            #assert 0
+
+    # Override defaults
+    for key in config:
+        config_out[key] = config[key]
+
+    return config_out
+
+def mark_code_blocks(txt, keyword='>>>', split='\n', tag="```", lang='python'):
+    """
+
+    Enclose code blocks in formatting tags. Default settings are consistent with
+    markdown-styled code blocks for Python code.
+
+    Args:
+        txt: String to search for code blocks.
+        keyword(optional, string): String that a code block must start with.
+        split(optional, string): String that a code block must end with.
+        tag(optional, string): String to enclose code block with.
+        lang(optional, string) : String that determines what programming
+            language is used in all code blocks. Set this to '' to disable
+            syntax highlighting in markdown.
+
+    Returns:
+        string: A copy of the input with code formatting tags inserted (if any
+        code blocks were found).
+
+    """
+    import re
+
+    blocks = re.split('^%s'%split, txt, flags=re.M)
+    out_blocks = []
+
+    for block in blocks:
+        lines = block.split(keyword)
+        match = re.findall('(\s*)(%s[\w\W]+)'%keyword, keyword.join(lines[1:]), 
+                           re.M)
+        if match:
+            before_code = lines[0]
+            indent = match[0][0]
+            indented_tag = '%s%s' % (indent, tag)
+            code = '%s%s'% (indent, match[0][1])
+            out_blocks.append('%s%s%s\n%s%s'%(before_code,
+                                              indented_tag, lang, code, 
+                                              indented_tag))
+        else:
+            out_blocks.append(block)
+    return split.join(out_blocks)
+

--- a/NetKet/Graph/pygraph.hpp
+++ b/NetKet/Graph/pygraph.hpp
@@ -229,7 +229,7 @@ void AddGraphModule(py::module& m) {
            Examples:
                A 10x10 square lattice with periodic boundary conditions can be
                constructed as follows:
-               
+
                ```python
                >>> from netket.graph import Hypercube
                >>> g=Hypercube(length=10,n_dim=2,pbc=True)
@@ -257,7 +257,9 @@ void AddGraphModule(py::module& m) {
                    Colors must be assigned to **all** edges.
            )EOF");
 
-  py::class_<CustomGraph, AbstractGraph>(subm, "CustomGraph")
+  py::class_<CustomGraph, AbstractGraph>(subm, "CustomGraph", R"EOF(
+      In addition to built-in graphs, NetKet provides the freedom to define
+      custom graphs, specifying a list of edges.)EOF")
       .def(py::init([](py::iterable xs,
                        std::vector<std::vector<int>> automorphisms,
                        bool const is_bipartite) {
@@ -286,7 +288,19 @@ void AddGraphModule(py::module& m) {
                    Notice that this is not deduced from the edge
                    list and it is left to the user to specify
                    whether the graph is bipartite or not.
-            )EOF");
+
+           Examples:
+               A 10-site one-dimensional lattice with periodic boundary conditions can be
+               constructed specifying the edges as follows:
+
+               ```python
+               >>> from netket.graph import CustomGraph
+               >>> g=CustomGraph([[i, (i + 1) % 10] for i in range(10)])
+               >>> print(g.n_sites)
+               10
+
+               ```
+           )EOF");
 }
 
 }  // namespace netket

--- a/NetKet/Graph/pygraph.hpp
+++ b/NetKet/Graph/pygraph.hpp
@@ -179,8 +179,7 @@ void AddGraphModule(py::module& m) {
   py::class_<AbstractGraph>(subm, "Graph")
       .def_property_readonly("n_sites", &AbstractGraph::Nsites,
                              R"EOF(
-              Returns the number of vertices in the graph.
-           )EOF")
+      int: The number of vertices in the graph.)EOF")
       .def_property_readonly(
           "edges",
           [](AbstractGraph const& x) {
@@ -189,61 +188,73 @@ void AddGraphModule(py::module& m) {
             return vector_type{x.Edges()};
           },
           R"EOF(
-               Returns the graph edges.
-           )EOF")
+      list: The graph edges.)EOF")
       .def_property_readonly("adjacency_list", &AbstractGraph::AdjacencyList,
                              R"EOF(
-               Returns the adjacency list of the graph where each node is
-               represented by an integer in ``[0, n_sites)``
-           )EOF")
+      list: The adjacency list of the graph where each node is
+          represented by an integer in `[0, n_sites)`)EOF")
       .def_property_readonly("is_bipartite", &AbstractGraph::IsBipartite,
                              R"EOF(
-               Whether the graph is bipartite.
-           )EOF")
+      bool: Whether the graph is bipartite.)EOF")
       .def_property_readonly("is_connected", &AbstractGraph::IsConnected,
                              R"EOF(
-               Whether the graph is connected.
-           )EOF")
+      bool: Whether the graph is connected.)EOF")
       .def_property_readonly("distances", &AbstractGraph::AllDistances,
                              R"EOF(
-               Returns distances between the nodes. The fact that some node
-               may not be reachable from another is represented by -1.
-           )EOF")
-      .def_property_readonly("symmetry_table", &AbstractGraph::SymmetryTable);
+      list[list]: The distances between the nodes. The fact that some node
+          may not be reachable from another is represented by -1.)EOF")
+      .def_property_readonly("automorphisms", &AbstractGraph::SymmetryTable,
+                             R"EOF(
+      list[list]: The automorphisms of the graph,
+          including translation symmetries only.)EOF");
 
-  py::class_<Hypercube, AbstractGraph>(subm, "Hypercube")
+  py::class_<Hypercube, AbstractGraph>(
+      subm, "Hypercube",
+      R"EOF(A hypercube lattice of side L in d dimensions.
+        Periodic boundary conditions can also be imposed.)EOF")
       .def(py::init<int, int, bool>(), py::arg("length"), py::arg("n_dim") = 1,
-           py::arg("pbc") = true,
-           R"EOF(
-               Constructs a new ``Hypercube`` given its side length and dimension.
+           py::arg("pbc") = true, R"EOF(
+           Constructs a new ``Hypercube`` given its side length and dimension.
 
-               :param length:
-                   side length of the hypercube. It must be always be >=1,
-                   but if ``pbc==True`` then the minimal valid length is 3.
-               :param n_dim:
-                   dimension of the hypercube. It must be at least 1.
-               :param pbc:
-                   if ``True`` then the constructed hypercube will have periodic
-                   boundary conditions, otherwise open boundary conditions are
-                   emposed.
+           Args:
+               length: Side length of the hypercube.
+                   It must always be >=1,
+                   but if ``pbc==True`` then the minimal
+                   valid length is 3.
+               n_dim: Dimension of the hypercube. It must be at least 1.
+               pbc: If ``True`` then the constructed hypercube
+                   will have periodic boundary conditions, otherwise
+                   open boundary conditions are imposed.
+
+           Examples:
+               A 10x10 square lattice with periodic boundary conditions can be
+               constructed as follows:
+               
+               ```python
+               >>> from netket.graph import Hypercube
+               >>> g=Hypercube(length=10,n_dim=2,pbc=True)
+               >>> print(g.n_sites)
+               100
+
+               ```
            )EOF")
       .def(py::init([](int length, py::iterable xs) {
              auto iterator = xs.attr("__iter__")();
              return Hypercube{length, detail::Iterable2ColorMap(iterator)};
            }),
-           py::arg("length"), py::arg("colors"),
-           R"EOF(
-               Constructs a new `Hypercube` given its side length and edge coloring.
+           py::arg("length"), py::arg("colors"), R"EOF(
+           Constructs a new `Hypercube` given its side length and edge coloring.
 
-               ``colors`` must be an iterable of ``Tuple[int, int, int]`` where each
-               element ``(i, j, c)`` represents an edge ``i <-> j`` of color ``c``.
-               Colors must be assigned to __all__ edges.
-
-               :param length:
-                   side length of the hypercube. It must be always be >=3 if the
-                   hypercube has periodic boundary conditions and >=1 otherwise.
-               :param colors:
-                   edge colors.
+           Args:
+               length: Side length of the hypercube.
+                   It must always be >=3 if the
+                   hypercube has periodic boundary conditions
+                   and >=1 otherwise.
+               colors: Edge colors, must be an iterable of
+                   `Tuple[int, int, int]` where each
+                   element `(i, j, c) represents an
+                   edge `i <-> j` of color `c`.
+                   Colors must be assigned to **all** edges.
            )EOF");
 
   py::class_<CustomGraph, AbstractGraph>(subm, "CustomGraph")
@@ -257,20 +268,25 @@ void AddGraphModule(py::module& m) {
            }),
            py::arg("edges"),
            py::arg("automorphisms") = std::vector<std::vector<int>>(),
-           py::arg("is_bipartite") = false,
-           R"EOF(
-               Constructs a new graph given a list of edges.
+           py::arg("is_bipartite") = false, R"EOF(
+           Constructs a new graph given a list of edges.
 
-                   * If `edges` has elements of type `Tuple[int, int]` it is treated
-                     as a list of edges. Then each element `(i, j)` means a connection
-                     between sites `i` and `j`. It is assumed that `0 <= i <= j`. Also,
-                     `edges` should contain no duplicates.
-
-                   * If `edges` has elements of type `Tuple[int, int, int]` each
-                     element `(i, j, c)` represents an edge between sites `i` and `j`
-                     colored into `c`. It is again assumed that `0 <= i <= j` and that
-                     there are no duplicate elements in `edges`.
-          )EOF");
+           Args:
+               edges: If `edges` has elements of type `Tuple[int, int]` it is treated
+                   as a list of edges. Then each element `(i, j)` means a connection
+                   between sites `i` and `j`. It is assumed that `0 <= i <= j`. Also,
+                   `edges` should contain no duplicates. If `edges` has elements of
+                   type `Tuple[int, int, int]` each element `(i, j, c)` represents an
+                   edge between sites `i` and `j` colored into `c`. It is again assumed
+                   that `0 <= i <= j` and that there are no duplicate elements in `edges`.
+               automorphisms: The automorphisms of the graph, i.e. a List[List[int]]
+                   where the inner List[int] is a unique permutation of the
+                   graph sites.
+               is_bipartite: Wheter the custom graph is bipartite.
+                   Notice that this is not deduced from the edge
+                   list and it is left to the user to specify
+                   whether the graph is bipartite or not.
+            )EOF");
 }
 
 }  // namespace netket

--- a/NetKet/Graph/pygraph.hpp
+++ b/NetKet/Graph/pygraph.hpp
@@ -208,10 +208,9 @@ void AddGraphModule(py::module& m) {
       list[list]: The automorphisms of the graph,
           including translation symmetries only.)EOF");
 
-  py::class_<Hypercube, AbstractGraph>(
-      subm, "Hypercube",
-      R"EOF(A hypercube lattice of side L in d dimensions.
-        Periodic boundary conditions can also be imposed.)EOF")
+  py::class_<Hypercube, AbstractGraph>(subm, "Hypercube", R"EOF(
+           A hypercube lattice of side L in d dimensions.
+           Periodic boundary conditions can also be imposed.)EOF")
       .def(py::init<int, int, bool>(), py::arg("length"), py::arg("n_dim") = 1,
            py::arg("pbc") = true, R"EOF(
            Constructs a new ``Hypercube`` given its side length and dimension.
@@ -254,12 +253,11 @@ void AddGraphModule(py::module& m) {
                    `Tuple[int, int, int]` where each
                    element `(i, j, c) represents an
                    edge `i <-> j` of color `c`.
-                   Colors must be assigned to **all** edges.
-           )EOF");
+                   Colors must be assigned to **all** edges.)EOF");
 
   py::class_<CustomGraph, AbstractGraph>(subm, "CustomGraph", R"EOF(
-      In addition to built-in graphs, NetKet provides the freedom to define
-      custom graphs, specifying a list of edges.)EOF")
+           In addition to built-in graphs, NetKet provides the freedom to define
+           custom graphs, specifying a list of edges.)EOF")
       .def(py::init([](py::iterable xs,
                        std::vector<std::vector<int>> automorphisms,
                        bool const is_bipartite) {

--- a/Tutorials/PyNetKet/graph.py
+++ b/Tutorials/PyNetKet/graph.py
@@ -27,3 +27,8 @@ g = nk.graph.CustomGraph(Gx.edges)
 print(g.distances)
 print(g.is_bipartite)
 print(g.is_connected)
+
+g = nk.graph.CustomGraph([[i, (i + 1) % 10] for i in range(10)])
+print(g.is_connected)
+print(g.distances)
+print(g.n_sites)


### PR DESCRIPTION
This PR introduces the tools necessary to extract the documentation from pybind-generated python classes. (see also issue #130) 

These tools are heavily based on [this project](https://github.com/ooreilly/mydocstring), and @ooreilly has played an important role in adapting his library to work with pybind11 generated docs. Thank you!

The tools are in `/Docs` and can be used from command line. For example, to generate markdown docs for a given NetKet class, one can do:  

```
python3 make_class_docs.py netket.graph.Hypercube > test.md 
```

Notice that pytablewriter is needed, and can be easily installed with `pip install pytablewriter`. 

At the moment we only have docs for `netket.graph` classes. Generated markdown documentation can be found in `Docs/Graph/`, for example [here](https://github.com/gcarleo/netket/blob/docs/Docs/Graph/Hypercube.md)

TODO: 
1. The tool `format.py` is not taking into account class functions (it only formats the constructors and class members).  Extending it to class-bound functions should be straightforward. 
2. NetKet website will use these markdown files to build the doc [pages here](https://www.netket.org/docs/home/)

**Action item**
We need to add documentation for all the other classes. Please volounteer to provide documentation for a few NetKet classes, so that we can quickly move to the final release! 
The documentation should follow the Google docstring format, as done for example in `NetKet/Graph/pygraph.hpp` 