### PR TITLE
WIP: Extract stochastic reconfiguration code from VMC class

### DIFF
--- a/NetKet/GroundState/matrix_replacement.hpp
+++ b/NetKet/GroundState/matrix_replacement.hpp
@@ -64,7 +64,7 @@ class MatrixReplacement : public Eigen::EigenBase<netket::MatrixReplacement> {
                           Eigen::AliasFreeProduct>(*this, x.derived());
   }
   // Custom API:
-  MatrixReplacement() : shift_(0), scale_(1) {}
+  explicit MatrixReplacement() : shift_(0), scale_(1) {}
   void attachMatrix(const Eigen::MatrixXcd &mat) { mp_mat_ = mat; }
   void attachMatrix(const Eigen::MatrixXd &mat) { mp_mat_ = mat; }
   void setShift(double shift) { shift_ = shift; }

--- a/NetKet/GroundState/variational_montecarlo.hpp
+++ b/NetKet/GroundState/variational_montecarlo.hpp
@@ -151,7 +151,9 @@ class VariationalMonteCarlo {
         sampler_(sampler),
         psi_(sampler.GetMachine()),
         opt_(optimizer),
-        elocvar_(0.) {
+        elocvar_(0.),
+        totalnodes_(MpiSize()),
+        mynode_(MpiRank()) {
     Init(nsamples, discarded_samples, discarded_samples_on_init, method,
          diag_shift, rescale_shift, use_iterative, use_cholesky);
   }
@@ -167,9 +169,6 @@ class VariationalMonteCarlo {
     Okmean_.resize(npar_);
 
     setSrParameters();
-
-    MPI_Comm_size(MPI_COMM_WORLD, &totalnodes_);
-    MPI_Comm_rank(MPI_COMM_WORLD, &mynode_);
 
     nsamples_ = nsamples;
 

--- a/NetKet/Stats/obs_manager.hpp
+++ b/NetKet/Stats/obs_manager.hpp
@@ -51,6 +51,12 @@ class ObsManager {
     vector_real_obs_[name] << data;
   }
 
+  void Reset() {
+    for (const auto &name : Names()) {
+      Reset(name);
+    }
+  }
+
   inline void Reset(const std::string &name) {
     if (scalar_real_obs_.count(name) > 0) {
       scalar_real_obs_[name].Reset();

--- a/NetKet/Utils/mpi_interface.hpp
+++ b/NetKet/Utils/mpi_interface.hpp
@@ -24,6 +24,18 @@
 
 namespace netket {
 
+int MpiRank(MPI_Comm comm = MPI_COMM_WORLD) {
+  int rank;
+  MPI_Comm_rank(comm, &rank);
+  return rank;
+}
+
+int MpiSize(MPI_Comm comm = MPI_COMM_WORLD) {
+  int size;
+  MPI_Comm_size(comm, &size);
+  return size;
+}
+
 inline void SendToAll(double &val, int sendnode = 0,
                       const MPI_Comm comm = MPI_COMM_WORLD) {
   MPI_Bcast(&val, 1, MPI_DOUBLE, sendnode, comm);


### PR DESCRIPTION
The main commit in this PR extracts the SR code from `VariationalMonteCarlo` to a separate class. 
So far, the interface of the VMC class is left unchanged. However, this could be a good point to discuss whether it should stay this way for v2.0.

Currently, the method to update the variational parameters is configurable in two ways:
1. First, the method to compute the parameter update `dp`. Can be either `Gd` or `Sr` and is set via several VMC constructor parameters. The actual computation steps happen in the `Gradient` and `UpdateParameters` methods of `VariationalMonteCarlo`.
1. Second, the method to apply `dp`, which is determined by the `AbstractOptimizer` passed to VMC. In the simplest case (the `Sgd` class), this is of the form `p(t+1) = p(t) + a(t) * dp` where `a(t)` is the current learning rate.

Part 2 is under control of the users since they can pass in a custom optimizer. Part 1 is currently less configurable. We could discuss whether we should make this extendable as well by providing a suitable base class with subclasses for the current SR and GD methods. What do you think?

(In any case, I think extracting the SR part from the VMC code makes it easier to understand.)