### PR TITLE
Improve hilbert

### DIFF
--- a/NetKet/Graph/py_graph.hpp
+++ b/NetKet/Graph/py_graph.hpp
@@ -116,6 +116,9 @@ void AddGraphModule(py::module& m) {
       .def_property_readonly("n_sites", &AbstractGraph::Nsites,
                              R"EOF(
       int: The number of vertices in the graph.)EOF")
+      .def_property_readonly("size", &AbstractGraph::Size,
+                             R"EOF(
+      int: The number of vertices in the graph.)EOF")
       .def_property_readonly(
           "edges",
           [](AbstractGraph const& x) {

--- a/NetKet/Hilbert/abstract_hilbert.hpp
+++ b/NetKet/Hilbert/abstract_hilbert.hpp
@@ -103,15 +103,35 @@ class AbstractHilbert {
                           const std::vector<int> &tochange,
                           const std::vector<double> &newconf) const = 0;
 
-  virtual const AbstractGraph &GetGraph() const noexcept = 0;
+  void SetGraph(const AbstractGraph &graph) {
+    if (graph.Size() != Size()) {
+      throw RuntimeError{"Trying to assign an invalid Graph to Hilbert"};
+    }
+    graph_ = &graph;
+  }
 
-  // Allow range-based for over all states in the Hilbert space, iff it is indexable
+  const AbstractGraph &GetGraph() const {
+    if (graph_ == nullptr) {
+      throw RuntimeError{"Hilbert does not contain a valid Graph"};
+    }
+    if (graph_->Size() != Size()) {
+      throw RuntimeError{"Invalid Graph assigned to Hilbert"};
+    }
+    return *graph_;
+  }
+
+  // Allow range-based for over all states in the Hilbert space, iff it is
+  // indexable
   StateIterator begin() const { return StateIterator(GetIndex()); };
   StateIterator end() const { return StateIterator(GetIndex()); };
 
   virtual ~AbstractHilbert() = default;
 
+ protected:
+  AbstractHilbert() { graph_ = nullptr; }
+
  private:
+  AbstractGraph const *graph_;
   mutable nonstd::optional<HilbertIndex> index_;
 };
 

--- a/NetKet/Hilbert/abstract_hilbert.hpp
+++ b/NetKet/Hilbert/abstract_hilbert.hpp
@@ -103,6 +103,11 @@ class AbstractHilbert {
                           const std::vector<int> &tochange,
                           const std::vector<double> &newconf) const = 0;
 
+  AbstractHilbert &operator*=(const AbstractHilbert &rhs) {
+    this->operator*=(rhs);
+    return *this;
+  }
+
   void SetGraph(const AbstractGraph &graph) {
     if (graph.Size() != Size()) {
       throw RuntimeError{"Trying to assign an invalid Graph to Hilbert"};

--- a/NetKet/Hilbert/bosons.hpp
+++ b/NetKet/Hilbert/bosons.hpp
@@ -168,6 +168,32 @@ class Boson : public AbstractHilbert {
       assert(CheckConstraint(v));
     }
   }
+
+  Boson &operator*=(const Boson &rhs) {
+    if (LocalSize() != rhs.LocalSize()) {
+      throw RuntimeError{"Cannot multiply the given hilbert spaces"};
+    }
+    nsites_ += rhs.Size();
+    if (constraintN_ && rhs.constraintN_) {
+      SetNbosons(nbosons_ + rhs.nbosons_);
+    } else {
+      constraintN_ = false;
+    }
+
+    return *this;
+  }
+
+  friend Boson Pow(const Boson &lhs, int iexp) {
+    Boson powsp = lhs;
+    powsp.nsites_ *= iexp;
+    if (powsp.constraintN_) {
+      int nbosons = powsp.nbosons_ * iexp;
+      powsp.SetNbosons(nbosons);
+    } else {
+      powsp.constraintN_ = false;
+    }
+    return powsp;
+  }
 };
 
 }  // namespace netket

--- a/NetKet/Hilbert/bosons.hpp
+++ b/NetKet/Hilbert/bosons.hpp
@@ -33,8 +33,6 @@ namespace netket {
 */
 
 class Boson : public AbstractHilbert {
-  const AbstractGraph &graph_;
-
   int nsites_;
 
   std::vector<double> local_;
@@ -51,22 +49,36 @@ class Boson : public AbstractHilbert {
   int nstates_;
 
  public:
-  explicit Boson(const AbstractGraph &graph, int nmax)
-      : graph_(graph), nmax_(nmax) {
-    nsites_ = graph.Size();
-
+  explicit Boson(int nsites, int nmax) : nsites_(nsites), nmax_(nmax) {
     Init();
 
     constraintN_ = false;
   }
 
+  explicit Boson(int nsites, int nmax, int nbosons)
+      : nsites_(nsites), nmax_(nmax) {
+    Init();
+
+    SetNbosons(nbosons);
+  }
+
+  explicit Boson(const AbstractGraph &graph, int nmax) : nmax_(nmax) {
+    nsites_ = graph.Size();
+
+    Init();
+
+    constraintN_ = false;
+    SetGraph(graph);
+  }
+
   explicit Boson(const AbstractGraph &graph, int nmax, int nbosons)
-      : graph_(graph), nmax_(nmax) {
+      : nmax_(nmax) {
     nsites_ = graph.Size();
 
     Init();
 
     SetNbosons(nbosons);
+    SetGraph(graph);
   }
 
   void Init() {
@@ -156,8 +168,6 @@ class Boson : public AbstractHilbert {
       assert(CheckConstraint(v));
     }
   }
-
-  const AbstractGraph &GetGraph() const noexcept override { return graph_; }
 };
 
 }  // namespace netket

--- a/NetKet/Hilbert/custom_hilbert.hpp
+++ b/NetKet/Hilbert/custom_hilbert.hpp
@@ -81,6 +81,23 @@ class CustomHilbert : public AbstractHilbert {
     }
   }
 
+  // Product of two hilbert spaces
+  CustomHilbert &operator*=(const CustomHilbert &rhs) {
+    if (LocalSize() != rhs.LocalSize()) {
+      throw RuntimeError{"Cannot multiply the given hilbert spaces"};
+    }
+
+    // TODO generalize this to spaces with different local sizes
+    size_ += rhs.Size();
+    return *this;
+  }
+
+  friend CustomHilbert Pow(const CustomHilbert &lhs, int iexp) {
+    CustomHilbert powres = lhs;
+    powres.size_ *= iexp;
+    return powres;
+  }
+
 };  // namespace netket
 
 }  // namespace netket

--- a/NetKet/Hilbert/custom_hilbert.hpp
+++ b/NetKet/Hilbert/custom_hilbert.hpp
@@ -32,19 +32,21 @@ namespace netket {
 */
 
 class CustomHilbert : public AbstractHilbert {
-  const AbstractGraph &graph_;
   std::vector<double> local_;
-
+  int size_;
   int nstates_;
 
-  int size_;
-
  public:
+  explicit CustomHilbert(int n_sites, const std::vector<double> &localstates)
+      : size_(n_sites), local_(localstates) {
+    nstates_ = local_.size();
+  }
   explicit CustomHilbert(const AbstractGraph &graph,
                          const std::vector<double> &localstates)
-      : graph_(graph), local_(localstates) {
+      : local_(localstates) {
     size_ = graph.Size();
     nstates_ = local_.size();
+    SetGraph(graph);
   }
 
   bool IsDiscrete() const override { return true; }
@@ -79,7 +81,6 @@ class CustomHilbert : public AbstractHilbert {
     }
   }
 
-  const AbstractGraph &GetGraph() const noexcept override { return graph_; }
 };  // namespace netket
 
 }  // namespace netket

--- a/NetKet/Hilbert/py_bosons.hpp
+++ b/NetKet/Hilbert/py_bosons.hpp
@@ -75,7 +75,22 @@ void AddBosons(py::module &subm) {
                100
 
                ```
-           )EOF");
+           )EOF")
+      .def("__imul__",
+           [](Boson &self, const Boson &rhs) {
+             self *= (rhs);
+             return self;
+           },
+           py::is_operator())
+      .def("__mul__",
+           [](const Boson &lhs, const Boson &rhs) {
+             Boson res = lhs;
+             res *= (rhs);
+             return res;
+           },
+           py::is_operator())
+      .def("__pow__", [](Boson &lhs, int iexp) { return Pow(lhs, iexp); },
+           py::is_operator());
 }
 
 }  // namespace netket

--- a/NetKet/Hilbert/py_custom_hilbert.hpp
+++ b/NetKet/Hilbert/py_custom_hilbert.hpp
@@ -74,7 +74,23 @@ void AddCustomHilbert(py::module &subm) {
                100
 
                ```
-           )EOF");
+           )EOF")
+      .def("__imul__",
+           [](CustomHilbert &self, const CustomHilbert &rhs) {
+             self *= (rhs);
+             return self;
+           },
+           py::is_operator())
+      .def("__mul__",
+           [](const CustomHilbert &lhs, const CustomHilbert &rhs) {
+             CustomHilbert res = lhs;
+             res *= (rhs);
+             return res;
+           },
+           py::is_operator())
+      .def("__pow__",
+           [](CustomHilbert &lhs, int iexp) { return Pow(lhs, iexp); },
+           py::is_operator());
 }
 
 }  // namespace netket

