### PR TITLE
Refactoring CMakeLists.txt and .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
     - os: osx
       osx_image: xcode10.2
       language: generic
-      env: PYTHON=3.6.0 CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=clang++ -DNETKET_USE_OPENMP=OFF -DCMAKE_CXX_FLAGS=-O1"
+      env: PYTHON=3.6.0 CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=clang++ -DNETKET_USE_OPENMP=OFF -DCMAKE_CXX_FLAGS=-O2"
 
     # The oldest supported configurations
     - os: linux
@@ -49,7 +49,7 @@ matrix:
     - os: linux
       dist: xenial
       python: 3.5
-      env: CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang-6.0 -DCMAKE_CXX_COMPILER=clang++-6.0 -DCMAKE_CXX_FLAGS=-O1"
+      env: CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang-6.0 -DCMAKE_CXX_COMPILER=clang++-6.0 -DCMAKE_CXX_FLAGS=-O2"
       addons:
         apt:
           sources:
@@ -80,7 +80,7 @@ matrix:
     - os: linux
       dist: xenial
       python: 3.7
-      env: CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang-8 -DCMAKE_CXX_COMPILER=clang++-8 -DCMAKE_CXX_FLAGS=-std=c++17 -DCMAKE_CXX_FLAGS=-O1"
+      env: CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang-8 -DCMAKE_CXX_COMPILER=clang++-8 -DCMAKE_CXX_FLAGS=-std=c++17 -DCMAKE_CXX_FLAGS=-O2"
       addons:
         apt:
           sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,70 +6,73 @@ matrix:
     - os: osx
       osx_image: xcode9.4
       language: generic
-      env: PYTHON=2.7 CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=clang++"
+      env: PYTHON=2.7 CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_CXX_FLAGS=-O1"
 
     - os: osx
-      osx_image: xcode10.1
+      osx_image: xcode10.2
       language: generic
-      env: PYTHON=3.6.0 CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=clang++"
-
-    - os: osx
-      osx_image: xcode10.1
-      language: generic
-      env: PYTHON=3.6.0 CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=clang++"
+      env: PYTHON=3.6.0 CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=clang++ -DNETKET_USE_OPENMP=OFF -DCMAKE_CXX_FLAGS=-O1"
 
     # The oldest supported configurations
     - os: linux
-      dist: trusty
+      dist: xenial
       python: 2.7
-      env: CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=clang++-4.0 -DCMAKE_CXX_FLAGS=-stdlib=libc++"
+      env: CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang-4.0 -DCMAKE_CXX_COMPILER=clang++-4.0 -DCMAKE_CXX_FLAGS='-stdlib=libc++ -I/usr/include/libcxxabi -O1'"
       addons:
         apt:
           sources:
-            - 'ubuntu-toolchain-r-test'
-            - 'llvm-toolchain-trusty'
-            - 'llvm-toolchain-trusty-4.0'
+            - 'llvm-toolchain-4.0'
           packages:
+            - 'ninja-build'
             - 'clang-4.0'
             - 'libc++-dev'
+            - 'libc++abi-dev'
+            - 'libomp-dev'
             - 'libmpich-dev'
+            - 'libopenblas-dev'
 
     - os: linux
-      dist: trusty
+      dist: xenial
       python: 2.7
-      env: CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=g++-5"
+      env: CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc-5 -DCMAKE_CXX_COMPILER=g++-5 -DCMAKE_CXX_FLAGS=-O1"
       addons:
         apt:
           sources:
             - 'ubuntu-toolchain-r-test'
           packages:
+            - 'ninja-build'
             - 'g++-5'
             - 'libmpich-dev'
+            - 'libatlas-base-dev'
 
     # Not too old toolsets
     - os: linux
-      dist: trusty
-      python: 3.6
-      env: CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=clang++-6.0"
+      dist: xenial
+      python: 3.5
+      env: CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang-6.0 -DCMAKE_CXX_COMPILER=clang++-6.0 -DCMAKE_CXX_FLAGS=-O1"
       addons:
         apt:
           sources:
             - 'ubuntu-toolchain-r-test'
