### PR TITLE
Split netket into Python and C++ parts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -149,8 +149,9 @@ install:
   - python -m pip install numpy networkx pytest python-igraph
   - python -m pytest --version
   - NETKET_CMAKE_FLAGS="$CMAKE_FLAGS" python -m pip install -v .
+  - mkdir workdir && cd workdir
 
 script:
   - python -c 'import netket; g = netket.graph.Hypercube(4, 1); h = netket.hilbert.Spin(g, 0.5); m = netket.machine.RbmSpin(h, 10)'
-  - python -m pytest --verbose Test/
-  - python -m pytest --verbose --doctest-glob='*.md' Docs/
+  - python -m pytest --verbose ../Test/
+  - python -m pytest --verbose --doctest-glob='*.md' ../Docs/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,6 +211,7 @@ target_link_libraries(netket PUBLIC netket_lib pybind11)
 set_target_properties(netket PROPERTIES PREFIX "${PYTHON_MODULE_PREFIX}"
                                         SUFFIX "${PYTHON_MODULE_EXTENSION}")
 add_dependencies(netket eigen_project pybind11_project)
+set_target_properties(netket PROPERTIES OUTPUT_NAME "_C_netket")
 
 if(NETKET_Sanitizer)
     message(STATUS "[NetKet] Building python library with address and UB sanitizers")

--- a/NetKet/pynetket.cc
+++ b/NetKet/pynetket.cc
@@ -42,7 +42,7 @@ static MPIInitializer _do_not_use_me_dummy_{};
 
 using ode::AddDynamicsModule;
 
-PYBIND11_MODULE(netket, m) {
+PYBIND11_MODULE(_C_netket, m) {
   AddDynamicsModule(m);
   AddGraphModule(m);
   AddGroundStateModule(m);

--- a/NetKet/pynetket.cc
+++ b/NetKet/pynetket.cc
@@ -15,6 +15,7 @@
 #ifndef NETKET_PYNETKET_CC
 #define NETKET_PYNETKET_CC
 
+// clang-format off
 #include <netket.hpp>
 #include "Dynamics/py_dynamics.hpp"
 #include "Graph/py_graph.hpp"
@@ -28,15 +29,16 @@
 #include "Stats/py_stats.hpp"
 #include "Supervised/py_supervised.hpp"
 #include "Unsupervised/py_unsupervised.hpp"
-#include "Utils/mpi_interface.hpp"  // for MPIInitializer
+#include "Utils/mpi_interface.hpp" // for MPIInitializer
 #include "Utils/py_utils.hpp"
 #include "Utils/pybind_helpers.hpp"
+// clang-format on
 
 namespace netket {
 
 namespace detail {
 static MPIInitializer _do_not_use_me_dummy_{};
-}  // namespace detail
+} // namespace detail
 
 using ode::AddDynamicsModule;
 
@@ -54,8 +56,8 @@ PYBIND11_MODULE(netket, m) {
   AddUtilsModule(m);
   AddSupervisedModule(m);
   AddUnsupervisedModule(m);
-}  // PYBIND11_MODULE
+} // PYBIND11_MODULE
 
-}  // namespace netket
+} // namespace netket
 
 #endif

--- a/NetKet/pynetket.cc
+++ b/NetKet/pynetket.cc
@@ -15,7 +15,6 @@
 #ifndef NETKET_PYNETKET_CC
 #define NETKET_PYNETKET_CC
 
-// clang-format off
 #include <netket.hpp>
 #include "Dynamics/py_dynamics.hpp"
 #include "Graph/py_graph.hpp"
@@ -29,16 +28,15 @@
 #include "Stats/py_stats.hpp"
 #include "Supervised/py_supervised.hpp"
 #include "Unsupervised/py_unsupervised.hpp"
-#include "Utils/mpi_interface.hpp" // for MPIInitializer
+#include "Utils/mpi_interface.hpp"  // for MPIInitializer
 #include "Utils/py_utils.hpp"
 #include "Utils/pybind_helpers.hpp"
-// clang-format on
 
 namespace netket {
 
 namespace detail {
 static MPIInitializer _do_not_use_me_dummy_{};
-} // namespace detail
+}  // namespace detail
 
 using ode::AddDynamicsModule;
 
@@ -56,8 +54,8 @@ PYBIND11_MODULE(_C_netket, m) {
   AddUtilsModule(m);
   AddSupervisedModule(m);
   AddUnsupervisedModule(m);
-} // PYBIND11_MODULE
+}  // PYBIND11_MODULE
 
-} // namespace netket
+}  // namespace netket
 
 #endif

--- a/netket/__init__.py
+++ b/netket/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2019 The Simons Foundation, Inc. - All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ._C_netket import *

