### PR TITLE
Move implementation of .iter methods on driver classes to Python

### DIFF
--- a/Sources/GroundState/imaginary_time.hpp
+++ b/Sources/GroundState/imaginary_time.hpp
@@ -13,8 +13,6 @@ namespace netket {
 
 class ImagTimePropagation {
  public:
-  class Iterator;
-
   using StateVector = Eigen::VectorXcd;
   using Stepper = ode::AbstractTimeStepper<StateVector>;
   using Matrix = AbstractMatrixWrapper<>;
@@ -48,18 +46,6 @@ class ImagTimePropagation {
     t_ += dt;
   }
 
-  /*void Run(StateVector& initial_state, ) {
-    assert(initial_state.size() == Dimension());
-    state_ = initial_state;
-    for (const auto& step : Iterate(range.t0, )) {
-    }
-  }*/
-
-  Iterator Iterate(double dt,
-                   nonstd::optional<Index> n_iter = nonstd::nullopt) {
-    return Iterator(*this, dt, std::move(n_iter));
-  }
-
   void ComputeObservables(const StateVector& state) {
     const auto mean_variance = matrix_->MeanVariance(state);
     obsmanager_.Reset("Energy");
@@ -81,46 +67,6 @@ class ImagTimePropagation {
 
   double GetTime() const { return t_; }
   void SetTime(double t) { t_ = t; }
-
-  class Iterator {
-   public:
-    // typedefs required for iterators
-    using iterator_category = std::input_iterator_tag;
-    using difference_type = Index;
-    using value_type = Index;
-    using pointer_type = Index*;
-    using reference_type = Index&;
-
-   private:
-    ImagTimePropagation& driver_;
-    nonstd::optional<Index> n_iter_;
-    double dt_;
-
-    Index cur_iter_;
-
-   public:
-    Iterator(ImagTimePropagation& driver, double dt,
-             nonstd::optional<Index> n_iter)
-        : driver_(driver), n_iter_(std::move(n_iter)), dt_(dt), cur_iter_(0) {}
-
-    Index operator*() const { return cur_iter_; };
-    Iterator& operator++() {
-      driver_.Advance(dt_);
-      cur_iter_ += 1;
-      return *this;
-    }
-
-    // TODO(C++17): Replace with comparison to special Sentinel type, since
-    // C++17 allows end() to return a different type from begin().
-    bool operator!=(const Iterator&) {
-      return !n_iter_.has_value() || cur_iter_ < n_iter_.value();
-    }
-    // pybind11::make_iterator requires operator==
-    bool operator==(const Iterator& other) { return !(*this != other); }
-
-    Iterator begin() const { return *this; }
-    Iterator end() const { return *this; }
-  };
 
  private:
   std::unique_ptr<Matrix> matrix_;

--- a/Sources/GroundState/py_exact.hpp
+++ b/Sources/GroundState/py_exact.hpp
@@ -90,6 +90,12 @@ void AddExactModule(py::module &m) {
                    other choices are `dense` and `direct`.
 
            )EOF")
+      .def("advance", &ImagTimePropagation::Advance, py::arg("dt"), R"EOF(
+           Advance the time propagation by dt.
+
+           Args:
+               dt (float): The time step.
+      )EOF")
       .def_property("t", &ImagTimePropagation::GetTime,
                     &ImagTimePropagation::SetTime,
                     R"EOF(double: Time in the simulation.)EOF")

--- a/Sources/GroundState/py_exact.hpp
+++ b/Sources/GroundState/py_exact.hpp
@@ -90,33 +90,20 @@ void AddExactModule(py::module &m) {
                    other choices are `dense` and `direct`.
 
            )EOF")
-      .def("iter", &ImagTimePropagation::Iterate, py::arg("dt"),
-           py::arg("n_iter") = nonstd::nullopt, R"EOF(
-           Iterate the optimization of the Vmc wavefunction.
-
-           Args:
-               dt: Number of iterations performed at a time.
-               n_iter: The maximum number of iterations.
-
-           )EOF")
       .def_property("t", &ImagTimePropagation::GetTime,
                     &ImagTimePropagation::SetTime,
                     R"EOF(double: Time in the simulation.)EOF")
-      .def("get_observable_stats",
-           [](const ImagTimePropagation &self) {
-             py::dict data;
-             self.GetObsManager().InsertAllStats(data);
-             return data;
-           },
-           R"EOF(
+      .def(
+          "get_observable_stats",
+          [](const ImagTimePropagation &self) {
+            py::dict data;
+            self.GetObsManager().InsertAllStats(data);
+            return data;
+          },
+          R"EOF(
         Calculate and return the value of the operators stored as observables.
 
         )EOF");
-
-  py::class_<ImagTimePropagation::Iterator>(m_exact, "ImagTimeIterator")
-      .def("__iter__", [](ImagTimePropagation::Iterator &self) {
-        return py::make_iterator(self.begin(), self.end());
-      });
 
   py::class_<eddetail::result_t>(
       m_exact, "EdResult",
@@ -127,15 +114,16 @@ void AddExactModule(py::module &m) {
       .def_property_readonly(
           "eigenvectors", &eddetail::result_t::eigenvectors,
           R"EOF(vector<Eigen::Matrix<Complex, Eigen::Dynamic, 1>>: The complex eigenvectors of the system hamiltonian.)EOF")
-      .def("mean",
-           [](eddetail::result_t &self, AbstractOperator &op, int which) {
-             if (which < 0 || static_cast<std::size_t>(which) >=
-                                  self.eigenvectors().size()) {
-               throw InvalidInputError("Invalid eigenvector index `which`");
-             }
-             return self.mean(op, which);
-           },
-           py::arg("operator"), py::arg("which") = 0);
+      .def(
+          "mean",
+          [](eddetail::result_t &self, AbstractOperator &op, int which) {
+            if (which < 0 ||
+                static_cast<std::size_t>(which) >= self.eigenvectors().size()) {
+              throw InvalidInputError("Invalid eigenvector index `which`");
+            }
+            return self.mean(op, which);
+          },
+          py::arg("operator"), py::arg("which") = 0);
 
   m_exact.def("lanczos_ed", &lanczos_ed, py::arg("operator"),
               py::arg("matrix_free") = false, py::arg("first_n") = 1,

--- a/Sources/GroundState/py_variational_montecarlo.hpp
+++ b/Sources/GroundState/py_variational_montecarlo.hpp
@@ -146,16 +146,7 @@ void AddVariationalMonteCarloModule(py::module &m) {
                ```
 
            )EOF")
-      .def("iter", &VariationalMonteCarlo::Iterate,
-           py::arg("n_iter") = nonstd::nullopt, py::arg("step_size") = 1, R"EOF(
-           Iterate the optimization of the Vmc wavefunction.
-
-           Args:
-               n_iter: The maximum number of iterations.
-               step_size: Number of iterations performed at a time. Default is
-                   1.
-
-           )EOF")
+      .def("reset", &VariationalMonteCarlo::Reset)
       .def("advance", &VariationalMonteCarlo::Advance, py::arg("steps") = 1,
            R"EOF(
            Perform one or several iteration steps of the VMC calculation. In each step,
@@ -166,22 +157,18 @@ void AddVariationalMonteCarloModule(py::module &m) {
                steps: Number of VMC steps to perform.
 
            )EOF")
-      .def("get_observable_stats",
-           [](VariationalMonteCarlo &self) {
-             py::dict data;
-             self.ComputeObservables();
-             self.GetObsManager().InsertAllStats(data);
-             return data;
-           },
-           R"EOF(
+      .def(
+          "get_observable_stats",
+          [](VariationalMonteCarlo &self) {
+            py::dict data;
+            self.ComputeObservables();
+            self.GetObsManager().InsertAllStats(data);
+            return data;
+          },
+          R"EOF(
         Calculate and return the value of the operators stored as observables.
 
         )EOF");
-
-  py::class_<VariationalMonteCarlo::Iterator>(m_vmc, "VmcIterator")
-      .def("__iter__", [](VariationalMonteCarlo::Iterator &self) {
-        return py::make_iterator(self.begin(), self.end());
-      });
 }
 
 }  // namespace netket

--- a/Sources/Unsupervised/py_unsupervised.hpp
+++ b/Sources/Unsupervised/py_unsupervised.hpp
@@ -68,16 +68,7 @@ void AddUnsupervisedModule(py::module &m) {
       .def("run", &QuantumStateReconstruction::Run, py::arg("output_prefix"),
            py::arg("n_iter"), py::arg("step_size") = 1,
            py::arg("save_params_every") = 50)
-      .def("iter", &QuantumStateReconstruction::Iterate,
-           py::arg("n_iter") = nonstd::nullopt, py::arg("step_size") = 1, R"EOF(
-                      Iterate the optimization of the wavefunction.
-
-                      Args:
-                          n_iter: The maximum number of iterations.
-                          step_size: Number of iterations performed at a time. Default is
-                              1.
-
-                      )EOF")
+      .def("reset", &QuantumStateReconstruction::Reset)
       .def("advance", &QuantumStateReconstruction::Advance,
            py::arg("steps") = 1,
            R"EOF(
@@ -119,10 +110,6 @@ void AddUnsupervisedModule(py::module &m) {
                       negative log-likelihood computed here is a meaningful
                       quantity.
                   )EOF");
-  py::class_<QuantumStateReconstruction::Iterator>(subm, "QsrIterator")
-      .def("__iter__", [](QuantumStateReconstruction::Iterator &self) {
-        return py::make_iterator(self.begin(), self.end());
-      });
 }
 
 }  // namespace netket

--- a/Sources/Unsupervised/quantum_state_reconstruction.hpp
+++ b/Sources/Unsupervised/quantum_state_reconstruction.hpp
@@ -82,50 +82,6 @@ class QuantumStateReconstruction {
   std::vector<int> trainingBases_;
 
  public:
-  class Iterator {
-   public:
-    // typedefs required for iterators
-    using iterator_category = std::input_iterator_tag;
-    using difference_type = Index;
-    using value_type = Index;
-    using pointer_type = Index *;
-    using reference_type = Index &;
-
-   private:
-    QuantumStateReconstruction &qst_;
-    Index step_size_;
-    nonstd::optional<Index> n_iter_;
-
-    Index cur_iter_;
-
-   public:
-    Iterator(QuantumStateReconstruction &qst, Index step_size,
-             nonstd::optional<Index> n_iter)
-        : qst_(qst),
-          step_size_(step_size),
-          n_iter_(std::move(n_iter)),
-          cur_iter_(0) {}
-
-    Index operator*() const { return cur_iter_; }
-
-    Iterator &operator++() {
-      qst_.Advance(step_size_);
-      cur_iter_ += step_size_;
-      return *this;
-    }
-
-    // TODO(C++17): Replace with comparison to special Sentinel type, since
-    // C++17 allows end() to return a different type from begin().
-    bool operator!=(const Iterator &) {
-      return !n_iter_.has_value() || cur_iter_ < n_iter_.value();
-    }
-    // pybind11::make_iterator requires operator==
-    bool operator==(const Iterator &other) { return !(*this != other); }
-
-    Iterator begin() const { return *this; }
-    Iterator end() const { return *this; }
-  };
-
   QuantumStateReconstruction(
       AbstractSampler &sampler, AbstractOptimizer &opt, int batchsize,
       int nsamples, std::vector<AbstractOperator *> rotations,
@@ -302,7 +258,8 @@ class QuantumStateReconstruction {
     }
     opt_.Reset();
 
-    for (const auto step : Iterate(n_iter, step_size)) {
+    for (Index step = 0; !n_iter.has_value() || step < *n_iter; step += step_size) {
+      Advance(step_size);
       ComputeObservables();
 
       // Note: This has to be called in all MPI processes, because converting
@@ -328,16 +285,9 @@ class QuantumStateReconstruction {
     }
   }
 
-  Iterator Iterate(const nonstd::optional<Index> &n_iter = nonstd::nullopt,
-                   Index step_size = 1) {
-    assert(!n_iter.has_value() || n_iter.value() > 0);
-    assert(step_size > 0);
-
+  void Reset() {
     opt_.Reset();
     InitSweeps();
-
-    Advance(step_size);
-    return Iterator(*this, step_size, n_iter);
   }
 
   void UpdateParameters() {

--- a/Test/GroundState/test_groundstate.py
+++ b/Test/GroundState/test_groundstate.py
@@ -36,7 +36,7 @@ def test_vmc_advance():
     ma1, vmc1 = _setup_vmc()
     ma2, vmc2 = _setup_vmc()
 
-    for i in range(11):
+    for i in range(10):
         vmc1.advance()
 
     for step in vmc2.iter(10):

--- a/Test/GroundState/test_groundstate.py
+++ b/Test/GroundState/test_groundstate.py
@@ -1,6 +1,7 @@
 import json
 from pytest import approx
 import netket as nk
+import numpy as np
 import shutil
 import tempfile
 
@@ -91,6 +92,21 @@ def test_vmc_run():
         last_obs = obs
 
     assert last_obs["Energy"]["Mean"] == approx(-10.25, abs=0.2)
+
+
+def test_imag_time_propagation():
+    g = nk.graph.Hypercube(length=8, n_dim=1, pbc=True)
+    hi = nk.hilbert.Spin(s=0.5, graph=g)
+    ha = nk.operator.Ising(h=0.0, hilbert=hi)
+
+    stepper = nk.dynamics.create_timestepper(hi.n_states, rel_tol=1e-10, abs_tol=1e-10)
+    psi0 = np.random.rand(hi.n_states)
+    driver = nk.exact.ImagTimePropagation(ha, stepper, t0=0, initial_state=psi0)
+
+    for step in driver.iter(dt=0.1, n_iter=1000):
+        pass
+
+    assert driver.get_observable_stats()["Energy"]["Mean"] == approx(-8.0)
 
 
 def test_ed():

--- a/netket/exact.py
+++ b/netket/exact.py
@@ -1,1 +1,25 @@
 from ._C_netket.exact import *
+
+import itertools
+
+
+def _ImagTimePropagation_iter(self, dt, n_iter=None):
+    """
+    Returns a generator which advances the time evolution by dt,
+    yielding after every step.
+
+    Args:
+        dt (float): The size of the time step.
+        n_iter (int, optional): The number of steps or None, for no limit.
+
+    Yields:
+        int: The current step.
+    """
+    for i in itertools.count():
+        if n_iter and i >= n_iter:
+            return
+        self.advance(dt)
+        yield i
+
+
+ImagTimePropagation.iter = _ImagTimePropagation_iter

--- a/netket/unsupervised.py
+++ b/netket/unsupervised.py
@@ -1,1 +1,26 @@
 from ._C_netket.unsupervised import *
+
+import itertools
+
+
+def _Qsr_iter(self, n_iter=None, step_size=1):
+    """
+    Returns a generator which advances the QSR optimization, yielding
+    after every step_size steps up to n_iter.
+
+    Args:
+        n_iter (int, optional): The number of steps or None, for no limit.
+        step_size (int): The number of steps the simulation is advanced.
+
+    Yields:
+        int: The current step.
+    """
+    self.reset()
+    for i in itertools.count(step=step_size):
+        if n_iter and i >= n_iter:
+            return
+        self.advance(step_size)
+        yield i
+
+
+Qsr.iter = _Qsr_iter

--- a/netket/variational.py
+++ b/netket/variational.py
@@ -1,1 +1,26 @@
 from ._C_netket.variational import *
+
+import itertools
+
+
+def _Vmc_iter(self, n_iter=None, step_size=1):
+    """
+    Returns a generator which advances the VMC optimization, yielding
+    after every step_size steps up to n_iter.
+
+    Args:
+        n_iter (int, optional): The number of steps or None, for no limit.
+        step_size (int): The number of steps the simulation is advanced.
+
+    Yields:
+        int: The current step.
+    """
+    self.reset()
+    for i in itertools.count(step=step_size):
+        if n_iter and i >= n_iter:
+            return
+        self.advance(step_size)
+        yield i
+
+
+Vmc.iter = _Vmc_iter


### PR DESCRIPTION
Implementing the iterator interface for the simulation drivers is quite a bit more complicated in C++ than to do it in Python (also compare #195, #198).

Now that we also have a straightforward way to add functionality in Python (#193), we can replace this with, essentially, something like
```python
for i in range(n_iter):
    driver.advance()
    yield i
```
which is done in this PR.