### PR TITLE
Pass Hilbert object around without cloning using shared_ptr

### DIFF
--- a/Sources/Hilbert/abstract_hilbert.hpp
+++ b/Sources/Hilbert/abstract_hilbert.hpp
@@ -114,8 +114,6 @@ class AbstractHilbert {
 
   virtual ~AbstractHilbert() = default;
 
-  virtual std::shared_ptr<AbstractHilbert> Clone() const = 0;
-
  private:
   mutable nonstd::optional<HilbertIndex> index_;
 };

--- a/Sources/Hilbert/bosons.cc
+++ b/Sources/Hilbert/bosons.cc
@@ -115,8 +115,4 @@ void Boson::UpdateConf(Eigen::Ref<Eigen::VectorXd> v,
   }
 }
 
-std::shared_ptr<AbstractHilbert> Boson::Clone() const {
-  return std::make_shared<Boson>(*this);
-}
-
 }  // namespace netket

--- a/Sources/Hilbert/bosons.hpp
+++ b/Sources/Hilbert/bosons.hpp
@@ -47,8 +47,6 @@ class Boson : public AbstractHilbert {
                   const std::vector<int> &tochange,
                   const std::vector<double> &newconf) const override;
 
-  std::shared_ptr<AbstractHilbert> Clone() const override;
-
  private:
   void Init();
   inline void SetNbosons(int nbosons);

--- a/Sources/Hilbert/custom_hilbert.cc
+++ b/Sources/Hilbert/custom_hilbert.cc
@@ -57,8 +57,4 @@ void CustomHilbert::UpdateConf(Eigen::Ref<Eigen::VectorXd> v,
 
 const AbstractGraph &CustomHilbert::GetGraph() const noexcept { return graph_; }
 
-std::shared_ptr<AbstractHilbert> CustomHilbert::Clone() const {
-  return std::make_shared<CustomHilbert>(*this);
-}
-
 }  // namespace netket

--- a/Sources/Hilbert/custom_hilbert.hpp
+++ b/Sources/Hilbert/custom_hilbert.hpp
@@ -48,8 +48,6 @@ class CustomHilbert : public AbstractHilbert {
   void UpdateConf(Eigen::Ref<Eigen::VectorXd> v,
                   const std::vector<int> &tochange,
                   const std::vector<double> &newconf) const override;
-
-  std::shared_ptr<AbstractHilbert> Clone() const override;
 };
 
 }  // namespace netket