-            - 'llvm-toolchain-trusty-6.0'
+            - 'llvm-toolchain-6.0'
           packages:
+            - 'ninja-build'
             - 'g++-7'
             - 'clang-6.0'
+            - 'libomp-dev'
             - 'libmpich-dev'
+            - 'libopenblas-dev'
 
     - os: linux
       dist: xenial
       python: 3.6
-      env: CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=g++-7"
+      env: CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc-7 -DCMAKE_CXX_COMPILER=g++-7 -DNETKET_USE_BLAS=OFF -DNETKET_USE_LAPACK=OFF -DCMAKE_CXX_FLAGS=-O1"
       addons:
         apt:
           sources:
             - 'ubuntu-toolchain-r-test'
           packages:
+            - 'ninja-build'
             - 'g++-7'
             - 'libopenmpi-dev'
 
@@ -77,16 +80,33 @@ matrix:
     - os: linux
       dist: xenial
       python: 3.7
-      env: CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=clang++-7 -DCMAKE_CXX_FLAGS=-std=c++17"
+      env: CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang-8 -DCMAKE_CXX_COMPILER=clang++-8 -DCMAKE_CXX_FLAGS=-std=c++17 -DCMAKE_CXX_FLAGS=-O1"
       addons:
         apt:
           sources:
             - 'ubuntu-toolchain-r-test'
-            - 'llvm-toolchain-xenial-7'
+            - 'llvm-toolchain-xenial-8'
           packages:
-            - 'clang-7'
-            - 'g++-8'
+            - 'ninja-build'
+            - 'clang-8'
+            - 'g++-9'
+            - 'libomp-dev'
             - 'libmpich-dev'
+            - 'libopenblas-dev'
+
+    - os: linux
+      dist: xenial
+      python: 3.7
+      env: CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=gcc-9 -DCMAKE_CXX_COMPILER=g++-9 -DCMAKE_CXX_FLAGS=-O1"
+      addons:
+        apt:
+          sources:
+            - 'ubuntu-toolchain-r-test'
+          packages:
+            - 'ninja-build'
+            - 'g++-9'
+            - 'libopenmpi-dev'
+            - 'libopenblas-dev'
 
 before_install:
   - |
@@ -97,6 +117,8 @@ before_install:
        brew ls --versions cmake && brew upgrade cmake || brew install cmake
        brew ls --versions openmpi && brew upgrade openmpi || brew install openmpi
        brew ls --versions pyenv && brew upgrade pyenv || brew install pyenv
+       brew ls --versions openmpi && brew upgrade libomp || brew install libomp
+       brew ls --versions openmpi && brew upgrade ninja-build || brew install ninja
      fi
   - |
      # Force OS X to use the correct python version. This is only because
@@ -146,6 +168,8 @@ install:
   - python -m pip --version
   - python -m easy_install -U setuptools
   - python -m pip install numpy networkx pytest python-igraph mpi4py
+  - python -m pip install -U pytest
+  - python -m pip install pytest-xdist
   - python -m pytest --version
   - NETKET_CMAKE_FLAGS="$CMAKE_FLAGS" python -m pip install -v .
   - mkdir workdir && cd workdir
@@ -153,5 +177,5 @@ install:
 script:
   - python -c 'from mpi4py import MPI; print(MPI.get_vendor())'
   - python -c 'import netket; g = netket.graph.Hypercube(4, 1); h = netket.hilbert.Spin(g, 0.5); m = netket.machine.RbmSpin(h, 10)'
-  - python -m pytest --verbose ../Test/
+  - python -m pytest -n 2 --verbose ../Test/
   - python -m pytest --verbose --doctest-glob='*.md' ../Docs/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,26 +2,31 @@ cmake_minimum_required(VERSION 3.1)
 
 set(CMAKE_DISABLE_SOURCE_CHANGES ON)
 set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
-option(ENABLE_TESTS "Enable unit tests." OFF)
-option(NETKET_Sanitizer "Build test suite with Clang sanitizer" OFF)
 
