### PR TITLE
Neural Density Matrices

### DIFF
--- a/Sources/Machine/DensityMatrices/abstract_density_matrix.hpp
+++ b/Sources/Machine/DensityMatrices/abstract_density_matrix.hpp
@@ -1,0 +1,101 @@
+// Copyright 2018 The Simons Foundation, Inc. - All
+// Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NETKET_ABSTRACT_DENSITY_MATRIX_HPP
+#define NETKET_ABSTRACT_DENSITY_MATRIX_HPP
+
+#include "Machine/abstract_machine.hpp"
+
+namespace netket {
+
+/* Abstract base class for Density Matrices.
+ * Contains the physical hilbert space and the doubled hilbert
+ * space where operators are defined.
+ */
+class AbstractDensityMatrix : public AbstractMachine {
+  // The physical hilbert space over which this operator acts
+  const AbstractHilbert &hilbert_physical_;
+
+  const std::unique_ptr<AbstractGraph> graph_doubled_;
+
+  // The doubled hilbert space where this operator is defined
+  const std::unique_ptr<AbstractHilbert> hilbert_doubled_;
+
+  using Edge = AbstractGraph::Edge;
+
+  /**
+   * Returns the disjoint union G of a graph g with itself. The resulting graph
+   * has twice the number of vertices and edges of g.
+   * The automorpisms of G are the automorphisms of g applied identically
+   * to both it's subgraphs.
+   */
+  static std::unique_ptr<CustomGraph> DoubledGraph(const AbstractGraph &graph) {
+    auto n_sites = graph.Nsites();
+    std::vector<Edge> d_edges(graph.Edges().size());
+    auto eclist = graph.EdgeColors();
+
+    // same graph
+    auto d_eclist = graph.EdgeColors();
+    for (auto edge : graph.Edges()) {
+      d_edges.push_back(edge);
+    }
+
+    // second graph
+    for (auto edge : graph.Edges()) {
+      Edge new_edge = edge;
+      new_edge[0] += n_sites;
+      new_edge[1] += n_sites;
+
+      d_edges.push_back(new_edge);
+      d_eclist.emplace(new_edge, eclist[edge]);
+    }
+
+    std::vector<std::vector<int>> d_automorphisms;
+    for (auto automorphism : graph.SymmetryTable()) {
+      std::vector<int> d_automorphism = automorphism;
+      for (auto s : automorphism) {
+        d_automorphism.push_back(s + n_sites);
+      }
+      d_automorphisms.push_back(d_automorphism);
+    }
+
+    return make_unique<CustomGraph>(
+        CustomGraph(d_edges, d_eclist, d_automorphisms));
+  }
+
+ public:
+  explicit AbstractDensityMatrix(const AbstractHilbert &hilbert)
+      : hilbert_physical_(hilbert),
+        graph_doubled_(DoubledGraph(hilbert.GetGraph())),
+        hilbert_doubled_(make_unique<CustomHilbert>(*graph_doubled_,
+                                                    hilbert.LocalStates())){};
+
+  const AbstractHilbert &GetHilbert() const noexcept override {
+    return *hilbert_doubled_;
+  }
+
+  /**
+   * Member function returning the Physical hilbert space over which
+   * this density matrix acts
+   * @return The physical hilbert space
+   */
+  const AbstractHilbert &GetHilbertPhysical() const noexcept {
+    return hilbert_physical_;
+  }
+
+};
+}  // namespace netket
+
+#endif  // NETKET_ABSTRACT_DENSITY_MATRIX_HPP

--- a/Sources/Machine/DensityMatrices/density_matrix_machine.hpp
+++ b/Sources/Machine/DensityMatrices/density_matrix_machine.hpp
@@ -1,4 +1,5 @@
-// Copyright 2018 The Simons Foundation, Inc. - All Rights Reserved.
+// Copyright 2018 The Simons Foundation, Inc. - All
+// Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,25 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef NETKET_MACHINE_HPP
-#define NETKET_MACHINE_HPP
+#ifndef NETKET_DENSITY_MATRIX_MACHINE_HPP
+#define NETKET_DENSITY_MATRIX_MACHINE_HPP
 
-#include <fstream>
-#include <memory>
+#include "abstract_density_matrix.hpp"
+#include "diagonal_density_matrix.hpp"
+#include "ndm_spin_phase.hpp"
 
-#include "Graph/graph.hpp"
-#include "Operator/operator.hpp"
-#include "abstract_machine.hpp"
-#include "ffnn.hpp"
-#include "jastrow.hpp"
-#include "jastrow_symm.hpp"
-#include "mps_periodic.hpp"
-#include "rbm_multival.hpp"
-#include "rbm_spin.hpp"
-#include "rbm_spin_phase.hpp"
-#include "rbm_spin_real.hpp"
-#include "rbm_spin_symm.hpp"
-
-#include "DensityMatrices/density_matrix_machine.hpp"
-
-#endif
+#endif  // NETKET_DENSITY_MATRIX_MACHINE_HPP