--- a/NetKet/Hilbert/py_custom_hilbert.hpp
+++ b/NetKet/Hilbert/py_custom_hilbert.hpp
@@ -53,6 +53,27 @@ void AddCustomHilbert(py::module &subm) {
                100
 
                ```
+           )EOF")
+      .def(py::init<int, std::vector<double>>(), py::arg("n") = 1,
+           py::arg("local_states"),
+           R"EOF(
+           Constructs a new ``CustomHilbert`` given a number of sites and a list of
+           local quantum numbers.
+
+           Args:
+               n: Number of sites.
+               local_states: Eigenvalues of the states.
+
+           Examples:
+               Simple custom hilbert space.
+
+               ```python
+               >>> from netket.hilbert import CustomHilbert
+               >>> hi = CustomHilbert(n=100, local_states=[-1232, 132, 0])
+               >>> print(hi.size)
+               100
+
+               ```
            )EOF");
 }
 

--- a/NetKet/Hilbert/py_hilbert.hpp
+++ b/NetKet/Hilbert/py_hilbert.hpp
@@ -102,9 +102,10 @@ void AddHilbertModule(py::module &m) {
           new_conf: Contains the value that those quantum numbers should take.
 
       )EOF");
+  // .def(py::self * py::self);
 
-  // Add HilbertIndex methods. For convenience, they are provided as methods on
-  // the Hilbert space directly.
+  // Add HilbertIndex methods. For convenience, they are provided as methods
+  // on the Hilbert space directly.
   hilbert_class
       .def_property_readonly(
           "n_states",

--- a/NetKet/Hilbert/py_hilbert.hpp
+++ b/NetKet/Hilbert/py_hilbert.hpp
@@ -62,6 +62,9 @@ void AddHilbertModule(py::module &m) {
           .def_property_readonly(
               "local_states", &AbstractHilbert::LocalStates,
               R"EOF(list[float]: List of discreet local quantum numbers.)EOF")
+          .def_property(
+              "graph", &AbstractHilbert::GetGraph, &AbstractHilbert::SetGraph,
+              R"EOF(netket.graph.Graph: A graph object associated with the Hilbert space.)EOF")
           .def("random_vals", &AbstractHilbert::RandomVals, py::arg("state"),
                py::arg("rgen"), R"EOF(
        Member function generating uniformely distributed local random states.

--- a/NetKet/Hilbert/py_qubits.hpp
+++ b/NetKet/Hilbert/py_qubits.hpp
@@ -67,7 +67,22 @@ void AddQubits(py::module &subm) {
                10
 
            ```
-         )EOF");
+         )EOF")
+      .def("__imul__",
+           [](Qubit &self, const Qubit &rhs) {
+             self *= (rhs);
+             return self;
+           },
+           py::is_operator())
+      .def("__mul__",
+           [](const Qubit &lhs, const Qubit &rhs) {
+             Qubit res = lhs;
+             res *= (rhs);
+             return res;
+           },
+           py::is_operator())
+      .def("__pow__", [](Qubit &lhs, int iexp) { return Pow(lhs, iexp); },
+           py::is_operator());
 }
 
 }  // namespace netket