--- a/netket/__init__.py
+++ b/netket/__init__.py
@@ -13,4 +13,21 @@
 # limitations under the License.
 
 from __future__ import absolute_import
-from ._C_netket import *
+from . import (
+    _C_netket,
+    dynamics,
+    exact,
+    graph,
+    hilbert,
+    layer,
+    machine,
+    operator,
+    optimizer,
+    output,
+    sampler,
+    stats,
+    supervised,
+    unsupervised,
+    utils,
+    variational,
+)

--- a/netket/__init__.py
+++ b/netket/__init__.py
@@ -12,4 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from ._C_netket import *

--- a/netket/dynamics.py
+++ b/netket/dynamics.py
@@ -1,0 +1,1 @@
+from ._C_netket.dynamics import *

--- a/netket/exact.py
+++ b/netket/exact.py
@@ -1,0 +1,1 @@
+from ._C_netket.exact import *

--- a/netket/graph.py
+++ b/netket/graph.py
@@ -1,0 +1,1 @@
+from ._C_netket.graph import *

--- a/netket/hilbert.py
+++ b/netket/hilbert.py
@@ -1,0 +1,1 @@
+from ._C_netket.hilbert import *

--- a/netket/layer.py
+++ b/netket/layer.py
@@ -1,0 +1,1 @@
+from ._C_netket.layer import *

--- a/netket/machine.py
+++ b/netket/machine.py
@@ -1,0 +1,1 @@
+from ._C_netket.machine import *

--- a/netket/operator.py
+++ b/netket/operator.py
@@ -1,0 +1,1 @@
+from ._C_netket.operator import *

--- a/netket/optimizer.py
+++ b/netket/optimizer.py
@@ -1,0 +1,1 @@
+from ._C_netket.optimizer import *

--- a/netket/output.py
+++ b/netket/output.py
@@ -1,0 +1,1 @@
+from ._C_netket.output import *

--- a/netket/sampler.py
+++ b/netket/sampler.py
@@ -1,0 +1,1 @@
+from ._C_netket.sampler import *

--- a/netket/stats.py
+++ b/netket/stats.py
@@ -1,0 +1,1 @@
+from ._C_netket.stats import *

--- a/netket/supervised.py
+++ b/netket/supervised.py
@@ -1,0 +1,1 @@
+from ._C_netket.supervised import *

--- a/netket/unsupervised.py
+++ b/netket/unsupervised.py
@@ -1,0 +1,1 @@
+from ._C_netket.unsupervised import *

--- a/netket/utils.py
+++ b/netket/utils.py
@@ -1,0 +1,1 @@
+from ._C_netket.utils import *