--- a/Sources/Machine/DensityMatrices/diagonal_density_matrix.hpp
+++ b/Sources/Machine/DensityMatrices/diagonal_density_matrix.hpp
@@ -1,0 +1,179 @@
+// Copyright 2018 The Simons Foundation, Inc. - All
+// Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NETKET_DIAGONALDENSITYMATRIX_HPP
+#define NETKET_DIAGONALDENSITYMATRIX_HPP
+
+#include <Eigen/Dense>
+#include <algorithm>
+#include <complex>
+#include <fstream>
+#include <utility>
+#include <vector>
+#include "Machine/abstract_machine.hpp"
+#include "Utils/lookup.hpp"
+#include "Utils/random_utils.hpp"
+#include "density_matrix_machine.hpp"
+
+namespace netket {
+class DiagonalDensityMatrix : public AbstractMachine {
+  using VisibleChangeInfo = std::pair<std::vector<int>, std::vector<double>>;
+
+  AbstractDensityMatrix &density_matrix_;
+
+ public:
+  explicit DiagonalDensityMatrix(AbstractDensityMatrix &dm)
+      : density_matrix_(dm){};
+
+  const AbstractHilbert &GetHilbert() const noexcept override {
+    return density_matrix_.GetHilbertPhysical();
+  }
+
+  const AbstractDensityMatrix &GetFullDensityMatrix() const noexcept {
+    return density_matrix_;
+  }
+
+ private:
+  /**
+   * Doubles a visible configuration v so that it represents an element on the
+   * diagonal of a density matrix.
+   * @param v is a visible configuration
+   * @return the vertical concatentation of [v, v]
+   */
+  VisibleType DoubleVisibleConfig(const VisibleConstType v) const {
+    VisibleType v2(2 * v.rows());
+    v2.head(v.rows()) = v;
+    v2.tail(v.rows()) = v;
+
+    return v2;
+  }
+
+  VisibleChangeInfo DoubleVisibleChangeInfo(const std::vector<int> &tochange,
+                                            const std::vector<double> &newconf,
+                                            int offset) const {
+    std::vector<int> tochange_doubled(tochange.size() * 2);
+    std::vector<double> newconf_doubled(newconf.size() * 2);
+
+    // Copy tochange on the first half of tochange_doubled and copy + offset on
+    // the other half.
+    std::copy(tochange.begin(), tochange.end(), tochange_doubled.begin());
+    std::copy(tochange.begin(), tochange.end(),
+              tochange_doubled.begin() + tochange.size());
+    for (auto tcd = tochange_doubled.begin() + tochange.size();
+         tcd != tochange_doubled.end(); ++tcd) {
+      *tcd += offset;
+    }
+
+    std::copy(newconf.begin(), newconf.end(), newconf_doubled.begin());
+    std::copy(newconf.begin(), newconf.end(),
+              newconf_doubled.begin() + newconf.size());
+
+    return VisibleChangeInfo(tochange_doubled, newconf_doubled);
+  };
+
+ public:
+  Complex LogVal(VisibleConstType v) override {
+    return density_matrix_.LogVal(DoubleVisibleConfig(v));
+  }
+
+  Complex LogVal(VisibleConstType v, const LookupType &lt) override {
+    return density_matrix_.LogVal(DoubleVisibleConfig(v), lt);
+  }
+
+  void InitLookup(VisibleConstType v, LookupType &lt) override {
+    return density_matrix_.InitLookup(DoubleVisibleConfig(v), lt);
+  }
+
+  void UpdateLookup(VisibleConstType v, const std::vector<int> &tochange,
+                    const std::vector<double> &newconf,
+                    LookupType &lt) override {
+    VisibleChangeInfo d_changes =
+        DoubleVisibleChangeInfo(tochange, newconf, v.size());
+    return density_matrix_.UpdateLookup(DoubleVisibleConfig(v), d_changes.first,
+                                        d_changes.second, lt);
+  }
+
+  VectorType LogValDiff(
+      VisibleConstType v, const std::vector<std::vector<int>> &tochange,
+      const std::vector<std::vector<double>> &newconf) override {
+    auto tochange_d = std::vector<std::vector<int>>(tochange.size());
+    auto newconf_d = std::vector<std::vector<double>>(newconf.size());
+    // double every element in tochange and newconf
+    {
+      auto tc = tochange.begin();
+      auto nc = newconf.begin();
+      int i = 0;
+      while (tc != tochange.end()) {
+        auto d_changes = DoubleVisibleChangeInfo(*tc, *nc, v.size());
+        tochange_d[i] = d_changes.first;
+        newconf_d[i] = d_changes.second;
+      }
+    }
+    return density_matrix_.LogValDiff(DoubleVisibleConfig(v), tochange_d,
+                                      newconf_d);
+  }
+
+  Complex LogValDiff(VisibleConstType v, const std::vector<int> &tochange,
+                     const std::vector<double> &newconf,
+                     const LookupType &lt) override {
+    VisibleChangeInfo d_changes =
+        DoubleVisibleChangeInfo(tochange, newconf, v.size());
+    return density_matrix_.LogValDiff(DoubleVisibleConfig(v), d_changes.first,
+                                      d_changes.second, lt);
+  }
+
+  VectorType DerLog(VisibleConstType v) override {
+    return density_matrix_.DerLog(DoubleVisibleConfig(v));
+  }
+
+  VectorType DerLog(VisibleConstType v, const LookupType &lt) override {
+    return density_matrix_.DerLog(DoubleVisibleConfig(v), lt);
+  }
+
+  VectorType DerLogChanged(VisibleConstType v, const std::vector<int> &tochange,
+                           const std::vector<double> &newconf) override {
+    VisibleChangeInfo d_changes =
+        DoubleVisibleChangeInfo(tochange, newconf, v.size());
+    return density_matrix_.DerLogChanged(DoubleVisibleConfig(v),
+                                         d_changes.first, d_changes.second);
+  }
+
+  int Npar() const override { return density_matrix_.Npar(); }
+
+  VectorType GetParameters() override {
+    return density_matrix_.GetParameters();
+  }
+
+  void SetParameters(VectorConstRefType pars) override {
+    return density_matrix_.SetParameters(pars);
+  }
+
+  void InitRandomPars(int seed, double sigma) override {
+    return density_matrix_.InitRandomPars(seed, sigma);
+  }
+
+  int Nvisible() const override { return density_matrix_.Nvisible(); }
+
+  bool IsHolomorphic() override { return density_matrix_.IsHolomorphic(); }
+
+  void to_json(json &j) const override { return density_matrix_.to_json(j); }
+
+  void from_json(const json &j) override {
+    return density_matrix_.from_json(j);
+  }
+};
+}  // namespace netket
+
+#endif  // NETKET_DIAGONALDENSITYMATRIX_HPP