-project(NetKet)
+project(NetKet LANGUAGES C CXX)
 
-add_library(netket_test INTERFACE)
-target_link_libraries(netket_test INTERFACE netket_lib Catch2)
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules/)
 
-set(NETKET_PYTHON_VERSION "" CACHE STRING "Python version to use for compiling modules")
-
-if(ENABLE_TESTS)
-   include(CTest) # adds option BUILD_TESTING (default ON)
-endif()
-
+include(CTest)
 include(ExternalProject)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules/)
+
+option(NETKET_BUILD_TESTING "Build unit tests." OFF)
+option(NETKET_USE_OPENMP "Use OpenMP for multithreading" ON)
+option(NETKET_USE_SANITIZER "Build test suite with Clang sanitizer" OFF)
+option(NETKET_USE_BLAS "Use system BLAS instead of Eigen's implementation" ON)
+option(NETKET_USE_LAPACK "Use system LAPACK instead of Eigen's implementation" ON)
+set(NETKET_PYTHON_VERSION "" CACHE STRING "Python version to use for compiling modules")
+
+if(NOT CMAKE_BUILD_TYPE)
+  message(STATUS "[NetKet] CMAKE_BUILD_TYPE not specified, setting it to "
+                 "Release. Use `-DCMAKE_BUILD_TYPE=...` to overwrite.")
+  set(CMAKE_BUILD_TYPE Release)
+endif()
+
 
 #
 # Dependencies
@@ -83,13 +88,13 @@ add_library(Eigen3 INTERFACE)
 target_include_directories(Eigen3 SYSTEM INTERFACE ${SOURCE_DIR})
 
 
-
 # IETL
 ################################################################################
 add_library(IETL INTERFACE)
 target_include_directories(IETL SYSTEM INTERFACE "${CMAKE_SOURCE_DIR}/External/ietl")
 
