### PR TITLE
Add consistency check for documentation tools

### DIFF
--- a/Docs/doc_diff.py
+++ b/Docs/doc_diff.py
@@ -1,5 +1,5 @@
 """
-usage: test_docs.py [DocPath1 DocPath2 ...]
+usage: doc_diff.py [DocPath1 DocPath2 ...]
 
 DocPath1, ...   List the directories to perform consistency check of
                 documentation for (optional).
@@ -18,7 +18,7 @@ How to use this test:
 3. Run this test.
 
 Example output:
- python3 test_docs.py Graph
+ python3 doc_diff.py Graph
  Building documentation for: netket.graph.Hypercube
  Mismatch found in: netket.graph.Hypercube
  Report written to: reports/graph/Hypercube.html


### PR DESCRIPTION
This tool generates html reports whenever there is a mismatch found between any new and old documentation.

Interestingly enough, there is an extra newline character introduced in the of the docs. I will investigate if it is coming from #143.