--- a/Sources/Machine/DensityMatrices/ndm_spin_phase.hpp
+++ b/Sources/Machine/DensityMatrices/ndm_spin_phase.hpp
@@ -1,0 +1,689 @@
+// Copyright 2018 The Simons Foundation, Inc. - All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NETKET_NDM_SPIN_PHASE_HPP
+#define NETKET_NDM_SPIN_PHASE_HPP
+
+#include <Eigen/Dense>
+#include <iostream>
+#include <vector>
+#include "Utils/all_utils.hpp"
+#include "Utils/lookup.hpp"
+#include "abstract_density_matrix.hpp"
+
+namespace netket {
+
+/** Neural Density Matrix machine class with spin 1/2 hidden units.
+This version has real-valued weights and two NDMs parameterizing phase and
+amplitude
+ *
+ */
+class NdmSpinPhase : public AbstractDensityMatrix {
+  // number of visible units
+  int nv_;
+
+  // number of hidden units
+  int nh_;
+
+  // number of ancillary units
+  int na_;
+
+  // number of parameters
+  int npar_;
+
+  // visible units bias
+  RealVectorType b1_;
+  RealVectorType b2_;
+
+  // hidden units bias
+  RealVectorType h1_;
+  RealVectorType h2_;
+
+  // ancillary units bias
+  RealVectorType d1_;
+
+  // hidden unit weights
+  RealMatrixType W1_;
+  RealMatrixType W2_;
+
+  // ancillary unit weights
+  RealMatrixType U1_;
+  RealMatrixType U2_;
+
+  // Caches
+  RealVectorType thetas_r1_;
+  RealVectorType thetas_r2_;
+  RealVectorType thetas_c1_;
+  RealVectorType thetas_c2_;
+  RealVectorType lnthetas_r1_;
+  RealVectorType lnthetas_r2_;
+  RealVectorType lnthetas_c1_;
+  RealVectorType lnthetas_c2_;
+  RealVectorType thetasnew_r1_;
+  RealVectorType thetasnew_r2_;
+  RealVectorType thetasnew_c1_;
+  RealVectorType thetasnew_c2_;
+  RealVectorType lnthetasnew_r1_;
+  RealVectorType lnthetasnew_r2_;
+  RealVectorType lnthetasnew_c1_;
+  RealVectorType lnthetasnew_c2_;
+
+  RealVectorType thetas_a1_;
+  RealVectorType thetas_a2_;
+  RealVectorType thetasnew_a1_;
+  RealVectorType thetasnew_a2_;
+  VectorType pi_;
+  VectorType lnpi_;
+  VectorType lnpinew_;
+
+  bool useb_;
+  bool useh_;
+  bool used_;
+
+  const Complex I_;
+
+ public:
+  explicit NdmSpinPhase(const AbstractHilbert &hilbert, int nhidden = 0,
+                        int nancilla = 0, int alpha = 0, int beta = 0,
+                        bool useb = true, bool useh = true, bool used = true)
+      : AbstractDensityMatrix(hilbert),
+        nv_(hilbert.Size()),
+        useb_(useb),
+        useh_(useh),
+        used_(used),
+        I_(0, 1) {
+    nh_ = std::max(nhidden, alpha * nv_);
+    na_ = std::max(nancilla, beta * nv_);
+
+    Init();
+  }
+
+  void Init() {
+    W1_.resize(nv_, nh_);
+    U1_.resize(nv_, na_);
+    b1_.resize(nv_);
+    h1_.resize(nh_);
+    d1_.resize(na_);
+
+    W2_.resize(nv_, nh_);
+    U2_.resize(nv_, na_);
+    b2_.resize(nv_);
+    h2_.resize(nh_);
+
+    thetas_r1_.resize(nh_);
+    thetas_r2_.resize(nh_);
+    thetas_c1_.resize(nh_);
+    thetas_c2_.resize(nh_);
+
+    lnthetas_r1_.resize(nh_);
+    lnthetas_r2_.resize(nh_);
+    lnthetas_c1_.resize(nh_);
+    lnthetas_c2_.resize(nh_);
+
+    thetasnew_r1_.resize(nh_);
+    thetasnew_r2_.resize(nh_);
+    thetasnew_c1_.resize(nh_);
+    thetasnew_c2_.resize(nh_);
+
+    lnthetasnew_r1_.resize(nh_);
+    lnthetasnew_r2_.resize(nh_);
+    lnthetasnew_c1_.resize(nh_);
+    lnthetasnew_c2_.resize(nh_);
+
+    thetas_a1_.resize(na_);
+    thetas_a2_.resize(na_);
+    thetasnew_a1_.resize(na_);
+    thetasnew_a2_.resize(na_);
+    pi_.resize(na_);
+    lnpi_.resize(na_);
+    lnpinew_.resize(na_);
+
+    npar_ = 2 * nv_ * (nh_ + na_);
+
+    if (useb_) {
+      npar_ += 2 * nv_;
+    } else {
+      b1_.setZero();
+      b2_.setZero();
+    }
+
+    if (useh_) {
+      npar_ += 2 * nh_;
+    } else {
+      h1_.setZero();
+      h2_.setZero();
+    }
+
+    if (used_) {
+      npar_ += na_;
+    } else {
+      d1_.setZero();
+    }
+
+    InfoMessage() << "Phase NDM Initizialized with nvisible = " << nv_
+                  << " and nhidden  = " << nh_ << " and nancilla = " << na_
+                  << std::endl;
+    InfoMessage() << "Using visible   bias = " << useb_ << std::endl;
+    InfoMessage() << "Using hidden    bias  = " << useh_ << std::endl;
+    InfoMessage() << "Using ancillary bias  = " << used_ << std::endl;
+  }
+
+  int Nvisible() const override { return nv_; }
+
+  int Nhidden() const { return nh_; }
+
+  int Nancilla() const { return na_; }
+
+  int Npar() const override { return npar_; }
+
+  void InitRandomPars(int seed, double sigma) override {
+    RealVectorType par(npar_);
+
+    netket::RandomGaussian(par, seed, sigma);
+
+    SetParameters(VectorType(par));
+  }
+
+  void InitLookup(VisibleConstType v, LookupType &lt) override {
+    if (lt.VectorSize() == 0) {
+      lt.AddVector(h1_.size());  // row 1
+      lt.AddVector(h2_.size());  // row 2
+      lt.AddVector(h1_.size());  // col 1
+      lt.AddVector(h2_.size());  // col 2
+      lt.AddVector(d1_.size());  // ancilla modulus
+      lt.AddVector(d1_.size());  // ancilla phase
+    }
+    if (lt.V(0).size() != h1_.size()) {
+      lt.V(0).resize(h1_.size());
+    }
+    if (lt.V(1).size() != h2_.size()) {
+      lt.V(1).resize(h2_.size());
+    }
+    if (lt.V(2).size() != h1_.size()) {
+      lt.V(2).resize(h1_.size());
+    }
+    if (lt.V(3).size() != h2_.size()) {
+      lt.V(3).resize(h2_.size());
+    }
+    if (lt.V(4).size() != d1_.size()) {
+      lt.V(4).resize(d1_.size());
+    }
+    if (lt.V(5).size() != d1_.size()) {
+      lt.V(5).resize(d1_.size());
+    }
+
+    VisibleConstType vr = v.head(GetHilbertPhysical().Size());
+    VisibleConstType vc = v.tail(GetHilbertPhysical().Size());
+
+    lt.V(0) = (W1_.transpose() * vr + h1_);
+    lt.V(1) = (W2_.transpose() * vr + h2_);
+    lt.V(2) = (W1_.transpose() * vc + h1_);
+    lt.V(3) = (W2_.transpose() * vc + h2_);
+
+    lt.V(4) = (0.5 * U1_.transpose() * (vr + vc) + d1_);
+    lt.V(5) = (0.5 * U2_.transpose() * (vr - vc));
+  }
+
+  void UpdateLookup(VisibleConstType v, const std::vector<int> &tochange,
+                    const std::vector<double> &newconf,
+                    LookupType &lt) override {
+    VisibleConstType vr = v.head(GetHilbertPhysical().Size());
+    VisibleConstType vc = v.tail(GetHilbertPhysical().Size());
+
+    if (tochange.size() != 0) {
+      for (std::size_t s = 0; s < tochange.size(); s++) {
+        const int sf = tochange[s];
+        if (sf < Nvisible()) {
+          lt.V(0) += W1_.row(sf) * (newconf[s] - vr(sf));
+          lt.V(1) += W2_.row(sf) * (newconf[s] - vr(sf));
+
+          lt.V(4) += 0.5 * U1_.row(sf) * (newconf[s] - vr(sf));
+          lt.V(5) += 0.5 * U2_.row(sf) * (newconf[s] - vr(sf));
+        } else {
+          const int sfc = sf - Nvisible();
+          lt.V(2) += W1_.row(sfc) * (newconf[s] - vc(sfc));
+          lt.V(3) += W2_.row(sfc) * (newconf[s] - vc(sfc));
+
+          lt.V(4) += 0.5 * U1_.row(sfc) * (newconf[s] - vc(sfc));
+          lt.V(5) -= 0.5 * U2_.row(sfc) * (newconf[s] - vc(sfc));
+        }
+      }
+    }
+  }
+
+  VectorType DerLog(VisibleConstType v) override {
+    LookupType ltnew;
+    InitLookup(v, ltnew);
+    return DerLog(v, ltnew);
+  }
+
+  VectorType DerLog(VisibleConstType v, const LookupType &lt) override {
+    VisibleConstType vr = v.head(GetHilbertPhysical().Size());
+    VisibleConstType vc = v.tail(GetHilbertPhysical().Size());
+
+    VectorType der(npar_);
+
+    const int impar = (npar_ + na_ * used_) / 2;
+
+    if (useb_) {
+      der.head(nv_) = 0.5 * (vr + vc);
+      der.segment(impar, nv_) = I_ * 0.5 * (vr - vc);
+    }
+
+    RbmSpin::tanh(lt.V(0).real(), lnthetas_r1_);
+    RbmSpin::tanh(lt.V(1).real(), lnthetas_r2_);
+    RbmSpin::tanh(lt.V(2).real(), lnthetas_c1_);
+    RbmSpin::tanh(lt.V(3).real(), lnthetas_c2_);
+
+    if (useh_) {
+      der.segment(useb_ * nv_, nh_) = 0.5 * (lnthetas_r1_ + lnthetas_c1_);
+      der.segment(impar + useb_ * nv_, nh_) =
+          I_ * 0.5 * (lnthetas_r2_ - lnthetas_c2_);
+    }
+
+    thetas_a1_ = 0.5 * U1_.transpose() * (vr + vc) + d1_;
+    thetas_a2_ = 0.5 * U2_.transpose() * (vr - vc);
+    RbmSpin::tanh(lt.V(4).real() + I_ * lt.V(5).real(), lnpi_);
+
+    if (used_) {
+      der.segment(useb_ * nv_ + useh_ * nh_, na_) = lnpi_;
+    }
+
+    const int initw_1 = nv_ * useb_ + nh_ * useh_ + na_ * used_;
+    const int initw_2 = nv_ * useb_ + nh_ * useh_;
+
+    MatrixType wder =
+        0.5 * (vr * lnthetas_r1_.transpose() + vc * lnthetas_c1_.transpose());
+    der.segment(initw_1, nv_ * nh_) =
+        Eigen::Map<VectorType>(wder.data(), nv_ * nh_);
+
+    wder = 0.5 * I_ *
+           (vr * lnthetas_r2_.transpose() - vc * lnthetas_c2_.transpose());
+    der.segment(impar + initw_2, nv_ * nh_) =
+        Eigen::Map<VectorType>(wder.data(), nv_ * nh_);
+
+    const int initu_1 = initw_1 + nv_ * nh_;
+    const int initu_2 = initw_2 + nv_ * nh_;
+
+    MatrixType uder = 0.5 * (vr + vc) * lnpi_.transpose();
+    der.segment(initu_1, nv_ * na_) =
+        Eigen::Map<VectorType>(uder.data(), nv_ * na_);
+
+    uder = 0.5 * I_ * (vr - vc) * lnpi_.transpose();
+    der.segment(impar + initu_2, nv_ * na_) =
+        Eigen::Map<VectorType>(uder.data(), nv_ * na_);
+
+    return der;
+  }
+
+  VectorType GetParameters() override {
+    VectorType pars(npar_);
+
+    const int impar = (npar_ + na_ * used_) / 2;
+
+    if (useb_) {
+      pars.head(nv_) = b1_;
+      pars.segment(impar, nv_) = b2_;
+    }
+
+    if (useh_) {
+      pars.segment(nv_ * useb_, nh_) = h1_;
+      pars.segment(impar + nv_ * useb_, nh_) = h2_;
+    }
+
+    if (used_) {
+      pars.segment(useb_ * nv_ + useh_ * nh_, na_) = d1_;
+    }
+
+    const int initw_1 = nv_ * useb_ + nh_ * useh_ + na_ * used_;
+    const int initw_2 = nv_ * useb_ + nh_ * useh_;
+
+    pars.segment(initw_1, nv_ * nh_) =
+        Eigen::Map<RealVectorType>(W1_.data(), nv_ * nh_);
+    pars.segment(impar + initw_2, nv_ * nh_) =
+        Eigen::Map<RealVectorType>(W2_.data(), nv_ * nh_);
+
+    const int initu_1 = initw_1 + nv_ * nh_;
+    const int initu_2 = initw_2 + nv_ * nh_;
+
+    pars.segment(initu_1, nv_ * na_) =
+        Eigen::Map<RealVectorType>(U1_.data(), nv_ * na_);
+    pars.segment(impar + initu_2, nv_ * na_) =
+        Eigen::Map<RealVectorType>(U2_.data(), nv_ * na_);
+
+    return pars;
+  }
+
+  void SetParameters(VectorConstRefType pars) override {
+    const int impar = (npar_ + na_ * used_) / 2;
+
+    if (useb_) {
+      b1_ = pars.head(nv_).real();
+      b2_ = pars.segment(impar, nv_).real();
+    }
+
+    if (useh_) {
+      h1_ = pars.segment(useb_ * nv_, nh_).real();
+      h2_ = pars.segment(impar + useb_ * nv_, nh_).real();
+    }
+
+    if (used_) {
+      d1_ = pars.segment(useb_ * nv_ + useh_ * nh_, na_).real();
+    }
+
+    const int initw_1 = nv_ * useb_ + nh_ * useh_ + na_ * used_;
+    const int initw_2 = nv_ * useb_ + nh_ * useh_;
+
+    VectorType Wpars = pars.segment(initw_1, nv_ * nh_);
+    W1_ = Eigen::Map<MatrixType>(Wpars.data(), nv_, nh_).real();
+
+    Wpars = pars.segment(impar + initw_2, nv_ * nh_);
+    W2_ = Eigen::Map<MatrixType>(Wpars.data(), nv_, nh_).real();
+
+    const int initu_1 = initw_1 + nv_ * nh_;
+    const int initu_2 = initw_2 + nv_ * nh_;
+
+    VectorType Upars = pars.segment(initu_1, nv_ * na_);
+    U1_ = Eigen::Map<MatrixType>(Upars.data(), nv_, na_).real();
+
+    Upars = pars.segment(impar + initu_2, nv_ * na_);
+    U2_ = Eigen::Map<MatrixType>(Upars.data(), nv_, na_).real();
+  }
+
+  // Value of the logarithm of the wave-function
+  Complex LogVal(VisibleConstType v) override {
+    VisibleConstType vr = v.head(GetHilbertPhysical().Size());
+    VisibleConstType vc = v.tail(GetHilbertPhysical().Size());
+
+    RbmSpin::lncosh(W1_.transpose() * vr + h1_, lnthetas_r1_);
+    RbmSpin::lncosh(W2_.transpose() * vr + h2_, lnthetas_r2_);
+    RbmSpin::lncosh(W1_.transpose() * vc + h1_, lnthetas_c1_);
+    RbmSpin::lncosh(W2_.transpose() * vc + h2_, lnthetas_c2_);
+
+    thetas_a1_ = 0.5 * U1_.transpose() * (vr + vc) + d1_;
+    thetas_a2_ = 0.5 * U2_.transpose() * (vr - vc);
+    RbmSpin::lncosh(thetas_a1_ + I_ * thetas_a2_, lnpi_);
+
+    auto gamma_1 =
+        0.5 * (lnthetas_r1_.sum() + lnthetas_c1_.sum() + (vr + vc).dot(b1_));
+
+    auto gamma_2 =
+        0.5 * (lnthetas_r2_.sum() - lnthetas_c2_.sum() + (vr - vc).dot(b2_));
+
+    return gamma_1 + I_ * gamma_2 + lnpi_.sum();
+  }
+
+  // Value of the logarithm of the wave-function
+  // using pre-computed look-up tables for efficiency
+  Complex LogVal(VisibleConstType v, const LookupType &lt) override {
+    VisibleConstType vr = v.head(GetHilbertPhysical().Size());
+    VisibleConstType vc = v.tail(GetHilbertPhysical().Size());
+
+    RbmSpin::lncosh(lt.V(0).real(), lnthetas_r1_);
+    RbmSpin::lncosh(lt.V(1).real(), lnthetas_r2_);
+    RbmSpin::lncosh(lt.V(2).real(), lnthetas_c1_);
+    RbmSpin::lncosh(lt.V(3).real(), lnthetas_c2_);
+    RbmSpin::lncosh(lt.V(4).real() + I_ * lt.V(5).real(), lnpi_);
+
+    auto gamma_1 =
+        0.5 * (lnthetas_r1_.sum() + lnthetas_c1_.sum() + (vr + vc).dot(b1_));
+    auto gamma_2 =
+        0.5 * (lnthetas_r2_.sum() - lnthetas_c2_.sum() + (vr - vc).dot(b2_));
+
+    return gamma_1 + I_ * gamma_2 + lnpi_.sum();
+  }
+
+  // Difference between logarithms of values, when one or more visible variables
+  // are being flipped
+  VectorType LogValDiff(
+      VisibleConstType v, const std::vector<std::vector<int>> &tochange,
+      const std::vector<std::vector<double>> &newconf) override {
+    VisibleConstType vr = v.head(GetHilbertPhysical().Size());
+    VisibleConstType vc = v.tail(GetHilbertPhysical().Size());
+
+    const std::size_t nconn = tochange.size();
+
+    thetas_r1_ = (W1_.transpose() * vr + h1_);
+    thetas_r2_ = (W2_.transpose() * vr + h2_);
+    thetas_c1_ = (W1_.transpose() * vc + h1_);
+    thetas_c2_ = (W2_.transpose() * vc + h2_);
+
+    RbmSpin::lncosh(thetas_r1_, lnthetas_r1_);
+    RbmSpin::lncosh(thetas_r2_, lnthetas_r2_);
+    RbmSpin::lncosh(thetas_c1_, lnthetas_c1_);
+    RbmSpin::lncosh(thetas_c2_, lnthetas_c2_);
+
+    thetas_a1_ = 0.5 * U1_.transpose() * (vr + vc) + d1_;
+    thetas_a2_ = 0.5 * U2_.transpose() * (vr - vc);
+    RbmSpin::lncosh(thetas_a1_ + I_ * thetas_a2_, lnpi_);
+
+    Complex logtsum = 0.5 * (lnthetas_r1_.sum() + lnthetas_c1_.sum()) +
+                      0.5 * I_ * (lnthetas_r2_.sum() - lnthetas_c2_.sum()) +
+                      lnpi_.sum();
+
+    VectorType logvaldiffs = VectorType::Zero(nconn);
+    for (std::size_t k = 0; k < nconn; k++) {
+      if (tochange[k].size() != 0) {
+        thetasnew_r1_ = thetas_r1_;
+        thetasnew_r2_ = thetas_r2_;
+        thetasnew_c1_ = thetas_c1_;
+        thetasnew_c2_ = thetas_c2_;
+
+        thetasnew_a1_ = thetas_a1_;
+        thetasnew_a2_ = thetas_a2_;
+
+        for (std::size_t s = 0; s < tochange[k].size(); s++) {
+          const int sf = tochange[k][s];
+
+          if (sf < Nvisible()) {
+            logvaldiffs(k) += 0.5 * b1_(sf) * (newconf[k][s] - vr(sf));
+            logvaldiffs(k) += 0.5 * I_ * b2_(sf) * (newconf[k][s] - vr(sf));
+
+            thetasnew_r1_ += W1_.row(sf) * (newconf[k][s] - vr(sf));
+            thetasnew_r2_ += W2_.row(sf) * (newconf[k][s] - vr(sf));
+            thetasnew_a1_ += 0.5 * U1_.row(sf) * (newconf[k][s] - vr(sf));
+            thetasnew_a2_ += 0.5 * U2_.row(sf) * (newconf[k][s] - vr(sf));
+          } else {
+            const int sfc = tochange[k][s] - Nvisible();
+            logvaldiffs(k) += 0.5 * b1_(sfc) * (newconf[k][s] - vc(sfc));
+            logvaldiffs(k) -= 0.5 * I_ * b2_(sfc) * (newconf[k][s] - vc(sfc));
+
+            thetasnew_c1_ += W1_.row(sfc) * (newconf[k][s] - vc(sfc));
+            thetasnew_c2_ += W2_.row(sfc) * (newconf[k][s] - vc(sfc));
+            thetasnew_a1_ += 0.5 * U1_.row(sfc) * (newconf[k][s] - vc(sfc));
+            thetasnew_a2_ -= 0.5 * U2_.row(sfc) * (newconf[k][s] - vc(sfc));
+          }
+        }
+        RbmSpin::lncosh(thetasnew_r1_, lnthetasnew_r1_);
+        RbmSpin::lncosh(thetasnew_r2_, lnthetasnew_r2_);
+        RbmSpin::lncosh(thetasnew_c1_, lnthetasnew_c1_);
+        RbmSpin::lncosh(thetasnew_c2_, lnthetasnew_c2_);
+        RbmSpin::lncosh(thetasnew_a1_ + I_ * thetasnew_a2_, lnpinew_);
+
+        logvaldiffs(k) +=
+            0.5 * (lnthetasnew_r1_.sum() + lnthetasnew_c1_.sum()) +
+            0.5 * I_ * (lnthetasnew_r2_.sum() - lnthetasnew_c2_.sum()) +
+            lnpinew_.sum() - logtsum;
+      }
+    }
+    return logvaldiffs;
+  }
+
+  // Difference between logarithms of values, when one or more visible variables
+  // are being flipped Version using pre-computed look-up tables for efficiency
+  // on a small number of spin flips
+  Complex LogValDiff(VisibleConstType v, const std::vector<int> &tochange,
+                     const std::vector<double> &newconf,
+                     const LookupType &lt) override {
+    VisibleConstType vr = v.head(GetHilbertPhysical().Size());
+    VisibleConstType vc = v.tail(GetHilbertPhysical().Size());
+
+    Complex logvaldiff = 0.;
+
+    if (tochange.size() != 0) {
+      RbmSpin::lncosh(lt.V(0).real(), lnthetas_r1_);
+      RbmSpin::lncosh(lt.V(1).real(), lnthetas_r2_);
+      RbmSpin::lncosh(lt.V(2).real(), lnthetas_c1_);
+      RbmSpin::lncosh(lt.V(3).real(), lnthetas_c2_);
+      RbmSpin::lncosh(lt.V(4).real() + I_ * lt.V(5).real(), lnpi_);
+
+      thetasnew_r1_ = lt.V(0).real();
+      thetasnew_r2_ = lt.V(1).real();
+      thetasnew_c1_ = lt.V(2).real();
+      thetasnew_c2_ = lt.V(3).real();
+      thetasnew_a1_ = lt.V(4).real();
+      thetasnew_a2_ = lt.V(5).real();
+
+      for (std::size_t s = 0; s < tochange.size(); s++) {
+        const int sf = tochange[s];
+
+        if (sf < Nvisible()) {
+          logvaldiff += 0.5 * b1_(sf) * (newconf[s] - vr(sf));
+          logvaldiff += 0.5 * I_ * b2_(sf) * (newconf[s] - vr(sf));
+
+          thetasnew_r1_ += W1_.row(sf) * (newconf[s] - vr(sf));
+          thetasnew_r2_ += W2_.row(sf) * (newconf[s] - vr(sf));
+          thetasnew_a1_ += 0.5 * U1_.row(sf) * (newconf[s] - vr(sf));
+          thetasnew_a2_ += 0.5 * U2_.row(sf) * (newconf[s] - vr(sf));
+        } else {
+          const int sfc = tochange[s] - Nvisible();
+          logvaldiff += 0.5 * b1_(sfc) * (newconf[s] - vc(sfc));
+          logvaldiff -= 0.5 * I_ * b2_(sfc) * (newconf[s] - vc(sfc));
+
+          thetasnew_c1_ += W1_.row(sfc) * (newconf[s] - vc(sfc));
+          thetasnew_c2_ += W2_.row(sfc) * (newconf[s] - vc(sfc));
+          thetasnew_a1_ += 0.5 * U1_.row(sfc) * (newconf[s] - vc(sfc));
+          thetasnew_a2_ -= 0.5 * U2_.row(sfc) * (newconf[s] - vc(sfc));
+        }
+      }
+
+      RbmSpin::lncosh(thetasnew_r1_, lnthetasnew_r1_);
+      RbmSpin::lncosh(thetasnew_r2_, lnthetasnew_r2_);
+      RbmSpin::lncosh(thetasnew_c1_, lnthetasnew_c1_);
+      RbmSpin::lncosh(thetasnew_c2_, lnthetasnew_c2_);
+      RbmSpin::lncosh(thetasnew_a1_ + I_ * thetasnew_a2_, lnpinew_);
+
+      logvaldiff += 0.5 * (lnthetasnew_r1_.sum() + lnthetasnew_c1_.sum());
+      logvaldiff -= 0.5 * (lnthetas_r1_.sum() + lnthetas_c1_.sum());
+      logvaldiff += 0.5 * I_ * (lnthetasnew_r2_.sum() - lnthetasnew_c2_.sum());
+      logvaldiff -= 0.5 * I_ * (lnthetas_r2_.sum() - lnthetas_c2_.sum());
+      logvaldiff += (lnpinew_.sum() - lnpi_.sum());
+    }
+    return logvaldiff;
+  }
+
+  inline static double lncosh(double x) {
+    const double xp = std::abs(x);
+    if (xp <= 12.) {
+      return std::log(std::cosh(xp));
+    } else {
+      const static double log2v = std::log(2.);
+      return xp - log2v;
+    }
+  }
+
+  void to_json(json &j) const override {
+    j["Name"] = "NdmSpinPhase";
+    j["Nvisible"] = nv_;
+    j["Nhidden"] = nh_;
+    j["Nancilla"] = na_;
+    j["UseVisibleBias"] = useb_;
+    j["UseHiddenBias"] = useh_;
+    j["UseAncillaBias"] = used_;
+    j["b1"] = b1_;
+    j["h1"] = h1_;
+    j["d1"] = d1_;
+    j["W1"] = W1_;
+    j["U1"] = U1_;
+
+    j["b2"] = b2_;
+    j["h2"] = h2_;
+    j["W2"] = W2_;
+    j["U2"] = U2_;
+  }
+
+  void from_json(const json &pars) override {
+    std::string name = FieldVal<std::string>(pars, "Name");
+    if (name != "NdmSpinPhase") {
+      throw InvalidInputError(
+          "Error while constructing RbmSpinPhase from input parameters");
+    }
+
+    if (FieldExists(pars, "Nvisible")) {
+      nv_ = FieldVal<int>(pars, "Nvisible");
+    }
+    if (nv_ != GetHilbertPhysical().Size()) {
+      throw InvalidInputError(
+          "Number of visible units is incompatible with given "
+          "Hilbert space");
+    }
+
+    if (FieldExists(pars, "Nhidden")) {
+      nh_ = FieldVal<int>(pars, "Nhidden");
+    } else {
+      nh_ = nv_ * double(FieldVal<double>(pars, "Alpha"));
+    }
+
+    if (FieldExists(pars, "Nancilla")) {
+      na_ = FieldVal<int>(pars, "Nancilla");
+    } else {
+      na_ = nv_ * double(FieldVal<double>(pars, "Beta"));
+    }
+
+    useb_ = FieldOrDefaultVal(pars, "UseVisibleBias", true);
+    useh_ = FieldOrDefaultVal(pars, "UseHiddenBias", true);
+    used_ = FieldOrDefaultVal(pars, "UseAncillaBias", true);
+
+    Init();
+
+    // Loading parameters, if defined in the input
+    if (FieldExists(pars, "b1")) {
+      b1_ = FieldVal<RealVectorType>(pars, "b1");
+      b2_ = FieldVal<RealVectorType>(pars, "b2");
+    } else {
+      b1_.setZero();
+      b2_.setZero();
+    }
+
+    if (FieldExists(pars, "h1")) {
+      h1_ = FieldVal<RealVectorType>(pars, "h1");
+      h2_ = FieldVal<RealVectorType>(pars, "h2");
+    } else {
+      h1_.setZero();
+      h2_.setZero();
+    }
+
+    if (FieldExists(pars, "d1")) {
+      d1_ = FieldVal<RealVectorType>(pars, "d1");
+    } else {
+      d1_.setZero();
+    }
+
+    if (FieldExists(pars, "W1")) {
+      W1_ = FieldVal<RealMatrixType>(pars, "W1");
+      W2_ = FieldVal<RealMatrixType>(pars, "W2");
+    }
+
+    if (FieldExists(pars, "U1")) {
+      U1_ = FieldVal<RealMatrixType>(pars, "U1");
+      U2_ = FieldVal<RealMatrixType>(pars, "U2");
+    }
+  }
+
+  bool IsHolomorphic() override { return false; }
+};
+
+}  // namespace netket
+
+#endif  // NETKET_NDM_SPIN_PHASE_HPP