--- a/netket/variational.py
+++ b/netket/variational.py
@@ -1,0 +1,1 @@
+from ._C_netket.variational import *

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ def steal_cmake_flags(args):
     accumulated. If there are no arguments of the specified form,
     ``NETKET_CMAKE_FLAGS`` environment variable is used instead.
     """
-    _ARG_PREFIX = '--cmake-args='
+    _ARG_PREFIX = "--cmake-args="
 
     def _unquote(x):
         m = re.match(r"'(.*)'", x)
@@ -29,16 +29,18 @@ def steal_cmake_flags(args):
         if m:
             return m.group(1)
         return x
+
     stolen_args = [x for x in args if x.startswith(_ARG_PREFIX)]
     for x in stolen_args:
         args.remove(x)
 
     if len(stolen_args) > 0:
         cmake_args = sum(
-            (shlex.split(_unquote(x[len(_ARG_PREFIX):])) for x in stolen_args), [])
+            (shlex.split(_unquote(x[len(_ARG_PREFIX) :])) for x in stolen_args), []
+        )
     else:
         try:
-            cmake_args = shlex.split(os.environ['NETKET_CMAKE_FLAGS'])
+            cmake_args = shlex.split(os.environ["NETKET_CMAKE_FLAGS"])
         except KeyError:
             cmake_args = []
     return cmake_args
@@ -51,7 +53,7 @@ _CMAKE_FLAGS = steal_cmake_flags(sys.argv)
 
 
 class CMakeExtension(Extension):
-    def __init__(self, name, sourcedir=''):
+    def __init__(self, name, sourcedir=""):
         Extension.__init__(self, name, sources=[])
         self.sourcedir = os.path.abspath(sourcedir)
 
@@ -77,9 +79,9 @@ class CMakeBuild(build_ext):
             # Options to pass to CMake during configuration
             cmake_args = _CMAKE_FLAGS
             cmake_args.append(
-                '-DNETKET_PYTHON_VERSION={}.{}.{}'.format(*sys.version_info[:3]))
-            cmake_args.append(
-                '-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={}'.format(lib_dir))
+                "-DNETKET_PYTHON_VERSION={}.{}.{}".format(*sys.version_info[:3])
+            )
+            cmake_args.append("-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={}".format(lib_dir))
 
             def _decode(x):
                 if sys.version_info >= (3, 0):
@@ -92,22 +94,27 @@ class CMakeBuild(build_ext):
             try:
                 # Configuration step
                 output = subprocess.check_output(
-                    ['cmake', ext.sourcedir] + cmake_args, stderr=subprocess.STDOUT)
+                    ["cmake", ext.sourcedir] + cmake_args, stderr=subprocess.STDOUT
+                )
                 if self.distribution.verbose:
                     log.info(_decode(output))
                 if not self.distribution.dry_run:
                     # Build step
                     output = subprocess.check_output(
-                        ['cmake', '--build', '.'], stderr=subprocess.STDOUT)
+                        ["cmake", "--build", "."], stderr=subprocess.STDOUT
+                    )
                     if self.distribution.verbose:
                         log.info(_decode(output))
             except subprocess.CalledProcessError as e:
-                if hasattr(ext, 'optional'):
+                if hasattr(ext, "optional"):
                     if not ext.optional:
                         self.warn(_decode(e.output))
                         raise
-                    self.warn('building extension "{}" failed:\n{}'.format(
-                        ext.name, _decode(e.output)))
+                    self.warn(
+                        'building extension "{}" failed:\n{}'.format(
+                            ext.name, _decode(e.output)
+                        )
+                    )
                 else:
                     self.warn(_decode(e.output))
                     raise
@@ -120,14 +127,14 @@ class CMakeBuild(build_ext):
 
 
 setup(
-    name='netket',
-    version='2.0b3',
-    author='Giuseppe Carleo et al.',
-    url='http://github.com/netket/netket',
-    author_email='netket@netket.org',
-    license='Apache 2.0',
-    packages=['netket'],
-    ext_modules=[CMakeExtension('netket._C_netket')],
+    name="netket",
+    version="2.0b3",
+    author="Giuseppe Carleo et al.",
+    url="http://github.com/netket/netket",
+    author_email="netket@netket.org",
+    license="Apache 2.0",
+    packages=["netket"],
+    ext_modules=[CMakeExtension("netket._C_netket")],
     long_description="""NetKet is an open - source project delivering cutting - edge
          methods for the study of many - body quantum systems with artificial
          neural networks and machine learning techniques.""",

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ class CMakeBuild(build_ext):
             # lib_dir is the directory, where the shared libraries will be
             # stored (it will probably be different from the build_temp
             # directory so that setuptools find the libraries)
-            lib_dir = os.path.abspath(self.build_lib)
+            lib_dir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
             if not os.path.exists(lib_dir):
                 os.makedirs(lib_dir)
             # Options to pass to CMake during configuration
@@ -118,11 +118,6 @@ class CMakeBuild(build_ext):
             else:
                 super(build_ext, self).build_extension(ext)
 
-        extdir = os.path.abspath(os.path.dirname(
-            self.get_ext_fullpath(ext.name)))
-        cmake_args = ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' + extdir,
-                      '-DPYTHON_EXECUTABLE=' + sys.executable]
-
 
 setup(
     name='netket',
@@ -131,7 +126,8 @@ setup(
     url='http://github.com/netket/netket',
     author_email='netket@netket.org',
     license='Apache 2.0',
-    ext_modules=[CMakeExtension('netket')],
+    packages=['netket'],
+    ext_modules=[CMakeExtension('netket._C_netket')],
     long_description="""NetKet is an open - source project delivering cutting - edge
          methods for the study of many - body quantum systems with artificial
          neural networks and machine learning techniques.""",


### PR DESCRIPTION
At some point (actually, pretty soon) we'll probably have some high-lever functionality which is simpler to implement in Python than in C++. Not simple enough though to require every user to re-implement it themselves.

It is then nice to convert NetKet into a "proper" Python package (i.e. with `__init__.py` files) and use the C++ extension just as an implementation detail. This PR achieves that. C++ code is compiled into `_C_netket` module which is loaded by `__init__.py`.

There's a bunch of one-line-long files in `netket` directory. The mirror the module structure of our C++ code in Python. This means that stuff like `from netket.layer import DenseLayer, LogCosh` still works. If someone knows a cooler way to achieve, I'm open to suggestions. But for now, that's the best I could come up with.

P.S.: Formatting changes in `setup.py` are made by Black. It looks like #190 didn't reformat `setup.py` properly.