--- a/Sources/Hilbert/py_hilbert.cc
+++ b/Sources/Hilbert/py_hilbert.cc
@@ -32,7 +32,7 @@ namespace netket {
 
 namespace {
 void AddBosons(py::module subm) {
-  py::class_<Boson, AbstractHilbert>(
+  py::class_<Boson, AbstractHilbert, std::shared_ptr<Boson>>(
       subm, "Boson", R"EOF(Hilbert space composed of bosonic states.)EOF")
       .def(py::init<const AbstractGraph &, int>(), py::keep_alive<1, 2>(),
            py::arg("graph"), py::arg("n_max"), R"EOF(
@@ -81,8 +81,8 @@ void AddBosons(py::module subm) {
 }
 
 void AddCustomHilbert(py::module subm) {
-  py::class_<CustomHilbert, AbstractHilbert>(subm, "CustomHilbert",
-                                             R"EOF(A custom hilbert space.)EOF")
+  py::class_<CustomHilbert, AbstractHilbert, std::shared_ptr<CustomHilbert>>(
+      subm, "CustomHilbert", R"EOF(A custom hilbert space.)EOF")
       .def(py::init<const AbstractGraph &, std::vector<double>>(),
            py::keep_alive<1, 2>(), py::arg("graph"), py::arg("local_states"),
            R"EOF(
@@ -109,7 +109,7 @@ void AddCustomHilbert(py::module subm) {
 }
 
 void AddQubits(py::module subm) {
-  py::class_<Qubit, AbstractHilbert>(
+  py::class_<Qubit, AbstractHilbert, std::shared_ptr<Qubit>>(
       subm, "Qubit", R"EOF(Hilbert space composed of qubits.)EOF")
       .def(py::init<const AbstractGraph &>(), py::keep_alive<1, 2>(),
            py::arg("graph"), R"EOF(
@@ -134,7 +134,7 @@ void AddQubits(py::module subm) {
 }
 
 void AddSpins(py::module subm) {
-  py::class_<Spin, AbstractHilbert>(
+  py::class_<Spin, AbstractHilbert, std::shared_ptr<Spin>>(
       subm, "Spin", R"EOF(Hilbert space composed of spin states.)EOF")
       .def(py::init<const AbstractGraph &, double>(), py::keep_alive<1, 2>(),
            py::arg("graph"), py::arg("s"), R"EOF(
@@ -187,7 +187,8 @@ void AddHilbertModule(py::module m) {
   auto subm = m.def_submodule("hilbert");
 
   auto hilbert_class =
-      py::class_<AbstractHilbert>(subm, "Hilbert")
+      py::class_<AbstractHilbert, std::shared_ptr<AbstractHilbert>>(subm,
+                                                                    "Hilbert")
           .def_property_readonly(
               "is_discrete", &AbstractHilbert::IsDiscrete,
               R"EOF(bool: Whether the hilbert space is discrete.)EOF")

--- a/Sources/Hilbert/qubits.cc
+++ b/Sources/Hilbert/qubits.cc
@@ -61,8 +61,4 @@ void Qubit::UpdateConf(Eigen::Ref<Eigen::VectorXd> v,
   }
 }
 
-std::shared_ptr<AbstractHilbert> Qubit::Clone() const {
-  return std::make_shared<Qubit>(*this);
-}
-
 }  // namespace netket

--- a/Sources/Hilbert/qubits.hpp
+++ b/Sources/Hilbert/qubits.hpp
@@ -42,8 +42,6 @@ class Qubit : public AbstractHilbert {
 
   const AbstractGraph &GetGraph() const noexcept override;
 
-  std::shared_ptr<AbstractHilbert> Clone() const override;
-
  private:
   inline void Init();
 

--- a/Sources/Hilbert/spins.cc
+++ b/Sources/Hilbert/spins.cc
@@ -142,8 +142,4 @@ void Spin::UpdateConf(Eigen::Ref<Eigen::VectorXd> v,
   }
 }
 
-std::shared_ptr<AbstractHilbert> Spin::Clone() const {
-  return std::make_shared<Spin>(*this);
-}
-
 }  // namespace netket

--- a/Sources/Hilbert/spins.hpp
+++ b/Sources/Hilbert/spins.hpp
@@ -47,8 +47,6 @@ class Spin : public AbstractHilbert {
                   const std::vector<int> &tochange,
                   const std::vector<double> &newconf) const override;
 
-  std::shared_ptr<AbstractHilbert> Clone() const override;
-
  private:
   void Init();
   inline void SetConstraint(double totalS);

--- a/Sources/Machine/DensityMatrices/abstract_density_matrix.hpp
+++ b/Sources/Machine/DensityMatrices/abstract_density_matrix.hpp
@@ -75,10 +75,11 @@ class AbstractDensityMatrix : public AbstractMachine {
   }
 
  public:
-  explicit AbstractDensityMatrix(const AbstractHilbert &hilbert)
-      : graph_doubled_(DoubledGraph(hilbert.GetGraph())) {
+  explicit AbstractDensityMatrix(std::shared_ptr<const AbstractHilbert> hilbert)
+      : graph_doubled_(DoubledGraph(hilbert->GetGraph())) {
     SetHilbertPhysical(hilbert);
-    SetHilbert(CustomHilbert(*graph_doubled_, hilbert.LocalStates()));
+    SetHilbert(std::make_shared<CustomHilbert>(*graph_doubled_,
+                                               hilbert->LocalStates()));
   };
 
   /**
@@ -86,16 +87,16 @@ class AbstractDensityMatrix : public AbstractMachine {
    * this density matrix acts
    * @return The physical hilbert space
    */
-  const AbstractHilbert &GetHilbertPhysical() const {
-    return *hilbert_physical_;
+  std::shared_ptr<const AbstractHilbert> GetHilbertPhysical() const {
+    return hilbert_physical_;
   }
 
-  void SetHilbertPhysical(const AbstractHilbert &hilbert) {
-    hilbert_physical_ = hilbert.Clone();
+  void SetHilbertPhysical(std::shared_ptr<const AbstractHilbert> hilbert) {
+    hilbert_physical_ = std::move(hilbert);
   }
 
  private:
-  std::shared_ptr<AbstractHilbert> hilbert_physical_;
+  std::shared_ptr<const AbstractHilbert> hilbert_physical_;
 };
 }  // namespace netket
 

--- a/Sources/Machine/DensityMatrices/abstract_density_matrix.hpp
+++ b/Sources/Machine/DensityMatrices/abstract_density_matrix.hpp
@@ -76,19 +76,27 @@ class AbstractDensityMatrix : public AbstractMachine {
 
  public:
   explicit AbstractDensityMatrix(std::shared_ptr<const AbstractHilbert> hilbert)
-      : graph_doubled_(DoubledGraph(hilbert->GetGraph())) {
-    SetHilbertPhysical(hilbert);
+      : graph_doubled_(DoubledGraph(hilbert->GetGraph())),
+        hilbert_physical_(hilbert) {
     SetHilbert(std::make_shared<CustomHilbert>(*graph_doubled_,
                                                hilbert->LocalStates()));
   };
 
   /**
-   * Member function returning the Physical hilbert space over which
-   * this density matrix acts
+   * Member function returning the physical hilbert space over which
+   * this density matrix acts as a shared pointer.
    * @return The physical hilbert space
    */
-  std::shared_ptr<const AbstractHilbert> GetHilbertPhysical() const {
+  std::shared_ptr<const AbstractHilbert> GetHilbertPhysicalShared() const {
     return hilbert_physical_;
+  }
+
+  /* Member function returning a reference to the physical hilbert space
+   * on which this density matrix acts.
+   * @return The physical hilbert space
+   */
+  const AbstractHilbert &GetHilbertPhysical() const {
+    return *hilbert_physical_;
   }
 
   void SetHilbertPhysical(std::shared_ptr<const AbstractHilbert> hilbert) {

--- a/Sources/Machine/DensityMatrices/diagonal_density_matrix.hpp
+++ b/Sources/Machine/DensityMatrices/diagonal_density_matrix.hpp
@@ -36,7 +36,7 @@ class DiagonalDensityMatrix : public AbstractMachine {
  public:
   explicit DiagonalDensityMatrix(AbstractDensityMatrix &dm)
       : density_matrix_(dm) {
-    SetHilbert(dm.GetHilbertPhysical());
+    SetHilbert(dm.GetHilbertPhysicalShared());
   };
 
   const AbstractDensityMatrix &GetFullDensityMatrix() const noexcept {

--- a/Sources/Machine/DensityMatrices/diagonal_density_matrix.hpp
+++ b/Sources/Machine/DensityMatrices/diagonal_density_matrix.hpp
@@ -35,9 +35,7 @@ class DiagonalDensityMatrix : public AbstractMachine {
 
  public:
   explicit DiagonalDensityMatrix(AbstractDensityMatrix &dm)
-      : density_matrix_(dm) {
-    SetHilbert(dm.GetHilbertPhysicalShared());
-  };
+      : AbstractMachine(dm.GetHilbertShared()), density_matrix_(dm){};
 
   const AbstractDensityMatrix &GetFullDensityMatrix() const noexcept {
     return density_matrix_;

--- a/Sources/Machine/DensityMatrices/ndm_spin_phase.hpp
+++ b/Sources/Machine/DensityMatrices/ndm_spin_phase.hpp
@@ -224,8 +224,8 @@ class NdmSpinPhase : public AbstractDensityMatrix {
       lt.V(5).resize(d1_.size());
     }
 
-    VisibleConstType vr = v.head(GetHilbertPhysical()->Size());
-    VisibleConstType vc = v.tail(GetHilbertPhysical()->Size());
+    VisibleConstType vr = v.head(GetHilbertPhysical().Size());
+    VisibleConstType vc = v.tail(GetHilbertPhysical().Size());
 
     lt.V(0) = (W1_.transpose() * vr + h1_);
     lt.V(1) = (W2_.transpose() * vr + h2_);
@@ -239,8 +239,8 @@ class NdmSpinPhase : public AbstractDensityMatrix {
   void UpdateLookup(VisibleConstType v, const std::vector<int> &tochange,
                     const std::vector<double> &newconf,
                     LookupType &lt) override {
-    VisibleConstType vr = v.head(GetHilbertPhysical()->Size());
-    VisibleConstType vc = v.tail(GetHilbertPhysical()->Size());
+    VisibleConstType vr = v.head(GetHilbertPhysical().Size());
+    VisibleConstType vc = v.tail(GetHilbertPhysical().Size());
 
     if (tochange.size() != 0) {
       for (std::size_t s = 0; s < tochange.size(); s++) {
@@ -270,8 +270,8 @@ class NdmSpinPhase : public AbstractDensityMatrix {
   }
 
   VectorType DerLog(VisibleConstType v, const LookupType &lt) override {
-    VisibleConstType vr = v.head(GetHilbertPhysical()->Size());
-    VisibleConstType vc = v.tail(GetHilbertPhysical()->Size());
+    VisibleConstType vr = v.head(GetHilbertPhysical().Size());
+    VisibleConstType vc = v.tail(GetHilbertPhysical().Size());
 
     VectorType der(npar_);
 
@@ -404,8 +404,8 @@ class NdmSpinPhase : public AbstractDensityMatrix {
 
   // Value of the logarithm of the wave-function
   Complex LogVal(VisibleConstType v) override {
-    VisibleConstType vr = v.head(GetHilbertPhysical()->Size());
-    VisibleConstType vc = v.tail(GetHilbertPhysical()->Size());
+    VisibleConstType vr = v.head(GetHilbertPhysical().Size());
+    VisibleConstType vc = v.tail(GetHilbertPhysical().Size());
 
     RbmSpin::lncosh(W1_.transpose() * vr + h1_, lnthetas_r1_);
     RbmSpin::lncosh(W2_.transpose() * vr + h2_, lnthetas_r2_);
@@ -428,8 +428,8 @@ class NdmSpinPhase : public AbstractDensityMatrix {
   // Value of the logarithm of the wave-function
   // using pre-computed look-up tables for efficiency
   Complex LogVal(VisibleConstType v, const LookupType &lt) override {
-    VisibleConstType vr = v.head(GetHilbertPhysical()->Size());
-    VisibleConstType vc = v.tail(GetHilbertPhysical()->Size());
+    VisibleConstType vr = v.head(GetHilbertPhysical().Size());
+    VisibleConstType vc = v.tail(GetHilbertPhysical().Size());
 
     RbmSpin::lncosh(lt.V(0).real(), lnthetas_r1_);
     RbmSpin::lncosh(lt.V(1).real(), lnthetas_r2_);
@@ -450,8 +450,8 @@ class NdmSpinPhase : public AbstractDensityMatrix {
   VectorType LogValDiff(
       VisibleConstType v, const std::vector<std::vector<int>> &tochange,
       const std::vector<std::vector<double>> &newconf) override {
-    VisibleConstType vr = v.head(GetHilbertPhysical()->Size());
-    VisibleConstType vc = v.tail(GetHilbertPhysical()->Size());
+    VisibleConstType vr = v.head(GetHilbertPhysical().Size());
+    VisibleConstType vc = v.tail(GetHilbertPhysical().Size());
 
     const std::size_t nconn = tochange.size();
 
@@ -527,8 +527,8 @@ class NdmSpinPhase : public AbstractDensityMatrix {
   Complex LogValDiff(VisibleConstType v, const std::vector<int> &tochange,
                      const std::vector<double> &newconf,
                      const LookupType &lt) override {
-    VisibleConstType vr = v.head(GetHilbertPhysical()->Size());
-    VisibleConstType vc = v.tail(GetHilbertPhysical()->Size());
+    VisibleConstType vr = v.head(GetHilbertPhysical().Size());
+    VisibleConstType vc = v.tail(GetHilbertPhysical().Size());
 
     Complex logvaldiff = 0.;
 
@@ -624,7 +624,7 @@ class NdmSpinPhase : public AbstractDensityMatrix {
     if (FieldExists(pars, "Nvisible")) {
       nv_ = FieldVal<int>(pars, "Nvisible");
     }
-    if (nv_ != GetHilbertPhysical()->Size()) {
+    if (nv_ != GetHilbertPhysical().Size()) {
       throw InvalidInputError(
           "Number of visible units is incompatible with given "
           "Hilbert space");

--- a/Sources/Machine/DensityMatrices/ndm_spin_phase.hpp
+++ b/Sources/Machine/DensityMatrices/ndm_spin_phase.hpp
@@ -95,11 +95,12 @@ class NdmSpinPhase : public AbstractDensityMatrix {
   const Complex I_;
 
  public:
-  explicit NdmSpinPhase(const AbstractHilbert &hilbert, int nhidden = 0,
-                        int nancilla = 0, int alpha = 0, int beta = 0,
-                        bool useb = true, bool useh = true, bool used = true)
+  explicit NdmSpinPhase(std::shared_ptr<const AbstractHilbert> hilbert,
+                        int nhidden = 0, int nancilla = 0, int alpha = 0,
+                        int beta = 0, bool useb = true, bool useh = true,
+                        bool used = true)
       : AbstractDensityMatrix(hilbert),
-        nv_(hilbert.Size()),
+        nv_(hilbert->Size()),
         useb_(useb),
         useh_(useh),
         used_(used),
@@ -223,8 +224,8 @@ class NdmSpinPhase : public AbstractDensityMatrix {
       lt.V(5).resize(d1_.size());
     }
 
-    VisibleConstType vr = v.head(GetHilbertPhysical().Size());
-    VisibleConstType vc = v.tail(GetHilbertPhysical().Size());
+    VisibleConstType vr = v.head(GetHilbertPhysical()->Size());
+    VisibleConstType vc = v.tail(GetHilbertPhysical()->Size());
 
     lt.V(0) = (W1_.transpose() * vr + h1_);
     lt.V(1) = (W2_.transpose() * vr + h2_);
@@ -238,8 +239,8 @@ class NdmSpinPhase : public AbstractDensityMatrix {
   void UpdateLookup(VisibleConstType v, const std::vector<int> &tochange,
                     const std::vector<double> &newconf,
                     LookupType &lt) override {
-    VisibleConstType vr = v.head(GetHilbertPhysical().Size());
-    VisibleConstType vc = v.tail(GetHilbertPhysical().Size());
+    VisibleConstType vr = v.head(GetHilbertPhysical()->Size());
+    VisibleConstType vc = v.tail(GetHilbertPhysical()->Size());
 
     if (tochange.size() != 0) {
       for (std::size_t s = 0; s < tochange.size(); s++) {
@@ -269,8 +270,8 @@ class NdmSpinPhase : public AbstractDensityMatrix {
   }
 
   VectorType DerLog(VisibleConstType v, const LookupType &lt) override {
-    VisibleConstType vr = v.head(GetHilbertPhysical().Size());
-    VisibleConstType vc = v.tail(GetHilbertPhysical().Size());
+    VisibleConstType vr = v.head(GetHilbertPhysical()->Size());
+    VisibleConstType vc = v.tail(GetHilbertPhysical()->Size());
 
     VectorType der(npar_);
 
@@ -403,8 +404,8 @@ class NdmSpinPhase : public AbstractDensityMatrix {
 
   // Value of the logarithm of the wave-function
   Complex LogVal(VisibleConstType v) override {
-    VisibleConstType vr = v.head(GetHilbertPhysical().Size());
-    VisibleConstType vc = v.tail(GetHilbertPhysical().Size());
+    VisibleConstType vr = v.head(GetHilbertPhysical()->Size());
+    VisibleConstType vc = v.tail(GetHilbertPhysical()->Size());
 
     RbmSpin::lncosh(W1_.transpose() * vr + h1_, lnthetas_r1_);
     RbmSpin::lncosh(W2_.transpose() * vr + h2_, lnthetas_r2_);
@@ -427,8 +428,8 @@ class NdmSpinPhase : public AbstractDensityMatrix {
   // Value of the logarithm of the wave-function
   // using pre-computed look-up tables for efficiency
   Complex LogVal(VisibleConstType v, const LookupType &lt) override {
-    VisibleConstType vr = v.head(GetHilbertPhysical().Size());
-    VisibleConstType vc = v.tail(GetHilbertPhysical().Size());
+    VisibleConstType vr = v.head(GetHilbertPhysical()->Size());
+    VisibleConstType vc = v.tail(GetHilbertPhysical()->Size());
 
     RbmSpin::lncosh(lt.V(0).real(), lnthetas_r1_);
     RbmSpin::lncosh(lt.V(1).real(), lnthetas_r2_);
@@ -449,8 +450,8 @@ class NdmSpinPhase : public AbstractDensityMatrix {
   VectorType LogValDiff(
       VisibleConstType v, const std::vector<std::vector<int>> &tochange,
       const std::vector<std::vector<double>> &newconf) override {
-    VisibleConstType vr = v.head(GetHilbertPhysical().Size());
-    VisibleConstType vc = v.tail(GetHilbertPhysical().Size());
+    VisibleConstType vr = v.head(GetHilbertPhysical()->Size());
+    VisibleConstType vc = v.tail(GetHilbertPhysical()->Size());
 
     const std::size_t nconn = tochange.size();
 
@@ -526,8 +527,8 @@ class NdmSpinPhase : public AbstractDensityMatrix {
   Complex LogValDiff(VisibleConstType v, const std::vector<int> &tochange,
                      const std::vector<double> &newconf,
                      const LookupType &lt) override {
-    VisibleConstType vr = v.head(GetHilbertPhysical().Size());
-    VisibleConstType vc = v.tail(GetHilbertPhysical().Size());
+    VisibleConstType vr = v.head(GetHilbertPhysical()->Size());
+    VisibleConstType vc = v.tail(GetHilbertPhysical()->Size());
 
     Complex logvaldiff = 0.;
 
@@ -623,7 +624,7 @@ class NdmSpinPhase : public AbstractDensityMatrix {
     if (FieldExists(pars, "Nvisible")) {
       nv_ = FieldVal<int>(pars, "Nvisible");
     }
-    if (nv_ != GetHilbertPhysical().Size()) {
+    if (nv_ != GetHilbertPhysical()->Size()) {
       throw InvalidInputError(
           "Number of visible units is incompatible with given "
           "Hilbert space");

--- a/Sources/Machine/DensityMatrices/py_density_matrix.hpp
+++ b/Sources/Machine/DensityMatrices/py_density_matrix.hpp
@@ -39,7 +39,7 @@ void AddDensityMatrixModule(py::module &subm) {
       .def(
           "to_matrix",
           [](AbstractDensityMatrix &self) -> AbstractDensityMatrix::MatrixType {
-            const auto &hind = self.GetHilbertPhysical()->GetIndex();
+            const auto &hind = self.GetHilbertPhysical().GetIndex();
             AbstractMachine::MatrixType vals(hind.NStates(), hind.NStates());
 
             double maxlog = std::numeric_limits<double>::lowest();

--- a/Sources/Machine/DensityMatrices/py_density_matrix.hpp
+++ b/Sources/Machine/DensityMatrices/py_density_matrix.hpp
@@ -39,7 +39,7 @@ void AddDensityMatrixModule(py::module &subm) {
       .def(
           "to_matrix",
           [](AbstractDensityMatrix &self) -> AbstractDensityMatrix::MatrixType {
-            const auto &hind = self.GetHilbertPhysical().GetIndex();
+            const auto &hind = self.GetHilbertPhysical()->GetIndex();
             AbstractMachine::MatrixType vals(hind.NStates(), hind.NStates());
 
             double maxlog = std::numeric_limits<double>::lowest();

--- a/Sources/Machine/DensityMatrices/py_ndm_spin_phase.hpp
+++ b/Sources/Machine/DensityMatrices/py_ndm_spin_phase.hpp
@@ -36,9 +36,9 @@ void AddNdmSpinPhase(py::module &subm) {
           In this case, two NDMs are taken to parameterize, respectively, phase
           and amplitude of the density matrix.
           This type of NDM has spin 1/2 hidden and ancilla units.)EOF")
-      .def(py::init<const AbstractHilbert &, int, int, int, int, bool, bool,
-                    bool>(),
-           py::keep_alive<1, 2>(), py::arg("hilbert"), py::arg("n_hidden") = 0,
+      .def(py::init<std::shared_ptr<const AbstractHilbert>, int, int, int, int,
+                    bool, bool, bool>(),
+           py::arg("hilbert"), py::arg("n_hidden") = 0,
            py::arg("n_ancilla") = 0, py::arg("alpha") = 0, py::arg("beta") = 0,
            py::arg("use_visible_bias") = true,
            py::arg("use_hidden_bias") = true,

--- a/Sources/Machine/abstract_machine.cc
+++ b/Sources/Machine/abstract_machine.cc
@@ -24,7 +24,7 @@ AbstractMachine::VectorType AbstractMachine::DerLogChanged(
     VisibleConstType v, const std::vector<int> &tochange,
     const std::vector<double> &newconf) {
   VisibleType vp(v);
-  GetHilbert().UpdateConf(vp, tochange, newconf);
+  hilbert_->UpdateConf(vp, tochange, newconf);
   return DerLog(vp);
 }
 
@@ -38,12 +38,6 @@ void AbstractMachine::Save(std::ofstream &stream) const {
   nlohmann::json j;
   to_json(j);
   stream << j << std::endl;
-}
-
-const AbstractHilbert &AbstractMachine::GetHilbert() const { return *hilbert_; }
-
-void AbstractMachine::SetHilbert(const AbstractHilbert &hilbert) {
-  hilbert_ = hilbert.Clone();
 }
 
 }  // namespace netket

--- a/Sources/Machine/abstract_machine.hpp
+++ b/Sources/Machine/abstract_machine.hpp
@@ -225,11 +225,6 @@ class AbstractMachine {
  protected:
   AbstractMachine(std::shared_ptr<const AbstractHilbert> hilbert)
       : hilbert_(std::move(hilbert)) {}
-  AbstractMachine() = default;
-
-  void SetHilbert(std::shared_ptr<const AbstractHilbert> hilbert) {
-    hilbert_ = std::move(hilbert);
-  }
 
  private:
   std::shared_ptr<const AbstractHilbert> hilbert_;

--- a/Sources/Machine/abstract_machine.hpp
+++ b/Sources/Machine/abstract_machine.hpp
@@ -215,14 +215,23 @@ class AbstractMachine {
   void Save(const std::string &filename) const;
   void Save(std::ofstream &stream) const;
 
-  std::shared_ptr<const AbstractHilbert> GetHilbert() const { return hilbert_; };
-  void SetHilbert(std::shared_ptr<const AbstractHilbert> hilbert) {
-    hilbert_ = std::move(hilbert);
-  }
+  const AbstractHilbert &GetHilbert() const { return *hilbert_; };
+  std::shared_ptr<const AbstractHilbert> GetHilbertShared() const {
+    return hilbert_;
+  };
 
   virtual ~AbstractMachine() = default;
 
  protected:
+  AbstractMachine(std::shared_ptr<const AbstractHilbert> hilbert)
+      : hilbert_(std::move(hilbert)) {}
+  AbstractMachine() = default;
+
+  void SetHilbert(std::shared_ptr<const AbstractHilbert> hilbert) {
+    hilbert_ = std::move(hilbert);
+  }
+
+ private:
   std::shared_ptr<const AbstractHilbert> hilbert_;
 };
 }  // namespace netket

--- a/Sources/Machine/abstract_machine.hpp
+++ b/Sources/Machine/abstract_machine.hpp
@@ -215,14 +215,15 @@ class AbstractMachine {
   void Save(const std::string &filename) const;
   void Save(std::ofstream &stream) const;
 
-  const AbstractHilbert &GetHilbert() const;
+  std::shared_ptr<const AbstractHilbert> GetHilbert() const { return hilbert_; };
+  void SetHilbert(std::shared_ptr<const AbstractHilbert> hilbert) {
+    hilbert_ = std::move(hilbert);
+  }
 
-  void SetHilbert(const AbstractHilbert &hilbert);
+  virtual ~AbstractMachine() = default;
 
-  virtual ~AbstractMachine() {}
-
- private:
-  std::shared_ptr<AbstractHilbert> hilbert_;
+ protected:
+  std::shared_ptr<const AbstractHilbert> hilbert_;
 };
 }  // namespace netket
 

--- a/Sources/Machine/ffnn.hpp
+++ b/Sources/Machine/ffnn.hpp
@@ -47,10 +47,10 @@ class FFNN : public AbstractMachine {
   std::unique_ptr<SumOutput> sum_output_layer_;
 
  public:
-  explicit FFNN(const AbstractHilbert &hilbert,
+  explicit FFNN(std::shared_ptr<const AbstractHilbert> hilbert,
                 std::vector<AbstractLayer *> layers)
-      : layers_(std::move(layers)), nv_(hilbert.Size()) {
-    SetHilbert(hilbert);
+      : layers_(std::move(layers)), nv_(hilbert->Size()) {
+    SetHilbert(std::move(hilbert));
     Init();
   }
 

--- a/Sources/Machine/ffnn.hpp
+++ b/Sources/Machine/ffnn.hpp
@@ -49,8 +49,9 @@ class FFNN : public AbstractMachine {
  public:
   explicit FFNN(std::shared_ptr<const AbstractHilbert> hilbert,
                 std::vector<AbstractLayer *> layers)
-      : layers_(std::move(layers)), nv_(hilbert->Size()) {
-    SetHilbert(std::move(hilbert));
+      : AbstractMachine(hilbert),
+        layers_(std::move(layers)),
+        nv_(hilbert->Size()) {
     Init();
   }
 

--- a/Sources/Machine/jastrow.cc
+++ b/Sources/Machine/jastrow.cc
@@ -21,8 +21,9 @@
 
 namespace netket {
 
-Jastrow::Jastrow(const AbstractHilbert &hilbert) : nv_(hilbert.Size()) {
-  SetHilbert(hilbert);
+Jastrow::Jastrow(std::shared_ptr<const AbstractHilbert> hilbert)
+    : nv_(hilbert->Size()) {
+  SetHilbert(std::move(hilbert));
   Init();
 }
 
@@ -196,7 +197,7 @@ void Jastrow::from_json(const json &pars) {
   if (FieldExists(pars, "Nvisible")) {
     nv_ = pars["Nvisible"];
   }
-  if (nv_ != GetHilbert().Size()) {
+  if (nv_ != hilbert_->Size()) {
     throw InvalidInputError(
         "Number of visible units is incompatible with given "
         "Hilbert space");

--- a/Sources/Machine/jastrow.cc
+++ b/Sources/Machine/jastrow.cc
@@ -22,8 +22,7 @@
 namespace netket {
 
 Jastrow::Jastrow(std::shared_ptr<const AbstractHilbert> hilbert)
-    : nv_(hilbert->Size()) {
-  SetHilbert(std::move(hilbert));
+    : AbstractMachine(hilbert), nv_(hilbert->Size()) {
   Init();
 }
 
@@ -197,7 +196,7 @@ void Jastrow::from_json(const json &pars) {
   if (FieldExists(pars, "Nvisible")) {
     nv_ = pars["Nvisible"];
   }
-  if (nv_ != hilbert_->Size()) {
+  if (nv_ != GetHilbert().Size()) {
     throw InvalidInputError(
         "Number of visible units is incompatible with given "
         "Hilbert space");

--- a/Sources/Machine/jastrow.hpp
+++ b/Sources/Machine/jastrow.hpp
@@ -39,7 +39,7 @@ class Jastrow : public AbstractMachine {
   VectorType thetasnew_;
 
  public:
-  explicit Jastrow(const AbstractHilbert &hilbert);
+  explicit Jastrow(std::shared_ptr<const AbstractHilbert> hilbert);
 
   inline void Init();
 

--- a/Sources/Machine/jastrow_symm.cc
+++ b/Sources/Machine/jastrow_symm.cc
@@ -23,10 +23,10 @@
 namespace netket {
 
 JastrowSymm::JastrowSymm(std::shared_ptr<const AbstractHilbert> hilbert)
-    : graph_(hilbert->GetGraph()), nv_(hilbert->Size()) {
-  SetHilbert(std::move(hilbert));
+    : AbstractMachine(hilbert),
+      graph_(hilbert->GetGraph()),
+      nv_(hilbert->Size()) {
   Init(graph_);
-
   SetBareParameters();
 }
 
@@ -287,7 +287,7 @@ void JastrowSymm::from_json(const json &pars) {
   if (FieldExists(pars, "Nvisible")) {
     nv_ = pars["Nvisible"];
   }
-  if (nv_ != hilbert_->Size()) {
+  if (nv_ != GetHilbert().Size()) {
     throw InvalidInputError(
         "Number of visible units is incompatible with given "
         "Hilbert space");

--- a/Sources/Machine/jastrow_symm.cc
+++ b/Sources/Machine/jastrow_symm.cc
@@ -22,9 +22,9 @@
 
 namespace netket {
 
-JastrowSymm::JastrowSymm(const AbstractHilbert &hilbert)
-    : graph_(hilbert.GetGraph()), nv_(hilbert.Size()) {
-  SetHilbert(hilbert);
+JastrowSymm::JastrowSymm(std::shared_ptr<const AbstractHilbert> hilbert)
+    : graph_(hilbert->GetGraph()), nv_(hilbert->Size()) {
+  SetHilbert(std::move(hilbert));
   Init(graph_);
 
   SetBareParameters();
@@ -287,7 +287,7 @@ void JastrowSymm::from_json(const json &pars) {
   if (FieldExists(pars, "Nvisible")) {
     nv_ = pars["Nvisible"];
   }
-  if (nv_ != GetHilbert().Size()) {
+  if (nv_ != hilbert_->Size()) {
     throw InvalidInputError(
         "Number of visible units is incompatible with given "
         "Hilbert space");

--- a/Sources/Machine/jastrow_symm.hpp
+++ b/Sources/Machine/jastrow_symm.hpp
@@ -51,7 +51,7 @@ class JastrowSymm : public AbstractMachine {
   Eigen::MatrixXi Wtemp_;
 
  public:
-  explicit JastrowSymm(const AbstractHilbert &hilbert);
+  explicit JastrowSymm(std::shared_ptr<const AbstractHilbert> hilbert);
 
   int Nvisible() const override;
   int Npar() const override;

--- a/Sources/Machine/mps_periodic.cc
+++ b/Sources/Machine/mps_periodic.cc
@@ -25,7 +25,8 @@ namespace netket {
 
 MPSPeriodic::MPSPeriodic(std::shared_ptr<const AbstractHilbert> hilbert,
                          int bond_dim, bool diag, int symperiod)
-    : N_{hilbert->Size()},
+    : AbstractMachine(hilbert),
+      N_{hilbert->Size()},
       d_{hilbert->LocalSize()},
       D_{bond_dim},
       symperiod_{symperiod},
@@ -33,7 +34,6 @@ MPSPeriodic::MPSPeriodic(std::shared_ptr<const AbstractHilbert> hilbert,
   if (symperiod_ == -1) {
     symperiod_ = N_;
   }
-  SetHilbert(std::move(hilbert));
   Init();
 }
 
@@ -113,7 +113,7 @@ void MPSPeriodic::Init() {
                   << std::endl;
   }
   // Initialize map from Hilbert space states to MPS indices
-  auto localstates = hilbert_->LocalStates();
+  auto localstates = GetHilbert().LocalStates();
   for (int i = 0; i < d_; i++) {
     confindex_[localstates[i]] = i;
   }
@@ -528,7 +528,7 @@ void MPSPeriodic::from_json(const json &pars) {
   if (FieldExists(pars, "Length")) {
     N_ = pars["Length"];
   }
-  if (N_ != hilbert_->Size()) {
+  if (N_ != GetHilbert().Size()) {
     throw InvalidInputError(
         "Number of spins is incompatible with given Hilbert space");
   }
@@ -536,7 +536,7 @@ void MPSPeriodic::from_json(const json &pars) {
   if (FieldExists(pars, "PhysDim")) {
     d_ = pars["PhysDim"];
   }
-  if (d_ != hilbert_->LocalSize()) {
+  if (d_ != GetHilbert().LocalSize()) {
     throw InvalidInputError(
         "Number of spins is incompatible with given Hilbert space");
   }

--- a/Sources/Machine/mps_periodic.cc
+++ b/Sources/Machine/mps_periodic.cc
@@ -23,17 +23,17 @@
 
 namespace netket {
 
-MPSPeriodic::MPSPeriodic(const AbstractHilbert &hilbert, int bond_dim,
-                         bool diag, int symperiod)
-    : N_{hilbert.Size()},
-      d_{hilbert.LocalSize()},
+MPSPeriodic::MPSPeriodic(std::shared_ptr<const AbstractHilbert> hilbert,
+                         int bond_dim, bool diag, int symperiod)
+    : N_{hilbert->Size()},
+      d_{hilbert->LocalSize()},
       D_{bond_dim},
       symperiod_{symperiod},
       is_diag_{diag} {
   if (symperiod_ == -1) {
     symperiod_ = N_;
   }
-  SetHilbert(hilbert);
+  SetHilbert(std::move(hilbert));
   Init();
 }
 
@@ -113,7 +113,7 @@ void MPSPeriodic::Init() {
                   << std::endl;
   }
   // Initialize map from Hilbert space states to MPS indices
-  auto localstates = GetHilbert().LocalStates();
+  auto localstates = hilbert_->LocalStates();
   for (int i = 0; i < d_; i++) {
     confindex_[localstates[i]] = i;
   }
@@ -528,7 +528,7 @@ void MPSPeriodic::from_json(const json &pars) {
   if (FieldExists(pars, "Length")) {
     N_ = pars["Length"];
   }
-  if (N_ != GetHilbert().Size()) {
+  if (N_ != hilbert_->Size()) {
     throw InvalidInputError(
         "Number of spins is incompatible with given Hilbert space");
   }
@@ -536,7 +536,7 @@ void MPSPeriodic::from_json(const json &pars) {
   if (FieldExists(pars, "PhysDim")) {
     d_ = pars["PhysDim"];
   }
-  if (d_ != GetHilbert().LocalSize()) {
+  if (d_ != hilbert_->LocalSize()) {
     throw InvalidInputError(
         "Number of spins is incompatible with given Hilbert space");
   }

--- a/Sources/Machine/mps_periodic.hpp
+++ b/Sources/Machine/mps_periodic.hpp
@@ -59,8 +59,8 @@ class MPSPeriodic : public AbstractMachine {
   MatrixType identity_mat_;
 
  public:
-  MPSPeriodic(std::shared_ptr<const AbstractHilbert> hilbert, int bond_dim, bool diag,
-              int symperiod = -1);
+  MPSPeriodic(std::shared_ptr<const AbstractHilbert> hilbert, int bond_dim,
+              bool diag, int symperiod = -1);
 
   int Npar() const override;
   int Nvisible() const override;

--- a/Sources/Machine/mps_periodic.hpp
+++ b/Sources/Machine/mps_periodic.hpp
@@ -59,7 +59,7 @@ class MPSPeriodic : public AbstractMachine {
   MatrixType identity_mat_;
 
  public:
-  MPSPeriodic(const AbstractHilbert &hilbert, int bond_dim, bool diag,
+  MPSPeriodic(std::shared_ptr<const AbstractHilbert> hilbert, int bond_dim, bool diag,
               int symperiod = -1);
 
   int Npar() const override;

--- a/Sources/Machine/py_machine.cc
+++ b/Sources/Machine/py_machine.cc
@@ -50,8 +50,9 @@ void AddRbmSpin(py::module subm) {
              \left(\sum_i^N W_{ij} s_i + b_j \right) $$
 
           for arbitrary local quantum numbers $$ s_i $$.)EOF")
-      .def(py::init<const AbstractHilbert &, int, int, bool, bool>(),
-           py::keep_alive<1, 2>(), py::arg("hilbert"), py::arg("n_hidden") = 0,
+      .def(py::init<std::shared_ptr<const AbstractHilbert>, int, int, bool,
+                    bool>(),
+           py::arg("hilbert"), py::arg("n_hidden") = 0,
            py::arg("alpha") = 0, py::arg("use_visible_bias") = true,
            py::arg("use_hidden_bias") = true,
            R"EOF(
@@ -98,8 +99,8 @@ void AddRbmSpinSymm(py::module subm) {
              for arbitrary local quantum numbers $$ s_i $$. However, the weights
              ($$ W_{ij} $$) and biases ($$ a_i $$, $$ b_i $$) respects the
              specified symmetries of the lattice.)EOF")
-      .def(py::init<const AbstractHilbert &, int, bool, bool>(),
-           py::keep_alive<1, 2>(), py::arg("hilbert"), py::arg("alpha") = 0,
+      .def(py::init<std::shared_ptr<const AbstractHilbert>, int, bool, bool>(),
+           py::arg("hilbert"), py::arg("alpha") = 0,
            py::arg("use_visible_bias") = true,
            py::arg("use_hidden_bias") = true,
            R"EOF(
@@ -137,8 +138,9 @@ void AddRbmMultival(py::module subm) {
   py::class_<RbmMultival, AbstractMachine>(subm, "RbmMultiVal", R"EOF(
              A fully connected Restricted Boltzmann Machine for handling larger
              local Hilbert spaces.)EOF")
-      .def(py::init<const AbstractHilbert &, int, int, bool, bool>(),
-           py::keep_alive<1, 2>(), py::arg("hilbert"), py::arg("n_hidden") = 0,
+      .def(py::init<std::shared_ptr<const AbstractHilbert>, int, int, bool,
+                    bool>(),
+           py::arg("hilbert"), py::arg("n_hidden") = 0,
            py::arg("alpha") = 0, py::arg("use_visible_bias") = true,
            py::arg("use_hidden_bias") = true);
 }
@@ -154,8 +156,9 @@ void AddRbmSpinPhase(py::module subm) {
              \left(\sum_i^N W_{ij} s_i + b_j \right) $$
 
           for arbitrary local quantum numbers $$ s_i $$.)EOF")
-      .def(py::init<const AbstractHilbert &, int, int, bool, bool>(),
-           py::keep_alive<1, 2>(), py::arg("hilbert"), py::arg("n_hidden") = 0,
+      .def(py::init<std::shared_ptr<const AbstractHilbert>, int, int, bool,
+                    bool>(),
+           py::arg("hilbert"), py::arg("n_hidden") = 0,
            py::arg("alpha") = 0, py::arg("use_visible_bias") = true,
            py::arg("use_hidden_bias") = true,
            R"EOF(
@@ -199,8 +202,9 @@ void AddRbmSpinReal(py::module subm) {
              \left(\sum_i^N W_{ij} s_i + b_j \right) $$
 
           for arbitrary local quantum numbers $$ s_i $$.)EOF")
-      .def(py::init<const AbstractHilbert &, int, int, bool, bool>(),
-           py::keep_alive<1, 2>(), py::arg("hilbert"), py::arg("n_hidden") = 0,
+      .def(py::init<std::shared_ptr<const AbstractHilbert>, int, int, bool,
+                    bool>(),
+           py::arg("hilbert"), py::arg("n_hidden") = 0,
            py::arg("alpha") = 0, py::arg("use_visible_bias") = true,
            py::arg("use_hidden_bias") = true,
            R"EOF(
@@ -242,11 +246,11 @@ void AddFFNN(py::module subm) {
              class. Each layer implements a transformation such that the
              information is transformed sequentially as it moves from the input
              nodes through the hidden layers and to the output nodes.)EOF")
-      .def(py::init([](AbstractHilbert const &hi, py::tuple tuple) {
+      .def(py::init([](std::shared_ptr<const AbstractHilbert> hi, py::tuple tuple) {
              auto layers = py::cast<std::vector<AbstractLayer *>>(tuple);
-             return FFNN{hi, std::move(layers)};
+             return FFNN{std::move(hi), std::move(layers)};
            }),
-           py::keep_alive<1, 2>(), py::keep_alive<1, 3>(), py::arg("hilbert"),
+           py::keep_alive<1, 3>(), py::arg("hilbert"),
            py::arg("layers"),
            R"EOF(
               Constructs a new ``FFNN`` machine:
@@ -286,7 +290,7 @@ void AddJastrow(py::module subm) {
 
            where $$ W_{ij} $$ are the Jastrow parameters.
            )EOF")
-      .def(py::init<const AbstractHilbert &>(), py::keep_alive<1, 2>(),
+      .def(py::init<std::shared_ptr<const AbstractHilbert>>(),
            py::arg("hilbert"), R"EOF(
                  Constructs a new ``Jastrow`` machine:
 
@@ -320,7 +324,7 @@ void AddJastrowSymm(py::module subm) {
 
            where $$ W_{ij} $$ are the Jastrow parameters respects the
            specified symmetries of the lattice.)EOF")
-      .def(py::init<const AbstractHilbert &>(), py::keep_alive<1, 2>(),
+      .def(py::init<std::shared_ptr<const AbstractHilbert>>(),
            py::arg("hilbert"), R"EOF(
                  Constructs a new ``JastrowSymm`` machine:
 
@@ -347,8 +351,8 @@ void AddJastrowSymm(py::module subm) {
 
 void AddMpsPeriodic(py::module subm) {
   py::class_<MPSPeriodic, AbstractMachine>(subm, "MPSPeriodic")
-      .def(py::init<const AbstractHilbert &, int, bool, int>(),
-           py::keep_alive<1, 2>(), py::arg("hilbert"), py::arg("bond_dim"),
+      .def(py::init<std::shared_ptr<const AbstractHilbert>, int, bool, int>(),
+           py::arg("hilbert"), py::arg("bond_dim"),
            py::arg("diag") = false, py::arg("symperiod") = -1);
 }
 
@@ -660,7 +664,7 @@ void AddMachineModule(py::module m) {
       .def(
           "to_array",
           [](AbstractMachine &self) -> AbstractMachine::VectorType {
-            const auto &hind = self.GetHilbert().GetIndex();
+            const auto &hind = self.GetHilbert()->GetIndex();
             AbstractMachine::VectorType vals(hind.NStates());
 
             double maxlog = std::numeric_limits<double>::lowest();
@@ -692,7 +696,7 @@ void AddMachineModule(py::module m) {
       .def(
           "log_norm",
           [](AbstractMachine &self) -> double {
-            const auto &hind = self.GetHilbert().GetIndex();
+            const auto &hind = self.GetHilbert()->GetIndex();
             AbstractMachine::VectorType vals(hind.NStates());
 
             double maxlog = std::numeric_limits<double>::lowest();

--- a/Sources/Machine/py_machine.cc
+++ b/Sources/Machine/py_machine.cc
@@ -52,8 +52,8 @@ void AddRbmSpin(py::module subm) {
           for arbitrary local quantum numbers $$ s_i $$.)EOF")
       .def(py::init<std::shared_ptr<const AbstractHilbert>, int, int, bool,
                     bool>(),
-           py::arg("hilbert"), py::arg("n_hidden") = 0,
-           py::arg("alpha") = 0, py::arg("use_visible_bias") = true,
+           py::arg("hilbert"), py::arg("n_hidden") = 0, py::arg("alpha") = 0,
+           py::arg("use_visible_bias") = true,
            py::arg("use_hidden_bias") = true,
            R"EOF(
                    Constructs a new ``RbmSpin`` machine:
@@ -140,8 +140,8 @@ void AddRbmMultival(py::module subm) {
              local Hilbert spaces.)EOF")
       .def(py::init<std::shared_ptr<const AbstractHilbert>, int, int, bool,
                     bool>(),
-           py::arg("hilbert"), py::arg("n_hidden") = 0,
-           py::arg("alpha") = 0, py::arg("use_visible_bias") = true,
+           py::arg("hilbert"), py::arg("n_hidden") = 0, py::arg("alpha") = 0,
+           py::arg("use_visible_bias") = true,
            py::arg("use_hidden_bias") = true);
 }
 
@@ -158,8 +158,8 @@ void AddRbmSpinPhase(py::module subm) {
           for arbitrary local quantum numbers $$ s_i $$.)EOF")
       .def(py::init<std::shared_ptr<const AbstractHilbert>, int, int, bool,
                     bool>(),
-           py::arg("hilbert"), py::arg("n_hidden") = 0,
-           py::arg("alpha") = 0, py::arg("use_visible_bias") = true,
+           py::arg("hilbert"), py::arg("n_hidden") = 0, py::arg("alpha") = 0,
+           py::arg("use_visible_bias") = true,
            py::arg("use_hidden_bias") = true,
            R"EOF(
                    Constructs a new ``RbmSpinPhase`` machine:
@@ -204,8 +204,8 @@ void AddRbmSpinReal(py::module subm) {
           for arbitrary local quantum numbers $$ s_i $$.)EOF")
       .def(py::init<std::shared_ptr<const AbstractHilbert>, int, int, bool,
                     bool>(),
-           py::arg("hilbert"), py::arg("n_hidden") = 0,
-           py::arg("alpha") = 0, py::arg("use_visible_bias") = true,
+           py::arg("hilbert"), py::arg("n_hidden") = 0, py::arg("alpha") = 0,
+           py::arg("use_visible_bias") = true,
            py::arg("use_hidden_bias") = true,
            R"EOF(
                    Constructs a new ``RbmSpinReal`` machine:
@@ -246,12 +246,12 @@ void AddFFNN(py::module subm) {
              class. Each layer implements a transformation such that the
              information is transformed sequentially as it moves from the input
              nodes through the hidden layers and to the output nodes.)EOF")
-      .def(py::init([](std::shared_ptr<const AbstractHilbert> hi, py::tuple tuple) {
-             auto layers = py::cast<std::vector<AbstractLayer *>>(tuple);
-             return FFNN{std::move(hi), std::move(layers)};
-           }),
-           py::keep_alive<1, 3>(), py::arg("hilbert"),
-           py::arg("layers"),
+      .def(py::init(
+               [](std::shared_ptr<const AbstractHilbert> hi, py::tuple tuple) {
+                 auto layers = py::cast<std::vector<AbstractLayer *>>(tuple);
+                 return FFNN{std::move(hi), std::move(layers)};
+               }),
+           py::keep_alive<1, 3>(), py::arg("hilbert"), py::arg("layers"),
            R"EOF(
               Constructs a new ``FFNN`` machine:
 
@@ -352,8 +352,8 @@ void AddJastrowSymm(py::module subm) {
 void AddMpsPeriodic(py::module subm) {
   py::class_<MPSPeriodic, AbstractMachine>(subm, "MPSPeriodic")
       .def(py::init<std::shared_ptr<const AbstractHilbert>, int, bool, int>(),
-           py::arg("hilbert"), py::arg("bond_dim"),
-           py::arg("diag") = false, py::arg("symperiod") = -1);
+           py::arg("hilbert"), py::arg("bond_dim"), py::arg("diag") = false,
+           py::arg("symperiod") = -1);
 }
 
 void AddLayerModule(py::module m) {
@@ -664,7 +664,7 @@ void AddMachineModule(py::module m) {
       .def(
           "to_array",
           [](AbstractMachine &self) -> AbstractMachine::VectorType {
-            const auto &hind = self.GetHilbert()->GetIndex();
+            const auto &hind = self.GetHilbert().GetIndex();
             AbstractMachine::VectorType vals(hind.NStates());
 
             double maxlog = std::numeric_limits<double>::lowest();
@@ -696,7 +696,7 @@ void AddMachineModule(py::module m) {
       .def(
           "log_norm",
           [](AbstractMachine &self) -> double {
-            const auto &hind = self.GetHilbert()->GetIndex();
+            const auto &hind = self.GetHilbert().GetIndex();
             AbstractMachine::VectorType vals(hind.NStates());
 
             double maxlog = std::numeric_limits<double>::lowest();

--- a/Sources/Machine/rbm_multival.cc
+++ b/Sources/Machine/rbm_multival.cc
@@ -25,11 +25,11 @@
 
 namespace netket {
 
-RbmMultival::RbmMultival(const AbstractHilbert &hilbert, int nhidden, int alpha,
+RbmMultival::RbmMultival(std::shared_ptr<const AbstractHilbert> hilbert, int nhidden, int alpha,
                          bool usea, bool useb)
-    : nv_(hilbert.Size()), ls_(hilbert.LocalSize()), usea_(usea), useb_(useb) {
+    : nv_(hilbert->Size()), ls_(hilbert->LocalSize()), usea_(usea), useb_(useb) {
   nh_ = std::max(nhidden, alpha * nv_);
-  SetHilbert(hilbert);
+  SetHilbert(std::move(hilbert));
   Init();
 }
 
@@ -57,7 +57,7 @@ void RbmMultival::Init() {
     b_.setZero();
   }
 
-  auto localstates = GetHilbert().LocalStates();
+  auto localstates = hilbert_->LocalStates();
 
   localconfs_.resize(nv_ * ls_);
   for (int i = 0; i < nv_ * ls_; i += ls_) {
@@ -336,7 +336,7 @@ void RbmMultival::from_json(const json &pars) {
     nv_ = pars["Nvisible"];
   }
 
-  if (nv_ != GetHilbert().Size()) {
+  if (nv_ != hilbert_->Size()) {
     throw InvalidInputError(
         "Loaded wave-function has incompatible Hilbert space");
   }
@@ -344,7 +344,7 @@ void RbmMultival::from_json(const json &pars) {
   if (FieldExists(pars, "LocalSize")) {
     ls_ = pars["LocalSize"];
   }
-  if (ls_ != GetHilbert().LocalSize()) {
+  if (ls_ != hilbert_->LocalSize()) {
     throw InvalidInputError(
         "Loaded wave-function has incompatible Hilbert space");
   }

--- a/Sources/Machine/rbm_multival.cc
+++ b/Sources/Machine/rbm_multival.cc
@@ -25,11 +25,14 @@
 
 namespace netket {
 
-RbmMultival::RbmMultival(std::shared_ptr<const AbstractHilbert> hilbert, int nhidden, int alpha,
-                         bool usea, bool useb)
-    : nv_(hilbert->Size()), ls_(hilbert->LocalSize()), usea_(usea), useb_(useb) {
+RbmMultival::RbmMultival(std::shared_ptr<const AbstractHilbert> hilbert,
+                         int nhidden, int alpha, bool usea, bool useb)
+    : AbstractMachine(hilbert),
+      nv_(hilbert->Size()),
+      ls_(hilbert->LocalSize()),
+      usea_(usea),
+      useb_(useb) {
   nh_ = std::max(nhidden, alpha * nv_);
-  SetHilbert(std::move(hilbert));
   Init();
 }
 
@@ -57,7 +60,7 @@ void RbmMultival::Init() {
     b_.setZero();
   }
 
-  auto localstates = hilbert_->LocalStates();
+  auto localstates = GetHilbert().LocalStates();
 
   localconfs_.resize(nv_ * ls_);
   for (int i = 0; i < nv_ * ls_; i += ls_) {
@@ -336,7 +339,7 @@ void RbmMultival::from_json(const json &pars) {
     nv_ = pars["Nvisible"];
   }
 
-  if (nv_ != hilbert_->Size()) {
+  if (nv_ != GetHilbert().Size()) {
     throw InvalidInputError(
         "Loaded wave-function has incompatible Hilbert space");
   }
@@ -344,7 +347,7 @@ void RbmMultival::from_json(const json &pars) {
   if (FieldExists(pars, "LocalSize")) {
     ls_ = pars["LocalSize"];
   }
-  if (ls_ != hilbert_->LocalSize()) {
+  if (ls_ != GetHilbert().LocalSize()) {
     throw InvalidInputError(
         "Loaded wave-function has incompatible Hilbert space");
   }

--- a/Sources/Machine/rbm_multival.hpp
+++ b/Sources/Machine/rbm_multival.hpp
@@ -67,7 +67,7 @@ class RbmMultival : public AbstractMachine {
   std::map<double, int> confindex_;
 
  public:
-  explicit RbmMultival(const AbstractHilbert &hilbert, int nhidden = 0,
+  explicit RbmMultival(std::shared_ptr<const AbstractHilbert> hilbert, int nhidden = 0,
                        int alpha = 0, bool usea = true, bool useb = true);
 
   int Npar() const override;

--- a/Sources/Machine/rbm_multival.hpp
+++ b/Sources/Machine/rbm_multival.hpp
@@ -67,8 +67,9 @@ class RbmMultival : public AbstractMachine {
   std::map<double, int> confindex_;
 
  public:
-  explicit RbmMultival(std::shared_ptr<const AbstractHilbert> hilbert, int nhidden = 0,
-                       int alpha = 0, bool usea = true, bool useb = true);
+  explicit RbmMultival(std::shared_ptr<const AbstractHilbert> hilbert,
+                       int nhidden = 0, int alpha = 0, bool usea = true,
+                       bool useb = true);
 
   int Npar() const override;
   int Nvisible() const override;

--- a/Sources/Machine/rbm_spin.cc
+++ b/Sources/Machine/rbm_spin.cc
@@ -19,11 +19,11 @@
 
 namespace netket {
 
-RbmSpin::RbmSpin(const AbstractHilbert &hilbert, int nhidden, int alpha,
-                 bool usea, bool useb)
-    : nv_(hilbert.Size()), usea_(usea), useb_(useb) {
+RbmSpin::RbmSpin(std::shared_ptr<const AbstractHilbert> hilbert, int nhidden,
+                 int alpha, bool usea, bool useb)
+    : nv_(hilbert->Size()), usea_(usea), useb_(useb) {
   nh_ = std::max(nhidden, alpha * nv_);
-  SetHilbert(hilbert);
+  SetHilbert(std::move(hilbert));
   Init();
 }
 
@@ -241,7 +241,7 @@ void RbmSpin::from_json(const json &pars) {
   if (FieldExists(pars, "Nvisible")) {
     nv_ = FieldVal<int>(pars, "Nvisible");
   }
-  if (nv_ != GetHilbert().Size()) {
+  if (nv_ != hilbert_->Size()) {
     throw InvalidInputError(
         "Number of visible units is incompatible with given "
         "Hilbert space");

--- a/Sources/Machine/rbm_spin.cc
+++ b/Sources/Machine/rbm_spin.cc
@@ -21,9 +21,8 @@ namespace netket {
 
 RbmSpin::RbmSpin(std::shared_ptr<const AbstractHilbert> hilbert, int nhidden,
                  int alpha, bool usea, bool useb)
-    : nv_(hilbert->Size()), usea_(usea), useb_(useb) {
+    : AbstractMachine(hilbert), nv_(hilbert->Size()), usea_(usea), useb_(useb) {
   nh_ = std::max(nhidden, alpha * nv_);
-  SetHilbert(std::move(hilbert));
   Init();
 }
 
@@ -241,7 +240,7 @@ void RbmSpin::from_json(const json &pars) {
   if (FieldExists(pars, "Nvisible")) {
     nv_ = FieldVal<int>(pars, "Nvisible");
   }
-  if (nv_ != hilbert_->Size()) {
+  if (nv_ != GetHilbert().Size()) {
     throw InvalidInputError(
         "Number of visible units is incompatible with given "
         "Hilbert space");

--- a/Sources/Machine/rbm_spin.hpp
+++ b/Sources/Machine/rbm_spin.hpp
@@ -54,8 +54,8 @@ class RbmSpin : public AbstractMachine {
   bool useb_;
 
  public:
-  RbmSpin(const AbstractHilbert &hilbert, int nhidden = 0, int alpha = 0,
-          bool usea = true, bool useb = true);
+  RbmSpin(std::shared_ptr<const AbstractHilbert> hilbert, int nhidden = 0,
+          int alpha = 0, bool usea = true, bool useb = true);
 
   int Nvisible() const override;
   int Npar() const override;

--- a/Sources/Machine/rbm_spin_phase.cc
+++ b/Sources/Machine/rbm_spin_phase.cc
@@ -20,11 +20,11 @@
 
 namespace netket {
 
-RbmSpinPhase::RbmSpinPhase(const AbstractHilbert &hilbert, int nhidden,
-                           int alpha, bool usea, bool useb)
-    : nv_(hilbert.Size()), usea_(usea), useb_(useb), I_(0, 1) {
+RbmSpinPhase::RbmSpinPhase(std::shared_ptr<const AbstractHilbert> hilbert,
+                           int nhidden, int alpha, bool usea, bool useb)
+    : nv_(hilbert->Size()), usea_(usea), useb_(useb), I_(0, 1) {
   nh_ = std::max(nhidden, alpha * nv_);
-  SetHilbert(hilbert);
+  SetHilbert(std::move(hilbert));
   Init();
 }
 
@@ -311,7 +311,7 @@ void RbmSpinPhase::from_json(const json &pars) {
   if (FieldExists(pars, "Nvisible")) {
     nv_ = FieldVal<int>(pars, "Nvisible");
   }
-  if (nv_ != GetHilbert().Size()) {
+  if (nv_ != hilbert_->Size()) {
     throw InvalidInputError(
         "Number of visible units is incompatible with given "
         "Hilbert space");

--- a/Sources/Machine/rbm_spin_phase.cc
+++ b/Sources/Machine/rbm_spin_phase.cc
@@ -22,9 +22,12 @@ namespace netket {
 
 RbmSpinPhase::RbmSpinPhase(std::shared_ptr<const AbstractHilbert> hilbert,
                            int nhidden, int alpha, bool usea, bool useb)
-    : nv_(hilbert->Size()), usea_(usea), useb_(useb), I_(0, 1) {
+    : AbstractMachine(hilbert),
+      nv_(hilbert->Size()),
+      usea_(usea),
+      useb_(useb),
+      I_(0, 1) {
   nh_ = std::max(nhidden, alpha * nv_);
-  SetHilbert(std::move(hilbert));
   Init();
 }
 
@@ -311,7 +314,7 @@ void RbmSpinPhase::from_json(const json &pars) {
   if (FieldExists(pars, "Nvisible")) {
     nv_ = FieldVal<int>(pars, "Nvisible");
   }
-  if (nv_ != hilbert_->Size()) {
+  if (nv_ != GetHilbert().Size()) {
     throw InvalidInputError(
         "Number of visible units is incompatible with given "
         "Hilbert space");

--- a/Sources/Machine/rbm_spin_phase.hpp
+++ b/Sources/Machine/rbm_spin_phase.hpp
@@ -69,8 +69,8 @@ class RbmSpinPhase : public AbstractMachine {
   const Complex I_;
 
  public:
-  RbmSpinPhase(const AbstractHilbert &hilbert, int nhidden = 0, int alpha = 0,
-               bool usea = true, bool useb = true);
+  RbmSpinPhase(std::shared_ptr<const AbstractHilbert> hilbert, int nhidden = 0,
+               int alpha = 0, bool usea = true, bool useb = true);
 
   int Npar() const override;
   int Nvisible() const override;

--- a/Sources/Machine/rbm_spin_real.cc
+++ b/Sources/Machine/rbm_spin_real.cc
@@ -22,9 +22,8 @@ namespace netket {
 
 RbmSpinReal::RbmSpinReal(std::shared_ptr<const AbstractHilbert> hilbert,
                          int nhidden, int alpha, bool usea, bool useb)
-    : nv_(hilbert->Size()), usea_(usea), useb_(useb) {
+    : AbstractMachine(hilbert), nv_(hilbert->Size()), usea_(usea), useb_(useb) {
   nh_ = std::max(nhidden, alpha * nv_);
-  SetHilbert(std::move(hilbert));
   Init();
 }
 
@@ -245,7 +244,7 @@ void RbmSpinReal::from_json(const json &pars) {
   if (FieldExists(pars, "Nvisible")) {
     nv_ = FieldVal<int>(pars, "Nvisible");
   }
-  if (nv_ != hilbert_->Size()) {
+  if (nv_ != GetHilbert().Size()) {
     throw InvalidInputError(
         "Number of visible units is incompatible with given "
         "Hilbert space");

--- a/Sources/Machine/rbm_spin_real.cc
+++ b/Sources/Machine/rbm_spin_real.cc
@@ -20,11 +20,11 @@
 
 namespace netket {
 
-RbmSpinReal::RbmSpinReal(const AbstractHilbert &hilbert, int nhidden, int alpha,
-                         bool usea, bool useb)
-    : nv_(hilbert.Size()), usea_(usea), useb_(useb) {
+RbmSpinReal::RbmSpinReal(std::shared_ptr<const AbstractHilbert> hilbert,
+                         int nhidden, int alpha, bool usea, bool useb)
+    : nv_(hilbert->Size()), usea_(usea), useb_(useb) {
   nh_ = std::max(nhidden, alpha * nv_);
-  SetHilbert(hilbert);
+  SetHilbert(std::move(hilbert));
   Init();
 }
 
@@ -245,7 +245,7 @@ void RbmSpinReal::from_json(const json &pars) {
   if (FieldExists(pars, "Nvisible")) {
     nv_ = FieldVal<int>(pars, "Nvisible");
   }
-  if (nv_ != GetHilbert().Size()) {
+  if (nv_ != hilbert_->Size()) {
     throw InvalidInputError(
         "Number of visible units is incompatible with given "
         "Hilbert space");

--- a/Sources/Machine/rbm_spin_real.hpp
+++ b/Sources/Machine/rbm_spin_real.hpp
@@ -53,8 +53,8 @@ class RbmSpinReal : public AbstractMachine {
   bool useb_;
 
  public:
-  RbmSpinReal(const AbstractHilbert &hilbert, int nhidden = 0, int alpha = 0,
-              bool usea = true, bool useb = true);
+  RbmSpinReal(std::shared_ptr<const AbstractHilbert> hilbert, int nhidden = 0,
+              int alpha = 0, bool usea = true, bool useb = true);
 
   int Npar() const override;
   int Nvisible() const override;

--- a/Sources/Machine/rbm_spin_symm.cc
+++ b/Sources/Machine/rbm_spin_symm.cc
@@ -20,14 +20,14 @@
 
 namespace netket {
 
-RbmSpinSymm::RbmSpinSymm(const AbstractHilbert &hilbert, int alpha, bool usea,
-                         bool useb)
-    : graph_(hilbert.GetGraph()),
-      nv_(hilbert.Size()),
+RbmSpinSymm::RbmSpinSymm(std::shared_ptr<const AbstractHilbert> hilbert,
+                         int alpha, bool usea, bool useb)
+    : graph_(hilbert->GetGraph()),
+      nv_(hilbert->Size()),
       alpha_(alpha),
       usea_(usea),
       useb_(useb) {
-  SetHilbert(hilbert);
+  SetHilbert(std::move(hilbert));
   Init(graph_);
   SetBareParameters();
 }
@@ -366,7 +366,7 @@ void RbmSpinSymm::from_json(const json &pars) {
   if (FieldExists(pars, "Nvisible")) {
     nv_ = pars["Nvisible"];
   }
-  if (nv_ != GetHilbert().Size()) {
+  if (nv_ != hilbert_->Size()) {
     throw InvalidInputError(
         "Number of visible units is incompatible with given "
         "Hilbert space");

--- a/Sources/Machine/rbm_spin_symm.cc
+++ b/Sources/Machine/rbm_spin_symm.cc
@@ -22,12 +22,12 @@ namespace netket {
 
 RbmSpinSymm::RbmSpinSymm(std::shared_ptr<const AbstractHilbert> hilbert,
                          int alpha, bool usea, bool useb)
-    : graph_(hilbert->GetGraph()),
+    : AbstractMachine(hilbert),
+      graph_(hilbert->GetGraph()),
       nv_(hilbert->Size()),
       alpha_(alpha),
       usea_(usea),
       useb_(useb) {
-  SetHilbert(std::move(hilbert));
   Init(graph_);
   SetBareParameters();
 }
@@ -366,7 +366,7 @@ void RbmSpinSymm::from_json(const json &pars) {
   if (FieldExists(pars, "Nvisible")) {
     nv_ = pars["Nvisible"];
   }
-  if (nv_ != hilbert_->Size()) {
+  if (nv_ != GetHilbert().Size()) {
     throw InvalidInputError(
         "Number of visible units is incompatible with given "
         "Hilbert space");

--- a/Sources/Machine/rbm_spin_symm.hpp
+++ b/Sources/Machine/rbm_spin_symm.hpp
@@ -70,8 +70,8 @@ class RbmSpinSymm : public AbstractMachine {
   bool useb_;
 
  public:
-  RbmSpinSymm(std::shared_ptr<const AbstractHilbert> hilbert, int alpha = 0, bool usea = true,
-              bool useb = true);
+  RbmSpinSymm(std::shared_ptr<const AbstractHilbert> hilbert, int alpha = 0,
+              bool usea = true, bool useb = true);
 
   int Npar() const override;
   int Nvisible() const override;

--- a/Sources/Machine/rbm_spin_symm.hpp
+++ b/Sources/Machine/rbm_spin_symm.hpp
@@ -70,7 +70,7 @@ class RbmSpinSymm : public AbstractMachine {
   bool useb_;
 
  public:
-  RbmSpinSymm(const AbstractHilbert &hilbert, int alpha = 0, bool usea = true,
+  RbmSpinSymm(std::shared_ptr<const AbstractHilbert> hilbert, int alpha = 0, bool usea = true,
               bool useb = true);
 
   int Npar() const override;

--- a/Sources/Operator/MatrixWrapper/dense_matrix_wrapper.hpp
+++ b/Sources/Operator/MatrixWrapper/dense_matrix_wrapper.hpp
@@ -80,7 +80,7 @@ class DenseMatrixWrapper : public AbstractMatrixWrapper<State> {
 
  private:
   void InitializeMatrix(const AbstractOperator& the_operator) {
-    const auto& hilbert_index = the_operator.GetHilbert()->GetIndex();
+    const auto& hilbert_index = the_operator.GetHilbert().GetIndex();
     dim_ = hilbert_index.NStates();
 
     matrix_.resize(dim_, dim_);

--- a/Sources/Operator/MatrixWrapper/dense_matrix_wrapper.hpp
+++ b/Sources/Operator/MatrixWrapper/dense_matrix_wrapper.hpp
@@ -80,8 +80,7 @@ class DenseMatrixWrapper : public AbstractMatrixWrapper<State> {
 
  private:
   void InitializeMatrix(const AbstractOperator& the_operator) {
-    const auto& hilbert = the_operator.GetHilbert();
-    const auto& hilbert_index = hilbert.GetIndex();
+    const auto& hilbert_index = the_operator.GetHilbert()->GetIndex();
     dim_ = hilbert_index.NStates();
 
     matrix_.resize(dim_, dim_);

--- a/Sources/Operator/MatrixWrapper/direct_matrix_wrapper.hpp
+++ b/Sources/Operator/MatrixWrapper/direct_matrix_wrapper.hpp
@@ -40,7 +40,7 @@ class DirectMatrixWrapper : public AbstractMatrixWrapper<State> {
  public:
   explicit DirectMatrixWrapper(const AbstractOperator& the_operator)
       : operator_(the_operator),
-        hilbert_index_(the_operator.GetHilbert()->GetIndex()),
+        hilbert_index_(the_operator.GetHilbert().GetIndex()),
         dim_(hilbert_index_.NStates()) {}
 
   State Apply(const State& state) const override {

--- a/Sources/Operator/MatrixWrapper/direct_matrix_wrapper.hpp
+++ b/Sources/Operator/MatrixWrapper/direct_matrix_wrapper.hpp
@@ -40,7 +40,7 @@ class DirectMatrixWrapper : public AbstractMatrixWrapper<State> {
  public:
   explicit DirectMatrixWrapper(const AbstractOperator& the_operator)
       : operator_(the_operator),
-        hilbert_index_(the_operator.GetHilbert().GetIndex()),
+        hilbert_index_(the_operator.GetHilbert()->GetIndex()),
         dim_(hilbert_index_.NStates()) {}
 
   State Apply(const State& state) const override {

--- a/Sources/Operator/MatrixWrapper/sparse_matrix_wrapper.hpp
+++ b/Sources/Operator/MatrixWrapper/sparse_matrix_wrapper.hpp
@@ -72,7 +72,7 @@ public:
 
 private:
   void InitializeMatrix(const AbstractOperator &the_operator) {
-    const auto& hilbert_index = the_operator.GetHilbert()->GetIndex();
+    const auto& hilbert_index = the_operator.GetHilbert().GetIndex();
     dim_ = hilbert_index.NStates();
 
     using Triplet = Eigen::Triplet<Complex>;

--- a/Sources/Operator/MatrixWrapper/sparse_matrix_wrapper.hpp
+++ b/Sources/Operator/MatrixWrapper/sparse_matrix_wrapper.hpp
@@ -72,8 +72,7 @@ public:
 
 private:
   void InitializeMatrix(const AbstractOperator &the_operator) {
-    const auto &hilbert = the_operator.GetHilbert();
-    const auto &hilbert_index = hilbert.GetIndex();
+    const auto& hilbert_index = the_operator.GetHilbert()->GetIndex();
     dim_ = hilbert_index.NStates();
 
     using Triplet = Eigen::Triplet<Complex>;

--- a/Sources/Operator/abstract_operator.hpp
+++ b/Sources/Operator/abstract_operator.hpp
@@ -100,16 +100,16 @@ class AbstractOperator {
   Member function returning the hilbert space associated with this Hamiltonian.
   @return Hilbert space specifier for this Hamiltonian
   */
-  const AbstractHilbert &GetHilbert() const { return *hilbert_; }
+  std::shared_ptr<const AbstractHilbert> GetHilbert() const { return hilbert_; }
 
-  void SetHilbert(const AbstractHilbert &hilbert) {
-    hilbert_ = hilbert.Clone();
+  void SetHilbert(std::shared_ptr<const AbstractHilbert> hilbert) {
+    hilbert_ = std::move(hilbert);
   }
 
-  virtual ~AbstractOperator() {}
+  virtual ~AbstractOperator() = default;
 
- private:
-  std::shared_ptr<AbstractHilbert> hilbert_;
+ protected:
+  std::shared_ptr<const AbstractHilbert> hilbert_;
 };
 
 void AbstractOperator::ForEachConn(VectorConstRefType v,

--- a/Sources/Operator/abstract_operator.hpp
+++ b/Sources/Operator/abstract_operator.hpp
@@ -100,15 +100,18 @@ class AbstractOperator {
   Member function returning the hilbert space associated with this Hamiltonian.
   @return Hilbert space specifier for this Hamiltonian
   */
-  std::shared_ptr<const AbstractHilbert> GetHilbert() const { return hilbert_; }
-
-  void SetHilbert(std::shared_ptr<const AbstractHilbert> hilbert) {
-    hilbert_ = std::move(hilbert);
+  const AbstractHilbert &GetHilbert() const { return *hilbert_; }
+  std::shared_ptr<const AbstractHilbert> GetHilbertShared() const {
+    return hilbert_;
   }
 
   virtual ~AbstractOperator() = default;
 
  protected:
+  AbstractOperator(std::shared_ptr<const AbstractHilbert> hilbert)
+      : hilbert_(std::move(hilbert)) {}
+
+ private:
   std::shared_ptr<const AbstractHilbert> hilbert_;
 };
 

--- a/Sources/Operator/bosonhubbard.hpp
+++ b/Sources/Operator/bosonhubbard.hpp
@@ -18,7 +18,9 @@
 #include <Eigen/Dense>
 #include <cmath>
 #include <iostream>
+#include <memory>
 #include <vector>
+
 #include "Graph/graph.hpp"
 #include "Hilbert/abstract_hilbert.hpp"
 #include "Utils/exceptions.hpp"
@@ -50,15 +52,15 @@ class BoseHubbard : public AbstractOperator {
   using VectorRefType = AbstractOperator::VectorRefType;
   using VectorConstRefType = AbstractOperator::VectorConstRefType;
 
-  explicit BoseHubbard(const AbstractHilbert &hilbert, double U, double V = 0.,
-                       double mu = 0.)
-      : graph_(hilbert.GetGraph()),
-        nsites_(hilbert.Size()),
+  BoseHubbard(std::shared_ptr<const AbstractHilbert> hilbert, double U, double V = 0.,
+              double mu = 0.)
+      : graph_(hilbert->GetGraph()),
+        nsites_(hilbert->Size()),
         U_(U),
         V_(V),
         mu_(mu) {
-    nmax_ = hilbert.LocalSize() - 1;
-    SetHilbert(hilbert);
+    nmax_ = hilbert->LocalSize() - 1;
+    SetHilbert(std::move(hilbert));
     Init();
   }
 

--- a/Sources/Operator/bosonhubbard.hpp
+++ b/Sources/Operator/bosonhubbard.hpp
@@ -52,15 +52,15 @@ class BoseHubbard : public AbstractOperator {
   using VectorRefType = AbstractOperator::VectorRefType;
   using VectorConstRefType = AbstractOperator::VectorConstRefType;
 
-  BoseHubbard(std::shared_ptr<const AbstractHilbert> hilbert, double U, double V = 0.,
-              double mu = 0.)
-      : graph_(hilbert->GetGraph()),
+  BoseHubbard(std::shared_ptr<const AbstractHilbert> hilbert, double U,
+              double V = 0., double mu = 0.)
+      : AbstractOperator(hilbert),
+        graph_(hilbert->GetGraph()),
         nsites_(hilbert->Size()),
         U_(U),
         V_(V),
         mu_(mu) {
     nmax_ = hilbert->LocalSize() - 1;
-    SetHilbert(std::move(hilbert));
     Init();
   }
 

--- a/Sources/Operator/graph_operator.hpp
+++ b/Sources/Operator/graph_operator.hpp
@@ -47,11 +47,10 @@ class GraphOperator : public AbstractOperator {
   GraphOperator(std::shared_ptr<const AbstractHilbert> hilbert,
                 OVecType siteops = OVecType(), OVecType bondops = OVecType(),
                 std::vector<int> bondops_colors = std::vector<int>())
-      : graph_(hilbert->GetGraph()),
+      : AbstractOperator(hilbert),
+        graph_(hilbert->GetGraph()),
         operator_(hilbert),
         nvertices_(hilbert->Size()) {
-    SetHilbert(hilbert);
-
     // Create the local operator as the sum of all site and bond operators
     // Ensure that at least one of SiteOps and BondOps was initialized
     if (!siteops.size() && !bondops.size()) {
@@ -97,9 +96,10 @@ class GraphOperator : public AbstractOperator {
   // Constructor to be used when overloading operators
   explicit GraphOperator(std::shared_ptr<const AbstractHilbert> hilbert,
                          const LocalOperator &lop)
-      : graph_(hilbert->GetGraph()), operator_(lop), nvertices_(hilbert->Size()) {
-    SetHilbert(std::move(hilbert));
-  }
+      : AbstractOperator(hilbert),
+        graph_(hilbert->GetGraph()),
+        operator_(lop),
+        nvertices_(hilbert->Size()) {}
 
   friend GraphOperator operator+(const GraphOperator &lhs,
                                  const GraphOperator &rhs) {
@@ -108,7 +108,7 @@ class GraphOperator : public AbstractOperator {
     auto lop = lhs.operator_;
     auto rop = rhs.operator_;
 
-    return GraphOperator(lhs.GetHilbert(), lop + rop);
+    return GraphOperator(lhs.GetHilbertShared(), lop + rop);
   }
 
   void FindConn(VectorConstRefType v, std::vector<Complex> &mel,

--- a/Sources/Operator/graph_operator.hpp
+++ b/Sources/Operator/graph_operator.hpp
@@ -44,13 +44,12 @@ class GraphOperator : public AbstractOperator {
   using VectorRefType = AbstractOperator::VectorRefType;
   using VectorConstRefType = AbstractOperator::VectorConstRefType;
 
-  explicit GraphOperator(const AbstractHilbert &hilbert,
-                         OVecType siteops = OVecType(),
-                         OVecType bondops = OVecType(),
-                         std::vector<int> bondops_colors = std::vector<int>())
-      : graph_(hilbert.GetGraph()),
+  GraphOperator(std::shared_ptr<const AbstractHilbert> hilbert,
+                OVecType siteops = OVecType(), OVecType bondops = OVecType(),
+                std::vector<int> bondops_colors = std::vector<int>())
+      : graph_(hilbert->GetGraph()),
         operator_(hilbert),
-        nvertices_(hilbert.Size()) {
+        nvertices_(hilbert->Size()) {
     SetHilbert(hilbert);
 
     // Create the local operator as the sum of all site and bond operators
@@ -96,10 +95,10 @@ class GraphOperator : public AbstractOperator {
   }
 
   // Constructor to be used when overloading operators
-  explicit GraphOperator(const AbstractHilbert &hilbert,
+  explicit GraphOperator(std::shared_ptr<const AbstractHilbert> hilbert,
                          const LocalOperator &lop)
-      : graph_(hilbert.GetGraph()), operator_(lop), nvertices_(hilbert.Size()) {
-    SetHilbert(hilbert);
+      : graph_(hilbert->GetGraph()), operator_(lop), nvertices_(hilbert->Size()) {
+    SetHilbert(std::move(hilbert));
   }
 
   friend GraphOperator operator+(const GraphOperator &lhs,

--- a/Sources/Operator/heisenberg.hpp
+++ b/Sources/Operator/heisenberg.hpp
@@ -42,8 +42,9 @@ class Heisenberg : public AbstractOperator {
   using VectorConstRefType = AbstractOperator::VectorConstRefType;
 
   explicit Heisenberg(std::shared_ptr<const AbstractHilbert> hilbert)
-      : graph_(hilbert->GetGraph()), nspins_(hilbert->Size()) {
-    SetHilbert(std::move(hilbert));
+      : AbstractOperator(hilbert),
+        graph_(hilbert->GetGraph()),
+        nspins_(hilbert->Size()) {
     Init();
   }
 

--- a/Sources/Operator/heisenberg.hpp
+++ b/Sources/Operator/heisenberg.hpp
@@ -41,9 +41,9 @@ class Heisenberg : public AbstractOperator {
   using VectorRefType = AbstractOperator::VectorRefType;
   using VectorConstRefType = AbstractOperator::VectorConstRefType;
 
-  explicit Heisenberg(const AbstractHilbert &hilbert)
-      : graph_(hilbert.GetGraph()), nspins_(hilbert.Size()) {
-    SetHilbert(hilbert);
+  explicit Heisenberg(std::shared_ptr<const AbstractHilbert> hilbert)
+      : graph_(hilbert->GetGraph()), nspins_(hilbert->Size()) {
+    SetHilbert(std::move(hilbert));
     Init();
   }
 

--- a/Sources/Operator/ising.hpp
+++ b/Sources/Operator/ising.hpp
@@ -50,8 +50,11 @@ class Ising : public AbstractOperator {
 
   explicit Ising(std::shared_ptr<const AbstractHilbert> hilbert, double h,
                  double J = 1)
-      : graph_(hilbert->GetGraph()), nspins_(hilbert->Size()), h_(h), J_(J) {
-    SetHilbert(std::move(hilbert));
+      : AbstractOperator(hilbert),
+        graph_(hilbert->GetGraph()),
+        nspins_(hilbert->Size()),
+        h_(h),
+        J_(J) {
     Init();
   }
 

--- a/Sources/Operator/ising.hpp
+++ b/Sources/Operator/ising.hpp
@@ -48,9 +48,10 @@ class Ising : public AbstractOperator {
   using VectorRefType = AbstractOperator::VectorRefType;
   using VectorConstRefType = AbstractOperator::VectorConstRefType;
 
-  explicit Ising(const AbstractHilbert &hilbert, double h, double J = 1)
-      : graph_(hilbert.GetGraph()), nspins_(hilbert.Size()), h_(h), J_(J) {
-    SetHilbert(hilbert);
+  explicit Ising(std::shared_ptr<const AbstractHilbert> hilbert, double h,
+                 double J = 1)
+      : graph_(hilbert->GetGraph()), nspins_(hilbert->Size()), h_(h), J_(J) {
+    SetHilbert(std::move(hilbert));
     Init();
   }
 

--- a/Sources/Operator/local_operator.hpp
+++ b/Sources/Operator/local_operator.hpp
@@ -76,16 +76,13 @@ class LocalOperator : public AbstractOperator {
 
   explicit LocalOperator(std::shared_ptr<const AbstractHilbert> hilbert,
                          double constant = 0.)
-      : constant_(constant), nops_(0) {
-    SetHilbert(std::move(hilbert));
-  }
+      : AbstractOperator(hilbert), constant_(constant), nops_(0) {}
 
   explicit LocalOperator(std::shared_ptr<const AbstractHilbert> hilbert,
                          const std::vector<MatType> &mat,
                          const std::vector<SiteType> &sites,
                          double constant = 0.)
-      : constant_(constant) {
-    SetHilbert(std::move(hilbert));
+      : AbstractOperator(hilbert), constant_(constant) {
     for (std::size_t i = 0; i < mat.size(); i++) {
       Push(mat[i], sites[i]);
     }
@@ -95,8 +92,7 @@ class LocalOperator : public AbstractOperator {
   explicit LocalOperator(std::shared_ptr<const AbstractHilbert> hilbert,
                          const MatType &mat, const SiteType &sites,
                          double constant = 0.)
-      : constant_(constant) {
-    SetHilbert(std::move(hilbert));
+      : AbstractOperator(hilbert), constant_(constant) {
     Push(mat, sites);
     // TODO sort sites and swap columns of mat accordingly
     Init();
@@ -118,7 +114,7 @@ class LocalOperator : public AbstractOperator {
   }
 
   void Init() {
-    if (!hilbert_->IsDiscrete()) {
+    if (!GetHilbert().IsDiscrete()) {
       throw InvalidInputError(
           "Cannot construct operators on infinite local hilbert spaces");
     }
@@ -145,12 +141,12 @@ class LocalOperator : public AbstractOperator {
       auto &invstate = invstate_[op];
 
       if (*std::max_element(sites.begin(), sites.end()) >=
-              hilbert_->Size() ||
+              GetHilbert().Size() ||
           *std::min_element(sites.begin(), sites.end()) < 0) {
         throw InvalidInputError("Operator acts on an invalid set of sites");
       }
 
-      auto localstates = hilbert_->LocalStates();
+      auto localstates = GetHilbert().LocalStates();
       const auto localsize = localstates.size();
 
       // Finding the non-zero matrix elements
@@ -205,7 +201,7 @@ class LocalOperator : public AbstractOperator {
   void FindConn(VectorConstRefType v, std::vector<Complex> &mel,
                 std::vector<std::vector<int>> &connectors,
                 std::vector<std::vector<double>> &newconfs) const override {
-    assert(v.size() == hilbert_->Size());
+    assert(v.size() == GetHilbert().Size());
 
     connectors.clear();
     newconfs.clear();
@@ -277,8 +273,7 @@ class LocalOperator : public AbstractOperator {
     std::transform(mat_.begin(), mat_.end(), mat_t.begin(),
                    netket::transpose_vecvec<MelType>);
 
-    return LocalOperator(GetHilbert(), mat_t, sites_,
-                         constant_);
+    return LocalOperator(GetHilbertShared(), mat_t, sites_, constant_);
   }
 
   LocalOperator Conjugate() const {
@@ -293,8 +288,7 @@ class LocalOperator : public AbstractOperator {
                      }
                      return out;
                    });
-    return LocalOperator(GetHilbert(), mat_c, sites_,
-                         constant_);
+    return LocalOperator(GetHilbertShared(), mat_c, sites_, constant_);
   }
 
   // Product of two local operators, performing KroneckerProducts as necessary
@@ -322,8 +316,7 @@ class LocalOperator : public AbstractOperator {
       }
     }
     auto constant = lhs.constant_ * rhs.constant_;
-    auto opret = LocalOperator(lhs.GetHilbert(), mat, sites,
-                               constant);
+    auto opret = LocalOperator(lhs.GetHilbertShared(), mat, sites, constant);
 
     if (std::abs(lhs.constant_) > mel_cutoff_) {
       opret += lhs.constant_ * rhs;
@@ -337,8 +330,8 @@ class LocalOperator : public AbstractOperator {
 
   friend LocalOperator operator+(const LocalOperator &lhs,
                                  const LocalOperator &rhs) {
-    assert(rhs.hilbert_->LocalStates().size() ==
-           lhs.hilbert_->LocalStates().size());
+    assert(rhs.GetHilbert().LocalStates().size() ==
+           lhs.GetHilbert().LocalStates().size());
 
     auto sites = lhs.sites_;
     auto mat = lhs.mat_;
@@ -346,7 +339,7 @@ class LocalOperator : public AbstractOperator {
     sites.insert(sites.end(), rhs.sites_.begin(), rhs.sites_.end());
     mat.insert(mat.end(), rhs.mat_.begin(), rhs.mat_.end());
 
-    return LocalOperator(lhs.GetHilbert(), mat, sites,
+    return LocalOperator(lhs.GetHilbertShared(), mat, sites,
                          lhs.constant_ + rhs.constant_);
   }
 
@@ -354,13 +347,13 @@ class LocalOperator : public AbstractOperator {
     auto sites = lhs.sites_;
     auto mat = lhs.mat_;
 
-    return LocalOperator(lhs.GetHilbert(), mat, sites,
+    return LocalOperator(lhs.GetHilbertShared(), mat, sites,
                          lhs.constant_ + constant);
   }
 
   LocalOperator &operator+=(const LocalOperator &rhs) {
-    assert(rhs.hilbert_->LocalStates().size() ==
-           this->hilbert_->LocalStates().size());
+    assert(rhs.GetHilbert().LocalStates().size() ==
+           this->GetHilbert().LocalStates().size());
 
     this->sites_.insert(this->sites_.end(), rhs.sites_.begin(),
                         rhs.sites_.end());
@@ -389,7 +382,7 @@ class LocalOperator : public AbstractOperator {
       }
     }
 
-    return LocalOperator(rhs.GetHilbert(), mat, sites,
+    return LocalOperator(rhs.GetHilbertShared(), mat, sites,
                          std::real(lhs * rhs.constant_));
   }
 

--- a/Sources/Operator/local_operator.hpp
+++ b/Sources/Operator/local_operator.hpp
@@ -74,27 +74,29 @@ class LocalOperator : public AbstractOperator {
   //   SetHilbert(rhs.GetHilbert());
   // }
 
-  explicit LocalOperator(const AbstractHilbert &hilbert, double constant = 0.)
+  explicit LocalOperator(std::shared_ptr<const AbstractHilbert> hilbert,
+                         double constant = 0.)
       : constant_(constant), nops_(0) {
-    SetHilbert(hilbert);
+    SetHilbert(std::move(hilbert));
   }
 
-  explicit LocalOperator(const AbstractHilbert &hilbert,
+  explicit LocalOperator(std::shared_ptr<const AbstractHilbert> hilbert,
                          const std::vector<MatType> &mat,
                          const std::vector<SiteType> &sites,
                          double constant = 0.)
       : constant_(constant) {
-    SetHilbert(hilbert);
+    SetHilbert(std::move(hilbert));
     for (std::size_t i = 0; i < mat.size(); i++) {
       Push(mat[i], sites[i]);
     }
     Init();
   }
 
-  explicit LocalOperator(const AbstractHilbert &hilbert, const MatType &mat,
-                         const SiteType &sites, double constant = 0.)
+  explicit LocalOperator(std::shared_ptr<const AbstractHilbert> hilbert,
+                         const MatType &mat, const SiteType &sites,
+                         double constant = 0.)
       : constant_(constant) {
-    SetHilbert(hilbert);
+    SetHilbert(std::move(hilbert));
     Push(mat, sites);
     // TODO sort sites and swap columns of mat accordingly
     Init();
@@ -116,7 +118,7 @@ class LocalOperator : public AbstractOperator {
   }
 
   void Init() {
-    if (!GetHilbert().IsDiscrete()) {
+    if (!hilbert_->IsDiscrete()) {
       throw InvalidInputError(
           "Cannot construct operators on infinite local hilbert spaces");
     }
@@ -143,12 +145,12 @@ class LocalOperator : public AbstractOperator {
       auto &invstate = invstate_[op];
 
       if (*std::max_element(sites.begin(), sites.end()) >=
-              GetHilbert().Size() ||
+              hilbert_->Size() ||
           *std::min_element(sites.begin(), sites.end()) < 0) {
         throw InvalidInputError("Operator acts on an invalid set of sites");
       }
 
-      auto localstates = GetHilbert().LocalStates();
+      auto localstates = hilbert_->LocalStates();
       const auto localsize = localstates.size();
 
       // Finding the non-zero matrix elements
@@ -203,7 +205,7 @@ class LocalOperator : public AbstractOperator {
   void FindConn(VectorConstRefType v, std::vector<Complex> &mel,
                 std::vector<std::vector<int>> &connectors,
                 std::vector<std::vector<double>> &newconfs) const override {
-    assert(v.size() == GetHilbert().Size());
+    assert(v.size() == hilbert_->Size());
 
     connectors.clear();
     newconfs.clear();
@@ -275,7 +277,8 @@ class LocalOperator : public AbstractOperator {
     std::transform(mat_.begin(), mat_.end(), mat_t.begin(),
                    netket::transpose_vecvec<MelType>);
 
-    return LocalOperator(GetHilbert(), mat_t, sites_, constant_);
+    return LocalOperator(GetHilbert(), mat_t, sites_,
+                         constant_);
   }
 
   LocalOperator Conjugate() const {
@@ -290,7 +293,8 @@ class LocalOperator : public AbstractOperator {
                      }
                      return out;
                    });
-    return LocalOperator(GetHilbert(), mat_c, sites_, constant_);
+    return LocalOperator(GetHilbert(), mat_c, sites_,
+                         constant_);
   }
 
   // Product of two local operators, performing KroneckerProducts as necessary
@@ -318,7 +322,8 @@ class LocalOperator : public AbstractOperator {
       }
     }
     auto constant = lhs.constant_ * rhs.constant_;
-    auto opret = LocalOperator(lhs.GetHilbert(), mat, sites, constant);
+    auto opret = LocalOperator(lhs.GetHilbert(), mat, sites,
+                               constant);
 
     if (std::abs(lhs.constant_) > mel_cutoff_) {
       opret += lhs.constant_ * rhs;
@@ -332,8 +337,8 @@ class LocalOperator : public AbstractOperator {
 
   friend LocalOperator operator+(const LocalOperator &lhs,
                                  const LocalOperator &rhs) {
-    assert(rhs.GetHilbert().LocalStates().size() ==
-           lhs.GetHilbert().LocalStates().size());
+    assert(rhs.hilbert_->LocalStates().size() ==
+           lhs.hilbert_->LocalStates().size());
 
     auto sites = lhs.sites_;
     auto mat = lhs.mat_;
@@ -354,8 +359,8 @@ class LocalOperator : public AbstractOperator {
   }
 
   LocalOperator &operator+=(const LocalOperator &rhs) {
-    assert(rhs.GetHilbert().LocalStates().size() ==
-           this->GetHilbert().LocalStates().size());
+    assert(rhs.hilbert_->LocalStates().size() ==
+           this->hilbert_->LocalStates().size());
 
     this->sites_.insert(this->sites_.end(), rhs.sites_.begin(),
                         rhs.sites_.end());

--- a/Sources/Operator/py_bosonhubbard.hpp
+++ b/Sources/Operator/py_bosonhubbard.hpp
@@ -32,7 +32,7 @@ void AddBoseHubbard(py::module &subm) {
   py::class_<BoseHubbard, AbstractOperator>(
       subm, "BoseHubbard",
       R"EOF(A Bose Hubbard model Hamiltonian operator.)EOF")
-      .def(py::init<const AbstractHilbert &, double, double, double>(),
+      .def(py::init<std::shared_ptr<const AbstractHilbert>, double, double, double>(),
            py::keep_alive<1, 2>(), py::arg("hilbert"), py::arg("U"),
            py::arg("V") = 0., py::arg("mu") = 0., R"EOF(
            Constructs a new ``BoseHubbard`` given a hilbert space and a Hubbard

--- a/Sources/Operator/py_bosonhubbard.hpp
+++ b/Sources/Operator/py_bosonhubbard.hpp
@@ -32,7 +32,8 @@ void AddBoseHubbard(py::module &subm) {
   py::class_<BoseHubbard, AbstractOperator>(
       subm, "BoseHubbard",
       R"EOF(A Bose Hubbard model Hamiltonian operator.)EOF")
-      .def(py::init<std::shared_ptr<const AbstractHilbert>, double, double, double>(),
+      .def(py::init<std::shared_ptr<const AbstractHilbert>, double, double,
+                    double>(),
            py::keep_alive<1, 2>(), py::arg("hilbert"), py::arg("U"),
            py::arg("V") = 0., py::arg("mu") = 0., R"EOF(
            Constructs a new ``BoseHubbard`` given a hilbert space and a Hubbard

--- a/Sources/Operator/py_graph_operator.hpp
+++ b/Sources/Operator/py_graph_operator.hpp
@@ -31,8 +31,9 @@ namespace netket {
 void AddGraphOperator(py::module &subm) {
   py::class_<GraphOperator, AbstractOperator>(
       subm, "GraphOperator", R"EOF(A custom graph based operator.)EOF")
-      .def(py::init<std::shared_ptr<const AbstractHilbert>, GraphOperator::OVecType,
-                    GraphOperator::OVecType, std::vector<int>>(),
+      .def(py::init<std::shared_ptr<const AbstractHilbert>,
+                    GraphOperator::OVecType, GraphOperator::OVecType,
+                    std::vector<int>>(),
            py::keep_alive<1, 2>(), py::arg("hilbert"),
            py::arg("siteops") = GraphOperator::OVecType(),
            py::arg("bondops") = GraphOperator::OVecType(),

--- a/Sources/Operator/py_graph_operator.hpp
+++ b/Sources/Operator/py_graph_operator.hpp
@@ -31,7 +31,7 @@ namespace netket {
 void AddGraphOperator(py::module &subm) {
   py::class_<GraphOperator, AbstractOperator>(
       subm, "GraphOperator", R"EOF(A custom graph based operator.)EOF")
-      .def(py::init<const AbstractHilbert &, GraphOperator::OVecType,
+      .def(py::init<std::shared_ptr<const AbstractHilbert>, GraphOperator::OVecType,
                     GraphOperator::OVecType, std::vector<int>>(),
            py::keep_alive<1, 2>(), py::arg("hilbert"),
            py::arg("siteops") = GraphOperator::OVecType(),

--- a/Sources/Operator/py_heisenberg.hpp
+++ b/Sources/Operator/py_heisenberg.hpp
@@ -31,7 +31,7 @@ namespace netket {
 void AddHeisenberg(py::module &subm) {
   py::class_<Heisenberg, AbstractOperator>(
       subm, "Heisenberg", R"EOF(A Heisenberg Hamiltonian operator.)EOF")
-      .def(py::init<const AbstractHilbert &>(), py::keep_alive<1, 2>(),
+      .def(py::init<std::shared_ptr<const AbstractHilbert>>(), py::keep_alive<1, 2>(),
            py::arg("hilbert"), R"EOF(
            Constructs a new ``Heisenberg`` given a hilbert space.
 

--- a/Sources/Operator/py_heisenberg.hpp
+++ b/Sources/Operator/py_heisenberg.hpp
@@ -31,8 +31,8 @@ namespace netket {
 void AddHeisenberg(py::module &subm) {
   py::class_<Heisenberg, AbstractOperator>(
       subm, "Heisenberg", R"EOF(A Heisenberg Hamiltonian operator.)EOF")
-      .def(py::init<std::shared_ptr<const AbstractHilbert>>(), py::keep_alive<1, 2>(),
-           py::arg("hilbert"), R"EOF(
+      .def(py::init<std::shared_ptr<const AbstractHilbert>>(),
+           py::keep_alive<1, 2>(), py::arg("hilbert"), R"EOF(
            Constructs a new ``Heisenberg`` given a hilbert space.
 
            Args:

--- a/Sources/Operator/py_ising.hpp
+++ b/Sources/Operator/py_ising.hpp
@@ -31,7 +31,7 @@ namespace netket {
 void AddIsing(py::module &subm) {
   py::class_<Ising, AbstractOperator>(subm, "Ising",
                                       R"EOF(An Ising Hamiltonian operator.)EOF")
-      .def(py::init<const AbstractHilbert &, double, double>(),
+      .def(py::init<std::shared_ptr<const AbstractHilbert>, double, double>(),
            py::keep_alive<1, 2>(), py::arg("hilbert"), py::arg("h"),
            py::arg("J") = 1.0, R"EOF(
          Constructs a new ``Ising`` given a hilbert space, a transverse field,

--- a/Sources/Operator/py_local_operator.hpp
+++ b/Sources/Operator/py_local_operator.hpp
@@ -89,8 +89,8 @@ void AddLocalOperator(py::module &subm) {
 
               ```
           )EOF")
-      .def(py::init<std::shared_ptr<const AbstractHilbert>, LocalOperator::MatType,
-                    LocalOperator::SiteType, double>(),
+      .def(py::init<std::shared_ptr<const AbstractHilbert>,
+                    LocalOperator::MatType, LocalOperator::SiteType, double>(),
            py::keep_alive<1, 2>(), py::arg("hilbert"), py::arg("operator"),
            py::arg("acting_on"), py::arg("constant") = 0., R"EOF(
            Constructs a new ``LocalOperator`` given a hilbert space, an

--- a/Sources/Operator/py_local_operator.hpp
+++ b/Sources/Operator/py_local_operator.hpp
@@ -31,8 +31,9 @@ namespace netket {
 void AddLocalOperator(py::module &subm) {
   py::class_<LocalOperator, AbstractOperator>(
       subm, "LocalOperator", R"EOF(A custom local operator.)EOF")
-      .def(py::init<const AbstractHilbert &, double>(), py::keep_alive<1, 2>(),
-           py::arg("hilbert"), py::arg("constant") = 0., R"EOF(
+      .def(py::init<std::shared_ptr<const AbstractHilbert>, double>(),
+           py::keep_alive<1, 2>(), py::arg("hilbert"), py::arg("constant") = 0.,
+           R"EOF(
            Constructs a new ``LocalOperator`` given a hilbert space and (if
            specified) a constant level shift.
 
@@ -55,11 +56,11 @@ void AddLocalOperator(py::module &subm) {
 
                ```
            )EOF")
-      .def(
-          py::init<const AbstractHilbert &, std::vector<LocalOperator::MatType>,
-                   std::vector<LocalOperator::SiteType>, double>(),
-          py::keep_alive<1, 2>(), py::arg("hilbert"), py::arg("operators"),
-          py::arg("acting_on"), py::arg("constant") = 0., R"EOF(
+      .def(py::init<std::shared_ptr<const AbstractHilbert>,
+                    std::vector<LocalOperator::MatType>,
+                    std::vector<LocalOperator::SiteType>, double>(),
+           py::keep_alive<1, 2>(), py::arg("hilbert"), py::arg("operators"),
+           py::arg("acting_on"), py::arg("constant") = 0., R"EOF(
           Constructs a new ``LocalOperator`` given a hilbert space, a vector of
           operators, a vector of sites, and (if specified) a constant level
           shift.
@@ -88,7 +89,7 @@ void AddLocalOperator(py::module &subm) {
 
               ```
           )EOF")
-      .def(py::init<const AbstractHilbert &, LocalOperator::MatType,
+      .def(py::init<std::shared_ptr<const AbstractHilbert>, LocalOperator::MatType,
                     LocalOperator::SiteType, double>(),
            py::keep_alive<1, 2>(), py::arg("hilbert"), py::arg("operator"),
            py::arg("acting_on"), py::arg("constant") = 0., R"EOF(
@@ -131,22 +132,30 @@ void AddLocalOperator(py::module &subm) {
       .def("conjugate", &LocalOperator::Conjugate,
            R"EOF(Returns the complex conjugation of this operator)EOF")
       .def(py::self + py::self)
-      .def("__mul__", [](const LocalOperator &a, double b) { return b * a; },
-           py::is_operator())
-      .def("__rmul__", [](const LocalOperator &a, double b) { return b * a; },
-           py::is_operator())
-      .def("__mul__", [](const LocalOperator &a, int b) { return b * a; },
-           py::is_operator())
-      .def("__rmul__", [](const LocalOperator &a, int b) { return b * a; },
-           py::is_operator())
-      .def("__add__", [](const LocalOperator &a, double b) { return a + b; },
-           py::is_operator())
-      .def("__add__", [](const LocalOperator &a, int b) { return a + b; },
-           py::is_operator())
-      .def("__radd__", [](const LocalOperator &a, double b) { return a + b; },
-           py::is_operator())
-      .def("__radd__", [](const LocalOperator &a, int b) { return a + b; },
-           py::is_operator())
+      .def(
+          "__mul__", [](const LocalOperator &a, double b) { return b * a; },
+          py::is_operator())
+      .def(
+          "__rmul__", [](const LocalOperator &a, double b) { return b * a; },
+          py::is_operator())
+      .def(
+          "__mul__", [](const LocalOperator &a, int b) { return b * a; },
+          py::is_operator())
+      .def(
+          "__rmul__", [](const LocalOperator &a, int b) { return b * a; },
+          py::is_operator())
+      .def(
+          "__add__", [](const LocalOperator &a, double b) { return a + b; },
+          py::is_operator())
+      .def(
+          "__add__", [](const LocalOperator &a, int b) { return a + b; },
+          py::is_operator())
+      .def(
+          "__radd__", [](const LocalOperator &a, double b) { return a + b; },
+          py::is_operator())
+      .def(
+          "__radd__", [](const LocalOperator &a, int b) { return a + b; },
+          py::is_operator())
       .def(py::self * py::self);
 }
 

--- a/Sources/Operator/py_operator.hpp
+++ b/Sources/Operator/py_operator.hpp
@@ -58,11 +58,12 @@ void AddOperatorModule(py::module &m) {
           .def_property_readonly(
               "hilbert", &AbstractOperator::GetHilbert,
               R"EOF(netket.hilbert.Hilbert: ``Hilbert`` space of operator.)EOF")
-          .def("to_sparse",
-               [](const AbstractOperator &self) {
-                 return SparseMatrixWrapper<>(self).GetMatrix();
-               },
-               R"EOF(
+          .def(
+              "to_sparse",
+              [](const AbstractOperator &self) {
+                return SparseMatrixWrapper<>(self).GetMatrix();
+              },
+              R"EOF(
          Returns the sparse matrix representation of the operator. Note that, in general,
          the size of the matrix is exponential in the number of quantum
          numbers, and this operation should thus only be performed for
@@ -70,11 +71,12 @@ void AddOperatorModule(py::module &m) {
 
          This method requires an indexable Hilbert space.
          )EOF")
-          .def("to_dense",
-               [](const AbstractOperator &self) {
-                 return DenseMatrixWrapper<>(self).GetMatrix();
-               },
-               R"EOF(
+          .def(
+              "to_dense",
+              [](const AbstractOperator &self) {
+                return DenseMatrixWrapper<>(self).GetMatrix();
+              },
+              R"EOF(
          Returns the dense matrix representation of the operator. Note that, in general,
          the size of the matrix is exponential in the number of quantum
          numbers, and this operation should thus only be performed for

--- a/Sources/Sampler/abstract_sampler.hpp
+++ b/Sources/Sampler/abstract_sampler.hpp
@@ -34,8 +34,6 @@ class AbstractSampler {
 
   virtual void SetVisible(const Eigen::VectorXd& v) = 0;
 
-  virtual AbstractMachine& GetMachine() noexcept = 0;
-
   virtual Eigen::VectorXd Acceptance() const = 0;
 
   // Computes the derivative of the machine on the current visible
@@ -59,8 +57,12 @@ class AbstractSampler {
     machine_func_ = std::move(machine_func);
   }
 
-  std::shared_ptr<const AbstractHilbert> GetHilbert() const noexcept {
-    return hilbert_;
+  const AbstractHilbert &GetHilbert() const noexcept {
+    return *hilbert_;
+  }
+
+  AbstractMachine &GetMachine() const noexcept {
+    return psi_;
   }
 
   const MachineFunction& GetMachineFunc() const noexcept {
@@ -68,10 +70,8 @@ class AbstractSampler {
   }
 
  protected:
-  std::shared_ptr<const AbstractHilbert> hilbert_;
-
-  AbstractSampler(std::shared_ptr<const AbstractHilbert> hilbert)
-      : hilbert_(std::move(hilbert)) {
+  AbstractSampler(AbstractMachine& psi)
+      : psi_(psi), hilbert_(psi.GetHilbertShared()) {
     // Default initialization for the machine function to be sampled from
     machine_func_ = static_cast<double (*)(const Complex&)>(&std::norm);
   }
@@ -81,6 +81,8 @@ class AbstractSampler {
  private:
   DistributedRandomEngine engine_;
   MachineFunction machine_func_;
+  AbstractMachine& psi_;
+  std::shared_ptr<const AbstractHilbert> hilbert_;
 };
 
 }  // namespace netket

--- a/Sources/Sampler/abstract_sampler.hpp
+++ b/Sources/Sampler/abstract_sampler.hpp
@@ -38,8 +38,6 @@ class AbstractSampler {
 
   virtual Eigen::VectorXd Acceptance() const = 0;
 
-  virtual const AbstractHilbert& GetHilbert() const noexcept = 0;
-
   // Computes the derivative of the machine on the current visible
   // Using the lookUp tables if possible
   virtual AbstractMachine::VectorType DerLogVisible() {
@@ -61,12 +59,19 @@ class AbstractSampler {
     machine_func_ = std::move(machine_func);
   }
 
+  std::shared_ptr<const AbstractHilbert> GetHilbert() const noexcept {
+    return hilbert_;
+  }
+
   const MachineFunction& GetMachineFunc() const noexcept {
     return machine_func_;
   }
 
  protected:
-  AbstractSampler() {
+  std::shared_ptr<const AbstractHilbert> hilbert_;
+
+  AbstractSampler(std::shared_ptr<const AbstractHilbert> hilbert)
+      : hilbert_(std::move(hilbert)) {
     // Default initialization for the machine function to be sampled from
     machine_func_ = static_cast<double (*)(const Complex&)>(&std::norm);
   }

--- a/Sources/Sampler/abstract_sampler.hpp
+++ b/Sources/Sampler/abstract_sampler.hpp
@@ -57,6 +57,10 @@ class AbstractSampler {
     machine_func_ = std::move(machine_func);
   }
 
+  std::shared_ptr<const AbstractHilbert> GetHilbertShared() const noexcept {
+    return hilbert_;
+  }
+
   const AbstractHilbert &GetHilbert() const noexcept {
     return *hilbert_;
   }

--- a/Sources/Sampler/custom_sampler_pt.hpp
+++ b/Sources/Sampler/custom_sampler_pt.hpp
@@ -30,8 +30,6 @@ namespace netket {
 
 // Metropolis sampling using custom moves provided by user
 class CustomSamplerPt : public AbstractSampler {
-  AbstractMachine& psi_;
-
   LocalOperator move_operators_;
   std::vector<double> operatorsweights_;
   // number of visible units
@@ -64,10 +62,9 @@ class CustomSamplerPt : public AbstractSampler {
   CustomSamplerPt(AbstractMachine& psi, const LocalOperator& move_operators,
                   const std::vector<double>& move_weights = {},
                   int nreplicas = 1)
-      : AbstractSampler(psi.GetHilbert()),
-        psi_(psi),
+      : AbstractSampler(psi),
         move_operators_(move_operators),
-        nv_(hilbert_->Size()),
+        nv_(GetHilbert().Size()),
         nrep_(nreplicas) {
     Init(move_weights);
   }
@@ -75,7 +72,7 @@ class CustomSamplerPt : public AbstractSampler {
   void Init(const std::vector<double>& move_weights) {
     CustomSampler::CheckMoveOperators(move_operators_);
 
-    if (hilbert_->Size() != move_operators_.GetHilbert()->Size()) {
+    if (GetHilbert().Size() != move_operators_.GetHilbert().Size()) {
       throw InvalidInputError(
           "Move operators in CustomSampler act on a different hilbert space "
           "than the Machine");
@@ -97,13 +94,13 @@ class CustomSamplerPt : public AbstractSampler {
     MPI_Comm_size(MPI_COMM_WORLD, &totalnodes_);
     MPI_Comm_rank(MPI_COMM_WORLD, &mynode_);
 
-    if (!hilbert_->IsDiscrete()) {
+    if (!GetHilbert().IsDiscrete()) {
       throw InvalidInputError(
           "Custom Metropolis sampler works only for discrete Hilbert spaces");
     }
 
-    nstates_ = hilbert_->LocalSize();
-    localstates_ = hilbert_->LocalStates();
+    nstates_ = GetHilbert().LocalSize();
+    localstates_ = GetHilbert().LocalStates();
 
     v_.resize(nrep_);
     for (int i = 0; i < nrep_; i++) {
@@ -130,12 +127,12 @@ class CustomSamplerPt : public AbstractSampler {
   void Reset(bool initrandom = false) override {
     if (initrandom) {
       for (int i = 0; i < nrep_; i++) {
-        hilbert_->RandomVals(v_[i], this->GetRandomEngine());
+        GetHilbert().RandomVals(v_[i], this->GetRandomEngine());
       }
     }
 
     for (int i = 0; i < nrep_; i++) {
-      psi_.InitLookup(v_[i], lt_[i]);
+      GetMachine().InitLookup(v_[i], lt_[i]);
     }
 
     accept_ = Eigen::VectorXd::Zero(2 * nrep_);
@@ -161,7 +158,7 @@ class CustomSamplerPt : public AbstractSampler {
       }
 
       auto explo = std::exp(beta_[rep] *
-                            psi_.LogValDiff(v_[rep], tochange_[exit_state],
+                            GetMachine().LogValDiff(v_[rep], tochange_[exit_state],
                                             newconfs_[exit_state], lt_[rep]));
 
       double ratio = this->GetMachineFunc()(explo);
@@ -169,9 +166,9 @@ class CustomSamplerPt : public AbstractSampler {
       // Metropolis acceptance test
       if (ratio > distu(this->GetRandomEngine())) {
         accept_(rep) += 1;
-        psi_.UpdateLookup(v_[rep], tochange_[exit_state], newconfs_[exit_state],
+        GetMachine().UpdateLookup(v_[rep], tochange_[exit_state], newconfs_[exit_state],
                           lt_[rep]);
-        hilbert_->UpdateConf(v_[rep], tochange_[exit_state],
+        GetHilbert().UpdateConf(v_[rep], tochange_[exit_state],
                             newconfs_[exit_state]);
       }
       moves_(rep) += 1;
@@ -210,8 +207,8 @@ class CustomSamplerPt : public AbstractSampler {
 
   // computes the probability to exchange two replicas
   double ExchangeProb(int r1, int r2) {
-    const double lf1 = 2 * std::real(psi_.LogVal(v_[r1], lt_[r1]));
-    const double lf2 = 2 * std::real(psi_.LogVal(v_[r2], lt_[r2]));
+    const double lf1 = 2 * std::real(GetMachine().LogVal(v_[r1], lt_[r1]));
+    const double lf2 = 2 * std::real(GetMachine().LogVal(v_[r2], lt_[r2]));
 
     return std::exp((beta_[r1] - beta_[r2]) * (lf2 - lf1));
   }
@@ -225,10 +222,8 @@ class CustomSamplerPt : public AbstractSampler {
 
   void SetVisible(const Eigen::VectorXd& v) override { v_[0] = v; }
 
-  AbstractMachine& GetMachine() noexcept override { return psi_; }
-
   AbstractMachine::VectorType DerLogVisible() override {
-    return psi_.DerLog(v_[0], lt_[0]);
+    return GetMachine().DerLog(v_[0], lt_[0]);
   }
 
   Eigen::VectorXd Acceptance() const override {

--- a/Sources/Sampler/exact_sampler.hpp
+++ b/Sources/Sampler/exact_sampler.hpp
@@ -29,8 +29,6 @@ namespace netket {
 class ExactSampler : public AbstractSampler {
   AbstractMachine& psi_;
 
-  const AbstractHilbert& hilbert_;
-
   // number of visible units
   const int nv_;
 
@@ -43,7 +41,7 @@ class ExactSampler : public AbstractSampler {
   int mynode_;
   int totalnodes_;
 
-  const HilbertIndex &hilbert_index_;
+  const HilbertIndex& hilbert_index_;
 
   const int dim_;
 
@@ -54,10 +52,10 @@ class ExactSampler : public AbstractSampler {
 
  public:
   explicit ExactSampler(AbstractMachine& psi)
-      : psi_(psi),
-        hilbert_(psi.GetHilbert()),
-        nv_(hilbert_.Size()),
-        hilbert_index_(hilbert_.GetIndex()),
+      : AbstractSampler(psi.GetHilbert()),
+        psi_(psi),
+        nv_(hilbert_->Size()),
+        hilbert_index_(hilbert_->GetIndex()),
         dim_(hilbert_index_.NStates()) {
     Init();
   }
@@ -68,7 +66,7 @@ class ExactSampler : public AbstractSampler {
     MPI_Comm_size(MPI_COMM_WORLD, &totalnodes_);
     MPI_Comm_rank(MPI_COMM_WORLD, &mynode_);
 
-    if (!hilbert_.IsDiscrete()) {
+    if (!hilbert_->IsDiscrete()) {
       throw InvalidInputError(
           "Exact sampler works only for discrete "
           "Hilbert spaces");
@@ -84,7 +82,7 @@ class ExactSampler : public AbstractSampler {
 
   void Reset(bool initrandom) override {
     if (initrandom) {
-      hilbert_.RandomVals(v_, this->GetRandomEngine());
+      hilbert_->RandomVals(v_, this->GetRandomEngine());
     }
 
     double logmax = -std::numeric_limits<double>::infinity();
@@ -121,10 +119,6 @@ class ExactSampler : public AbstractSampler {
   void SetVisible(const Eigen::VectorXd& v) override { v_ = v; }
 
   AbstractMachine& GetMachine() noexcept override { return psi_; }
-
-  const AbstractHilbert& GetHilbert() const noexcept override {
-    return hilbert_;
-  }
 
   Eigen::VectorXd Acceptance() const override {
     Eigen::VectorXd acc = accept_;

--- a/Sources/Sampler/exact_sampler.hpp
+++ b/Sources/Sampler/exact_sampler.hpp
@@ -27,8 +27,6 @@ namespace netket {
 
 // Exact sampling using heat bath, mostly for testing purposes on small systems
 class ExactSampler : public AbstractSampler {
-  AbstractMachine& psi_;
-
   // number of visible units
   const int nv_;
 
@@ -52,10 +50,9 @@ class ExactSampler : public AbstractSampler {
 
  public:
   explicit ExactSampler(AbstractMachine& psi)
-      : AbstractSampler(psi.GetHilbert()),
-        psi_(psi),
-        nv_(hilbert_->Size()),
-        hilbert_index_(hilbert_->GetIndex()),
+      : AbstractSampler(psi),
+        nv_(GetHilbert().Size()),
+        hilbert_index_(GetHilbert().GetIndex()),
         dim_(hilbert_index_.NStates()) {
     Init();
   }
@@ -66,7 +63,7 @@ class ExactSampler : public AbstractSampler {
     MPI_Comm_size(MPI_COMM_WORLD, &totalnodes_);
     MPI_Comm_rank(MPI_COMM_WORLD, &mynode_);
 
-    if (!hilbert_->IsDiscrete()) {
+    if (!GetHilbert().IsDiscrete()) {
       throw InvalidInputError(
           "Exact sampler works only for discrete "
           "Hilbert spaces");
@@ -82,7 +79,7 @@ class ExactSampler : public AbstractSampler {
 
   void Reset(bool initrandom) override {
     if (initrandom) {
-      hilbert_->RandomVals(v_, this->GetRandomEngine());
+      GetHilbert().RandomVals(v_, this->GetRandomEngine());
     }
 
     double logmax = -std::numeric_limits<double>::infinity();
@@ -92,7 +89,7 @@ class ExactSampler : public AbstractSampler {
 
     for (int i = 0; i < dim_; ++i) {
       auto v = hilbert_index_.NumberToState(i);
-      logpsivals_[i] = psi_.LogVal(v);
+      logpsivals_[i] = GetMachine().LogVal(v);
       logmax = std::max(logmax, std::real(logpsivals_[i]));
     }
 
@@ -117,8 +114,6 @@ class ExactSampler : public AbstractSampler {
   Eigen::VectorXd Visible() override { return v_; }
 
   void SetVisible(const Eigen::VectorXd& v) override { v_ = v; }
-
-  AbstractMachine& GetMachine() noexcept override { return psi_; }
 
   Eigen::VectorXd Acceptance() const override {
     Eigen::VectorXd acc = accept_;

--- a/Sources/Sampler/metropolis_exchange.hpp
+++ b/Sources/Sampler/metropolis_exchange.hpp
@@ -28,8 +28,6 @@ namespace netket {
 class MetropolisExchange : public AbstractSampler {
   AbstractMachine &psi_;
 
-  const AbstractHilbert &hilbert_;
-
   // number of visible units
   const int nv_;
 
@@ -51,7 +49,7 @@ class MetropolisExchange : public AbstractSampler {
  public:
   MetropolisExchange(const AbstractGraph &graph, AbstractMachine &psi,
                      int dmax = 1)
-      : psi_(psi), hilbert_(psi.GetHilbert()), nv_(hilbert_.Size()) {
+      : AbstractSampler(psi.GetHilbert()), psi_(psi), nv_(hilbert_->Size()) {
     Init(graph, dmax);
   }
 
@@ -92,7 +90,7 @@ class MetropolisExchange : public AbstractSampler {
   void Reset(bool initrandom = false) override {
     if (initrandom) {
       if (initrandom) {
-        hilbert_.RandomVals(v_, this->GetRandomEngine());
+        hilbert_->RandomVals(v_, this->GetRandomEngine());
       }
     }
 
@@ -129,7 +127,7 @@ class MetropolisExchange : public AbstractSampler {
         if (ratio > distu(this->GetRandomEngine())) {
           accept_[0] += 1;
           psi_.UpdateLookup(v_, tochange, newconf, lt_);
-          hilbert_.UpdateConf(v_, tochange, newconf);
+          hilbert_->UpdateConf(v_, tochange, newconf);
         }
       }
       moves_[0] += 1;
@@ -141,10 +139,6 @@ class MetropolisExchange : public AbstractSampler {
   void SetVisible(const Eigen::VectorXd &v) override { v_ = v; }
 
   AbstractMachine &GetMachine() noexcept override { return psi_; }
-
-  const AbstractHilbert &GetHilbert() const noexcept override {
-    return hilbert_;
-  }
 
   AbstractMachine::VectorType DerLogVisible() override {
     return psi_.DerLog(v_, lt_);

--- a/Sources/Sampler/metropolis_exchange.hpp
+++ b/Sources/Sampler/metropolis_exchange.hpp
@@ -26,8 +26,6 @@ namespace netket {
 
 // Metropolis sampling generating local exchanges
 class MetropolisExchange : public AbstractSampler {
-  AbstractMachine &psi_;
-
   // number of visible units
   const int nv_;
 
@@ -49,7 +47,7 @@ class MetropolisExchange : public AbstractSampler {
  public:
   MetropolisExchange(const AbstractGraph &graph, AbstractMachine &psi,
                      int dmax = 1)
-      : AbstractSampler(psi.GetHilbert()), psi_(psi), nv_(hilbert_->Size()) {
+      : AbstractSampler(psi), nv_(GetHilbert().Size()) {
     Init(graph, dmax);
   }
 
@@ -90,11 +88,11 @@ class MetropolisExchange : public AbstractSampler {
   void Reset(bool initrandom = false) override {
     if (initrandom) {
       if (initrandom) {
-        hilbert_->RandomVals(v_, this->GetRandomEngine());
+        GetHilbert().RandomVals(v_, this->GetRandomEngine());
       }
     }
 
-    psi_.InitLookup(v_, lt_);
+    GetMachine().InitLookup(v_, lt_);
 
     accept_ = Eigen::VectorXd::Zero(1);
     moves_ = Eigen::VectorXd::Zero(1);
@@ -120,14 +118,14 @@ class MetropolisExchange : public AbstractSampler {
         newconf[0] = v_(sj);
         newconf[1] = v_(si);
 
-        auto explo = std::exp(psi_.LogValDiff(v_, tochange, newconf, lt_));
+        auto explo = std::exp(GetMachine().LogValDiff(v_, tochange, newconf, lt_));
 
         double ratio = this->GetMachineFunc()(explo);
 
         if (ratio > distu(this->GetRandomEngine())) {
           accept_[0] += 1;
-          psi_.UpdateLookup(v_, tochange, newconf, lt_);
-          hilbert_->UpdateConf(v_, tochange, newconf);
+          GetMachine().UpdateLookup(v_, tochange, newconf, lt_);
+          GetHilbert().UpdateConf(v_, tochange, newconf);
         }
       }
       moves_[0] += 1;
@@ -138,10 +136,8 @@ class MetropolisExchange : public AbstractSampler {
 
   void SetVisible(const Eigen::VectorXd &v) override { v_ = v; }
 
-  AbstractMachine &GetMachine() noexcept override { return psi_; }
-
   AbstractMachine::VectorType DerLogVisible() override {
-    return psi_.DerLog(v_, lt_);
+    return GetMachine().DerLog(v_, lt_);
   }
 
   Eigen::VectorXd Acceptance() const override {

--- a/Sources/Sampler/metropolis_exchange_pt.hpp
+++ b/Sources/Sampler/metropolis_exchange_pt.hpp
@@ -28,7 +28,6 @@ namespace netket {
 // Parallel tempering is also used
 class MetropolisExchangePt : public AbstractSampler {
   AbstractMachine &psi_;
-  const AbstractHilbert &hilbert_;
 
   // number of visible units
   const int nv_;
@@ -55,9 +54,9 @@ class MetropolisExchangePt : public AbstractSampler {
  public:
   MetropolisExchangePt(const AbstractGraph &graph, AbstractMachine &psi,
                        int dmax = 1, int nreplicas = 1)
-      : psi_(psi),
-        hilbert_(psi.GetHilbert()),
-        nv_(hilbert_.Size()),
+      : AbstractSampler(psi.GetHilbert()),
+        psi_(psi),
+        nv_(hilbert_->Size()),
         nrep_(nreplicas) {
     Init(graph, dmax);
   }
@@ -109,7 +108,7 @@ class MetropolisExchangePt : public AbstractSampler {
   void Reset(bool initrandom = false) override {
     if (initrandom) {
       for (int i = 0; i < nrep_; i++) {
-        hilbert_.RandomVals(v_[i], this->GetRandomEngine());
+        hilbert_->RandomVals(v_[i], this->GetRandomEngine());
       }
     }
 
@@ -150,7 +149,7 @@ class MetropolisExchangePt : public AbstractSampler {
         if (ratio > distu(this->GetRandomEngine())) {
           accept_(rep) += 1;
           psi_.UpdateLookup(v_[rep], tochange, newconf, lt_[rep]);
-          hilbert_.UpdateConf(v_[rep], tochange, newconf);
+          hilbert_->UpdateConf(v_[rep], tochange, newconf);
         }
       }
 
@@ -206,10 +205,6 @@ class MetropolisExchangePt : public AbstractSampler {
   void SetVisible(const Eigen::VectorXd &v) override { v_[0] = v; }
 
   AbstractMachine &GetMachine() noexcept override { return psi_; }
-
-  const AbstractHilbert &GetHilbert() const noexcept override {
-    return hilbert_;
-  }
 
   AbstractMachine::VectorType DerLogVisible() override {
     return psi_.DerLog(v_[0], lt_[0]);

--- a/Sources/Sampler/metropolis_exchange_pt.hpp
+++ b/Sources/Sampler/metropolis_exchange_pt.hpp
@@ -27,8 +27,6 @@ namespace netket {
 // Metropolis sampling generating local exchanges
 // Parallel tempering is also used
 class MetropolisExchangePt : public AbstractSampler {
-  AbstractMachine &psi_;
-
   // number of visible units
   const int nv_;
 
@@ -54,9 +52,8 @@ class MetropolisExchangePt : public AbstractSampler {
  public:
   MetropolisExchangePt(const AbstractGraph &graph, AbstractMachine &psi,
                        int dmax = 1, int nreplicas = 1)
-      : AbstractSampler(psi.GetHilbert()),
-        psi_(psi),
-        nv_(hilbert_->Size()),
+      : AbstractSampler(psi),
+        nv_(GetHilbert().Size()),
         nrep_(nreplicas) {
     Init(graph, dmax);
   }
@@ -108,12 +105,12 @@ class MetropolisExchangePt : public AbstractSampler {
   void Reset(bool initrandom = false) override {
     if (initrandom) {
       for (int i = 0; i < nrep_; i++) {
-        hilbert_->RandomVals(v_[i], this->GetRandomEngine());
+        GetHilbert().RandomVals(v_[i], this->GetRandomEngine());
       }
     }
 
     for (int i = 0; i < nrep_; i++) {
-      psi_.InitLookup(v_[i], lt_[i]);
+      GetMachine().InitLookup(v_[i], lt_[i]);
     }
 
     accept_ = Eigen::VectorXd::Zero(2 * nrep_);
@@ -143,13 +140,13 @@ class MetropolisExchangePt : public AbstractSampler {
         newconf[1] = v_[rep](si);
 
         auto explo = std::exp(
-            beta_[rep] * psi_.LogValDiff(v_[rep], tochange, newconf, lt_[rep]));
+            beta_[rep] * GetMachine().LogValDiff(v_[rep], tochange, newconf, lt_[rep]));
         double ratio = this->GetMachineFunc()(explo);
 
         if (ratio > distu(this->GetRandomEngine())) {
           accept_(rep) += 1;
-          psi_.UpdateLookup(v_[rep], tochange, newconf, lt_[rep]);
-          hilbert_->UpdateConf(v_[rep], tochange, newconf);
+          GetMachine().UpdateLookup(v_[rep], tochange, newconf, lt_[rep]);
+          GetHilbert().UpdateConf(v_[rep], tochange, newconf);
         }
       }
 
@@ -189,8 +186,8 @@ class MetropolisExchangePt : public AbstractSampler {
 
   // computes the probability to exchange two replicas
   double ExchangeProb(int r1, int r2) {
-    const double lf1 = 2 * std::real(psi_.LogVal(v_[r1], lt_[r1]));
-    const double lf2 = 2 * std::real(psi_.LogVal(v_[r2], lt_[r2]));
+    const double lf1 = 2 * std::real(GetMachine().LogVal(v_[r1], lt_[r1]));
+    const double lf2 = 2 * std::real(GetMachine().LogVal(v_[r2], lt_[r2]));
 
     return std::exp((beta_[r1] - beta_[r2]) * (lf2 - lf1));
   }
@@ -204,10 +201,8 @@ class MetropolisExchangePt : public AbstractSampler {
 
   void SetVisible(const Eigen::VectorXd &v) override { v_[0] = v; }
 
-  AbstractMachine &GetMachine() noexcept override { return psi_; }
-
   AbstractMachine::VectorType DerLogVisible() override {
-    return psi_.DerLog(v_[0], lt_[0]);
+    return GetMachine().DerLog(v_[0], lt_[0]);
   }
 
   Eigen::VectorXd Acceptance() const override {

--- a/Sources/Sampler/metropolis_hamiltonian.hpp
+++ b/Sources/Sampler/metropolis_hamiltonian.hpp
@@ -29,8 +29,6 @@ template <class H>
 class MetropolisHamiltonian : public AbstractSampler {
   AbstractMachine &psi_;
 
-  const AbstractHilbert &hilbert_;
-
   H &hamiltonian_;
 
   // number of visible units
@@ -60,10 +58,10 @@ class MetropolisHamiltonian : public AbstractSampler {
 
  public:
   MetropolisHamiltonian(AbstractMachine &psi, H &hamiltonian)
-      : psi_(psi),
-        hilbert_(psi.GetHilbert()),
+      : AbstractSampler(psi.GetHilbert()),
+        psi_(psi),
         hamiltonian_(hamiltonian),
-        nv_(hilbert_.Size()) {
+        nv_(hilbert_->Size()) {
     Init();
   }
 
@@ -73,7 +71,7 @@ class MetropolisHamiltonian : public AbstractSampler {
     MPI_Comm_size(MPI_COMM_WORLD, &totalnodes_);
     MPI_Comm_rank(MPI_COMM_WORLD, &mynode_);
 
-    if (!hilbert_.IsDiscrete()) {
+    if (!hilbert_->IsDiscrete()) {
       throw InvalidInputError(
           "Hamiltonian Metropolis sampler works only for discrete "
           "Hilbert spaces");
@@ -89,7 +87,7 @@ class MetropolisHamiltonian : public AbstractSampler {
 
   void Reset(bool initrandom = false) override {
     if (initrandom) {
-      hilbert_.RandomVals(v_, this->GetRandomEngine());
+      hilbert_->RandomVals(v_, this->GetRandomEngine());
     }
 
     psi_.InitLookup(v_, lt_);
@@ -112,7 +110,7 @@ class MetropolisHamiltonian : public AbstractSampler {
 
       // Inverse transition
       v1_ = v_;
-      hilbert_.UpdateConf(v1_, tochange_[si], newconfs_[si]);
+      hilbert_->UpdateConf(v1_, tochange_[si], newconfs_[si]);
 
       hamiltonian_.FindConn(v1_, mel1_, tochange1_, newconfs1_);
 
@@ -155,10 +153,6 @@ class MetropolisHamiltonian : public AbstractSampler {
   Eigen::VectorXd Visible() override { return v_; }
 
   void SetVisible(const Eigen::VectorXd &v) override { v_ = v; }
-
-  const AbstractHilbert &GetHilbert() const noexcept override {
-    return hilbert_;
-  }
 
   AbstractMachine &GetMachine() noexcept override { return psi_; }
 

--- a/Sources/Sampler/metropolis_hamiltonian_pt.hpp
+++ b/Sources/Sampler/metropolis_hamiltonian_pt.hpp
@@ -27,8 +27,6 @@ namespace netket {
 // Metropolis sampling generating transitions using the Hamiltonian
 template <class H>
 class MetropolisHamiltonianPt : public AbstractSampler {
-  AbstractMachine &psi_;
-
   H &hamiltonian_;
 
   // number of visible units
@@ -60,10 +58,9 @@ class MetropolisHamiltonianPt : public AbstractSampler {
 
  public:
   MetropolisHamiltonianPt(AbstractMachine &psi, H &hamiltonian, int nrep)
-      : AbstractSampler(psi.GetHilbert()),
-        psi_(psi),
+      : AbstractSampler(psi),
         hamiltonian_(hamiltonian),
-        nv_(hilbert_->Size()),
+        nv_(GetHilbert().Size()),
         nrep_(nrep) {
     Init();
   }
@@ -72,7 +69,7 @@ class MetropolisHamiltonianPt : public AbstractSampler {
     MPI_Comm_size(MPI_COMM_WORLD, &totalnodes_);
     MPI_Comm_rank(MPI_COMM_WORLD, &mynode_);
 
-    if (!hilbert_->IsDiscrete()) {
+    if (!GetHilbert().IsDiscrete()) {
       throw InvalidInputError(
           "Hamiltonian Metropolis sampler works only for discrete "
           "Hilbert spaces");
@@ -103,12 +100,12 @@ class MetropolisHamiltonianPt : public AbstractSampler {
   void Reset(bool initrandom = false) override {
     if (initrandom) {
       for (int i = 0; i < nrep_; i++) {
-        hilbert_->RandomVals(v_[i], this->GetRandomEngine());
+        GetHilbert().RandomVals(v_[i], this->GetRandomEngine());
       }
     }
 
     for (int i = 0; i < nrep_; i++) {
-      psi_.InitLookup(v_[i], lt_[i]);
+      GetMachine().InitLookup(v_[i], lt_[i]);
     }
 
     accept_ = Eigen::VectorXd::Zero(2 * nrep_);
@@ -129,24 +126,24 @@ class MetropolisHamiltonianPt : public AbstractSampler {
 
       // Inverse transition
       v1_ = v_[rep];
-      hilbert_->UpdateConf(v1_, tochange_[si], newconfs_[si]);
+      GetHilbert().UpdateConf(v1_, tochange_[si], newconfs_[si]);
 
       hamiltonian_.FindConn(v1_, mel1_, tochange1_, newconfs1_);
 
       double w2 = tochange1_.size();
 
       const auto lvd =
-          psi_.LogValDiff(v_[rep], tochange_[si], newconfs_[si], lt_[rep]);
+          GetMachine().LogValDiff(v_[rep], tochange_[si], newconfs_[si], lt_[rep]);
       double ratio =
           this->GetMachineFunc()(std::exp(beta_[rep] * lvd)) * w1 / w2;
 
 #ifndef NDEBUG
-      const auto psival1 = psi_.LogVal(v_[rep]);
+      const auto psival1 = GetMachine().LogVal(v_[rep]);
       if (std::abs(
-              std::exp(psi_.LogVal(v_[rep]) - psi_.LogVal(v_[rep], lt_[rep])) -
+              std::exp(GetMachine().LogVal(v_[rep]) - GetMachine().LogVal(v_[rep], lt_[rep])) -
               1.) > 1.0e-8) {
-        std::cerr << psi_.LogVal(v_[rep]) << "  and LogVal with Lt is "
-                  << psi_.LogVal(v_[rep], lt_[rep]) << std::endl;
+        std::cerr << GetMachine().LogVal(v_[rep]) << "  and LogVal with Lt is "
+                  << GetMachine().LogVal(v_[rep], lt_[rep]) << std::endl;
         std::abort();
       }
 #endif
@@ -154,16 +151,16 @@ class MetropolisHamiltonianPt : public AbstractSampler {
       // Metropolis acceptance test
       if (ratio > distu(this->GetRandomEngine())) {
         accept_(rep) += 1;
-        psi_.UpdateLookup(v_[rep], tochange_[si], newconfs_[si], lt_[rep]);
+        GetMachine().UpdateLookup(v_[rep], tochange_[si], newconfs_[si], lt_[rep]);
         v_[rep] = v1_;
 
 #ifndef NDEBUG
-        const auto psival2 = psi_.LogVal(v_[rep]);
+        const auto psival2 = GetMachine().LogVal(v_[rep]);
         if (std::abs(std::exp(psival2 - psival1 - lvd) - 1.) > 1.0e-8) {
           std::cerr << psival2 - psival1 << " and logvaldiff is " << lvd
                     << std::endl;
           std::cerr << psival2 << " and LogVal with Lt is "
-                    << psi_.LogVal(v_[rep], lt_[rep]) << std::endl;
+                    << GetMachine().LogVal(v_[rep], lt_[rep]) << std::endl;
           std::abort();
         }
 #endif
@@ -204,8 +201,8 @@ class MetropolisHamiltonianPt : public AbstractSampler {
 
   // computes the probability to exchange two replicas
   double ExchangeProb(int r1, int r2) {
-    const double lf1 = 2 * std::real(psi_.LogVal(v_[r1], lt_[r1]));
-    const double lf2 = 2 * std::real(psi_.LogVal(v_[r2], lt_[r2]));
+    const double lf1 = 2 * std::real(GetMachine().LogVal(v_[r1], lt_[r1]));
+    const double lf2 = 2 * std::real(GetMachine().LogVal(v_[r2], lt_[r2]));
 
     return std::exp((beta_[r1] - beta_[r2]) * (lf2 - lf1));
   }
@@ -219,10 +216,8 @@ class MetropolisHamiltonianPt : public AbstractSampler {
 
   void SetVisible(const Eigen::VectorXd &v) override { v_[0] = v; }
 
-  AbstractMachine &GetMachine() noexcept override { return psi_; }
-
   AbstractMachine::VectorType DerLogVisible() override {
-    return psi_.DerLog(v_[0], lt_[0]);
+    return GetMachine().DerLog(v_[0], lt_[0]);
   }
 
   Eigen::VectorXd Acceptance() const override {

--- a/Sources/Sampler/metropolis_hop.hpp
+++ b/Sources/Sampler/metropolis_hop.hpp
@@ -27,8 +27,6 @@ namespace netket {
 class MetropolisHop : public AbstractSampler {
   AbstractMachine &psi_;
 
-  const AbstractHilbert &hilbert_;
-
   // number of visible units
   const int nv_;
 
@@ -52,8 +50,8 @@ class MetropolisHop : public AbstractSampler {
 
  public:
   MetropolisHop(AbstractMachine &psi, int dmax = 1)
-      : psi_(psi), hilbert_(psi.GetHilbert()), nv_(hilbert_.Size()) {
-    Init(hilbert_.GetGraph(), dmax);
+      : AbstractSampler(psi.GetHilbert()), psi_(psi), nv_(hilbert_->Size()) {
+    Init(hilbert_->GetGraph(), dmax);
   }
 
   void Init(const AbstractGraph &graph, int dmax) {
@@ -65,8 +63,8 @@ class MetropolisHop : public AbstractSampler {
     accept_.resize(1);
     moves_.resize(1);
 
-    nstates_ = hilbert_.LocalSize();
-    localstates_ = hilbert_.LocalStates();
+    nstates_ = hilbert_->LocalSize();
+    localstates_ = hilbert_->LocalStates();
 
     GenerateClusters(graph, dmax);
 
@@ -95,7 +93,7 @@ class MetropolisHop : public AbstractSampler {
 
   void Reset(bool initrandom = false) override {
     if (initrandom) {
-      hilbert_.RandomVals(v_, this->GetRandomEngine());
+      hilbert_->RandomVals(v_, this->GetRandomEngine());
     }
 
     psi_.InitLookup(v_, lt_);
@@ -156,7 +154,7 @@ class MetropolisHop : public AbstractSampler {
       if (ratio > distu(this->GetRandomEngine())) {
         accept_[0] += 1;
         psi_.UpdateLookup(v_, tochange, newconf, lt_);
-        hilbert_.UpdateConf(v_, tochange, newconf);
+        hilbert_->UpdateConf(v_, tochange, newconf);
 
 #ifndef NDEBUG
         const auto psival2 = psi_.LogVal(v_);
@@ -178,10 +176,6 @@ class MetropolisHop : public AbstractSampler {
   void SetVisible(const Eigen::VectorXd &v) override { v_ = v; }
 
   AbstractMachine &GetMachine() noexcept override { return psi_; }
-
-  const AbstractHilbert &GetHilbert() const noexcept override {
-    return hilbert_;
-  }
 
   AbstractMachine::VectorType DerLogVisible() override {
     return psi_.DerLog(v_, lt_);

--- a/Sources/Sampler/metropolis_hop.hpp
+++ b/Sources/Sampler/metropolis_hop.hpp
@@ -25,8 +25,6 @@ namespace netket {
 
 // Metropolis sampling generating local hoppings
 class MetropolisHop : public AbstractSampler {
-  AbstractMachine &psi_;
-
   // number of visible units
   const int nv_;
 
@@ -50,8 +48,8 @@ class MetropolisHop : public AbstractSampler {
 
  public:
   MetropolisHop(AbstractMachine &psi, int dmax = 1)
-      : AbstractSampler(psi.GetHilbert()), psi_(psi), nv_(hilbert_->Size()) {
-    Init(hilbert_->GetGraph(), dmax);
+      : AbstractSampler(psi), nv_(GetHilbert().Size()) {
+    Init(GetHilbert().GetGraph(), dmax);
   }
 
   void Init(const AbstractGraph &graph, int dmax) {
@@ -63,8 +61,8 @@ class MetropolisHop : public AbstractSampler {
     accept_.resize(1);
     moves_.resize(1);
 
-    nstates_ = hilbert_->LocalSize();
-    localstates_ = hilbert_->LocalStates();
+    nstates_ = GetHilbert().LocalSize();
+    localstates_ = GetHilbert().LocalStates();
 
     GenerateClusters(graph, dmax);
 
@@ -93,10 +91,10 @@ class MetropolisHop : public AbstractSampler {
 
   void Reset(bool initrandom = false) override {
     if (initrandom) {
-      hilbert_->RandomVals(v_, this->GetRandomEngine());
+      GetHilbert().RandomVals(v_, this->GetRandomEngine());
     }
 
-    psi_.InitLookup(v_, lt_);
+    GetMachine().InitLookup(v_, lt_);
 
     accept_ = Eigen::VectorXd::Zero(1);
     moves_ = Eigen::VectorXd::Zero(1);
@@ -138,31 +136,31 @@ class MetropolisHop : public AbstractSampler {
         }
       }
 
-      const auto lvd = psi_.LogValDiff(v_, tochange, newconf, lt_);
+      const auto lvd = GetMachine().LogValDiff(v_, tochange, newconf, lt_);
       double ratio = this->GetMachineFunc()(std::exp(lvd));
 
 #ifndef NDEBUG
-      const auto psival1 = psi_.LogVal(v_);
-      if (std::abs(std::exp(psi_.LogVal(v_) - psi_.LogVal(v_, lt_)) - 1.) >
+      const auto psival1 = GetMachine().LogVal(v_);
+      if (std::abs(std::exp(GetMachine().LogVal(v_) - GetMachine().LogVal(v_, lt_)) - 1.) >
           1.0e-8) {
-        std::cerr << psi_.LogVal(v_) << "  and LogVal with Lt is "
-                  << psi_.LogVal(v_, lt_) << std::endl;
+        std::cerr << GetMachine().LogVal(v_) << "  and LogVal with Lt is "
+                  << GetMachine().LogVal(v_, lt_) << std::endl;
         std::abort();
       }
 #endif
 
       if (ratio > distu(this->GetRandomEngine())) {
         accept_[0] += 1;
-        psi_.UpdateLookup(v_, tochange, newconf, lt_);
-        hilbert_->UpdateConf(v_, tochange, newconf);
+        GetMachine().UpdateLookup(v_, tochange, newconf, lt_);
+        GetHilbert().UpdateConf(v_, tochange, newconf);
 
 #ifndef NDEBUG
-        const auto psival2 = psi_.LogVal(v_);
+        const auto psival2 = GetMachine().LogVal(v_);
         if (std::abs(std::exp(psival2 - psival1 - lvd) - 1.) > 1.0e-8) {
           std::cerr << psival2 - psival1 << " and logvaldiff is " << lvd
                     << std::endl;
           std::cerr << psival2 << " and LogVal with Lt is "
-                    << psi_.LogVal(v_, lt_) << std::endl;
+                    << GetMachine().LogVal(v_, lt_) << std::endl;
           std::abort();
         }
 #endif
@@ -175,10 +173,8 @@ class MetropolisHop : public AbstractSampler {
 
   void SetVisible(const Eigen::VectorXd &v) override { v_ = v; }
 
-  AbstractMachine &GetMachine() noexcept override { return psi_; }
-
   AbstractMachine::VectorType DerLogVisible() override {
-    return psi_.DerLog(v_, lt_);
+    return GetMachine().DerLog(v_, lt_);
   }
 
   Eigen::VectorXd Acceptance() const override {

--- a/Sources/Sampler/metropolis_local.hpp
+++ b/Sources/Sampler/metropolis_local.hpp
@@ -27,8 +27,6 @@ namespace netket {
 
 // Metropolis sampling generating local moves in hilbert space
 class MetropolisLocal : public AbstractSampler {
-  AbstractMachine& psi_;
-
   // number of visible units
   const int nv_;
 
@@ -49,7 +47,7 @@ class MetropolisLocal : public AbstractSampler {
 
  public:
   explicit MetropolisLocal(AbstractMachine& psi)
-      : AbstractSampler(psi.GetHilbert()), psi_(psi), nv_(hilbert_->Size()) {
+      : AbstractSampler(psi), nv_(GetHilbert().Size()) {
     Init();
   }
 
@@ -59,7 +57,7 @@ class MetropolisLocal : public AbstractSampler {
     MPI_Comm_size(MPI_COMM_WORLD, &totalnodes_);
     MPI_Comm_rank(MPI_COMM_WORLD, &mynode_);
 
-    if (!hilbert_->IsDiscrete()) {
+    if (!GetHilbert().IsDiscrete()) {
       throw InvalidInputError(
           "Local Metropolis sampler works only for discrete "
           "Hilbert spaces");
@@ -68,8 +66,8 @@ class MetropolisLocal : public AbstractSampler {
     accept_.resize(1);
     moves_.resize(1);
 
-    nstates_ = hilbert_->LocalSize();
-    localstates_ = hilbert_->LocalStates();
+    nstates_ = GetHilbert().LocalSize();
+    localstates_ = GetHilbert().LocalStates();
 
     Reset(true);
 
@@ -78,10 +76,10 @@ class MetropolisLocal : public AbstractSampler {
 
   void Reset(bool initrandom) override {
     if (initrandom) {
-      hilbert_->RandomVals(v_, this->GetRandomEngine());
+      GetHilbert().RandomVals(v_, this->GetRandomEngine());
     }
 
-    psi_.InitLookup(v_, lt_);
+    GetMachine().InitLookup(v_, lt_);
 
     accept_ = Eigen::VectorXd::Zero(1);
     moves_ = Eigen::VectorXd::Zero(1);
@@ -112,15 +110,15 @@ class MetropolisLocal : public AbstractSampler {
         newconf[0] = localstates_[newstate];
       }
 
-      const auto lvd = psi_.LogValDiff(v_, tochange, newconf, lt_);
+      const auto lvd = GetMachine().LogValDiff(v_, tochange, newconf, lt_);
       double ratio = this->GetMachineFunc()(std::exp(lvd));
 
 #ifndef NDEBUG
-      const auto psival1 = psi_.LogVal(v_);
-      if (std::abs(std::exp(psi_.LogVal(v_) - psi_.LogVal(v_, lt_)) - 1.) >
+      const auto psival1 = GetMachine().LogVal(v_);
+      if (std::abs(std::exp(GetMachine().LogVal(v_) - GetMachine().LogVal(v_, lt_)) - 1.) >
           1.0e-8) {
-        std::cerr << psi_.LogVal(v_) << "  and LogVal with Lt is "
-                  << psi_.LogVal(v_, lt_) << std::endl;
+        std::cerr << GetMachine().LogVal(v_) << "  and LogVal with Lt is "
+                  << GetMachine().LogVal(v_, lt_) << std::endl;
         std::abort();
       }
 #endif
@@ -128,16 +126,16 @@ class MetropolisLocal : public AbstractSampler {
       // Metropolis acceptance test
       if (ratio > distu(this->GetRandomEngine())) {
         accept_[0] += 1;
-        psi_.UpdateLookup(v_, tochange, newconf, lt_);
-        hilbert_->UpdateConf(v_, tochange, newconf);
+        GetMachine().UpdateLookup(v_, tochange, newconf, lt_);
+        GetHilbert().UpdateConf(v_, tochange, newconf);
 
 #ifndef NDEBUG
-        const auto psival2 = psi_.LogVal(v_);
+        const auto psival2 = GetMachine().LogVal(v_);
         if (std::abs(std::exp(psival2 - psival1 - lvd) - 1.) > 1.0e-8) {
           std::cerr << psival2 - psival1 << " and logvaldiff is " << lvd
                     << std::endl;
           std::cerr << psival2 << " and LogVal with Lt is "
-                    << psi_.LogVal(v_, lt_) << std::endl;
+                    << GetMachine().LogVal(v_, lt_) << std::endl;
           std::abort();
         }
 #endif
@@ -150,10 +148,8 @@ class MetropolisLocal : public AbstractSampler {
 
   void SetVisible(const Eigen::VectorXd& v) override { v_ = v; }
 
-  AbstractMachine& GetMachine() noexcept override { return psi_; }
-
   AbstractMachine::VectorType DerLogVisible() override {
-    return psi_.DerLog(v_, lt_);
+    return GetMachine().DerLog(v_, lt_);
   }
 
   Eigen::VectorXd Acceptance() const override {

--- a/Sources/Sampler/py_sampler.hpp
+++ b/Sources/Sampler/py_sampler.hpp
@@ -92,7 +92,8 @@ void AddSamplerModule(py::module &m) {
       .def_property_readonly("acceptance", &AbstractSampler::Acceptance, R"EOF(
         numpy.array: The measured acceptance rate for the sampling.
         In the case of rejection-free sampling this is always equal to 1.  )EOF")
-      .def_property_readonly("hilbert", &AbstractSampler::GetHilbert, R"EOF(
+      .def_property_readonly("hilbert", &AbstractSampler::GetHilbertShared,
+                             R"EOF(
         netket.hilbert: The Hilbert space used for the sampling.  )EOF")
       .def_property_readonly("machine", &AbstractSampler::GetMachine, R"EOF(
         netket.machine: The machine used for the sampling.  )EOF")

--- a/Sources/Unsupervised/quantum_state_reconstruction.hpp
+++ b/Sources/Unsupervised/quantum_state_reconstruction.hpp
@@ -39,7 +39,6 @@ class QuantumStateReconstruction {
 
   AbstractSampler &sampler_;
   AbstractMachine &psi_;
-  const AbstractHilbert &hilbert_;
   AbstractOptimizer &opt_;
   SR sr_;
   bool dosr_;
@@ -92,7 +91,6 @@ class QuantumStateReconstruction {
       bool use_cholesky = true)
       : sampler_(sampler),
         psi_(sampler_.GetMachine()),
-        hilbert_(psi_.GetHilbert()),
         opt_(opt),
         rotations_(rotations),
         trainingSamples_(trainingSamples),

--- a/Test/Machine/test_machine.py
+++ b/Test/Machine/test_machine.py
@@ -12,7 +12,6 @@ def merge_dicts(x, y):
 
 machines = {}
 
-
 # TESTS FOR SPIN HILBERT
 # Constructing a 1d lattice
 g = nk.graph.Hypercube(length=4, n_dim=1)

--- a/Test/Operator/test_operator.py
+++ b/Test/Operator/test_operator.py
@@ -130,3 +130,16 @@ def test_operator_is_hermitean():
                         foundinv = True
                         assert meli == np.conj(mel)
                 assert foundinv
+
+def test_no_segfault():
+    g = nk.graph.Hypercube(8, 1)
+    hi = nk.hilbert.Spin(g, 0.5)
+
+    lo = nk.operator.LocalOperator(hi, [[1,0],[0,1]], [0])
+    lo = lo.transpose()
+
+    hi = None
+
+    lo = lo * lo
+
+    assert True


### PR DESCRIPTION
This PR should contain all the necessary changes to consistently pass around the Hilbert space without copies using `shared_ptr`. Based on #207.