--- a/Sources/Machine/DensityMatrices/py_density_matrix.hpp
+++ b/Sources/Machine/DensityMatrices/py_density_matrix.hpp
@@ -1,0 +1,78 @@
+// Copyright 2018 The Simons Foundation, Inc. - All
+// Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NETKET_PY_DENSITY_MATRIX_HPP
+#define NETKET_PY_DENSITY_MATRIX_HPP
+
+#include <mpi.h>
+#include <pybind11/complex.h>
+#include <pybind11/eigen.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+#include <complex>
+#include <vector>
+#include "abstract_density_matrix.hpp"
+#include "py_diagonal_density_matrix.hpp"
+#include "py_ndm_spin_phase.hpp"
+
+namespace py = pybind11;
+
+namespace netket {
+void AddDensityMatrixModule(py::module &subm) {
+  py::class_<AbstractDensityMatrix, AbstractMachine>(subm, "DensityMatrix")
+      .def_property_readonly(
+          "hilbert_physical", &AbstractDensityMatrix::GetHilbertPhysical,
+          R"EOF(netket.hilbert.Hilbert: The physical hilbert space object of the density matrix.)EOF")
+      .def(
+          "to_matrix",
+          [](AbstractDensityMatrix &self) -> AbstractDensityMatrix::VectorType {
+            const auto &hind = self.GetHilbert().GetIndex();
+            AbstractMachine::VectorType vals(hind.NStates());
+
+            double maxlog = std::numeric_limits<double>::lowest();
+
+            for (Index i = 0; i < hind.NStates(); i++) {
+              vals(i) = self.LogVal(hind.NumberToState(i));
+              if (std::real(vals(i)) > maxlog) {
+                maxlog = std::real(vals(i));
+              }
+            }
+
+            for (Index i = 0; i < hind.NStates(); i++) {
+              vals(i) -= maxlog;
+              vals(i) = std::exp(vals(i));
+            }
+
+            vals /= vals.norm();
+            return vals;
+          },
+          R"EOF( a
+                Returns a numpy matrix representation of the machine.
+                The returned matrix has trace normalized to 1,
+                Note that, in general, the size of the matrix is exponential
+                in the number of quantum numbers, and this operation should thus
+                only be performed for low-dimensional Hilbert spaces.
+
+                This method requires an indexable Hilbert space.
+              )EOF");
+
+  AddDiagonalDensityMatrix(subm);
+
+  AddNdmSpinPhase(subm);
+}
+}  // namespace netket
+
+#endif  // NETKET_PY_DENSITY_MATRIX_HPP

