### PR TITLE
Remove some templates

### DIFF
--- a/NetKet/GroundState/matrix_replacement.hpp
+++ b/NetKet/GroundState/matrix_replacement.hpp
@@ -36,8 +36,7 @@ namespace internal {
 // MatrixReplacement looks-like a SparseMatrix, so let's inherits its traits:
 template <>
 struct traits<netket::MatrixReplacement>
-    : public Eigen::internal::traits<
-          Eigen::SparseMatrix<std::complex<double>>> {};
+    : public Eigen::internal::traits<Eigen::SparseMatrix<netket::Complex>> {};
 }  // namespace internal
 }  // namespace Eigen
 
@@ -47,7 +46,7 @@ namespace netket {
 class MatrixReplacement : public Eigen::EigenBase<netket::MatrixReplacement> {
  public:
   // Required typedefs, constants, and method:
-  typedef std::complex<double> Scalar;
+  typedef Complex Scalar;
   typedef double RealScalar;
   typedef int StorageIndex;
   enum {

--- a/NetKet/GroundState/py_variational_montecarlo.hpp
+++ b/NetKet/GroundState/py_variational_montecarlo.hpp
@@ -35,7 +35,7 @@ void AddVariationalMonteCarloModule(py::module &m) {
   py::class_<VariationalMonteCarlo>(
       m_vmc, "Vmc",
       R"EOF(Variational Monte Carlo schemes to learn the ground state using stochastic reconfiguration and gradient descent optimizers.)EOF")
-      .def(py::init<const AbstractOperator &, SamplerType &,
+      .def(py::init<const AbstractOperator &, AbstractSampler &,
                     AbstractOptimizer &, int, int, int, const std::string &,
                     double, bool, bool, bool>(),
            py::keep_alive<1, 2>(), py::keep_alive<1, 3>(),

--- a/NetKet/GroundState/variational_montecarlo.hpp
+++ b/NetKet/GroundState/variational_montecarlo.hpp
@@ -46,14 +46,12 @@ namespace netket {
 // 2) Gradient Descent optimizer
 class VariationalMonteCarlo {
   using GsType = Complex;
-  using VectorT = Eigen::Matrix<typename AbstractMachine<GsType>::StateType,
-                                Eigen::Dynamic, 1>;
-  using MatrixT = Eigen::Matrix<typename AbstractMachine<GsType>::StateType,
-                                Eigen::Dynamic, Eigen::Dynamic>;
+  using VectorT = Eigen::Matrix<Complex, Eigen::Dynamic, 1>;
+  using MatrixT = Eigen::Matrix<Complex, Eigen::Dynamic, Eigen::Dynamic>;
 
   const AbstractOperator &ham_;
-  AbstractSampler<AbstractMachine<GsType>> &sampler_;
-  AbstractMachine<GsType> &psi_;
+  AbstractSampler &sampler_;
+  AbstractMachine &psi_;
 
   std::vector<std::vector<int>> connectors_;
   std::vector<std::vector<double>> newconfs_;
@@ -140,9 +138,8 @@ class VariationalMonteCarlo {
   };
 
   VariationalMonteCarlo(const AbstractOperator &hamiltonian,
-                        AbstractSampler<AbstractMachine<GsType>> &sampler,
-                        AbstractOptimizer &optimizer, int nsamples,
-                        int discarded_samples = -1,
+                        AbstractSampler &sampler, AbstractOptimizer &optimizer,
+                        int nsamples, int discarded_samples = -1,
                         int discarded_samples_on_init = 0,
                         const std::string &method = "Sr",
                         double diag_shift = 0.01, bool rescale_shift = false,
@@ -463,7 +460,7 @@ class VariationalMonteCarlo {
     use_cholesky_ = use_cholesky;
   }
 
-  AbstractMachine<Complex> &GetMachine() { return psi_; }
+  AbstractMachine &GetMachine() { return psi_; }
   const ObsManager &GetObsManager() const { return obsmanager_; }
 };
 

--- a/NetKet/Machine/Layers/abstract_layer.hpp
+++ b/NetKet/Machine/Layers/abstract_layer.hpp
@@ -26,15 +26,14 @@ namespace netket {
 /**
   Abstract class for Neural Network layer.
 */
-template <typename T>
 class AbstractLayer {
  public:
-  using VectorType = Eigen::Matrix<T, Eigen::Dynamic, 1>;
-  using MatrixType = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
-  using StateType = T;
-  using LookupType = std::vector<VectorType>;
-  using VectorRefType = Eigen::Ref<VectorType>;
-  using VectorConstRefType = Eigen::Ref<const VectorType>;
+  using VectorType = AbstractMachine::VectorType;
+  using MatrixType = AbstractMachine::MatrixType;
+  using LookupType = AbstractMachine::LookupType;
+  using VectorRefType = AbstractMachine::VectorRefType;
+  using VectorConstRefType = AbstractMachine::VectorConstRefType;
+  using VisibleConstType = AbstractMachine::VisibleConstType;
 
   /**
   Member function returning the name of the layer.

--- a/NetKet/Machine/Layers/activation_layer.hpp
+++ b/NetKet/Machine/Layers/activation_layer.hpp
@@ -26,22 +26,14 @@
 
 namespace netket {
 
-template <typename T, typename A>
-class Activation : public AbstractLayer<T> {
-  using VectorType = typename AbstractLayer<T>::VectorType;
-  using MatrixType = typename AbstractLayer<T>::MatrixType;
-  using VectorRefType = typename AbstractLayer<T>::VectorRefType;
-  using VectorConstRefType = typename AbstractLayer<T>::VectorConstRefType;
-
+template <typename A>
+class Activation : public AbstractLayer {
   A activation_;  // activation
   int size_;      // size_ = input size = output size
 
   std::string name_;
 
  public:
-  using StateType = typename AbstractLayer<T>::StateType;
-  using LookupType = typename AbstractLayer<T>::LookupType;
-
   /// Constructor
   Activation(const int input_size) : activation_(), size_(input_size) {
     Init();

--- a/NetKet/Machine/Layers/activations.hpp
+++ b/NetKet/Machine/Layers/activations.hpp
@@ -28,7 +28,7 @@ namespace netket {
 */
 class AbstractActivation {
  public:
-  using VectorType = Eigen::Matrix<std::complex<double>, Eigen::Dynamic, 1>;
+  using VectorType = Eigen::Matrix<Complex, Eigen::Dynamic, 1>;
   using VectorRefType = Eigen::Ref<VectorType>;
   using VectorConstRefType = Eigen::Ref<const VectorType>;
 
@@ -56,13 +56,13 @@ inline double lncosh(double x) {
 // ln(cos(x)) for std::complex argument
 // the modulus is computed by means of the previously defined function
 // for real argument
-inline std::complex<double> lncosh(std::complex<double> x) {
+inline Complex lncosh(Complex x) {
   const double xr = x.real();
   const double xi = x.imag();
 
-  std::complex<double> res = lncosh(xr);
+  Complex res = lncosh(xr);
   res += std::log(
-      std::complex<double>(std::cos(xi), std::tanh(xr) * std::sin(xi)));
+      Complex(std::cos(xi), std::tanh(xr) * std::sin(xi)));
 
   return res;
 }

--- a/NetKet/Machine/Layers/fullconn_layer.hpp
+++ b/NetKet/Machine/Layers/fullconn_layer.hpp
@@ -27,13 +27,7 @@
 
 namespace netket {
 
-template <typename T>
-class FullyConnected : public AbstractLayer<T> {
-  using VectorType = typename AbstractLayer<T>::VectorType;
-  using MatrixType = typename AbstractLayer<T>::MatrixType;
-  using VectorRefType = typename AbstractLayer<T>::VectorRefType;
-  using VectorConstRefType = typename AbstractLayer<T>::VectorConstRefType;
-
+class FullyConnected : public AbstractLayer {
   bool usebias_;
 
   int in_size_;        // input size
@@ -49,9 +43,6 @@ class FullyConnected : public AbstractLayer<T> {
   std::size_t scalar_bytesize_;
 
  public:
-  using StateType = typename AbstractLayer<T>::StateType;
-  using LookupType = typename AbstractLayer<T>::LookupType;
-
   /// Constructor
   FullyConnected(const int input_size, const int output_size,
                  const bool use_bias = false)
@@ -60,7 +51,7 @@ class FullyConnected : public AbstractLayer<T> {
   }
 
   void Init() {
-    scalar_bytesize_ = sizeof(std::complex<double>);
+    scalar_bytesize_ = sizeof(Complex);
 
     weight_.resize(in_size_, out_size_);
     bias_.resize(out_size_);

--- a/NetKet/Machine/Layers/hypercube_conv_layer.hpp
+++ b/NetKet/Machine/Layers/hypercube_conv_layer.hpp
@@ -34,13 +34,7 @@ namespace netket {
  Important: In order for this to work correctly, VectorType and MatrixType must
  be column major.
  */
-template <typename T>
-class ConvolutionalHypercube : public AbstractLayer<T> {
-  using VectorType = typename AbstractLayer<T>::VectorType;
-  using MatrixType = typename AbstractLayer<T>::MatrixType;
-  using VectorRefType = typename AbstractLayer<T>::VectorRefType;
-  using VectorConstRefType = typename AbstractLayer<T>::VectorConstRefType;
-
+class ConvolutionalHypercube : public AbstractLayer {
   static_assert(!MatrixType::IsRowMajor, "MatrixType must be column-major");
 
   bool usebias_;  // boolean to turn or off bias
@@ -74,9 +68,6 @@ class ConvolutionalHypercube : public AbstractLayer<T> {
   MatrixType flipped_kernels_;
 
  public:
-  using StateType = typename AbstractLayer<T>::StateType;
-  using LookupType = typename AbstractLayer<T>::LookupType;
-
   /// Constructor
   ConvolutionalHypercube(const int length, const int dim,
                          const int input_channels, const int output_channels,

--- a/NetKet/Machine/Layers/py_layer.hpp
+++ b/NetKet/Machine/Layers/py_layer.hpp
@@ -25,21 +25,21 @@ namespace netket {
 void AddLayerModule(py::module &m) {
   auto subm = m.def_submodule("layer");
 
-  py::class_<LayerType>(subm, "Layer")
+  py::class_<AbstractLayer>(subm, "Layer")
       .def_property_readonly(
-          "n_input", &LayerType::Ninput,
+          "n_input", &AbstractLayer::Ninput,
           R"EOF(int: The number of inputs into the layer.)EOF")
       .def_property_readonly(
-          "n_output", &LayerType::Noutput,
+          "n_output", &AbstractLayer::Noutput,
           R"EOF(int: The number of outputs from the layer.)EOF")
       .def_property_readonly(
-          "n_par", &LayerType::Npar,
+          "n_par", &AbstractLayer::Npar,
           R"EOF(int: The number parameters within the layer.)EOF")
-      .def_property("parameters", &LayerType::GetParameters,
-                    &LayerType::SetParameters,
+      .def_property("parameters", &AbstractLayer::GetParameters,
+                    &AbstractLayer::SetParameters,
                     R"EOF(list: List containing the parameters within the layer.
             Readable and writable)EOF")
-      .def("init_random_parameters", &LayerType::InitRandomPars,
+      .def("init_random_parameters", &AbstractLayer::InitRandomPars,
            py::arg("seed") = 1234, py::arg("sigma") = 0.1, R"EOF(
         Member function to initialise layer parameters.
 
@@ -51,8 +51,8 @@ void AddLayerModule(py::module &m) {
   // TODO add more methods
 
   {
-    using DerType = FullyConnected<StateType>;
-    py::class_<DerType, LayerType>(subm, "FullyConnected", R"EOF(
+    using DerType = FullyConnected;
+    py::class_<DerType, AbstractLayer>(subm, "FullyConnected", R"EOF(
              A fully connected feedforward layer. This layer implements the
              transformation from a m-dimensional input vector
              $$ \boldsymbol{v}_n $$ to a n-dimensional output vector
@@ -90,8 +90,8 @@ void AddLayerModule(py::module &m) {
              )EOF");
   }
   {
-    using DerType = ConvolutionalHypercube<StateType>;
-    py::class_<DerType, LayerType>(subm, "ConvolutionalHypercube", R"EOF(
+    using DerType = ConvolutionalHypercube;
+    py::class_<DerType, AbstractLayer>(subm, "ConvolutionalHypercube", R"EOF(
              A convolutional feedforward layer for hypercubes. This layer works
              only for the ``Hypercube`` graph defined in ``graph``. This layer
              implements the standard convolution with periodic boundary
@@ -126,8 +126,8 @@ void AddLayerModule(py::module &m) {
              )EOF");
   }
   {
-    using DerType = SumOutput<StateType>;
-    py::class_<DerType, LayerType>(subm, "SumOutput", R"EOF(
+    using DerType = SumOutput;
+    py::class_<DerType, AbstractLayer>(subm, "SumOutput", R"EOF(
              A feedforward layer which sums the inputs to give a single output.)EOF")
         .def(py::init<int>(), py::arg("input_size"), R"EOF(
         Constructs a new ``SumOutput`` layer.
@@ -148,8 +148,8 @@ void AddLayerModule(py::module &m) {
         )EOF");
   }
   {
-    using DerType = Activation<StateType, Lncosh>;
-    py::class_<DerType, LayerType>(subm, "Lncosh", R"EOF(
+    using DerType = Activation<Lncosh>;
+    py::class_<DerType, AbstractLayer>(subm, "Lncosh", R"EOF(
              An activation layer which applies Lncosh to each input.)EOF")
         .def(py::init<int>(), py::arg("input_size"), R"EOF(
         Constructs a new ``Lncosh`` activation layer.
@@ -171,8 +171,8 @@ void AddLayerModule(py::module &m) {
         )EOF");
   }
   {
-    using DerType = Activation<StateType, Tanh>;
-    py::class_<DerType, LayerType>(subm, "Tanh", R"EOF(
+    using DerType = Activation<Tanh>;
+    py::class_<DerType, AbstractLayer>(subm, "Tanh", R"EOF(
              An activation layer which applies Tanh to each input.)EOF")
         .def(py::init<int>(), py::arg("input_size"), R"EOF(
         Constructs a new ``Tanh`` activation layer.
@@ -194,8 +194,8 @@ void AddLayerModule(py::module &m) {
         )EOF");
   }
   {
-    using DerType = Activation<StateType, Relu>;
-    py::class_<DerType, LayerType>(subm, "Relu", R"EOF(
+    using DerType = Activation<Relu>;
+    py::class_<DerType, AbstractLayer>(subm, "Relu", R"EOF(
              An activation layer which applies ReLu to each input.)EOF")
         .def(py::init<int>(), py::arg("input_size"), R"EOF(
         Constructs a new ``Relu`` activation layer.
@@ -212,7 +212,7 @@ void AddLayerModule(py::module &m) {
             >>> l=Relu(input_size=10)
             >>> print(l.n_par)
             0
-            
+
             ```
         )EOF");
   }

--- a/NetKet/Machine/Layers/sum_output.hpp
+++ b/NetKet/Machine/Layers/sum_output.hpp
@@ -28,13 +28,7 @@
 
 namespace netket {
 
-template <typename T>
-class SumOutput : public AbstractLayer<T> {
-  using VectorType = typename AbstractLayer<T>::VectorType;
-  using MatrixType = typename AbstractLayer<T>::MatrixType;
-  using VectorRefType = typename AbstractLayer<T>::VectorRefType;
-  using VectorConstRefType = typename AbstractLayer<T>::VectorConstRefType;
-
+class SumOutput : public AbstractLayer {
   int in_size_;   // input size: should be multiple of no. of sites
   int out_size_;  // output size: should be multiple of no. of sites
 
@@ -43,9 +37,6 @@ class SumOutput : public AbstractLayer<T> {
   std::string name_;
 
  public:
-  using StateType = typename AbstractLayer<T>::StateType;
-  using LookupType = typename AbstractLayer<T>::LookupType;
-
   /// Constructor
   explicit SumOutput(int in_size) : in_size_(in_size) {
     out_size_ = 1;

--- a/NetKet/Machine/abstract_machine.hpp
+++ b/NetKet/Machine/abstract_machine.hpp
@@ -28,13 +28,11 @@ namespace netket {
   This class prototypes the methods needed
   by a class satisfying the Machine concept.
 */
-template <typename T>
 class AbstractMachine {
  public:
-  using VectorType = Eigen::Matrix<T, Eigen::Dynamic, 1>;
-  using MatrixType = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
-  using StateType = T;
-  using LookupType = Lookup<T>;
+  using VectorType = Eigen::Matrix<Complex, Eigen::Dynamic, 1>;
+  using MatrixType = Eigen::Matrix<Complex, Eigen::Dynamic, Eigen::Dynamic>;
+  using LookupType = Lookup<Complex>;
   using VectorRefType = Eigen::Ref<VectorType>;
   using VectorConstRefType = Eigen::Ref<const VectorType>;
   using VisibleConstType = Eigen::Ref<const Eigen::VectorXd>;
@@ -76,7 +74,7 @@ class AbstractMachine {
   @param v a constant reference to a visible configuration.
   @return Logarithm of the wave function.
   */
-  virtual T LogVal(VisibleConstType v) = 0;
+  virtual Complex LogVal(VisibleConstType v) = 0;
 
   /**
   Member function computing the logarithm of the wave function for a given
@@ -87,7 +85,7 @@ class AbstractMachine {
   @param lt a constant eference to the look-up table.
   @return Logarithm of the wave function.
   */
-  virtual T LogVal(VisibleConstType v, const LookupType &lt) = 0;
+  virtual Complex LogVal(VisibleConstType v, const LookupType &lt) = 0;
 
   /**
   Member function initializing the look-up tables.
@@ -153,9 +151,9 @@ class AbstractMachine {
   @param lt a constant eference to the look-up table.
   @return The value of log(Psi(v')) - log(Psi(v))
   */
-  virtual T LogValDiff(VisibleConstType v, const std::vector<int> &toflip,
-                       const std::vector<double> &newconf,
-                       const LookupType &lt) = 0;
+  virtual Complex LogValDiff(VisibleConstType v, const std::vector<int> &toflip,
+                             const std::vector<double> &newconf,
+                             const LookupType &lt) = 0;
 
   /**
   Member function computing the derivative of the logarithm of the wave function

--- a/NetKet/Machine/ffnn.hpp
+++ b/NetKet/Machine/ffnn.hpp
@@ -1,4 +1,5 @@
-// Copyright 2018 The Simons Foundation, Inc. - All Rights Reserved.
+// Copyright 2018 The Simons Foundation, Inc. - All
+// Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,17 +27,10 @@
 
 namespace netket {
 
-template <typename T>
-class FFNN : public AbstractMachine<T> {
-  using VectorType = typename AbstractMachine<T>::VectorType;
-  using MatrixType = typename AbstractMachine<T>::MatrixType;
-  using VectorRefType = typename AbstractMachine<T>::VectorRefType;
-  using VectorConstRefType = typename AbstractMachine<T>::VectorConstRefType;
-  using VisibleConstType = typename AbstractMachine<T>::VisibleConstType;
-
+class FFNN : public AbstractMachine {
   const AbstractHilbert &hilbert_;
 
-  std::vector<AbstractLayer<T> *> layers_;  // Pointers to hidden layers
+  std::vector<AbstractLayer *> layers_;  // Pointers to hidden layers
 
   std::vector<int> layersizes_;
   int depth_;
@@ -47,16 +41,13 @@ class FFNN : public AbstractMachine<T> {
 
   std::vector<std::vector<int>> changed_nodes_;
   std::vector<VectorType> new_output_;
-  typename AbstractMachine<T>::LookupType ltnew_;
+  LookupType ltnew_;
 
-  std::unique_ptr<SumOutput<T>> sum_output_layer_;
+  std::unique_ptr<SumOutput> sum_output_layer_;
 
  public:
-  using StateType = typename AbstractMachine<T>::StateType;
-  using LookupType = typename AbstractMachine<T>::LookupType;
-
   explicit FFNN(const AbstractHilbert &hilbert,
-                std::vector<AbstractLayer<T> *> layers)
+                std::vector<AbstractLayer *> layers)
       : hilbert_(hilbert), layers_(std::move(layers)), nv_(hilbert.Size()) {
     Init();
   }
@@ -79,7 +70,7 @@ class FFNN : public AbstractMachine<T> {
     if (layersizes_.back() != 1) {
       nlayer_ += 1;
 
-      sum_output_layer_ = netket::make_unique<SumOutput<T>>(layersizes_.back());
+      sum_output_layer_ = netket::make_unique<SumOutput>(layersizes_.back());
       layers_.push_back(sum_output_layer_.get());
       layersizes_.push_back(1);
     }
@@ -211,14 +202,14 @@ class FFNN : public AbstractMachine<T> {
     }
   }
 
-  T LogVal(VisibleConstType v) override {
+  Complex LogVal(VisibleConstType v) override {
     LookupType lt;
     InitLookup(v, lt);
     assert(nlayer_ > 0);
     return (lt.V(nlayer_ - 1))(0);
   }
 
-  T LogVal(VisibleConstType /*v*/, const LookupType &lt) override {
+  Complex LogVal(VisibleConstType /*v*/, const LookupType &lt) override {
     assert(nlayer_ > 0);
     return (lt.V(nlayer_ - 1))(0);
   }
@@ -265,7 +256,7 @@ class FFNN : public AbstractMachine<T> {
     VectorType logvaldiffs = VectorType::Zero(nconn);
     LookupType lt;
     InitLookup(v, lt);
-    T current_val = LogVal(v, lt);
+    auto current_val = LogVal(v, lt);
 
     for (int k = 0; k < nconn; ++k) {
       logvaldiffs(k) = 0;
@@ -279,9 +270,9 @@ class FFNN : public AbstractMachine<T> {
     return logvaldiffs;
   }
 
-  T LogValDiff(VisibleConstType v, const std::vector<int> &tochange,
-               const std::vector<double> &newconf,
-               const LookupType &lt) override {
+  Complex LogValDiff(VisibleConstType v, const std::vector<int> &tochange,
+                     const std::vector<double> &newconf,
+                     const LookupType &lt) override {
     if (tochange.size() != 0) {
       LookupType ltnew = lt;
       UpdateLookup(v, tochange, newconf, ltnew);

--- a/NetKet/Machine/jastrow.hpp
+++ b/NetKet/Machine/jastrow.hpp
@@ -28,14 +28,7 @@ namespace netket {
 /** Jastrow machine class.
  *
  */
-template <typename T>
-class Jastrow : public AbstractMachine<T> {
-  using VectorType = typename AbstractMachine<T>::VectorType;
-  using MatrixType = typename AbstractMachine<T>::MatrixType;
-  using VectorRefType = typename AbstractMachine<T>::VectorRefType;
-  using VectorConstRefType = typename AbstractMachine<T>::VectorConstRefType;
-  using VisibleConstType = typename AbstractMachine<T>::VisibleConstType;
-
+class Jastrow : public AbstractMachine {
   const AbstractHilbert &hilbert_;
 
   // number of visible units
@@ -52,9 +45,6 @@ class Jastrow : public AbstractMachine<T> {
   VectorType thetasnew_;
 
  public:
-  using StateType = typename AbstractMachine<T>::StateType;
-  using LookupType = typename AbstractMachine<T>::LookupType;
-
   // constructor
   explicit Jastrow(const AbstractHilbert &hilbert)
       : hilbert_(hilbert), nv_(hilbert.Size()) {
@@ -110,7 +100,7 @@ class Jastrow : public AbstractMachine<T> {
     int k = 0;
 
     for (int i = 0; i < nv_; i++) {
-      W_(i, i) = T(0.);
+      W_(i, i) = Complex(0.);
       for (int j = i + 1; j < nv_; j++) {
         W_(i, j) = pars(k);
         W_(j, i) = W_(i, j);  // create the lower triangle
@@ -142,11 +132,11 @@ class Jastrow : public AbstractMachine<T> {
     }
   }
 
-  T LogVal(VisibleConstType v) override { return 0.5 * v.dot(W_ * v); }
+  Complex LogVal(VisibleConstType v) override { return 0.5 * v.dot(W_ * v); }
 
   // Value of the logarithm of the wave-function
   // using pre-computed look-up tables for efficiency
-  T LogVal(VisibleConstType v, const LookupType &lt) override {
+  Complex LogVal(VisibleConstType v, const LookupType &lt) override {
     return 0.5 * v.dot(lt.V(0));
   }
 
@@ -159,7 +149,7 @@ class Jastrow : public AbstractMachine<T> {
     VectorType logvaldiffs = VectorType::Zero(nconn);
 
     thetas_ = (W_.transpose() * v);
-    T logtsum = 0.5 * v.dot(thetas_);
+    Complex logtsum = 0.5 * v.dot(thetas_);
 
     for (std::size_t k = 0; k < nconn; k++) {
       if (tochange[k].size() != 0) {
@@ -179,13 +169,13 @@ class Jastrow : public AbstractMachine<T> {
     return logvaldiffs;
   }
 
-  T LogValDiff(VisibleConstType v, const std::vector<int> &tochange,
-               const std::vector<double> &newconf,
-               const LookupType &lt) override {
-    T logvaldiff = 0.;
+  Complex LogValDiff(VisibleConstType v, const std::vector<int> &tochange,
+                     const std::vector<double> &newconf,
+                     const LookupType &lt) override {
+    Complex logvaldiff = 0.;
 
     if (tochange.size() != 0) {
-      T logtsum = 0.5 * v.dot(lt.V(0));
+      Complex logtsum = 0.5 * v.dot(lt.V(0));
       thetasnew_ = lt.V(0);
       Eigen::VectorXd vnew(v);
 

--- a/NetKet/Machine/jastrow_symm.hpp
+++ b/NetKet/Machine/jastrow_symm.hpp
@@ -1,4 +1,5 @@
-// Copyright 2018 The Simons Foundation, Inc. - All Rights Reserved.
+// Copyright 2018 The Simons Foundation, Inc. - All
+// Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,14 +28,7 @@
 namespace netket {
 
 // Jastrow with permutation symmetries
-template <typename T>
-class JastrowSymm : public AbstractMachine<T> {
-  using VectorType = typename AbstractMachine<T>::VectorType;
-  using MatrixType = typename AbstractMachine<T>::MatrixType;
-  using VectorRefType = typename AbstractMachine<T>::VectorRefType;
-  using VectorConstRefType = typename AbstractMachine<T>::VectorConstRefType;
-  using VisibleConstType = typename AbstractMachine<T>::VisibleConstType;
-
+class JastrowSymm : public AbstractMachine {
   const AbstractHilbert &hilbert_;
   const AbstractGraph &graph_;
 
@@ -63,9 +57,6 @@ class JastrowSymm : public AbstractMachine<T> {
   Eigen::MatrixXi Wtemp_;
 
  public:
-  using StateType = typename AbstractMachine<T>::StateType;
-  using LookupType = typename AbstractMachine<T>::LookupType;
-
   // constructor
   explicit JastrowSymm(const AbstractHilbert &hilbert)
       : hilbert_(hilbert), graph_(hilbert.GetGraph()), nv_(hilbert.Size()) {
@@ -250,21 +241,21 @@ class JastrowSymm : public AbstractMachine<T> {
       for (int j = i + 1; j < nv_; j++) {
         W_(i, j) = Wsymm_(Wtemp_(i, j) - 1, 0);
         W_(j, i) = W_(i, j);  // create the lover triangle
-        W_(i, i) = T(0);
+        W_(i, i) = Complex(0);
       }
     }
   }
 
-  T LogVal(VisibleConstType v) override { return 0.5 * v.dot(W_ * v); }
+  Complex LogVal(VisibleConstType v) override { return 0.5 * v.dot(W_ * v); }
 
   // Value of the logarithm of the wave-function
   // using pre-computed look-up tables for efficiency
-  T LogVal(VisibleConstType v, const LookupType &lt) override {
+  Complex LogVal(VisibleConstType v, const LookupType &lt) override {
     return 0.5 * v.dot(lt.V(0));
   }
 
-  // Difference between logarithms of values, when one or more visible variables
-  // are being flipped
+  // Difference between logarithms of values, when one or more visible
+  // variables are being flipped
   VectorType LogValDiff(
       VisibleConstType v, const std::vector<std::vector<int>> &tochange,
       const std::vector<std::vector<double>> &newconf) override {
@@ -272,7 +263,7 @@ class JastrowSymm : public AbstractMachine<T> {
     VectorType logvaldiffs = VectorType::Zero(nconn);
 
     thetas_ = (W_.transpose() * v);
-    T logtsum = 0.5 * v.dot(thetas_);
+    Complex logtsum = 0.5 * v.dot(thetas_);
 
     for (std::size_t k = 0; k < nconn; k++) {
       if (tochange[k].size() != 0) {
@@ -293,13 +284,13 @@ class JastrowSymm : public AbstractMachine<T> {
     return logvaldiffs;
   }
 
-  T LogValDiff(VisibleConstType v, const std::vector<int> &tochange,
-               const std::vector<double> &newconf,
-               const LookupType &lt) override {
-    T logvaldiff = 0.;
+  Complex LogValDiff(VisibleConstType v, const std::vector<int> &tochange,
+                     const std::vector<double> &newconf,
+                     const LookupType &lt) override {
+    Complex logvaldiff = 0.;
 
     if (tochange.size() != 0) {
-      T logtsum = 0.5 * v.dot(lt.V(0));
+      Complex logtsum = 0.5 * v.dot(lt.V(0));
       thetasnew_ = lt.V(0);
       Eigen::VectorXd vnew(v);
 

--- a/NetKet/Machine/mps_periodic.hpp
+++ b/NetKet/Machine/mps_periodic.hpp
@@ -25,14 +25,8 @@
 
 namespace netket {
 
-template <typename T, bool diag>
-class MPSPeriodic : public AbstractMachine<T> {
-  using VectorType = typename AbstractMachine<T>::VectorType;
-  using MatrixType = typename AbstractMachine<T>::MatrixType;
-  using VectorRefType = typename AbstractMachine<T>::VectorRefType;
-  using VectorConstRefType = typename AbstractMachine<T>::VectorConstRefType;
-  using VisibleConstType = typename AbstractMachine<T>::VisibleConstType;
-
+template <bool diag>
+class MPSPeriodic : public AbstractMachine {
   const AbstractHilbert &hilbert_;
 
   // Number of sites
@@ -68,9 +62,6 @@ class MPSPeriodic : public AbstractMachine<T> {
   MatrixType identity_mat_;
 
  public:
-  using StateType = T;
-  using LookupType = Lookup<T>;
-
   explicit MPSPeriodic(const AbstractHilbert &hilbert, double bond_dim,
                        int symperiod = -1)
       : hilbert_(hilbert),
@@ -93,7 +84,7 @@ class MPSPeriodic : public AbstractMachine<T> {
     return m1 * m2;
   }
 
-  inline T trace(const MatrixType &m) const {
+  inline Complex trace(const MatrixType &m) const {
     if (diag) {
       return m.sum();
     }
@@ -103,14 +94,14 @@ class MPSPeriodic : public AbstractMachine<T> {
   inline void setparamsident(MatrixType &m, VectorConstRefType pars) const {
     if (diag) {
       for (int i = 0; i < D_; i++) {
-        m(i, 0) = T(1, 0) + pars(i);
+        m(i, 0) = Complex(1, 0) + pars(i);
       }
     } else {
       for (int i = 0; i < D_; i++) {
         for (int j = 0; j < D_; j++) {
           m(i, j) = pars(i * D_ + j);
           if (i == j) {
-            m(i, j) += T(1, 0);
+            m(i, j) += Complex(1, 0);
           }
         }
       }
@@ -401,11 +392,11 @@ class MPSPeriodic : public AbstractMachine<T> {
     return c;
   }
 
-  T LogVal(VisibleConstType v) override {
+  Complex LogVal(VisibleConstType v) override {
     return std::log(trace(mps_contraction(v, 0, N_)));
   }
 
-  T LogVal(VisibleConstType /* v */, const LookupType &lt) override {
+  Complex LogVal(VisibleConstType /* v */, const LookupType &lt) override {
     return std::log(trace(lt.M(Nleaves_ - 1)));
   }
 
@@ -416,7 +407,7 @@ class MPSPeriodic : public AbstractMachine<T> {
 
     std::vector<std::size_t> sorted_ind;
     VectorType logvaldiffs = VectorType::Zero(nconn);
-    StateType current_psi = trace(mps_contraction(v, 0, N_));
+    Complex current_psi = trace(mps_contraction(v, 0, N_));
     MatrixType new_prods(D_, Dsec_);
 
     for (std::size_t k = 0; k < nconn; k++) {
@@ -451,13 +442,13 @@ class MPSPeriodic : public AbstractMachine<T> {
     return logvaldiffs;
   }
 
-  T LogValDiff(VisibleConstType v, const std::vector<int> &toflip,
-               const std::vector<double> &newconf,
-               const LookupType &lt) override {
+  Complex LogValDiff(VisibleConstType v, const std::vector<int> &toflip,
+                     const std::vector<double> &newconf,
+                     const LookupType &lt) override {
     // Assumes number of levels > 1 (?)
     std::size_t nflip = toflip.size();
     if (nflip <= 0) {
-      return T(0, 0);
+      return Complex(0, 0);
     }
 
     MatrixType empty_matrix = MatrixType::Zero(D_, Dsec_);

--- a/NetKet/Machine/py_ffnn.hpp
+++ b/NetKet/Machine/py_ffnn.hpp
@@ -31,17 +31,15 @@ namespace netket {
 
 void AddFFNN(py::module &subm) {
   {
-    using DerMachine = FFNN<StateType>;
-    py::class_<DerMachine, MachineType>(subm, "FFNN", R"EOF(
+    py::class_<FFNN, AbstractMachine>(subm, "FFNN", R"EOF(
              A feedforward neural network (FFNN) Machine. This machine is
              constructed by providing a sequence of layers from the ``layer``
              class. Each layer implements a transformation such that the
              information is transformed sequentially as it moves from the input
              nodes through the hidden layers and to the output nodes.)EOF")
         .def(py::init([](AbstractHilbert const &hi, py::tuple tuple) {
-               auto layers =
-                   py::cast<std::vector<AbstractLayer<StateType> *>>(tuple);
-               return DerMachine{hi, std::move(layers)};
+               auto layers = py::cast<std::vector<AbstractLayer *>>(tuple);
+               return FFNN{hi, std::move(layers)};
              }),
              py::keep_alive<1, 2>(), py::keep_alive<1, 3>(), py::arg("hilbert"),
              py::arg("layers"),

--- a/NetKet/Machine/py_jastrow.hpp
+++ b/NetKet/Machine/py_jastrow.hpp
@@ -30,7 +30,7 @@ namespace py = pybind11;
 namespace netket {
 
 void AddJastrow(py::module &subm) {
-  py::class_<Jastrow<StateType>, MachineType>(subm, "Jastrow", R"EOF(
+  py::class_<Jastrow, AbstractMachine>(subm, "Jastrow", R"EOF(
            A Jastrow wavefunction Machine. This machine defines the following
            wavefunction:
 

--- a/NetKet/Machine/py_jastrow_symm.hpp
+++ b/NetKet/Machine/py_jastrow_symm.hpp
@@ -30,7 +30,7 @@ namespace py = pybind11;
 namespace netket {
 
 void AddJastrowSymm(py::module &subm) {
-  py::class_<JastrowSymm<StateType>, MachineType>(subm, "JastrowSymm", R"EOF(
+  py::class_<JastrowSymm, AbstractMachine>(subm, "JastrowSymm", R"EOF(
            A Jastrow wavefunction Machine with lattice symmetries.This machine
            defines the wavefunction as follows:
 

--- a/NetKet/Machine/py_machine.hpp
+++ b/NetKet/Machine/py_machine.hpp
@@ -40,15 +40,15 @@ namespace netket {
 void AddMachineModule(py::module &m) {
   auto subm = m.def_submodule("machine");
 
-  py::class_<MachineType>(subm, "Machine")
+  py::class_<AbstractMachine>(subm, "Machine")
       .def_property_readonly(
-          "n_par", &MachineType::Npar,
+          "n_par", &AbstractMachine::Npar,
           R"EOF(int: The number of parameters in the machine.)EOF")
-      .def_property("parameters", &MachineType::GetParameters,
-                    &MachineType::SetParameters,
+      .def_property("parameters", &AbstractMachine::GetParameters,
+                    &AbstractMachine::SetParameters,
                     R"EOF(list: List containing the parameters within the layer.
             Read and write)EOF")
-      .def("init_random_parameters", &MachineType::InitRandomPars,
+      .def("init_random_parameters", &AbstractMachine::InitRandomPars,
            py::arg("seed") = 1234, py::arg("sigma") = 0.1,
            R"EOF(
              Member function to initialise machine parameters.
@@ -59,8 +59,8 @@ void AddMachineModule(py::module &m) {
                      parameters are drawn.
            )EOF")
       .def("log_val",
-           (StateType(MachineType::*)(MachineType::VisibleConstType)) &
-               MachineType::LogVal,
+           (Complex(AbstractMachine::*)(AbstractMachine::VisibleConstType)) &
+               AbstractMachine::LogVal,
            py::arg("v"),
            R"EOF(
                  Member function to obtain log value of machine given an input
@@ -70,11 +70,11 @@ void AddMachineModule(py::module &m) {
                      v: Input vector to machine.
            )EOF")
       .def("log_val_diff",
-           (MachineType::VectorType(MachineType::*)(
-               MachineType::VisibleConstType,
+           (AbstractMachine::VectorType(AbstractMachine::*)(
+               AbstractMachine::VisibleConstType,
                const std::vector<std::vector<int>> &,
                const std::vector<std::vector<double>> &)) &
-               MachineType::LogValDiff,
+               AbstractMachine::LogValDiff,
            py::arg("v"), py::arg("tochange"), py::arg("newconf"),
            R"EOF(
                  Member function to obtain difference in log value of machine
@@ -88,9 +88,9 @@ void AddMachineModule(py::module &m) {
                          indices specified in tochange
            )EOF")
       .def("der_log",
-           (MachineType::VectorType(MachineType::*)(
-               MachineType::VisibleConstType)) &
-               MachineType::DerLog,
+           (AbstractMachine::VectorType(AbstractMachine::*)(
+               AbstractMachine::VisibleConstType)) &
+               AbstractMachine::DerLog,
            py::arg("v"),
            R"EOF(
                  Member function to obtain the derivatives of log value of
@@ -100,14 +100,14 @@ void AddMachineModule(py::module &m) {
                      v: Input vector to machine.
            )EOF")
       .def_property_readonly(
-          "n_visible", &MachineType::Nvisible,
+          "n_visible", &AbstractMachine::Nvisible,
           R"EOF(int: The number of inputs into the machine aka visible units in
             the case of Restricted Boltzmann Machines.)EOF")
       .def_property_readonly(
-          "hilbert", &MachineType::GetHilbert,
+          "hilbert", &AbstractMachine::GetHilbert,
           R"EOF(netket.hilbert.Hilbert: The hilbert space object of the system.)EOF")
       .def("save",
-           [](const MachineType &a, std::string filename) {
+           [](const AbstractMachine &a, std::string filename) {
              json j;
              a.to_json(j);
              std::ofstream filewf(filename);
@@ -122,7 +122,7 @@ void AddMachineModule(py::module &m) {
                      filename: name of file to save parameters to.
            )EOF")
       .def("load",
-           [](MachineType &a, std::string filename) {
+           [](AbstractMachine &a, std::string filename) {
              std::ifstream filewf(filename);
              if (filewf.is_open()) {
                json j;

--- a/NetKet/Machine/py_mps_periodic.hpp
+++ b/NetKet/Machine/py_mps_periodic.hpp
@@ -30,13 +30,12 @@ namespace py = pybind11;
 namespace netket {
 
 void AddMpsPeriodic(py::module &subm) {
-  py::class_<MPSPeriodic<StateType, false>, MachineType>(subm, "MPSPeriodic")
+  py::class_<MPSPeriodic<false>, AbstractMachine>(subm, "MPSPeriodic")
       .def(py::init<const AbstractHilbert &, double, int>(),
            py::keep_alive<1, 2>(), py::arg("hilbert"), py::arg("bond_dim"),
            py::arg("symperiod") = -1);
 
-  py::class_<MPSPeriodic<StateType, true>, MachineType>(subm,
-                                                        "MPSPeriodicDiagonal")
+  py::class_<MPSPeriodic<true>, AbstractMachine>(subm, "MPSPeriodicDiagonal")
       .def(py::init<const AbstractHilbert &, double, int>(),
            py::keep_alive<1, 2>(), py::arg("hilbert"), py::arg("bond_dim"),
            py::arg("symperiod") = -1);

--- a/NetKet/Machine/py_rbm_multival.hpp
+++ b/NetKet/Machine/py_rbm_multival.hpp
@@ -30,7 +30,7 @@ namespace py = pybind11;
 namespace netket {
 
 void AddRbmMultival(py::module &subm) {
-  py::class_<RbmMultival<StateType>, MachineType>(subm, "RbmMultiVal", R"EOF(
+  py::class_<RbmMultival, AbstractMachine>(subm, "RbmMultiVal", R"EOF(
              A fully connected Restricted Boltzmann Machine for handling larger
              local Hilbert spaces.)EOF")
       .def(py::init<const AbstractHilbert &, int, int, bool, bool>(),

--- a/NetKet/Machine/py_rbm_spin.hpp
+++ b/NetKet/Machine/py_rbm_spin.hpp
@@ -30,7 +30,7 @@ namespace py = pybind11;
 namespace netket {
 
 void AddRbmSpin(py::module &subm) {
-  py::class_<RbmSpin<StateType>, MachineType>(subm, "RbmSpin", R"EOF(
+  py::class_<RbmSpin, AbstractMachine>(subm, "RbmSpin", R"EOF(
           A fully connected Restricted Boltzmann Machine (RBM). This type of
           RBM has spin 1/2 hidden units and is defined by:
 

--- a/NetKet/Machine/py_rbm_spin_symm.hpp
+++ b/NetKet/Machine/py_rbm_spin_symm.hpp
@@ -30,7 +30,7 @@ namespace py = pybind11;
 namespace netket {
 
 void AddRbmSpinSymm(py::module &subm) {
-  py::class_<RbmSpinSymm<StateType>, MachineType>(subm, "RbmSpinSymm", R"EOF(
+  py::class_<RbmSpinSymm, AbstractMachine>(subm, "RbmSpinSymm", R"EOF(
              A fully connected Restricted Boltzmann Machine with lattice
              symmetries. This type of RBM has spin 1/2 hidden units and is
              defined by:

--- a/NetKet/Machine/rbm_multival.hpp
+++ b/NetKet/Machine/rbm_multival.hpp
@@ -28,14 +28,7 @@ namespace netket {
 
 // Restricted Boltzman Machine wave function
 // for generic (finite) local hilbert space
-template <typename T>
-class RbmMultival : public AbstractMachine<T> {
-  using VectorType = typename AbstractMachine<T>::VectorType;
-  using MatrixType = typename AbstractMachine<T>::MatrixType;
-  using VectorRefType = typename AbstractMachine<T>::VectorRefType;
-  using VectorConstRefType = typename AbstractMachine<T>::VectorConstRefType;
-  using VisibleConstType = typename AbstractMachine<T>::VisibleConstType;
-
+class RbmMultival : public AbstractMachine {
   const AbstractHilbert &hilbert_;
 
   // number of visible units
@@ -75,9 +68,6 @@ class RbmMultival : public AbstractMachine<T> {
   std::map<double, int> confindex_;
 
  public:
-  using StateType = typename AbstractMachine<T>::StateType;
-  using LookupType = typename AbstractMachine<T>::LookupType;
-
   explicit RbmMultival(const AbstractHilbert &hilbert, int nhidden = 0,
                        int alpha = 0, bool usea = true, bool useb = true)
       : hilbert_(hilbert),
@@ -195,7 +185,7 @@ class RbmMultival : public AbstractMachine<T> {
       }
     }
 
-    RbmSpin<T>::tanh(thetas_, lnthetas_);
+    RbmSpin::tanh(thetas_, lnthetas_);
 
     if (useb_) {
       for (int p = 0; p < nh_; p++) {
@@ -266,17 +256,17 @@ class RbmMultival : public AbstractMachine<T> {
   }
 
   // Value of the logarithm of the wave-function
-  T LogVal(VisibleConstType v) override {
+  Complex LogVal(VisibleConstType v) override {
     ComputeTheta(v, thetas_);
-    RbmSpin<T>::lncosh(thetas_, lnthetas_);
+    RbmSpin::lncosh(thetas_, lnthetas_);
 
     return (vtilde_.dot(a_) + lnthetas_.sum());
   }
 
   // Value of the logarithm of the wave-function
   // using pre-computed look-up tables for efficiency
-  T LogVal(VisibleConstType v, const LookupType &lt) override {
-    RbmSpin<T>::lncosh(lt.V(0), lnthetas_);
+  Complex LogVal(VisibleConstType v, const LookupType &lt) override {
+    RbmSpin::lncosh(lt.V(0), lnthetas_);
 
     ComputeVtilde(v, vtilde_);
     return (vtilde_.dot(a_) + lnthetas_.sum());
@@ -291,9 +281,9 @@ class RbmMultival : public AbstractMachine<T> {
     VectorType logvaldiffs = VectorType::Zero(nconn);
 
     ComputeTheta(v, thetas_);
-    RbmSpin<T>::lncosh(thetas_, lnthetas_);
+    RbmSpin::lncosh(thetas_, lnthetas_);
 
-    T logtsum = lnthetas_.sum();
+    Complex logtsum = lnthetas_.sum();
 
     for (std::size_t k = 0; k < nconn; k++) {
       if (tochange[k].size() != 0) {
@@ -311,7 +301,7 @@ class RbmMultival : public AbstractMachine<T> {
           thetasnew_ += W_.row(ls_ * sf + newtilde);
         }
 
-        RbmSpin<T>::lncosh(thetasnew_, lnthetasnew_);
+        RbmSpin::lncosh(thetasnew_, lnthetasnew_);
         logvaldiffs(k) += lnthetasnew_.sum() - logtsum;
       }
     }
@@ -321,13 +311,13 @@ class RbmMultival : public AbstractMachine<T> {
   // Difference between logarithms of values, when one or more visible variables
   // are being changed Version using pre-computed look-up tables for efficiency
   // on a small number of local changes
-  T LogValDiff(VisibleConstType v, const std::vector<int> &tochange,
-               const std::vector<double> &newconf,
-               const LookupType &lt) override {
-    T logvaldiff = 0.;
+  Complex LogValDiff(VisibleConstType v, const std::vector<int> &tochange,
+                     const std::vector<double> &newconf,
+                     const LookupType &lt) override {
+    Complex logvaldiff = 0.;
 
     if (tochange.size() != 0) {
-      RbmSpin<T>::lncosh(lt.V(0), lnthetas_);
+      RbmSpin::lncosh(lt.V(0), lnthetas_);
 
       thetasnew_ = lt.V(0);
 
@@ -343,7 +333,7 @@ class RbmMultival : public AbstractMachine<T> {
         thetasnew_ += W_.row(ls_ * sf + newtilde);
       }
 
-      RbmSpin<T>::lncosh(thetasnew_, lnthetasnew_);
+      RbmSpin::lncosh(thetasnew_, lnthetasnew_);
       logvaldiff += (lnthetasnew_.sum() - lnthetas_.sum());
     }
     return logvaldiff;

--- a/NetKet/Machine/rbm_spin.hpp
+++ b/NetKet/Machine/rbm_spin.hpp
@@ -26,14 +26,7 @@ namespace netket {
 /** Restricted Boltzmann machine class with spin 1/2 hidden units.
  *
  */
-template <typename T>
-class RbmSpin : public AbstractMachine<T> {
-  using VectorType = typename AbstractMachine<T>::VectorType;
-  using MatrixType = typename AbstractMachine<T>::MatrixType;
-  using VectorRefType = typename AbstractMachine<T>::VectorRefType;
-  using VectorConstRefType = typename AbstractMachine<T>::VectorConstRefType;
-  using VisibleConstType = typename AbstractMachine<T>::VisibleConstType;
-
+class RbmSpin : public AbstractMachine {
   const AbstractHilbert &hilbert_;
 
   // number of visible units
@@ -63,9 +56,6 @@ class RbmSpin : public AbstractMachine<T> {
   bool useb_;
 
  public:
-  using StateType = typename AbstractMachine<T>::StateType;
-  using LookupType = typename AbstractMachine<T>::LookupType;
-
   explicit RbmSpin(const AbstractHilbert &hilbert, int nhidden = 0,
                    int alpha = 0, bool usea = true, bool useb = true)
       : hilbert_(hilbert), nv_(hilbert.Size()), usea_(usea), useb_(useb) {
@@ -222,7 +212,7 @@ class RbmSpin : public AbstractMachine<T> {
   }
 
   // Value of the logarithm of the wave-function
-  T LogVal(VisibleConstType v) override {
+  Complex LogVal(VisibleConstType v) override {
     RbmSpin::lncosh(W_.transpose() * v + b_, lnthetas_);
 
     return (v.dot(a_) + lnthetas_.sum());
@@ -230,7 +220,7 @@ class RbmSpin : public AbstractMachine<T> {
 
   // Value of the logarithm of the wave-function
   // using pre-computed look-up tables for efficiency
-  T LogVal(VisibleConstType v, const LookupType &lt) override {
+  Complex LogVal(VisibleConstType v, const LookupType &lt) override {
     RbmSpin::lncosh(lt.V(0), lnthetas_);
 
     return (v.dot(a_) + lnthetas_.sum());
@@ -247,7 +237,7 @@ class RbmSpin : public AbstractMachine<T> {
     thetas_ = (W_.transpose() * v + b_);
     RbmSpin::lncosh(thetas_, lnthetas_);
 
-    T logtsum = lnthetas_.sum();
+    Complex logtsum = lnthetas_.sum();
 
     for (std::size_t k = 0; k < nconn; k++) {
       if (tochange[k].size() != 0) {
@@ -271,10 +261,10 @@ class RbmSpin : public AbstractMachine<T> {
   // Difference between logarithms of values, when one or more visible variables
   // are being flipped Version using pre-computed look-up tables for efficiency
   // on a small number of spin flips
-  T LogValDiff(VisibleConstType v, const std::vector<int> &tochange,
-               const std::vector<double> &newconf,
-               const LookupType &lt) override {
-    T logvaldiff = 0.;
+  Complex LogValDiff(VisibleConstType v, const std::vector<int> &tochange,
+                     const std::vector<double> &newconf,
+                     const LookupType &lt) override {
+    Complex logvaldiff = 0.;
 
     if (tochange.size() != 0) {
       RbmSpin::lncosh(lt.V(0), lnthetas_);
@@ -308,13 +298,12 @@ class RbmSpin : public AbstractMachine<T> {
   // ln(cos(x)) for std::complex argument
   // the modulus is computed by means of the previously defined function
   // for real argument
-  inline static std::complex<double> lncosh(std::complex<double> x) {
+  inline static Complex lncosh(Complex x) {
     const double xr = x.real();
     const double xi = x.imag();
 
-    std::complex<double> res = RbmSpin::lncosh(xr);
-    res += std::log(
-        std::complex<double>(std::cos(xi), std::tanh(xr) * std::sin(xi)));
+    Complex res = RbmSpin::lncosh(xr);
+    res += std::log(Complex(std::cos(xi), std::tanh(xr) * std::sin(xi)));
 
     return res;
   }

--- a/NetKet/Machine/rbm_spin_symm.hpp
+++ b/NetKet/Machine/rbm_spin_symm.hpp
@@ -26,14 +26,7 @@
 namespace netket {
 
 // Rbm with permutation symmetries
-template <typename T>
-class RbmSpinSymm : public AbstractMachine<T> {
-  using VectorType = typename AbstractMachine<T>::VectorType;
-  using MatrixType = typename AbstractMachine<T>::MatrixType;
-  using VectorRefType = typename AbstractMachine<T>::VectorRefType;
-  using VectorConstRefType = typename AbstractMachine<T>::VectorConstRefType;
-  using VisibleConstType = typename AbstractMachine<T>::VisibleConstType;
-
+class RbmSpinSymm : public AbstractMachine {
   const AbstractHilbert &hilbert_;
 
   const AbstractGraph &graph_;
@@ -65,7 +58,7 @@ class RbmSpinSymm : public AbstractMachine<T> {
   // visible units bias
   VectorType a_;
 
-  T asymm_;
+  Complex asymm_;
 
   // hidden units bias
   VectorType b_;
@@ -83,9 +76,6 @@ class RbmSpinSymm : public AbstractMachine<T> {
   bool useb_;
 
  public:
-  using StateType = typename AbstractMachine<T>::StateType;
-  using LookupType = typename AbstractMachine<T>::LookupType;
-
   explicit RbmSpinSymm(const AbstractHilbert &hilbert, int alpha = 0,
                        bool usea = true, bool useb = true)
       : hilbert_(hilbert),
@@ -230,7 +220,7 @@ class RbmSpinSymm : public AbstractMachine<T> {
       }
     }
 
-    RbmSpin<T>::tanh(W_.transpose() * v + b_, lnthetas_);
+    RbmSpin::tanh(W_.transpose() * v + b_, lnthetas_);
 
     if (useb_) {
       for (int p = 0; p < nh_; p++) {
@@ -328,16 +318,16 @@ class RbmSpinSymm : public AbstractMachine<T> {
   }
 
   // Value of the logarithm of the wave-function
-  T LogVal(VisibleConstType v) override {
-    RbmSpin<T>::lncosh(W_.transpose() * v + b_, lnthetas_);
+  Complex LogVal(VisibleConstType v) override {
+    RbmSpin::lncosh(W_.transpose() * v + b_, lnthetas_);
 
     return (v.dot(a_) + lnthetas_.sum());
   }
 
   // Value of the logarithm of the wave-function
   // using pre-computed look-up tables for efficiency
-  T LogVal(VisibleConstType v, const LookupType &lt) override {
-    RbmSpin<T>::lncosh(lt.V(0), lnthetas_);
+  Complex LogVal(VisibleConstType v, const LookupType &lt) override {
+    RbmSpin::lncosh(lt.V(0), lnthetas_);
 
     return (v.dot(a_) + lnthetas_.sum());
   }
@@ -351,9 +341,9 @@ class RbmSpinSymm : public AbstractMachine<T> {
     VectorType logvaldiffs = VectorType::Zero(nconn);
 
     thetas_ = (W_.transpose() * v + b_);
-    RbmSpin<T>::lncosh(thetas_, lnthetas_);
+    RbmSpin::lncosh(thetas_, lnthetas_);
 
-    T logtsum = lnthetas_.sum();
+    Complex logtsum = lnthetas_.sum();
 
     for (std::size_t k = 0; k < nconn; k++) {
       if (tochange[k].size() != 0) {
@@ -367,7 +357,7 @@ class RbmSpinSymm : public AbstractMachine<T> {
           thetasnew_ += W_.row(sf) * (newconf[k][s] - v(sf));
         }
 
-        RbmSpin<T>::lncosh(thetasnew_, lnthetasnew_);
+        RbmSpin::lncosh(thetasnew_, lnthetasnew_);
         logvaldiffs(k) += lnthetasnew_.sum() - logtsum;
       }
     }
@@ -377,13 +367,13 @@ class RbmSpinSymm : public AbstractMachine<T> {
   // Difference between logarithms of values, when one or more visible variables
   // are being flipped Version using pre-computed look-up tables for efficiency
   // on a small number of spin flips
-  T LogValDiff(VisibleConstType v, const std::vector<int> &tochange,
-               const std::vector<double> &newconf,
-               const LookupType &lt) override {
-    T logvaldiff = 0.;
+  Complex LogValDiff(VisibleConstType v, const std::vector<int> &tochange,
+                     const std::vector<double> &newconf,
+                     const LookupType &lt) override {
+    Complex logvaldiff = 0.;
 
     if (tochange.size() != 0) {
-      RbmSpin<T>::lncosh(lt.V(0), lnthetas_);
+      RbmSpin::lncosh(lt.V(0), lnthetas_);
 
       thetasnew_ = lt.V(0);
 
@@ -395,7 +385,7 @@ class RbmSpinSymm : public AbstractMachine<T> {
         thetasnew_ += W_.row(sf) * (newconf[s] - v(sf));
       }
 
-      RbmSpin<T>::lncosh(thetasnew_, lnthetasnew_);
+      RbmSpin::lncosh(thetasnew_, lnthetasnew_);
       logvaldiff += (lnthetasnew_.sum() - lnthetas_.sum());
     }
     return logvaldiff;
@@ -440,7 +430,7 @@ class RbmSpinSymm : public AbstractMachine<T> {
 
     // Loading parameters, if defined in the input
     if (FieldExists(pars, "asymm")) {
-      asymm_ = pars["asymm"].get<T>();
+      asymm_ = pars["asymm"].get<Complex>();
     } else {
       asymm_ = 0;
     }

--- a/NetKet/Operator/abstract_operator.hpp
+++ b/NetKet/Operator/abstract_operator.hpp
@@ -15,12 +15,12 @@
 #ifndef NETKET_ABSTRACT_OPERATOR_HPP
 #define NETKET_ABSTRACT_OPERATOR_HPP
 
-#include "Hilbert/hilbert.hpp"
 #include <Eigen/Dense>
 #include <complex>
 #include <nonstd/span.hpp>
 #include <tuple>
 #include <vector>
+#include "Hilbert/hilbert.hpp"
 
 namespace netket {
 /**
@@ -29,7 +29,7 @@ namespace netket {
  */
 struct ConnectorRef {
   /// The matrix element H(v,v')
-  std::complex<double> mel;
+  Complex mel;
   /// The indices at which v needs to be changed to obtain v'
   nonstd::span<const int> tochange;
   /// The new values such that
@@ -46,11 +46,11 @@ struct ConnectorRef {
    own class from this class.
 */
 class AbstractOperator {
-public:
+ public:
   using VectorType = Eigen::VectorXd;
   using VectorRefType = Eigen::Ref<VectorType>;
   using VectorConstRefType = Eigen::Ref<const VectorType>;
-  using MelType = std::vector<std::complex<double>>;
+  using MelType = std::vector<Complex>;
   using ConnectorsType = std::vector<std::vector<int>>;
   using NewconfsType = std::vector<std::vector<double>>;
 
@@ -75,9 +75,9 @@ public:
 
   using ConnCallback = std::function<void(ConnectorRef)>;
 
-  virtual std::tuple<MelType, ConnectorsType, NewconfsType>
-  GetConn(VectorConstRefType v) const {
-    std::vector<std::complex<double>> mel;
+  virtual std::tuple<MelType, ConnectorsType, NewconfsType> GetConn(
+      VectorConstRefType v) const {
+    std::vector<Complex> mel;
     std::vector<std::vector<int>> connectors;
     std::vector<std::vector<double>> newconfs;
     FindConn(v, mel, connectors, newconfs);
@@ -107,7 +107,7 @@ public:
 
 void AbstractOperator::ForEachConn(VectorConstRefType v,
                                    ConnCallback callback) const {
-  std::vector<std::complex<double>> weights;
+  std::vector<Complex> weights;
   std::vector<std::vector<int>> connectors;
   std::vector<std::vector<double>> newconfs;
 
@@ -119,6 +119,6 @@ void AbstractOperator::ForEachConn(VectorConstRefType v,
   }
 }
 
-} // namespace netket
+}  // namespace netket
 
 #endif

--- a/NetKet/Operator/bosonhubbard.hpp
+++ b/NetKet/Operator/bosonhubbard.hpp
@@ -86,7 +86,7 @@ class BoseHubbard : public AbstractOperator {
     }
   }
 
-  void FindConn(VectorConstRefType v, std::vector<std::complex<double>> &mel,
+  void FindConn(VectorConstRefType v, std::vector<Complex> &mel,
                 std::vector<std::vector<int>> &connectors,
                 std::vector<std::vector<double>> &newconfs) const override {
     connectors.clear();

--- a/NetKet/Operator/local_operator.hpp
+++ b/NetKet/Operator/local_operator.hpp
@@ -39,7 +39,7 @@ namespace netket {
 
 class LocalOperator : public AbstractOperator {
  public:
-  using MelType = std::complex<double>;
+  using MelType = Complex;
   using MatType = std::vector<std::vector<MelType>>;
   using SiteType = std::vector<int>;
   using MapType = std::map<std::vector<double>, int>;
@@ -186,7 +186,7 @@ class LocalOperator : public AbstractOperator {
     }
   }
 
-  void FindConn(VectorConstRefType v, std::vector<std::complex<double>> &mel,
+  void FindConn(VectorConstRefType v, std::vector<Complex> &mel,
                 std::vector<std::vector<int>> &connectors,
                 std::vector<std::vector<double>> &newconfs) const override {
     assert(v.size() == hilbert_.Size());
@@ -223,7 +223,7 @@ class LocalOperator : public AbstractOperator {
 
   // FindConn for a specific operator
   void FindConn(std::size_t opn, VectorConstRefType v,
-                std::vector<std::complex<double>> &mel,
+                std::vector<Complex> &mel,
                 std::vector<std::vector<int>> &connectors,
                 std::vector<std::vector<double>> &newconfs) const {
     assert(opn < mat_.size() && opn >= 0);

--- a/NetKet/Output/json_output_writer.hpp
+++ b/NetKet/Output/json_output_writer.hpp
@@ -110,8 +110,7 @@ class JsonOutputWriter {
   // Member functions functions for saving the state.
   // The first overload works for classes inheriting from AbstractMachine, the
   // second one for Eigen matrices.
-  template <typename T>
-  void SaveState_Impl(std::ofstream& stream, const AbstractMachine<T>& state) {
+  void SaveState_Impl(std::ofstream& stream, const AbstractMachine& state) {
     state.Save(stream);
   }
 

--- a/NetKet/Sampler/abstract_sampler.hpp
+++ b/NetKet/Sampler/abstract_sampler.hpp
@@ -21,7 +21,6 @@
 
 namespace netket {
 
-template <class WfType>
 class AbstractSampler {
  public:
   virtual void Reset(bool initrandom = false) = 0;
@@ -32,7 +31,7 @@ class AbstractSampler {
 
   virtual void SetVisible(const Eigen::VectorXd& v) = 0;
 
-  virtual WfType& GetMachine() noexcept = 0;
+  virtual AbstractMachine& GetMachine() noexcept = 0;
 
   virtual Eigen::VectorXd Acceptance() const = 0;
 

--- a/NetKet/Sampler/custom_sampler.hpp
+++ b/NetKet/Sampler/custom_sampler.hpp
@@ -29,9 +29,8 @@
 namespace netket {
 
 // Metropolis sampling using custom moves provided by user
-template <class WfType>
-class CustomSampler: public AbstractSampler<WfType> {
-  WfType &psi_;
+class CustomSampler : public AbstractSampler {
+  AbstractMachine &psi_;
   const AbstractHilbert &hilbert_;
   LocalOperator move_operators_;
   std::vector<double> operatorsweights_;
@@ -49,17 +48,17 @@ class CustomSampler: public AbstractSampler<WfType> {
   int totalnodes_;
 
   // Look-up tables
-  typename WfType::LookupType lt_;
+  typename AbstractMachine::LookupType lt_;
 
   std::vector<std::vector<int>> tochange_;
   std::vector<std::vector<double>> newconfs_;
-  std::vector<std::complex<double>> mel_;
+  std::vector<Complex> mel_;
 
   int nstates_;
   std::vector<double> localstates_;
 
  public:
-  CustomSampler(WfType &psi, const LocalOperator &move_operators,
+  CustomSampler(AbstractMachine &psi, const LocalOperator &move_operators,
                 const std::vector<double> &move_weights = {})
       : psi_(psi),
         hilbert_(psi.GetHilbert()),
@@ -159,7 +158,7 @@ class CustomSampler: public AbstractSampler<WfType> {
 
   void SetVisible(const Eigen::VectorXd &v) override { v_ = v; }
 
-  WfType &GetMachine() noexcept override { return psi_; }
+  AbstractMachine &GetMachine() noexcept override { return psi_; }
 
   const AbstractHilbert &GetHilbert() const noexcept override {
     return hilbert_;

--- a/NetKet/Sampler/custom_sampler_pt.hpp
+++ b/NetKet/Sampler/custom_sampler_pt.hpp
@@ -29,9 +29,8 @@
 namespace netket {
 
 // Metropolis sampling using custom moves provided by user
-template <class WfType>
-class CustomSamplerPt: public AbstractSampler<WfType> {
-  WfType& psi_;
+class CustomSamplerPt : public AbstractSampler {
+  AbstractMachine& psi_;
   const AbstractHilbert& hilbert_;
   LocalOperator move_operators_;
   std::vector<double> operatorsweights_;
@@ -49,11 +48,11 @@ class CustomSamplerPt: public AbstractSampler<WfType> {
   int totalnodes_;
 
   // Look-up tables
-  std::vector<typename WfType::LookupType> lt_;
+  std::vector<typename AbstractMachine::LookupType> lt_;
 
   std::vector<std::vector<int>> tochange_;
   std::vector<std::vector<double>> newconfs_;
-  std::vector<std::complex<double>> mel_;
+  std::vector<Complex> mel_;
 
   int nstates_;
   std::vector<double> localstates_;
@@ -62,7 +61,7 @@ class CustomSamplerPt: public AbstractSampler<WfType> {
   std::vector<double> beta_;
 
  public:
-  CustomSamplerPt(WfType& psi, const LocalOperator& move_operators,
+  CustomSamplerPt(AbstractMachine& psi, const LocalOperator& move_operators,
                   const std::vector<double>& move_weights = {},
                   int nreplicas = 1)
       : psi_(psi),
@@ -74,7 +73,7 @@ class CustomSamplerPt: public AbstractSampler<WfType> {
   }
 
   void Init(const std::vector<double>& move_weights) {
-    CustomSampler<WfType>::CheckMoveOperators(move_operators_);
+    CustomSampler::CheckMoveOperators(move_operators_);
 
     if (hilbert_.Size() != move_operators_.GetHilbert().Size()) {
       throw InvalidInputError(
@@ -224,7 +223,7 @@ class CustomSamplerPt: public AbstractSampler<WfType> {
 
   void SetVisible(const Eigen::VectorXd& v) override { v_[0] = v; }
 
-  WfType& GetMachine() noexcept override { return psi_; }
+  AbstractMachine& GetMachine() noexcept override { return psi_; }
 
   const AbstractHilbert& GetHilbert() const noexcept override {
     return hilbert_;

--- a/NetKet/Sampler/exact_sampler.hpp
+++ b/NetKet/Sampler/exact_sampler.hpp
@@ -26,9 +26,8 @@
 namespace netket {
 
 // Exact sampling using heat bath, mostly for testing purposes on small systems
-template <class WfType>
-class ExactSampler: public AbstractSampler<WfType> {
-  WfType& psi_;
+class ExactSampler : public AbstractSampler {
+  AbstractMachine& psi_;
 
   const AbstractHilbert& hilbert_;
 
@@ -50,11 +49,11 @@ class ExactSampler: public AbstractSampler<WfType> {
 
   std::discrete_distribution<int> dist_;
 
-  std::vector<std::complex<double>> logpsivals_;
+  std::vector<Complex> logpsivals_;
   std::vector<double> psivals_;
 
  public:
-  explicit ExactSampler(WfType& psi)
+  explicit ExactSampler(AbstractMachine& psi)
       : psi_(psi),
         hilbert_(psi.GetHilbert()),
         nv_(hilbert_.Size()),
@@ -121,7 +120,7 @@ class ExactSampler: public AbstractSampler<WfType> {
 
   void SetVisible(const Eigen::VectorXd& v) override { v_ = v; }
 
-  WfType& GetMachine() noexcept override { return psi_; }
+  AbstractMachine& GetMachine() noexcept override { return psi_; }
 
   const AbstractHilbert& GetHilbert() const noexcept override {
     return hilbert_;

--- a/NetKet/Sampler/metropolis_exchange.hpp
+++ b/NetKet/Sampler/metropolis_exchange.hpp
@@ -25,9 +25,8 @@
 namespace netket {
 
 // Metropolis sampling generating local exchanges
-template <class WfType>
-class MetropolisExchange: public AbstractSampler<WfType> {
-  WfType &psi_;
+class MetropolisExchange : public AbstractSampler {
+  AbstractMachine &psi_;
 
   const AbstractHilbert &hilbert_;
 
@@ -47,10 +46,10 @@ class MetropolisExchange: public AbstractSampler<WfType> {
   std::vector<std::vector<int>> clusters_;
 
   // Look-up tables
-  typename WfType::LookupType lt_;
+  typename AbstractMachine::LookupType lt_;
 
  public:
-  MetropolisExchange(const AbstractGraph &graph, WfType &psi, int dmax = 1)
+  MetropolisExchange(const AbstractGraph &graph, AbstractMachine &psi, int dmax = 1)
       : psi_(psi), hilbert_(psi.GetHilbert()), nv_(hilbert_.Size()) {
     Init(graph, dmax);
   }
@@ -139,7 +138,7 @@ class MetropolisExchange: public AbstractSampler<WfType> {
 
   void SetVisible(const Eigen::VectorXd &v) override { v_ = v; }
 
-  WfType &GetMachine() noexcept override { return psi_; }
+  AbstractMachine &GetMachine() noexcept override { return psi_; }
 
   const AbstractHilbert &GetHilbert() const noexcept override {
     return hilbert_;

--- a/NetKet/Sampler/metropolis_exchange_pt.hpp
+++ b/NetKet/Sampler/metropolis_exchange_pt.hpp
@@ -26,9 +26,8 @@ namespace netket {
 
 // Metropolis sampling generating local exchanges
 // Parallel tempering is also used
-template <class WfType>
-class MetropolisExchangePt: public AbstractSampler<WfType> {
-  WfType &psi_;
+class MetropolisExchangePt : public AbstractSampler {
+  AbstractMachine &psi_;
   const AbstractHilbert &hilbert_;
 
   // number of visible units
@@ -51,11 +50,11 @@ class MetropolisExchangePt: public AbstractSampler<WfType> {
   std::vector<std::vector<int>> clusters_;
 
   // Look-up tables
-  std::vector<typename WfType::LookupType> lt_;
+  std::vector<typename AbstractMachine::LookupType> lt_;
 
  public:
-  MetropolisExchangePt(const AbstractGraph &graph, WfType &psi, int dmax = 1,
-                       int nreplicas = 1)
+  MetropolisExchangePt(const AbstractGraph &graph, AbstractMachine &psi,
+                       int dmax = 1, int nreplicas = 1)
       : psi_(psi),
         hilbert_(psi.GetHilbert()),
         nv_(hilbert_.Size()),
@@ -206,7 +205,7 @@ class MetropolisExchangePt: public AbstractSampler<WfType> {
 
   void SetVisible(const Eigen::VectorXd &v) override { v_[0] = v; }
 
-  WfType &GetMachine() noexcept override { return psi_; }
+  AbstractMachine &GetMachine() noexcept override { return psi_; }
 
   const AbstractHilbert &GetHilbert() const noexcept override {
     return hilbert_;

--- a/NetKet/Sampler/metropolis_hamiltonian.hpp
+++ b/NetKet/Sampler/metropolis_hamiltonian.hpp
@@ -25,9 +25,9 @@
 namespace netket {
 
 // Metropolis sampling generating transitions using the Hamiltonian
-template <class WfType, class H>
-class MetropolisHamiltonian : public AbstractSampler<WfType> {
-  WfType &psi_;
+template <class H>
+class MetropolisHamiltonian : public AbstractSampler {
+  AbstractMachine &psi_;
 
   const AbstractHilbert &hilbert_;
 
@@ -46,20 +46,20 @@ class MetropolisHamiltonian : public AbstractSampler<WfType> {
   int totalnodes_;
 
   // Look-up tables
-  typename WfType::LookupType lt_;
+  typename AbstractMachine::LookupType lt_;
 
   std::vector<std::vector<int>> tochange_;
   std::vector<std::vector<double>> newconfs_;
-  std::vector<std::complex<double>> mel_;
+  std::vector<Complex> mel_;
 
   std::vector<std::vector<int>> tochange1_;
   std::vector<std::vector<double>> newconfs1_;
-  std::vector<std::complex<double>> mel1_;
+  std::vector<Complex> mel1_;
 
   Eigen::VectorXd v1_;
 
  public:
-  MetropolisHamiltonian(WfType &psi, H &hamiltonian)
+  MetropolisHamiltonian(AbstractMachine &psi, H &hamiltonian)
       : psi_(psi),
         hilbert_(psi.GetHilbert()),
         hamiltonian_(hamiltonian),
@@ -160,7 +160,7 @@ class MetropolisHamiltonian : public AbstractSampler<WfType> {
     return hilbert_;
   }
 
-  WfType &GetMachine() noexcept override { return psi_; }
+  AbstractMachine &GetMachine() noexcept override { return psi_; }
 
   Eigen::VectorXd Acceptance() const override {
     Eigen::VectorXd acc = accept_;

--- a/NetKet/Sampler/metropolis_hamiltonian_pt.hpp
+++ b/NetKet/Sampler/metropolis_hamiltonian_pt.hpp
@@ -25,9 +25,9 @@
 namespace netket {
 
 // Metropolis sampling generating transitions using the Hamiltonian
-template <class WfType, class H>
-class MetropolisHamiltonianPt : public AbstractSampler<WfType> {
-  WfType &psi_;
+template <class H>
+class MetropolisHamiltonianPt : public AbstractSampler {
+  AbstractMachine &psi_;
 
   const AbstractHilbert &hilbert_;
 
@@ -50,18 +50,18 @@ class MetropolisHamiltonianPt : public AbstractSampler<WfType> {
   int totalnodes_;
 
   // Look-up tables
-  std::vector<typename WfType::LookupType> lt_;
+  std::vector<typename AbstractMachine::LookupType> lt_;
 
   std::vector<std::vector<int>> tochange_;
   std::vector<std::vector<double>> newconfs_;
-  std::vector<std::complex<double>> mel_;
+  std::vector<Complex> mel_;
 
   std::vector<std::vector<int>> tochange1_;
   std::vector<std::vector<double>> newconfs1_;
-  std::vector<std::complex<double>> mel1_;
+  std::vector<Complex> mel1_;
 
  public:
-  MetropolisHamiltonianPt(WfType &psi, H &hamiltonian, int nrep)
+  MetropolisHamiltonianPt(AbstractMachine &psi, H &hamiltonian, int nrep)
       : psi_(psi),
         hilbert_(psi.GetHilbert()),
         hamiltonian_(hamiltonian),
@@ -220,7 +220,7 @@ class MetropolisHamiltonianPt : public AbstractSampler<WfType> {
 
   void SetVisible(const Eigen::VectorXd &v) override { v_[0] = v; }
 
-  WfType &GetMachine() noexcept override { return psi_; }
+  AbstractMachine &GetMachine() noexcept override { return psi_; }
 
   const AbstractHilbert &GetHilbert() const noexcept override {
     return hilbert_;

--- a/NetKet/Sampler/metropolis_hop.hpp
+++ b/NetKet/Sampler/metropolis_hop.hpp
@@ -24,9 +24,8 @@
 namespace netket {
 
 // Metropolis sampling generating local hoppings
-template <class WfType>
-class MetropolisHop: public AbstractSampler<WfType> {
-  WfType &psi_;
+class MetropolisHop : public AbstractSampler {
+  AbstractMachine &psi_;
 
   const AbstractHilbert &hilbert_;
 
@@ -46,13 +45,13 @@ class MetropolisHop: public AbstractSampler<WfType> {
   std::vector<std::vector<int>> clusters_;
 
   // Look-up tables
-  typename WfType::LookupType lt_;
+  typename AbstractMachine::LookupType lt_;
 
   int nstates_;
   std::vector<double> localstates_;
 
  public:
-  MetropolisHop(WfType &psi, int dmax = 1)
+  MetropolisHop(AbstractMachine &psi, int dmax = 1)
       : psi_(psi), hilbert_(psi.GetHilbert()), nv_(hilbert_.Size()) {
     Init(hilbert_.GetGraph(), dmax);
   }
@@ -178,7 +177,7 @@ class MetropolisHop: public AbstractSampler<WfType> {
 
   void SetVisible(const Eigen::VectorXd &v) override { v_ = v; }
 
-  WfType &GetMachine() noexcept override { return psi_; }
+  AbstractMachine &GetMachine() noexcept override { return psi_; }
 
   const AbstractHilbert &GetHilbert() const noexcept override {
     return hilbert_;

--- a/NetKet/Sampler/metropolis_local.hpp
+++ b/NetKet/Sampler/metropolis_local.hpp
@@ -26,9 +26,8 @@
 namespace netket {
 
 // Metropolis sampling generating local moves in hilbert space
-template <class WfType>
-class MetropolisLocal: public AbstractSampler<WfType> {
-  WfType& psi_;
+class MetropolisLocal : public AbstractSampler {
+  AbstractMachine& psi_;
 
   const AbstractHilbert& hilbert_;
 
@@ -45,13 +44,13 @@ class MetropolisLocal: public AbstractSampler<WfType> {
   int totalnodes_;
 
   // Look-up tables
-  typename WfType::LookupType lt_;
+  typename AbstractMachine::LookupType lt_;
 
   int nstates_;
   std::vector<double> localstates_;
 
  public:
-  explicit MetropolisLocal(WfType& psi)
+  explicit MetropolisLocal(AbstractMachine& psi)
       : psi_(psi), hilbert_(psi.GetHilbert()), nv_(hilbert_.Size()) {
     Init();
   }
@@ -153,7 +152,7 @@ class MetropolisLocal: public AbstractSampler<WfType> {
 
   void SetVisible(const Eigen::VectorXd& v) override { v_ = v; }
 
-  WfType& GetMachine() noexcept override { return psi_; }
+  AbstractMachine& GetMachine() noexcept override { return psi_; }
 
   const AbstractHilbert& GetHilbert() const noexcept override {
     return hilbert_;

--- a/NetKet/Sampler/metropolis_local_pt.hpp
+++ b/NetKet/Sampler/metropolis_local_pt.hpp
@@ -26,9 +26,8 @@ namespace netket {
 
 // Metropolis sampling generating local changes
 // Parallel tempering is also used
-template <class WfType>
-class MetropolisLocalPt: public AbstractSampler<WfType> {
-  WfType& psi_;
+class MetropolisLocalPt : public AbstractSampler {
+  AbstractMachine& psi_;
 
   const AbstractHilbert& hilbert_;
 
@@ -49,7 +48,7 @@ class MetropolisLocalPt: public AbstractSampler<WfType> {
   std::vector<std::vector<int>> clusters_;
 
   // Look-up tables
-  std::vector<typename WfType::LookupType> lt_;
+  std::vector<typename AbstractMachine::LookupType> lt_;
 
   int nrep_;
 
@@ -60,7 +59,7 @@ class MetropolisLocalPt: public AbstractSampler<WfType> {
 
  public:
   // Constructor with one replica by default
-  explicit MetropolisLocalPt(WfType& psi, int nreplicas = 1)
+  explicit MetropolisLocalPt(AbstractMachine& psi, int nreplicas = 1)
       : psi_(psi),
         hilbert_(psi.GetHilbert()),
         nv_(hilbert_.Size()),
@@ -224,7 +223,7 @@ class MetropolisLocalPt: public AbstractSampler<WfType> {
 
   void SetVisible(const Eigen::VectorXd& v) override { v_[0] = v; }
 
-  WfType& GetMachine() noexcept override { return psi_; }
+  AbstractMachine& GetMachine() noexcept override { return psi_; }
 
   const AbstractHilbert& GetHilbert() const noexcept override {
     return hilbert_;

--- a/NetKet/Sampler/py_custom_sampler.hpp
+++ b/NetKet/Sampler/py_custom_sampler.hpp
@@ -23,8 +23,7 @@ namespace py = pybind11;
 namespace netket {
 
 void AddCustomSampler(py::module &subm) {
-  using DerSampler = CustomSampler<MachineType>;
-  py::class_<DerSampler, SamplerType>(subm, "CustomSampler", R"EOF(
+  py::class_<CustomSampler, AbstractSampler>(subm, "CustomSampler", R"EOF(
     Custom Sampler, where transition operators are specified by the user.
     For the moment, this functionality is limited to transition operators which
     are sums of $$k$$-local operators:
@@ -50,7 +49,7 @@ void AddCustomSampler(py::module &subm) {
     $$ |m\rangle $$ is given by
     $$ \langle n|  M_i | m \rangle $$.
     )EOF")
-      .def(py::init<MachineType &, const LocalOperator &,
+      .def(py::init<AbstractMachine &, const LocalOperator &,
                     const std::vector<double> &>(),
            py::keep_alive<1, 2>(), py::arg("machine"),
            py::arg("move_operators"),

--- a/NetKet/Sampler/py_custom_sampler_pt.hpp
+++ b/NetKet/Sampler/py_custom_sampler_pt.hpp
@@ -23,9 +23,8 @@ namespace py = pybind11;
 namespace netket {
 
 void AddCustomSamplerPt(py::module &subm) {
-  using DerSampler = CustomSamplerPt<MachineType>;
-  py::class_<DerSampler, SamplerType>(subm, "CustomSamplerPt")
-      .def(py::init<MachineType &, const LocalOperator &,
+  py::class_<CustomSamplerPt, AbstractSampler>(subm, "CustomSamplerPt")
+      .def(py::init<AbstractMachine &, const LocalOperator &,
                     const std::vector<double> &, int>(),
            py::keep_alive<1, 2>(), py::arg("machine"),
            py::arg("move_operators"),

--- a/NetKet/Sampler/py_exact_sampler.hpp
+++ b/NetKet/Sampler/py_exact_sampler.hpp
@@ -23,8 +23,7 @@ namespace py = pybind11;
 namespace netket {
 
 void AddExactSampler(py::module &subm) {
-  using DerSampler = ExactSampler<MachineType>;
-  py::class_<DerSampler, SamplerType>(subm, "ExactSampler", R"EOF(
+  py::class_<ExactSampler, AbstractSampler>(subm, "ExactSampler", R"EOF(
     This sampler generates i.i.d. samples from $$|\Psi(s)|^2$$.
     In order to perform exact sampling, $$|\Psi(s)|^2$$ is precomputed an all
     the possible values of the quantum numbers $$s$$. This sampler has thus an
@@ -32,7 +31,7 @@ void AddExactSampler(py::module &subm) {
     for large systems, where Metropolis-based sampling are instead a viable
     option.
     )EOF")
-      .def(py::init<MachineType &>(), py::keep_alive<1, 2>(),
+      .def(py::init<AbstractMachine &>(), py::keep_alive<1, 2>(),
            py::arg("machine"), R"EOF(
              Constructs a new ``ExactSampler`` given a machine.
 

--- a/NetKet/Sampler/py_metropolis_exchange.hpp
+++ b/NetKet/Sampler/py_metropolis_exchange.hpp
@@ -23,8 +23,8 @@ namespace py = pybind11;
 namespace netket {
 
 void AddMetropolisExchange(py::module &subm) {
-  using DerSampler = MetropolisExchange<MachineType>;
-  py::class_<DerSampler, SamplerType>(subm, "MetropolisExchange", R"EOF(
+  py::class_<MetropolisExchange, AbstractSampler>(subm, "MetropolisExchange",
+                                                  R"EOF(
     This sampler acts locally only on two local degree of freedom $$ s_i $$ and $$ s_j $$,
     and proposes a new state: $$ s_1 \dots s^\prime_i \dots s^\prime_j \dots s_N $$,
     where in general $$ s^\prime_i \neq s_i $$ and $$ s^\prime_j \neq s_j $$ .
@@ -46,7 +46,7 @@ void AddMetropolisExchange(py::module &subm) {
     region where $$ \sum_i s_i = \mathrm{constant} $$ is needed,
     otherwise the sampling would be strongly not ergodic.
     )EOF")
-      .def(py::init<const AbstractGraph &, MachineType &, int>(),
+      .def(py::init<const AbstractGraph &, AbstractMachine &, int>(),
            py::keep_alive<1, 2>(), py::keep_alive<1, 3>(), py::arg("graph"),
            py::arg("machine"), py::arg("d_max") = 1, R"EOF(
              Constructs a new ``MetropolisExchange`` sampler given a machine and a

--- a/NetKet/Sampler/py_metropolis_exchange_pt.hpp
+++ b/NetKet/Sampler/py_metropolis_exchange_pt.hpp
@@ -23,13 +23,13 @@ namespace py = pybind11;
 namespace netket {
 
 void AddMetropolisExchangePt(py::module &subm) {
-  using DerSampler = MetropolisExchangePt<MachineType>;
-  py::class_<DerSampler, SamplerType>(subm, "MetropolisExchangePt", R"EOF(
+  py::class_<MetropolisExchangePt, AbstractSampler>(
+      subm, "MetropolisExchangePt", R"EOF(
     This sampler performs parallel-tempering moves in addition to
     the local exchange moves implemented in `MetropolisExchange`.
     The number of replicas can be $$ N_{\mathrm{rep}} $$ chosen by the user.
     )EOF")
-      .def(py::init<const AbstractGraph &, MachineType &, int, int>(),
+      .def(py::init<const AbstractGraph &, AbstractMachine &, int, int>(),
            py::keep_alive<1, 2>(), py::keep_alive<1, 3>(), py::arg("graph"),
            py::arg("machine"), py::arg("d_max") = 1, py::arg("n_replicas") = 1,
            R"EOF(

--- a/NetKet/Sampler/py_metropolis_hamiltonian.hpp
+++ b/NetKet/Sampler/py_metropolis_hamiltonian.hpp
@@ -23,8 +23,8 @@ namespace py = pybind11;
 namespace netket {
 
 void AddMetropolisHamiltonian(py::module &subm) {
-  using DerSampler = MetropolisHamiltonian<MachineType, AbstractOperator>;
-  py::class_<DerSampler, SamplerType>(subm, "MetropolisHamiltonian", R"EOF(
+  using DerSampler = MetropolisHamiltonian<AbstractOperator>;
+  py::class_<DerSampler, AbstractSampler>(subm, "MetropolisHamiltonian", R"EOF(
     Sampling based on the off-diagonal elements of a Hamiltonian (or a generic Operator).
     In this case, the transition matrix is taken to be:
 
@@ -40,7 +40,7 @@ void AddMetropolisHamiltonian(py::module &subm) {
     Notice that this sampler preserves by construction all the symmetries
     of the Hamiltonian. This is in generally not true for the local samplers instead.
     )EOF")
-      .def(py::init<MachineType &, AbstractOperator &>(),
+      .def(py::init<AbstractMachine &, AbstractOperator &>(),
            py::keep_alive<1, 2>(), py::keep_alive<1, 3>(), py::arg("machine"),
            py::arg("hamiltonian"), R"EOF(
              Constructs a new ``MetropolisHamiltonian`` sampler given a machine

--- a/NetKet/Sampler/py_metropolis_hamiltonian_pt.hpp
+++ b/NetKet/Sampler/py_metropolis_hamiltonian_pt.hpp
@@ -23,13 +23,14 @@ namespace py = pybind11;
 namespace netket {
 
 void AddMetropolisHamiltonianPt(py::module &subm) {
-  using DerSampler = MetropolisHamiltonianPt<MachineType, AbstractOperator>;
-  py::class_<DerSampler, SamplerType>(subm, "MetropolisHamiltonianPt", R"EOF(
+  using DerSampler = MetropolisHamiltonianPt<AbstractOperator>;
+  py::class_<DerSampler, AbstractSampler>(subm, "MetropolisHamiltonianPt",
+                                          R"EOF(
     This sampler performs parallel-tempering moves in addition to
     the local moves implemented in `MetropolisHamiltonian`.
     The number of replicas can be $$ N_{\mathrm{rep}} $$ chosen by the user.
     )EOF")
-      .def(py::init<MachineType &, AbstractOperator &, int>(),
+      .def(py::init<AbstractMachine &, AbstractOperator &, int>(),
            py::keep_alive<1, 2>(), py::keep_alive<1, 3>(), py::arg("machine"),
            py::arg("hamiltonian"), py::arg("n_replicas"), R"EOF(
              Constructs a new ``MetropolisHamiltonianPt`` sampler given a machine,

--- a/NetKet/Sampler/py_metropolis_hop.hpp
+++ b/NetKet/Sampler/py_metropolis_hop.hpp
@@ -23,9 +23,8 @@ namespace py = pybind11;
 namespace netket {
 
 void AddMetropolisHop(py::module &subm) {
-  using DerSampler = MetropolisHop<MachineType>;
-  py::class_<DerSampler, SamplerType>(subm, "MetropolisHop")
-      .def(py::init<MachineType &, int>(), py::keep_alive<1, 3>(),
+  py::class_<MetropolisHop, AbstractSampler>(subm, "MetropolisHop")
+      .def(py::init<AbstractMachine &, int>(), py::keep_alive<1, 3>(),
            py::arg("machine"), py::arg("d_max") = 1);
 }
 }  // namespace netket

--- a/NetKet/Sampler/py_metropolis_local.hpp
+++ b/NetKet/Sampler/py_metropolis_local.hpp
@@ -23,8 +23,7 @@ namespace py = pybind11;
 namespace netket {
 
 void AddMetropolisLocal(py::module &subm) {
-  using DerSampler = MetropolisLocal<MachineType>;
-  py::class_<DerSampler, SamplerType>(subm, "MetropolisLocal", R"EOF(
+  py::class_<MetropolisLocal, AbstractSampler>(subm, "MetropolisLocal", R"EOF(
       This sampler acts locally only on one local degree of freedom $$s_i$$,
       and proposes a new state: $$ s_1 \dots s^\prime_i \dots s_N $$,
       where $$ s^\prime_i \neq s_i $$.
@@ -46,7 +45,7 @@ void AddMetropolisLocal(py::module &subm) {
       would pick a random local occupation number uniformly between $$0$$
       and $$n_{\mathrm{max}}$$.
       )EOF")
-      .def(py::init<MachineType &>(), py::keep_alive<1, 2>(),
+      .def(py::init<AbstractMachine &>(), py::keep_alive<1, 2>(),
            py::arg("machine"), R"EOF(
              Constructs a new ``MetropolisLocal`` sampler given a machine.
 

--- a/NetKet/Sampler/py_metropolis_local_pt.hpp
+++ b/NetKet/Sampler/py_metropolis_local_pt.hpp
@@ -23,13 +23,13 @@ namespace py = pybind11;
 namespace netket {
 
 void AddMetropolisLocalPt(py::module &subm) {
-  using DerSampler = MetropolisLocalPt<MachineType>;
-  py::class_<DerSampler, SamplerType>(subm, "MetropolisLocalPt", R"EOF(
+  py::class_<MetropolisLocalPt, AbstractSampler>(subm, "MetropolisLocalPt",
+                                                 R"EOF(
     This sampler performs parallel-tempering
     moves in addition to the local moves implemented in `MetropolisLocal`.
     The number of replicas can be $$ N_{\mathrm{rep}} $$ chosen by the user.
       )EOF")
-      .def(py::init<MachineType &, int>(), py::keep_alive<1, 2>(),
+      .def(py::init<AbstractMachine &, int>(), py::keep_alive<1, 2>(),
            py::arg("machine"), py::arg("n_replicas") = 1, R"EOF(
              Constructs a new ``MetropolisLocalPt`` sampler given a machine
              and the number of replicas.

--- a/NetKet/Sampler/py_sampler.hpp
+++ b/NetKet/Sampler/py_sampler.hpp
@@ -46,7 +46,7 @@ namespace netket {
 void AddSamplerModule(py::module &m) {
   auto subm = m.def_submodule("sampler");
 
-  py::class_<SamplerType>(subm, "Sampler", R"EOF(
+  py::class_<AbstractSampler>(subm, "Sampler", R"EOF(
     NetKet implements generic sampling routines to be used in conjunction with
     suitable variational states, the `Machines`.
     A `Sampler` generates quantum numbers distributed according to the square modulus
@@ -61,7 +61,7 @@ void AddSamplerModule(py::module &m) {
 
     $$T( \mathbf{s} \rightarrow \mathbf{s}^\prime) .$$
     )EOF")
-      .def("seed", &SamplerType::Seed, py::arg("base_seed"), R"EOF(
+      .def("seed", &AbstractSampler::Seed, py::arg("base_seed"), R"EOF(
       Seeds the random number generator used by the ``Sampler``.
 
       Args:
@@ -69,7 +69,8 @@ void AddSamplerModule(py::module &m) {
           used by the sampler. Each MPI node is guarantueed to be initialized
           with a distinct seed.
       )EOF")
-      .def("reset", &SamplerType::Reset, py::arg("init_random") = false, R"EOF(
+      .def("reset", &AbstractSampler::Reset, py::arg("init_random") = false,
+           R"EOF(
       Resets the state of the sampler, including the acceptance rate statistics
       and optionally initializing at random the visible units being sampled.
 
@@ -77,20 +78,21 @@ void AddSamplerModule(py::module &m) {
           init_random: If ``True`` the quantum numbers (visible units)
           are initialized at random, otherwise their value is preserved.
       )EOF")
-      .def("sweep", &SamplerType::Sweep, R"EOF(
+      .def("sweep", &AbstractSampler::Sweep, R"EOF(
       Performs a sampling sweep. Typically a single sweep
       consists of an extensive number of local moves.
       )EOF")
-      .def_property("visible", &SamplerType::Visible, &SamplerType::SetVisible,
+      .def_property("visible", &AbstractSampler::Visible,
+                    &AbstractSampler::SetVisible,
                     R"EOF(
                       numpy.array: The quantum numbers being sampled,
                        and distributed according to $$|\Psi(v)|^2$$ )EOF")
-      .def_property_readonly("acceptance", &SamplerType::Acceptance, R"EOF(
+      .def_property_readonly("acceptance", &AbstractSampler::Acceptance, R"EOF(
         numpy.array: The measured acceptance rate for the sampling.
         In the case of rejection-free sampling this is always equal to 1.  )EOF")
-      .def_property_readonly("hilbert", &SamplerType::GetHilbert, R"EOF(
+      .def_property_readonly("hilbert", &AbstractSampler::GetHilbert, R"EOF(
         netket.hilbert: The Hilbert space used for the sampling.  )EOF")
-      .def_property_readonly("machine", &SamplerType::GetMachine, R"EOF(
+      .def_property_readonly("machine", &AbstractSampler::GetMachine, R"EOF(
         netket.machine: The machine used for the sampling.  )EOF");
 
   AddMetropolisLocal(subm);

--- a/NetKet/Supervised/py_supervised.hpp
+++ b/NetKet/Supervised/py_supervised.hpp
@@ -35,7 +35,7 @@ void AddSupervisedModule(py::module &m) {
   py::class_<Supervised>(
       subm, "Supervised",
       R"EOF(Supervised learning scheme to learn data, i.e. the given state, by stochastic gradient descent with log overlap loss or MSE loss.)EOF")
-      .def(py::init([](MachineType &ma, AbstractOptimizer &op, int batch_size,
+      .def(py::init([](AbstractMachine &ma, AbstractOptimizer &op, int batch_size,
                        std::vector<Eigen::VectorXd> samples,
                        std::vector<Eigen::VectorXcd> targets) {
              return Supervised{ma, op, batch_size, std::move(samples),

--- a/NetKet/Supervised/supervised.hpp
+++ b/NetKet/Supervised/supervised.hpp
@@ -33,9 +33,7 @@
 namespace netket {
 
 class Supervised {
-  using complex = std::complex<double>;
-
-  AbstractMachine<complex> &psi_;
+  AbstractMachine &psi_;
   AbstractOptimizer &opt_;
 
   // Total batchsize
@@ -53,8 +51,8 @@ class Supervised {
   Eigen::VectorXcd grad_;
   Eigen::VectorXcd grad_part_1_;
   Eigen::VectorXcd grad_part_2_;
-  complex grad_num_1_;
-  complex grad_num_2_;
+  Complex grad_num_1_;
+  Complex grad_num_2_;
 
   // Training samples and targets
   std::vector<Eigen::VectorXd> trainingSamples_;
@@ -79,8 +77,8 @@ class Supervised {
   DistributedRandomEngine engine_;
 
  public:
-  Supervised(AbstractMachine<complex> &psi, AbstractOptimizer &opt,
-             int batchsize, std::vector<Eigen::VectorXd> trainingSamples,
+  Supervised(AbstractMachine &psi, AbstractOptimizer &opt, int batchsize,
+             std::vector<Eigen::VectorXd> trainingSamples,
              std::vector<Eigen::VectorXcd> trainingTargets)
       : psi_(psi),
         opt_(opt),
@@ -132,7 +130,7 @@ class Supervised {
     double max_log_psi = 0;
     /// [TODO] avoid going through psi twice.
     for (int i = 0; i < batchsize_node_; i++) {
-      complex value(psi_.LogVal(batchSamples[i]));
+      Complex value(psi_.LogVal(batchSamples[i]));
       if (max_log_psi < value.real()) {
         max_log_psi = value.real();
       }
@@ -144,11 +142,11 @@ class Supervised {
       Eigen::VectorXd sample(batchSamples[i]);
       // And the corresponding target
       Eigen::VectorXcd target(batchTargets[i]);
-      complex t(target[0].real(), target[0].imag());
+      Complex t(target[0].real(), target[0].imag());
       // Undo log
       t = exp(t);
 
-      complex value(psi_.LogVal(sample));
+      Complex value(psi_.LogVal(sample));
       // Undo Log
       value = value - max_log_psi;
       value = exp(value);
@@ -185,7 +183,7 @@ class Supervised {
     double max_log_psi = -std::numeric_limits<double>::infinity();
     /// [TODO] avoid going through psi twice.
     for (int i = 0; i < batchsize_node_; i++) {
-      complex value(psi_.LogVal(batchSamples[i]));
+      Complex value(psi_.LogVal(batchSamples[i]));
       if (max_log_psi < value.real()) {
         max_log_psi = value.real();
       }
@@ -197,11 +195,11 @@ class Supervised {
       Eigen::VectorXd sample(batchSamples[i]);
       // And the corresponding target
       Eigen::VectorXcd target(batchTargets[i]);
-      complex t = target[0];
+      Complex t = target[0];
       // Undo log
       t = exp(t);
 
-      complex value(psi_.LogVal(sample));
+      Complex value(psi_.LogVal(sample));
       // Undo Log
       value = value - max_log_psi;
       value = exp(value);
@@ -240,11 +238,11 @@ class Supervised {
     for (int i = 0; i < batchsize_node_; i++) {
       // Extract complex value of log(config)
       Eigen::VectorXd sample(batchSamples[i]);
-      complex value(psi_.LogVal(sample));
+      Complex value(psi_.LogVal(sample));
 
       // And the corresponding target
       Eigen::VectorXcd target(batchTargets[i]);
-      complex t(target[0].real(), target[0].imag());
+      Complex t(target[0].real(), target[0].imag());
 
       // Compute derivative of log(psi)
       auto partial_gradient = psi_.DerLog(sample);
@@ -364,10 +362,10 @@ class Supervised {
     double mse = 0.0;
     for (int i = 0; i < numSamples; i++) {
       Eigen::VectorXd sample = trainingSamples_[i];
-      complex value(psi_.LogVal(sample));
+      Complex value(psi_.LogVal(sample));
 
       Eigen::VectorXcd target = trainingTargets_[i];
-      complex t(target[0].real(), target[0].imag());
+      Complex t(target[0].real(), target[0].imag());
 
       mse_log += 0.5 * std::norm(value - t);
       mse += 0.5 * std::norm(exp(value) - exp(t));
@@ -385,10 +383,10 @@ class Supervised {
     const int numSamples = trainingSamples_.size();
 
     // Allocate vectors for storing the derivatives ...
-    complex num1(0.0, 0.0);
-    complex num2(0.0, 0.0);
-    complex num3(0.0, 0.0);
-    complex num4(0.0, 0.0);
+    Complex num1(0.0, 0.0);
+    Complex num2(0.0, 0.0);
+    Complex num3(0.0, 0.0);
+    Complex num4(0.0, 0.0);
 
     Eigen::VectorXcd logpsi(numSamples);
     double max_log_psi = -std::numeric_limits<double>::infinity();
@@ -406,10 +404,10 @@ class Supervised {
       // And the corresponding target
       Eigen::VectorXcd target(trainingTargets_[i]);
 
-      // Cast value and target to std::complex<double> and undo logs
-      complex value(psi_.LogVal(sample));
+      // Cast value and target to Complex and undo logs
+      Complex value(psi_.LogVal(sample));
       value = exp(value - max_log_psi);
-      complex t(target[0].real(), target[0].imag());
+      Complex t(target[0].real(), target[0].imag());
       t = exp(t);
 
       num1 += std::conj(value) * t;
@@ -418,7 +416,7 @@ class Supervised {
       num4 += std::norm(t);
     }
 
-    complex complex_log_overlap_ =
+    Complex complex_log_overlap_ =
         -(log(num1) + log(num2) - log(num3) - log(num4));
     assert(std::abs(complex_log_overlap_.imag()) < 1e-8);
     loss_log_overlap_ = complex_log_overlap_.real();

--- a/NetKet/Unsupervised/py_unsupervised.hpp
+++ b/NetKet/Unsupervised/py_unsupervised.hpp
@@ -33,30 +33,31 @@ void AddUnsupervisedModule(py::module &m) {
   auto subm = m.def_submodule("unsupervised");
 
   py::class_<QuantumStateReconstruction>(subm, "Qsr")
-      .def(py::init([](SamplerType &sa, AbstractOptimizer &op, int batch_size,
-                       int n_samples, int niter_opt, py::tuple rotations,
-                       std::vector<Eigen::VectorXd> samples,
-                       std::vector<int> bases, std::string output_file,
-                       int discarded_samples, int discarded_samples_on_init) {
-             auto rots = py::cast<std::vector<AbstractOperator *>>(rotations);
-             return QuantumStateReconstruction{sa,
-                                               op,
-                                               batch_size,
-                                               n_samples,
-                                               niter_opt,
-                                               std::move(rots),
-                                               std::move(samples),
-                                               std::move(bases),
-                                               output_file,
-                                               discarded_samples,
-                                               discarded_samples_on_init};
-           }),
-           py::keep_alive<1, 2>(), py::keep_alive<1, 3>(),
-           py::keep_alive<1, 7>(), py::arg("sampler"), py::arg("optimizer"),
-           py::arg("batch_size"), py::arg("n_samples"), py::arg("niter_opt"),
-           py::arg("rotations"), py::arg("samples"), py::arg("bases"),
-           py::arg("output_file"), py::arg("discarded_samples") = -1,
-           py::arg("discarded_samples_on_init") = 0)
+      .def(
+          py::init([](AbstractSampler &sa, AbstractOptimizer &op,
+                      int batch_size, int n_samples, int niter_opt,
+                      py::tuple rotations, std::vector<Eigen::VectorXd> samples,
+                      std::vector<int> bases, std::string output_file,
+                      int discarded_samples, int discarded_samples_on_init) {
+            auto rots = py::cast<std::vector<AbstractOperator *>>(rotations);
+            return QuantumStateReconstruction{sa,
+                                              op,
+                                              batch_size,
+                                              n_samples,
+                                              niter_opt,
+                                              std::move(rots),
+                                              std::move(samples),
+                                              std::move(bases),
+                                              output_file,
+                                              discarded_samples,
+                                              discarded_samples_on_init};
+          }),
+          py::keep_alive<1, 2>(), py::keep_alive<1, 3>(),
+          py::keep_alive<1, 7>(), py::arg("sampler"), py::arg("optimizer"),
+          py::arg("batch_size"), py::arg("n_samples"), py::arg("niter_opt"),
+          py::arg("rotations"), py::arg("samples"), py::arg("bases"),
+          py::arg("output_file"), py::arg("discarded_samples") = -1,
+          py::arg("discarded_samples_on_init") = 0)
       .def("add_observable", &QuantumStateReconstruction::AddObservable,
            py::keep_alive<1, 2>())
       .def("run", &QuantumStateReconstruction::Run);

--- a/NetKet/Unsupervised/quantum_state_reconstruction.hpp
+++ b/NetKet/Unsupervised/quantum_state_reconstruction.hpp
@@ -34,14 +34,11 @@
 namespace netket {
 
 class QuantumStateReconstruction {
-  using GsType = std::complex<double>;
-  using VectorT = Eigen::Matrix<typename AbstractMachine<GsType>::StateType,
-                                Eigen::Dynamic, 1>;
-  using MatrixT = Eigen::Matrix<typename AbstractMachine<GsType>::StateType,
-                                Eigen::Dynamic, Eigen::Dynamic>;
+  using VectorT = Eigen::Matrix<Complex, Eigen::Dynamic, 1>;
+  using MatrixT = Eigen::Matrix<Complex, Eigen::Dynamic, Eigen::Dynamic>;
 
-  AbstractSampler<AbstractMachine<GsType>> &sampler_;
-  AbstractMachine<GsType> &psi_;
+  AbstractSampler &sampler_;
+  AbstractMachine &psi_;
   const AbstractHilbert &hilbert_;
   AbstractOptimizer &opt_;
 
@@ -49,7 +46,7 @@ class QuantumStateReconstruction {
 
   std::vector<std::vector<int>> connectors_;
   std::vector<std::vector<double>> newconfs_;
-  std::vector<std::complex<double>> mel_;
+  std::vector<Complex> mel_;
 
   MatrixT Ok_;
   VectorT Okmean_;
@@ -84,9 +81,8 @@ class QuantumStateReconstruction {
   std::vector<int> trainingBases_;
 
  public:
-  QuantumStateReconstruction(AbstractSampler<AbstractMachine<GsType>> &sampler,
-                             AbstractOptimizer &opt, int batchsize,
-                             int nsamples, int niter_opt,
+  QuantumStateReconstruction(AbstractSampler &sampler, AbstractOptimizer &opt,
+                             int batchsize, int nsamples, int niter_opt,
                              std::vector<AbstractOperator *> rotations,
                              std::vector<Eigen::VectorXd> trainingSamples,
                              std::vector<int> trainingBases,
@@ -215,7 +211,7 @@ class QuantumStateReconstruction {
 
     assert(mel_.size() == std::size_t(logvaldiffs.size()));
 
-    std::complex<double> obval = 0;
+    Complex obval = 0;
 
     for (int i = 0; i < logvaldiffs.size(); i++) {
       obval += mel_[i] * std::exp(logvaldiffs(i));
@@ -262,7 +258,7 @@ class QuantumStateReconstruction {
   // basis identified by b_index
   void RotateGradient(int b_index, const Eigen::VectorXd &state,
                       Eigen::VectorXcd &rotated_gradient) {
-    std::complex<double> den;
+    Complex den;
     Eigen::VectorXcd num;
     Eigen::VectorXd v(psi_.Nvisible());
     rotations_[b_index]->FindConn(state, mel_, connectors_, newconfs_);

--- a/NetKet/Utils/json_dumps.hpp
+++ b/NetKet/Utils/json_dumps.hpp
@@ -62,14 +62,16 @@ void from_json(const nlohmann::json &js,
   std::vector<std::vector<T>> temp = js.get<std::vector<std::vector<T>>>();
 
   if (temp[0].size() == 0) {
-    throw netket::InvalidInputError("Error while loading Eigen Matrix from Json");
+    throw netket::InvalidInputError(
+        "Error while loading Eigen Matrix from Json");
   }
 
   v.resize(temp.size(), temp[0].size());
   for (std::size_t i = 0; i < temp.size(); i++) {
     for (std::size_t j = 0; j < temp[i].size(); j++) {
       if (temp[i].size() != temp[0].size()) {
-        throw netket::InvalidInputError("Error while loading Eigen Matrix from Json");
+        throw netket::InvalidInputError(
+            "Error while loading Eigen Matrix from Json");
       }
       v(i, j) = temp[i][j];
     }

--- a/NetKet/Utils/mpi_interface.hpp
+++ b/NetKet/Utils/mpi_interface.hpp
@@ -32,7 +32,7 @@ inline void SendToAll(int &val, int sendnode = 0,
                       const MPI_Comm comm = MPI_COMM_WORLD) {
   MPI_Bcast(&val, 1, MPI_INT, sendnode, comm);
 }
-inline void SendToAll(std::complex<double> &val, int sendnode = 0,
+inline void SendToAll(Complex &val, int sendnode = 0,
                       const MPI_Comm comm = MPI_COMM_WORLD) {
   MPI_Bcast(&val, 1, MPI_DOUBLE_COMPLEX, sendnode, comm);
 }
@@ -53,7 +53,7 @@ void SendToAll(std::vector<double> &value, int root = 0,
                const MPI_Comm comm = MPI_COMM_WORLD) {
   MPI_Bcast(&value[0], value.size(), MPI_DOUBLE, root, comm);
 }
-void SendToAll(std::vector<std::complex<double>> &value, int root = 0,
+void SendToAll(std::vector<Complex> &value, int root = 0,
                const MPI_Comm comm = MPI_COMM_WORLD) {
   MPI_Bcast(&value[0], value.size(), MPI_DOUBLE_COMPLEX, root, comm);
 }
@@ -85,7 +85,7 @@ inline void SumOnNodes(int &value, const MPI_Comm comm = MPI_COMM_WORLD) {
   MPI_Allreduce(MPI_IN_PLACE, &value, 1, MPI_INT, MPI_SUM, comm);
 }
 
-inline void SumOnNodes(std::complex<double> &val, std::complex<double> &sum,
+inline void SumOnNodes(Complex &val, Complex &sum,
                        const MPI_Comm comm = MPI_COMM_WORLD) {
   MPI_Allreduce(&val, &sum, 1, MPI_DOUBLE_COMPLEX, MPI_SUM, comm);
 }
@@ -145,25 +145,25 @@ inline void SumOnNodes(double *value, int size,
   MPI_Allreduce(MPI_IN_PLACE, value, size, MPI_DOUBLE, MPI_SUM, comm);
 }
 
-inline void SumOnNodes(std::complex<double> *value, int size,
+inline void SumOnNodes(Complex *value, int size,
                        const MPI_Comm comm = MPI_COMM_WORLD) {
   MPI_Allreduce(MPI_IN_PLACE, value, size, MPI_DOUBLE_COMPLEX, MPI_SUM, comm);
 }
 
-inline void SumOnNodes(std::vector<std::complex<double>> &val,
-                       std::vector<std::complex<double>> &sum,
+inline void SumOnNodes(std::vector<Complex> &val,
+                       std::vector<Complex> &sum,
                        const MPI_Comm comm = MPI_COMM_WORLD) {
   MPI_Allreduce(&val[0], &sum[0], val.size(), MPI_DOUBLE_COMPLEX, MPI_SUM,
                 comm);
 }
 
-inline void SumOnNodes(std::vector<std::complex<double>> &value,
+inline void SumOnNodes(std::vector<Complex> &value,
                        const MPI_Comm comm = MPI_COMM_WORLD) {
   MPI_Allreduce(MPI_IN_PLACE, &value[0], value.size(), MPI_DOUBLE_COMPLEX,
                 MPI_SUM, comm);
 }
 
-inline void SumOnNodes(std::complex<double> &value,
+inline void SumOnNodes(Complex &value,
                        const MPI_Comm comm = MPI_COMM_WORLD) {
   MPI_Allreduce(MPI_IN_PLACE, &value, 1, MPI_DOUBLE_COMPLEX, MPI_SUM, comm);
 }

--- a/NetKet/Utils/py_utils.hpp
+++ b/NetKet/Utils/py_utils.hpp
@@ -41,7 +41,7 @@ void AddUtilsModule(py::module &m) {
 
   py::class_<Lookup<double>>(m, "LookupReal").def(py::init<>());
 
-  py::class_<Lookup<std::complex<double>>>(m, "LookupComplex")
+  py::class_<Lookup<Complex>>(m, "LookupComplex")
       .def(py::init<>());
 
   py::class_<MPIHelpers>(m, "MPI")

--- a/NetKet/Utils/random_utils.hpp
+++ b/NetKet/Utils/random_utils.hpp
@@ -31,13 +31,13 @@ void RandomGaussian(Eigen::Matrix<double, Eigen::Dynamic, 1> &par, int seed,
   }
 }
 
-void RandomGaussian(Eigen::Matrix<std::complex<double>, Eigen::Dynamic, 1> &par,
+void RandomGaussian(Eigen::Matrix<Complex, Eigen::Dynamic, 1> &par,
                     int seed, double sigma) {
   std::default_random_engine generator(seed);
   std::normal_distribution<double> distribution(0, sigma);
   for (int i = 0; i < par.size(); i++) {
     par(i) =
-        std::complex<double>(distribution(generator), distribution(generator));
+        Complex(distribution(generator), distribution(generator));
   }
 }
 

--- a/NetKet/common_types.hpp
+++ b/NetKet/common_types.hpp
@@ -1,10 +1,12 @@
 #ifndef NETKET_COMMON_TYPES_HPP
 #define NETKET_COMMON_TYPES_HPP
 /**
- * This header contains standard type aliases to be used throughout the NetKet codebase.
+ * This header contains standard type aliases to be used throughout the NetKet
+ * codebase.
  */
 
 #include <complex>
+#include <cstddef>
 
 namespace netket {
 

--- a/NetKet/pynetket.cc
+++ b/NetKet/pynetket.cc
@@ -16,17 +16,6 @@
 #define NETKET_PYNETKET_CC
 
 #include <netket.hpp>
-#include "Utils/mpi_interface.hpp"  // for MPIInitializer
-
-namespace netket {
-using StateType = Complex;
-using MachineType = AbstractMachine<StateType>;
-using LayerType = AbstractLayer<StateType>;
-using SamplerType = AbstractSampler<MachineType>;
-}  // namespace netket
-
-#include "Utils/pybind_helpers.hpp"
-
 #include "Dynamics/py_dynamics.hpp"
 #include "Graph/py_graph.hpp"
 #include "GroundState/py_ground_state.hpp"
@@ -39,8 +28,9 @@ using SamplerType = AbstractSampler<MachineType>;
 #include "Stats/py_stats.hpp"
 #include "Supervised/py_supervised.hpp"
 #include "Unsupervised/py_unsupervised.hpp"
+#include "Utils/mpi_interface.hpp"  // for MPIInitializer
 #include "Utils/py_utils.hpp"
-
+#include "Utils/pybind_helpers.hpp"
 
 namespace netket {
 


### PR DESCRIPTION
This PR removes some templates (in `Machine`) that are not used anymore (they were used in an archaical version of NetKet), and also are not necessary to handle machine with real parameters only (see issue #178 ) 

A future PR will handle issue #178 separately, also connecting to #150 . 