--- a/NetKet/Hilbert/py_qubits.hpp
+++ b/NetKet/Hilbert/py_qubits.hpp
@@ -50,7 +50,24 @@ void AddQubits(py::module &subm) {
                100
 
                ```
-           )EOF");
+           )EOF")
+      .def(py::init<int>(), py::arg("n") = 1, R"EOF(
+           Constructs a new Hilbert space tensor product of n ``Qubit`` spaces .
+
+           Args:
+               n: Total number of qubits.
+
+           Examples:
+               Simple qubit hilbert space.
+
+               ```python
+               >>> from netket.hilbert import Qubit
+               >>> hi = Qubit(10)
+               >>> print(hi.size)
+               10
+
+           ```
+         )EOF");
 }
 
 }  // namespace netket

--- a/NetKet/Hilbert/py_spins.hpp
+++ b/NetKet/Hilbert/py_spins.hpp
@@ -31,6 +31,27 @@ namespace netket {
 void AddSpins(py::module &subm) {
   py::class_<Spin, AbstractHilbert>(
       subm, "Spin", R"EOF(Hilbert space composed of spin states.)EOF")
+      .def(py::init<int, double>(), py::arg("n") = 1, py::arg("s"), R"EOF(
+           Constructs a new ``Spin`` hilbert space as the tensor product of n
+           local spin spaces.
+
+           Args:
+               n: Number of spins.
+               s: Spin at each site. Must be integer or half-integer.
+
+           Examples:
+               Simple spin hilbert space.
+
+               ```python
+               >>> from netket.graph import Hypercube
+               >>> from netket.hilbert import Spin
+               >>> g = Hypercube(length=10,n_dim=2,pbc=True)
+               >>> hi = Spin(graph=g, s=0.5)
+               >>> print(hi.size)
+               100
+
+               ```
+           )EOF")
       .def(py::init<const AbstractGraph &, double>(), py::keep_alive<1, 2>(),
            py::arg("graph"), py::arg("s"), R"EOF(
            Constructs a new ``Spin`` given a graph and the value of each spin.
@@ -63,7 +84,7 @@ void AddSpins(py::module &subm) {
                total_sz: Constrain total spin of system to a particular value.
 
            Examples:
-               Simple spin hilbert space.
+               Simple spin hilbert space with constrained total spin.
 
                ```python
                >>> from netket.graph import Hypercube

--- a/NetKet/Hilbert/py_spins.hpp
+++ b/NetKet/Hilbert/py_spins.hpp
@@ -95,7 +95,22 @@ void AddSpins(py::module &subm) {
                100
 
                ```
-           )EOF");
+           )EOF")
+      .def("__imul__",
+           [](Spin &self, const Spin &rhs) {
+             self *= (rhs);
+             return self;
+           },
+           py::is_operator())
+      .def("__mul__",
+           [](const Spin &lhs, const Spin &rhs) {
+             Spin res = lhs;
+             res *= (rhs);
+             return res;
+           },
+           py::is_operator())
+      .def("__pow__", [](Spin &lhs, int iexp) { return Pow(lhs, iexp); },
+           py::is_operator());
 }
 }  // namespace netket
 #endif

--- a/NetKet/Hilbert/qubits.hpp
+++ b/NetKet/Hilbert/qubits.hpp
@@ -32,17 +32,18 @@ namespace netket {
 */
 
 class Qubit : public AbstractHilbert {
-  const AbstractGraph &graph_;
-
   std::vector<double> local_;
 
   int nqubits_;
 
  public:
-  explicit Qubit(const AbstractGraph &graph) : graph_(graph) {
+  explicit Qubit(const AbstractGraph &graph) {
     const int nqubits = graph.Size();
     Init(nqubits);
+    SetGraph(graph);
   }
+
+  explicit Qubit(int nqubits) { Init(nqubits); }
 
   void Init(int nqubits) {
     nqubits_ = nqubits;
@@ -84,8 +85,6 @@ class Qubit : public AbstractHilbert {
       i++;
     }
   }
-
-  const AbstractGraph &GetGraph() const noexcept override { return graph_; }
 };
 
 }  // namespace netket

--- a/NetKet/Hilbert/qubits.hpp
+++ b/NetKet/Hilbert/qubits.hpp
@@ -85,6 +85,17 @@ class Qubit : public AbstractHilbert {
       i++;
     }
   }
+
+  Qubit &operator*=(const Qubit &rhs) {
+    nqubits_ += rhs.Size();
+    return *this;
+  }
+
+  friend Qubit Pow(const Qubit &lhs, int iexp) {
+    Qubit powsp = lhs;
+    powsp.nqubits_ *= iexp;
+    return powsp;
+  }
 };
 
 }  // namespace netket

--- a/NetKet/Hilbert/spins.hpp
+++ b/NetKet/Hilbert/spins.hpp
@@ -180,6 +180,31 @@ class Spin : public AbstractHilbert {
       i++;
     }
   }
+
+  Spin &operator*=(const Spin &rhs) {
+    if (LocalSize() != rhs.LocalSize()) {
+      throw RuntimeError{"Cannot multiply the given hilbert spaces"};
+    }
+    nspins_ += rhs.Size();
+    if (constraintSz_ && rhs.constraintSz_ &&
+        std::abs(totalS_ - rhs.totalS_) < 1.0e-8) {
+      SetConstraint(totalS_);
+    } else {
+      constraintSz_ = false;
+    }
+
+    return *this;
+  }
+  friend Spin Pow(const Spin &lhs, int iexp) {
+    Spin powsp = lhs;
+    powsp.nspins_ *= iexp;
+    if (powsp.constraintSz_) {
+      powsp.SetConstraint(powsp.totalS_);
+    } else {
+      powsp.constraintSz_ = false;
+    }
+    return powsp;
+  }
 };
 
 }  // namespace netket

--- a/NetKet/Hilbert/spins.hpp
+++ b/NetKet/Hilbert/spins.hpp
@@ -36,8 +36,6 @@ namespace netket {
 */
 
 class Spin : public AbstractHilbert {
-  const AbstractGraph &graph_;
-
   double S_;
   double totalS_;
   bool constraintSz_;
@@ -49,20 +47,28 @@ class Spin : public AbstractHilbert {
   int nspins_;
 
  public:
-  explicit Spin(const AbstractGraph &graph, double S) : graph_(graph) {
-    const int nspins = graph.Size();
-
+  explicit Spin(int nspins, double S) {
     Init(nspins, S);
 
     constraintSz_ = false;
   }
-  explicit Spin(const AbstractGraph &graph, double S, double totalSz)
-      : graph_(graph) {
-    const int nspins = graph.Size();
+
+  explicit Spin(const AbstractGraph &graph, double S) {
+    int nspins = graph.Size();
+
+    Init(nspins, S);
+
+    constraintSz_ = false;
+    SetGraph(graph);
+  }
+
+  explicit Spin(const AbstractGraph &graph, double S, double totalSz) {
+    int nspins = graph.Size();
 
     Init(nspins, S);
 
     SetConstraint(totalSz);
+    SetGraph(graph);
   }
 
   void Init(int nspins, double S) {
@@ -174,8 +180,6 @@ class Spin : public AbstractHilbert {
       i++;
     }
   }
-
-  const AbstractGraph &GetGraph() const noexcept override { return graph_; }
 };
 
 }  // namespace netket

--- a/NetKet/Operator/MatrixWrapper/direct_matrix_wrapper.hpp
+++ b/NetKet/Operator/MatrixWrapper/direct_matrix_wrapper.hpp
@@ -47,7 +47,7 @@ class DirectMatrixWrapper : public AbstractMatrixWrapper<State> {
     State result(dim_);
     result.setZero();
 
-    for (size_t i = 0; i < dim_; ++i) {
+    for (int i = 0; i < dim_; ++i) {
       const auto v = hilbert_index_.NumberToState(i);
       operator_.ForEachConn(v, [&](ConnectorRef conn) {
         const auto j = i + hilbert_index_.DeltaStateToNumber(v, conn.tochange,

--- a/Test/Hilbert/test_hilbert.py
+++ b/Test/Hilbert/test_hilbert.py
@@ -22,31 +22,42 @@ hilberts = {}
 
 # Spin 1/2
 hilberts["Spin 1/2"] = nk.hilbert.Spin(
-    s=0.5, graph=nk.graph.Hypercube(length=20, n_dim=1))
+    s=0.5, graph=nk.graph.Hypercube(length=20, n_dim=1)
+)
+
+hilberts["Spin 1/2 n"] = nk.hilbert.Spin(s=0.5, n=10)
 
 # Spin 1/2 with total Sz
 hilberts["Spin 1/2 with total Sz"] = nk.hilbert.Spin(
-    s=0.5, total_sz=1.0, graph=nk.graph.Hypercube(length=20, n_dim=1))
+    s=0.5, total_sz=1.0, graph=nk.graph.Hypercube(length=20, n_dim=1)
+)
 
 # Spin 3
-hilberts["Spin 3"] = nk.hilbert.Spin(
-    s=3, graph=nk.graph.Hypercube(length=25, n_dim=1))
+hilberts["Spin 3"] = nk.hilbert.Spin(s=3, graph=nk.graph.Hypercube(length=25, n_dim=1))
 
 # Boson
 hilberts["Boson"] = nk.hilbert.Boson(
-    n_max=5, graph=nk.graph.Hypercube(length=21, n_dim=1))
+    n_max=5, graph=nk.graph.Hypercube(length=21, n_dim=1)
+)
 
 # Boson with total number
 hilberts["Bosons with total number"] = nk.hilbert.Boson(
-    n_max=5, n_bosons=11, graph=nk.graph.Hypercube(length=21, n_dim=1))
+    n_max=5, n_bosons=11, graph=nk.graph.Hypercube(length=21, n_dim=1)
+)
 
 # Qubit
-hilberts["Qubit"] = nk.hilbert.Qubit(
-    graph=nk.graph.Hypercube(length=32, n_dim=1))
+hilberts["Qubit"] = nk.hilbert.Qubit(graph=nk.graph.Hypercube(length=32, n_dim=1))
+
+hilberts["Qubit n=1"] = nk.hilbert.Qubit()
 
 # Custom Hilbert
 hilberts["Custom Hilbert"] = nk.hilbert.CustomHilbert(
-    local_states=[-1232, 132, 0], graph=nk.graph.Hypercube(length=34, n_dim=1))
+    local_states=[-1232, 132, 0], graph=nk.graph.Hypercube(length=34, n_dim=1)
+)
+
+hilberts["Custom Hilbert n"] = nk.hilbert.CustomHilbert(
+    local_states=[-1232, 132, 0], n=2
+)
 
 # Heisenberg 1d
 g = nk.graph.Hypercube(length=20, n_dim=1, pbc=True)
@@ -64,23 +75,28 @@ hilberts["Bose Hubbard"] = hi
 
 # Spin 1/2
 hilberts["Spin 1/2 Small"] = nk.hilbert.Spin(
-    s=0.5, graph=nk.graph.Hypercube(length=10, n_dim=1))
+    s=0.5, graph=nk.graph.Hypercube(length=10, n_dim=1)
+)
 
 # Spin 3
 hilberts["Spin 1/2 with total Sz Small"] = nk.hilbert.Spin(
-    s=3, total_sz=1.0, graph=nk.graph.Hypercube(length=4, n_dim=1))
+    s=3, total_sz=1.0, graph=nk.graph.Hypercube(length=4, n_dim=1)
+)
 
 # Boson
 hilberts["Boson Small"] = nk.hilbert.Boson(
-    n_max=3, graph=nk.graph.Hypercube(length=5, n_dim=1))
+    n_max=3, graph=nk.graph.Hypercube(length=5, n_dim=1)
+)
 
 # Qubit
 hilberts["Qubit Small"] = nk.hilbert.Qubit(
-    graph=nk.graph.Hypercube(length=1, n_dim=1, pbc=False))
+    graph=nk.graph.Hypercube(length=1, n_dim=1, pbc=False)
+)
 
 # Custom Hilbert
 hilberts["Custom Hilbert Small"] = nk.hilbert.CustomHilbert(
-    local_states=[-1232, 132, 0], graph=nk.graph.Hypercube(length=5, n_dim=1))
+    local_states=[-1232, 132, 0], graph=nk.graph.Hypercube(length=5, n_dim=1)
+)
 
 #
 # Tests
@@ -91,22 +107,22 @@ def test_consistent_size():
     """"""
 
     for name, hi in hilberts.items():
-        #print("Hilbert test: %s" % name)
-        assert (hi.size > 0)
-        assert (hi.local_size > 0)
+        # print("Hilbert test: %s" % name)
+        assert hi.size > 0
+        assert hi.local_size > 0
         if hi.is_discrete:
-            assert (len(hi.local_states) == hi.local_size)
+            assert len(hi.local_states) == hi.local_size
             for state in hi.local_states:
-                assert (np.isfinite(state).all())
+                assert np.isfinite(state).all()
 
 
 def test_random_states():
     """"""
 
     for name, hi in hilberts.items():
-        assert (hi.size > 0)
-        assert (hi.local_size > 0)
-        assert (len(hi.local_states) == hi.local_size)
+        assert hi.size > 0
+        assert hi.local_size > 0
+        assert len(hi.local_states) == hi.local_size
 
         if hi.is_discrete:
             rstate = np.zeros(hi.size)
@@ -116,16 +132,15 @@ def test_random_states():
             for i in range(100):
                 hi.random_vals(rstate, rg)
                 for state in rstate:
-                    assert (state in local_states)
+                    assert state in local_states
 
 
-#TODO (jamesETsmith)
 def test_hilbert_index():
     """"""
 
     for name, hi in hilberts.items():
-        assert (hi.size > 0)
-        assert (hi.local_size > 0)
+        assert hi.size > 0
+        assert hi.local_size > 0
 
         log_max_states = np.log(nk.hilbert.max_states)
         if hi.size * np.log(hi.local_size) < log_max_states:
@@ -148,11 +163,12 @@ def test_hilbert_index():
             with pytest.raises(RuntimeError):
                 dw = nk.operator.DirectMatrixWrapper(op)
 
+
 def test_state_iteration():
     g = nk.graph.Hypercube(10, 1)
     hilbert = nk.hilbert.Spin(g, s=0.5)
 
-    reference = [np.array(el) for el in itertools.product([-1., 1.], repeat=10)]
+    reference = [np.array(el) for el in itertools.product([-1.0, 1.0], repeat=10)]
 
     for state, ref in zip(hilbert.states(), reference):
         assert np.allclose(state, ref)


### PR DESCRIPTION
This PR partially adresses #188 . Specifically, it is now possible to do things like 

```python
hi = nk.hilbert.Spin(s=0.5) ** 20
hi *=hi
hi1=h1*nk.hilbert.Spin(n=10,s=0.5)

#standard constructor
hi=nk.hilbert.Spin(graph=g,s=0.5) 
```
etc. 

Apart from the last constructor, the last ones do not assing a graph by default, however one can 
attach graphs in this way 

```python
# Hilbert space of spins on the graph
hi = nk.hilbert.Spin(s=0.5) ** 20
hi.graph = nk.graph.Hypercube(length=20, n_dim=1)
```

Support for heterogeneous spaces remains to be addressed, but this seems to me a good starting point. 