--- a/Sources/Machine/DensityMatrices/py_diagonal_density_matrix.hpp
+++ b/Sources/Machine/DensityMatrices/py_diagonal_density_matrix.hpp
@@ -1,0 +1,38 @@
+//
+// Created by Filippo Vicentini on 2019-06-05.
+//
+
+#ifndef NETKET_PY_DIAGONAL_DENSITY_MATRIX_HPP
+#define NETKET_PY_DIAGONAL_DENSITY_MATRIX_HPP
+
+#include <mpi.h>
+#include <pybind11/complex.h>
+#include <pybind11/eigen.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+#include <complex>
+#include <vector>
+#include "diagonal_density_matrix.hpp"
+
+namespace py = pybind11;
+
+namespace netket {
+
+void AddDiagonalDensityMatrix(py::module &subm) {
+  py::class_<DiagonalDensityMatrix, AbstractMachine>(
+      subm, "DiagonalDensityMatrix", R"EOF(
+  A Machine sampling the diagonal of a density matrix.)EOF")
+      .def(py::init<AbstractDensityMatrix &>(), py::keep_alive<1, 2>(),
+           py::arg("dm"), R"EOF(
+
+               Constructs a new ``DiagonalDensityMatrix`` machine sampling the
+               diagonal of the provided density matrix.
+
+               Args:
+                    dm: the density matrix.
+)EOF");
+}
+
+}  // namespace netket
+#endif  // NETKET_PY_DIAGONAL_DENSITY_MATRIX_HPP