-# PYBIND11
+
+# pybind11
 ###############################################################################
 ExternalProject_Add(
     pybind11_project
@@ -113,13 +118,30 @@ target_link_libraries(pybind11 INTERFACE ${PYTHON_LIBRARIES})
 # Greatly reduces the code bloat
 target_compile_options(pybind11 INTERFACE "-fvisibility=hidden")
 
+
 # MPI
 ################################################################################
 find_package(MPI REQUIRED)
 
+
+# OpenMP
+################################################################################
+if(NETKET_USE_OPENMP)
+    find_package(OpenMP REQUIRED)
+    if(NOT TARGET OpenMP::OpenMP_CXX)
+        find_package(Threads REQUIRED)
+        add_library(OpenMP::OpenMP_CXX IMPORTED INTERFACE)
+        set_property(TARGET OpenMP::OpenMP_CXX
+                     PROPERTY INTERFACE_COMPILE_OPTIONS ${OpenMP_CXX_FLAGS})
+        # Only works if the same flag is passed to the linker; use CMake 3.9+ otherwise (Intel, AppleClang)
+        set_property(TARGET OpenMP::OpenMP_CXX
+                     PROPERTY INTERFACE_LINK_LIBRARIES ${OpenMP_CXX_FLAGS} Threads::Threads)
+    endif()
+endif()
+
 # Catch2
 ################################################################################
-if (BUILD_TESTING)
+if (BUILD_TESTING AND NETKET_BUILD_TESTING)
     if (NOT EXISTS "${CMAKE_BINARY_DIR}/External/Catch2/catch2/catch.hpp")
         file(DOWNLOAD
             "https://github.com/catchorg/Catch2/releases/download/v2.4.0/catch.hpp"
@@ -130,46 +152,6 @@ if (BUILD_TESTING)
         INTERFACE "${CMAKE_BINARY_DIR}/External/Catch2/catch2")
 endif()
 
-#
-################################################################################
-
-# option(NETKET_ENABLE_BENCHMARKS "Enable building benchmarks." ON)
-# option(BENCHMARK_ENABLE_TESTING "" OFF)
-# option(BENCHMARK_ENABLE_INSTALL "" OFF)
-# option(BENCHMARK_DOWNLOAD_DEPENDENCIES "" ON)
-# add_subdirectory(External/benchmark)
-
-if(NOT CMAKE_BUILD_TYPE)
-  message(STATUS "[NetKet] CMAKE_BUILD_TYPE not specified, setting it to "
-                 "Release. Use `-DCMAKE_BUILD_TYPE=...` to overwrite.")
-  set(CMAKE_BUILD_TYPE Release)
-endif()
-
-# Set -O3 in debug mode unless explicitly disabled
-if((${CMAKE_BUILD_TYPE} STREQUAL "Debug") AND NOT NETKET_DISABLE_OPTIMIZATION)
-    set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -O3")
-endif()
-
-if(MSVC)
-  # Force to always compile with W4
-  if(CMAKE_CXX_FLAGS MATCHES "/W[0-4]")
-    string(REGEX REPLACE "/W[0-4]" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-  else()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
-  endif()
-elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX  OR (CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
-  # Update if necessary
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-long-long -pedantic -Wextra -Wshadow")
-endif()
-
-
-if("Ninja" STREQUAL ${CMAKE_GENERATOR})
-    include(CheckCXXCompilerFlag)
-    CHECK_CXX_COMPILER_FLAG("-fdiagnostics-color" COMPILER_SUPPORTS_-fdiagnostics-color)
-    if (COMPILER_SUPPORTS_-fdiagnostics-color)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fdiagnostics-color")
-    endif()
-endif()
 
 #
 # NetKet
@@ -188,90 +170,96 @@ target_link_libraries(netket_lib
         IETL
         ${CMAKE_DL_LIBS}
 )
+if(NETKET_USE_OPENMP)
+    target_link_libraries(netket_lib INTERFACE OpenMP::OpenMP_CXX)
+endif()
 
-# Check if we should use native Lapack with Eigen
-option(USE_LAPACK "Enable Lapack Support." OFF)
-if(USE_LAPACK)
-    find_package(LAPACK REQUIRED)
-    add_definitions(-DEIGEN_USE_BLAS)
-    target_link_libraries(netket_lib INTERFACE ${LAPACK_LIBRARIES})
-    find_package(LAPACKE)
-    if(LAPACKE_FOUND)
-    add_definitions(-DEIGEN_USE_LAPACKE)
-    target_link_libraries(netket_lib INTERFACE ${LAPACKE_LIBRARIES})
+set(NETKET_WARNING_FLAGS
+    -Wall -Wextra -pedantic
+    -Wshadow
+)
+target_compile_options(netket_lib INTERFACE ${NEKET_WARNING_FLAGS})
+
+if(${CMAKE_GENERATOR} STREQUAL "Ninja")
+    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+        target_compile_options(netket_lib INTERFACE -fcolor-diagnostics)
+    elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+        target_compile_options(netket_lib INTERFACE -fdiagnostics-color=always)
     endif()
+endif()
 
+if(NETKET_USE_BLAS)
+    find_package(BLAS REQUIRED)
+    target_compile_definitions(netket_lib INTERFACE EIGEN_USE_BLAS=1)
+    target_link_libraries(netket_lib INTERFACE ${BLAS_LIBRARIES})
+endif()
+
+if(NEKET_USE_LAPACK)
+    find_package(LAPACK REQUIRED)
+    target_compile_definitions(netket_lib INTERFACE EIGEN_USE_LAPACK=1 EIGEN_USE_LAPACKE=1)
+    target_link_libraries(netket_lib INTERFACE ${LAPACK_LIBRARIES})
 endif()
 
 
-
-#target_link_libraries(netket PUBLIC netket_lib)
-# Yes, this is ugly, but until CMake 3.5, we can't add an external project
-# dependency to an interface library
-#add_dependencies(netket eigen_project)
-
-
-
-add_library(netket MODULE
+set(NETKET_SOURCES
+    Sources/pynetket.cc
     Sources/Dynamics/py_dynamics.cpp
-    Sources/Graph/abstract_graph.cc
-    Sources/Graph/custom_graph.cc
     Sources/Graph/hypercube.cc
     Sources/Graph/lattice.cc
+    Sources/Graph/custom_graph.cc
+    Sources/Graph/abstract_graph.cc
     Sources/Graph/py_graph.cc
-    Sources/Hilbert/bosons.cc
-    Sources/Hilbert/custom_hilbert.cc
     Sources/Hilbert/hilbert_index.cc
-    Sources/Hilbert/py_hilbert.cc
+    Sources/Hilbert/bosons.cc
     Sources/Hilbert/spins.cc
+    Sources/Hilbert/custom_hilbert.cc
+    Sources/Hilbert/py_hilbert.cc
     Sources/Machine/abstract_machine.cc
-    Sources/Machine/jastrow_symm.cc
     Sources/Machine/jastrow.cc
+    Sources/Machine/jastrow_symm.cc
     Sources/Machine/mps_periodic.cc
-    Sources/Machine/py_abstract_machine.cc
-    Sources/Machine/py_machine.cc
     Sources/Machine/rbm_multival.cc
+    Sources/Machine/rbm_spin.cc
     Sources/Machine/rbm_spin_phase.cc
     Sources/Machine/rbm_spin_real.cc
     Sources/Machine/rbm_spin_symm.cc
-    Sources/Machine/rbm_spin.cc
+    Sources/Machine/py_machine.cc
+    Sources/Machine/py_abstract_machine.cc
     Sources/Operator/abstract_operator.cc
     Sources/Sampler/vmc_sampling.cc
-    Sources/Utils/json_utils.cc
     Sources/Utils/mpi_interface.cc
+    Sources/Utils/json_utils.cc
     Sources/Utils/py_utils.cc
-    Sources/pynetket.cc
 )
+
+add_library(netket MODULE ${NETKET_SOURCES})
 target_link_libraries(netket PUBLIC netket_lib pybind11)
 set_target_properties(netket PROPERTIES PREFIX "${PYTHON_MODULE_PREFIX}"
                                         SUFFIX "${PYTHON_MODULE_EXTENSION}")
 add_dependencies(netket json_project eigen_project pybind11_project)
 set_target_properties(netket PROPERTIES OUTPUT_NAME "_C_netket")
 
-if(NETKET_Sanitizer)
-    message(STATUS "[NetKet] Building python library with address and UB sanitizers")
-    target_compile_options(netket_lib
-        INTERFACE
-            -g -fno-omit-frame-pointer
-            -fsanitize=address -fsanitize=undefined
-    )
-    target_link_libraries(netket_lib
-        INTERFACE
-            -fsanitize=address -fsanitize=undefined
-    )
-endif()
+
+# if(NETKET_SANITIZER)
+#     message(STATUS "[NetKet] Building python library with address and UB sanitizers")
+#     target_compile_options(netket_lib
+#         INTERFACE
+#             -g -fno-omit-frame-pointer
+#             -fsanitize=address -fsanitize=undefined
+#     )
+#     target_link_libraries(netket_lib
+#         INTERFACE
+#             -fsanitize=address -fsanitize=undefined
+#     )
+# endif()
 
 #
 # Testing
 #
 
-if(BUILD_TESTING)
-   enable_testing()
-   add_subdirectory(Test)
+if(BUILD_TESTING AND NETKET_BUILD_TESTING)
+    add_library(netket_test INTERFACE)
+    target_link_libraries(netket_test INTERFACE netket_lib Catch2)
+    enable_testing()
+    add_subdirectory(Test)
 endif()
-
-#
-# Installing
-#
-
-# install (TARGETS netket DESTINATION bin)


### PR DESCRIPTION
The important changes are:

  * builds on Travis CI are done on multiple cores now using Ninja;
  * tests on Travis CI also run in parallel;
  * system BLAS and LAPACK are used by default with Eigen (fixes #113);
  * OpenMP is enabled by default meaning Eigen computations can now run on multiple cores;
  * `-O3` flag is not used anymore in  Debug builds; Travis config mostly uses `-O1` now;
  * Ubuntu 14.04 is now in ESM so we switch to 16.04 for tests;