### PR TITLE
Rename StateIterator to StateGenerator

### DIFF
--- a/Sources/Hilbert/abstract_hilbert.hpp
+++ b/Sources/Hilbert/abstract_hilbert.hpp
@@ -106,8 +106,8 @@ class AbstractHilbert {
   virtual const AbstractGraph &GetGraph() const noexcept = 0;
 
   // Allow range-based for over all states in the Hilbert space, iff it is indexable
-  StateIterator begin() const { return StateIterator(GetIndex()); };
-  StateIterator end() const { return StateIterator(GetIndex()); };
+  StateGenerator begin() const { return StateGenerator(GetIndex()); };
+  StateGenerator end() const { return StateGenerator(GetIndex()); };
 
   virtual ~AbstractHilbert() = default;
 

--- a/Sources/Hilbert/hilbert_index.hpp
+++ b/Sources/Hilbert/hilbert_index.hpp
@@ -112,32 +112,29 @@ class HilbertIndex {
   int nstates_;
 };
 
-class StateIterator {
+class StateGenerator {
  public:
-  // typedefs required for iterators
-  using iterator_category = std::input_iterator_tag;
   using difference_type = Index;
   using value_type = Eigen::VectorXd;
-  using pointer_type = Eigen::VectorXd *;
-  using reference_type = Eigen::VectorXd &;
+  using reference = value_type;
 
-  explicit StateIterator(const HilbertIndex &index) : i_(0), index_(index) {}
+  explicit StateGenerator(const HilbertIndex &index) : i_(0), index_(index) {}
 
-  value_type operator*() const { return index_.NumberToState(i_); }
+  reference operator*() const { return index_.NumberToState(i_); }
 
-  StateIterator &operator++() {
+  StateGenerator &operator++() {
     ++i_;
     return *this;
   }
 
   // TODO(C++17): Replace with comparison to special Sentinel type, since
   // C++17 allows end() to return a different type from begin().
-  bool operator!=(const StateIterator &) { return i_ < index_.NStates(); }
+  bool operator!=(const StateGenerator &) { return i_ < index_.NStates(); }
   // pybind11::make_iterator requires operator==
-  bool operator==(const StateIterator &other) { return !(*this != other); }
+  bool operator==(const StateGenerator &other) { return !(*this != other); }
 
-  StateIterator begin() const { return *this; }
-  StateIterator end() const { return *this; }
+  StateGenerator begin() const { return *this; }
+  StateGenerator end() const { return *this; }
 
  private:
   int i_;

--- a/Sources/Hilbert/py_hilbert.hpp
+++ b/Sources/Hilbert/py_hilbert.hpp
@@ -127,15 +127,15 @@ void AddHilbertModule(py::module &m) {
       .def(
           "states",
           [](const AbstractHilbert &self) {
-            return StateIterator(self.GetIndex());
+            return StateGenerator(self.GetIndex());
           },
           R"EOF(Returns an iterator over all valid configurations of the Hilbert space.
                  Throws an exception iff the space is not indexable.)EOF");
 
   subm.attr("max_states") = HilbertIndex::MaxStates;
 
-  py::class_<StateIterator>(subm, "_StateIterator")
-      .def("__iter__", [](StateIterator &self) {
+  py::class_<StateGenerator>(subm, "_StateGenerator")
+      .def("__iter__", [](StateGenerator &self) {
         return py::make_iterator(self.begin(), self.end());
       });
 


### PR DESCRIPTION
Addressing #195.

This may prevent confusion since `StateGenerator` does not fully satisfy the `InputIterator` concept of the C++ standard library.