--- a/Sources/Machine/DensityMatrices/py_ndm_spin_phase.hpp
+++ b/Sources/Machine/DensityMatrices/py_ndm_spin_phase.hpp
@@ -1,0 +1,86 @@
+// Copyright 2018 The Simons Foundation, Inc. - All
+// Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NETKET_PY_NDM_SPIN_PHASE_HPP
+#define NETKET_PY_NDM_SPIN_PHASE_HPP
+
+#include <mpi.h>
+#include <pybind11/complex.h>
+#include <pybind11/eigen.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+#include <complex>
+#include <vector>
+#include "ndm_spin_phase.hpp"
+
+namespace py = pybind11;
+
+namespace netket {
+
+void AddNdmSpinPhase(py::module &subm) {
+  py::class_<NdmSpinPhase, AbstractDensityMatrix>(subm, "NdmSpinPhase", R"EOF(
+          A positive semidefinite Neural Density Matrix (NDM) with real-valued parameters.
+          In this case, two NDMs are taken to parameterize, respectively, phase
+          and amplitude of the density matrix.
+          This type of NDM has spin 1/2 hidden and ancilla units.)EOF")
+      .def(py::init<const AbstractHilbert &, int, int, int, int, bool, bool,
+                    bool>(),
+           py::keep_alive<1, 2>(), py::arg("hilbert"), py::arg("n_hidden") = 0,
+           py::arg("n_ancilla") = 0, py::arg("alpha") = 0, py::arg("beta") = 0,
+           py::arg("use_visible_bias") = true,
+           py::arg("use_hidden_bias") = true,
+           py::arg("use_ancilla_bias") = true,
+           R"EOF(
+                   Constructs a new ``NdmSpinPhase`` machine:
+
+                   Args:
+                       hilbert: physical Hilbert space over which the density matrix acts.
+                       n_hidden:  Number of hidden units.
+                       n_ancilla: Number of ancilla units.
+                       alpha: Hidden unit density.
+                       beta:  Ancilla unit density.
+                       use_visible_bias: If ``True`` then there would be a
+                                        bias on the visible units.
+                                        Default ``True``.
+                       use_hidden_bias:  If ``True`` then there would be a
+                                       bias on the visible units.
+                                       Default ``True``.
+                       use_ancilla_bias: If ``True`` then there would be a
+                                       bias on the ancilla units.
+                                       Default ``True``.
+
+                   Examples:
+                       A ``NdmSpinPhase`` machine with hidden unit density
+                       alpha = 1 and ancilla unit density beta = 2 for a
+                       one-dimensional L=9 spin-half system:
+
+                       ```python
+                       >>> from netket.machine import NdmSpinPhase
+                       >>> from netket.hilbert import Spin
+                       >>> from netket.graph import Hypercube
+                       >>> g = Hypercube(length=9, n_dim=1)
+                       >>> hi = Spin(s=0.5, total_sz=0, graph=g)
+                       >>> ma = NdmSpinPhase(hilbert=hi,alpha=1, beta=2)
+                       >>> print(ma.n_par)
+                       1720
+
+                       ```
+                   )EOF");
+}
+
+}  // namespace netket
+
+#endif  // NETKET_PY_NDM_SPIN_PHASE_HPP

--- a/Sources/Machine/py_machine.hpp
+++ b/Sources/Machine/py_machine.hpp
@@ -35,6 +35,7 @@
 #include "py_rbm_spin_phase.hpp"
 #include "py_rbm_spin_real.hpp"
 #include "py_rbm_spin_symm.hpp"
+#include "DensityMatrices/py_density_matrix.hpp"
 
 namespace py = pybind11;
 
@@ -216,6 +217,8 @@ void AddMachineModule(py::module &m) {
   AddMpsPeriodic(subm);
   AddFFNN(subm);
   AddLayerModule(m);
+
+  AddDensityMatrixModule(subm);
 }
 
 }  // namespace netket

--- a/Test/Machine/test_machine.py
+++ b/Test/Machine/test_machine.py
@@ -5,6 +5,11 @@ import pytest
 from pytest import approx
 import os
 
+def merge_dicts(x, y):
+     z = x.copy()   # start with x's keys and values
+     z.update(y)    # modifies z with y's keys and values & returns None
+     return z
+
 machines = {}
 
 
@@ -28,6 +33,8 @@ machines["Jastrow 1d Hypercube spin"] = nk.machine.Jastrow(hilbert=hi)
 hi = nk.hilbert.Spin(s=0.5, graph=g, total_sz=0)
 machines["Jastrow 1d Hypercube spin"] = nk.machine.JastrowSymm(hilbert=hi)
 
+dm_machines = {}
+ dm_machines["Phase NDM"] = nk.machine.NdmSpinPhase(hilbert=hi, alpha=2, beta=2, use_visible_bias=True, use_hidden_bias=True, use_ancilla_bias=True)
 
 # Layers
 layers = (
@@ -104,7 +111,7 @@ def check_holomorphic(func, x, eps, *args):
 
 
 def test_set_get_parameters():
-    for name, machine in machines.items():
+    for name, machine in merge_dicts(machines, dm_machines).items():
         print("Machine test: %s" % name)
         assert machine.n_par > 0
         npar = machine.n_par
@@ -117,7 +124,7 @@ def test_set_get_parameters():
 
 
 def test_save_load_parameters(tmpdir):
-    for name, machine in machines.items():
+    for name, machine in merge_dicts(machines, dm_machines).items():
         print("Machine test: %s" % name)
         assert machine.n_par > 0
         n_par = machine.n_par
@@ -140,7 +147,7 @@ def test_save_load_parameters(tmpdir):
 
 
 def test_log_derivative():
-    for name, machine in machines.items():
+    for name, machine in merge_dicts(machines, dm_machines).items():
         print("Machine test: %s" % name)
 
         npar = machine.n_par
@@ -172,7 +179,7 @@ def test_log_derivative():
 
 
 def test_log_val_diff():
-    for name, machine in machines.items():
+    for name, machine in merge_dicts(machines, dm_machines).items():
         print("Machine test: %s" % name)
 
         npar = machine.n_par
@@ -233,3 +240,13 @@ def test_nvisible():
         hi = machine.hilbert
 
         assert machine.n_visible == hi.size
+
+
+    for name, machine in dm_machines.items():
+        print("Machine test: %s" % name)
+        hip = machine.hilbert_physical
+        hi  = machine.hilbert
+
+        assert machine.n_visible == hip.size
+        assert machine.n_visible * 2 ==  hi.size  
+

--- a/Test/Machine/test_machine.py
+++ b/Test/Machine/test_machine.py
@@ -34,7 +34,7 @@ hi = nk.hilbert.Spin(s=0.5, graph=g, total_sz=0)
 machines["Jastrow 1d Hypercube spin"] = nk.machine.JastrowSymm(hilbert=hi)
 
 dm_machines = {}
- dm_machines["Phase NDM"] = nk.machine.NdmSpinPhase(hilbert=hi, alpha=2, beta=2, use_visible_bias=True, use_hidden_bias=True, use_ancilla_bias=True)
+dm_machines["Phase NDM"] = nk.machine.NdmSpinPhase(hilbert=hi, alpha=2, beta=2, use_visible_bias=True, use_hidden_bias=True, use_ancilla_bias=True)
 
 # Layers
 layers = (

--- a/Test/Sampler/test_sampler.py
+++ b/Test/Sampler/test_sampler.py
@@ -78,6 +78,12 @@ move_op = nk.operator.LocalOperator(hilbert=hi, operators=ops, acting_on=acting_
 sa = nk.sampler.CustomSampler(machine=ma, move_operators=move_op)
 samplers["CustomSampler Spin 2 moves"] = sa
 
+# Diagonal density matrix sampling
+ma = nk.machine.NdmSpinPhase(hilbert=hi, alpha=1, beta=1, use_visible_bias=True, use_hidden_bias=True, use_ancilla_bias=True)
+ma.init_random_parameters(seed=1234, sigma=0.2)
+dm = nk.machine.DiagonalDensityMatrix(ma)
+sa = nk.sampler.MetropolisLocal(machine=dm)
+samplers["Diagonal Density Matrix"] = sa
 
 def test_states_in_hilbert():
     for name, sa in samplers.items():


### PR DESCRIPTION
As discussed with @gcarleo, this PR adds support for Neural Network representations of density matrices. 

An abstract base class `AbstractDensityMatrix` is added which stores a doubled Hilbert space and the original _physical_ space. A first implementation of the real-valued Neural Density Matrix ansatz originally proposed on arXiv:1801.09684 is also included.

Ideally this is a first step into supporting the variational search for non-equilibrium steady states.
