### PR TITLE
Changes to exact time propagation (and some minor improvements)

### DIFF
--- a/Docs/exact/ExactTimePropagation.md
+++ b/Docs/exact/ExactTimePropagation.md
@@ -25,7 +25,7 @@ Solving 1D Ising model with imaginary time propagation:
 >>> hilbert = nk.hilbert.Spin(graph, 0.5)
 >>> n_states = hilbert.n_states
 >>> hamiltonian = nk.operator.Ising(hilbert, h=1.0)
->>> stepper = nk.dynamics.create_timestepper(n_states, rel_tol=1e-10, abs_tol=1e-10)
+>>> stepper = nk.dynamics.timestepper(n_states, rel_tol=1e-10, abs_tol=1e-10)
 >>> output = nk.output.JsonOutputWriter('test.log', 'test.wf')
 >>> psi0 = np.random.rand(n_states)
 >>> driver = nk.exact.ExactTimePropagation(hamiltonian, stepper, t0=0,

--- a/Docs/exact/ExactTimePropagation.md
+++ b/Docs/exact/ExactTimePropagation.md
@@ -1,20 +1,21 @@
-# ImagTimePropagation
+# ExactTimePropagation
 Solving for the ground state of the wavefunction using imaginary time propagation.
 
 ## Class Constructor
-Constructs an ``ImagTimePropagation`` object from a hamiltonian, a stepper,
+Constructs an ``ExactTimePropagation`` object from a hamiltonian, a stepper,
 a time, and an initial state.
 
-|  Argument   |                    Type                     |                                                                   Description                                                                    |
-|-------------|---------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
-|hamiltonian  |netket::AbstractOperator                     |The hamiltonian of the system.                                                                                                                    |
-|stepper      |netket._C_netket.dynamics.AbstractTimeStepper|Stepper (i.e. propagator) that transforms the state of the system from one timestep to the next.                                                  |
-|t0           |float                                        |The initial time.                                                                                                                                 |
-|initial_state|numpy.ndarray[complex128[m, 1]]              |The initial state of the system (when propagation begins.)                                                                                        |
-|matrix_type  |str='sparse'                                 |The type of matrix used for the Hamiltonian when creating the matrix wrapper. The default is `sparse`. The other choices are `dense` and `direct`.|
+|    Argument    |                    Type                     |                                                                   Description                                                                    |
+|----------------|---------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
+|hamiltonian     |netket::AbstractOperator                     |The hamiltonian of the system.                                                                                                                    |
+|stepper         |netket._C_netket.dynamics.AbstractTimeStepper|Stepper (i.e. propagator) that transforms the state of the system from one timestep to the next.                                                  |
+|t0              |float                                        |The initial time.                                                                                                                                 |
+|initial_state   |numpy.ndarray[complex128[m, 1]]              |The initial state of the system (when propagation begins.)                                                                                        |
+|matrix_type     |str='sparse'                                 |The type of matrix used for the Hamiltonian when creating the matrix wrapper. The default is `sparse`. The other choices are `dense` and `direct`.|
+|propagation_type|str='exact'                                  |Specifies whether the imaginary or real-time Schroedinger equation is solved. Should be one of "real" or "imaginary".                             |
 
 ### Examples
-Solving 1D ising model with imagniary time propagation.
+Solving 1D Ising model with imaginary time propagation:
 
 ```python
 >>> import netket as nk
@@ -27,7 +28,9 @@ Solving 1D ising model with imagniary time propagation.
 >>> stepper = nk.dynamics.create_timestepper(n_states, rel_tol=1e-10, abs_tol=1e-10)
 >>> output = nk.output.JsonOutputWriter('test.log', 'test.wf')
 >>> psi0 = np.random.rand(n_states)
->>> driver = nk.exact.ImagTimePropagation(hamiltonian, stepper, t0=0, initial_state=psi0)
+>>> driver = nk.exact.ExactTimePropagation(hamiltonian, stepper, t0=0,
+...                                        initial_state=psi0,
+...                                        propagation_type="imaginary")
 >>> driver.add_observable(hamiltonian, 'Hamiltonian')
 >>> for step in driver.iter(dt=0.05, n_iter=10):
 ...     obs = driver.get_observable_stats()

--- a/Docs/exact/ImagTimePropagation.md
+++ b/Docs/exact/ImagTimePropagation.md
@@ -19,7 +19,7 @@ Solving 1D ising model with imagniary time propagation.
 ```python
 >>> import netket as nk
 >>> import numpy as np
->>> L = 20
+>>> L = 10
 >>> graph = nk.graph.Hypercube(L, n_dim=1, pbc=True)
 >>> hilbert = nk.hilbert.Spin(graph, 0.5)
 >>> n_states = hilbert.n_states
@@ -29,7 +29,7 @@ Solving 1D ising model with imagniary time propagation.
 >>> psi0 = np.random.rand(n_states)
 >>> driver = nk.exact.ImagTimePropagation(hamiltonian, stepper, t0=0, initial_state=psi0)
 >>> driver.add_observable(hamiltonian, 'Hamiltonian')
->>> for step in driver.iter(dt=0.05, n_iter=2):
+>>> for step in driver.iter(dt=0.05, n_iter=10):
 ...     obs = driver.get_observable_stats()
 
 ```

--- a/Docs/hilbert/Boson.md
+++ b/Docs/hilbert/Boson.md
@@ -99,8 +99,8 @@ where the local changes have been done.
 |Argument |                    Type                     |                       Description                        |
 |---------|---------------------------------------------|----------------------------------------------------------|
 |v        |numpy.ndarray[float64[m, 1], flags.writeable]|The vector of visible units to be modified.               |
-|to_change|List[int]                                    |A list of which qunatum numbers will be modified.         |
-|new_conf |List[float]                                  |Contains the value that those quantum numbers should take.|
+|to_change|numpy.ndarray[int32]                         |A list of which qunatum numbers will be modified.         |
+|new_conf |numpy.ndarray[float64]                       |Contains the value that those quantum numbers should take.|
 
 ## Properties
 

--- a/Docs/hilbert/Boson.md
+++ b/Docs/hilbert/Boson.md
@@ -99,7 +99,7 @@ where the local changes have been done.
 |Argument |                    Type                     |                       Description                        |
 |---------|---------------------------------------------|----------------------------------------------------------|
 |v        |numpy.ndarray[float64[m, 1], flags.writeable]|The vector of visible units to be modified.               |
-|to_change|numpy.ndarray[int32]                         |A list of which qunatum numbers will be modified.         |
+|to_change|numpy.ndarray[int32]                         |A list of which quantum numbers will be modified.         |
 |new_conf |numpy.ndarray[float64]                       |Contains the value that those quantum numbers should take.|
 
 ## Properties

--- a/Docs/hilbert/CustomHilbert.md
+++ b/Docs/hilbert/CustomHilbert.md
@@ -76,8 +76,8 @@ where the local changes have been done.
 |Argument |                    Type                     |                       Description                        |
 |---------|---------------------------------------------|----------------------------------------------------------|
 |v        |numpy.ndarray[float64[m, 1], flags.writeable]|The vector of visible units to be modified.               |
-|to_change|List[int]                                    |A list of which qunatum numbers will be modified.         |
-|new_conf |List[float]                                  |Contains the value that those quantum numbers should take.|
+|to_change|numpy.ndarray[int32]                         |A list of which qunatum numbers will be modified.         |
+|new_conf |numpy.ndarray[float64]                       |Contains the value that those quantum numbers should take.|
 
 ## Properties
 

--- a/Docs/hilbert/CustomHilbert.md
+++ b/Docs/hilbert/CustomHilbert.md
@@ -76,7 +76,7 @@ where the local changes have been done.
 |Argument |                    Type                     |                       Description                        |
 |---------|---------------------------------------------|----------------------------------------------------------|
 |v        |numpy.ndarray[float64[m, 1], flags.writeable]|The vector of visible units to be modified.               |
-|to_change|numpy.ndarray[int32]                         |A list of which qunatum numbers will be modified.         |
+|to_change|numpy.ndarray[int32]                         |A list of which quantum numbers will be modified.         |
 |new_conf |numpy.ndarray[float64]                       |Contains the value that those quantum numbers should take.|
 
 ## Properties

--- a/Docs/hilbert/Spin.md
+++ b/Docs/hilbert/Spin.md
@@ -98,7 +98,7 @@ where the local changes have been done.
 |Argument |                    Type                     |                       Description                        |
 |---------|---------------------------------------------|----------------------------------------------------------|
 |v        |numpy.ndarray[float64[m, 1], flags.writeable]|The vector of visible units to be modified.               |
-|to_change|numpy.ndarray[int32]                         |A list of which qunatum numbers will be modified.         |
+|to_change|numpy.ndarray[int32]                         |A list of which quantum numbers will be modified.         |
 |new_conf |numpy.ndarray[float64]                       |Contains the value that those quantum numbers should take.|
 
 ## Properties

--- a/Docs/hilbert/Spin.md
+++ b/Docs/hilbert/Spin.md
@@ -98,8 +98,8 @@ where the local changes have been done.
 |Argument |                    Type                     |                       Description                        |
 |---------|---------------------------------------------|----------------------------------------------------------|
 |v        |numpy.ndarray[float64[m, 1], flags.writeable]|The vector of visible units to be modified.               |
-|to_change|List[int]                                    |A list of which qunatum numbers will be modified.         |
-|new_conf |List[float]                                  |Contains the value that those quantum numbers should take.|
+|to_change|numpy.ndarray[int32]                         |A list of which qunatum numbers will be modified.         |
+|new_conf |numpy.ndarray[float64]                       |Contains the value that those quantum numbers should take.|
 
 ## Properties
 

--- a/Examples/ImaginaryTime/ising1d_imag.py
+++ b/Examples/ImaginaryTime/ising1d_imag.py
@@ -52,7 +52,9 @@ import numpy as np
 psi0 = np.random.rand(n_states)
 
 # create ground state driver
-driver = nk.exact.ImagTimePropagation(hamiltonian, stepper, t0=0, initial_state=psi0)
+driver = nk.exact.ExactTimePropagation(
+    hamiltonian, stepper, t0=0, initial_state=psi0, propagation_type="imaginary"
+)
 
 # add observable (TODO: more interesting observable)
 driver.add_observable(hamiltonian, "Hamiltonian")

--- a/Examples/ImaginaryTime/ising1d_imag.py
+++ b/Examples/ImaginaryTime/ising1d_imag.py
@@ -40,7 +40,7 @@ n_states = hilbert.n_states
 hamiltonian = nk.operator.Ising(hilbert, h=1.0)
 
 # create time stepper
-stepper = nk.dynamics.create_timestepper(n_states, rel_tol=1e-10, abs_tol=1e-10)
+stepper = nk.dynamics.timestepper(n_states, rel_tol=1e-10, abs_tol=1e-10)
 
 # prepare output
 output = nk.output.JsonOutputWriter("test.log", "test.wf")

--- a/Sources/Dynamics/py_dynamics.cpp
+++ b/Sources/Dynamics/py_dynamics.cpp
@@ -62,7 +62,7 @@ void AddDynamicsModule(py::module m) {
 
   py::class_<ode::AbstractTimeStepper<State>>(subm, "AbstractTimeStepper");
 
-  subm.def("create_timestepper", &ode::CreateStepper<State>, py::arg("dim"),
+  subm.def("timestepper", &ode::CreateStepper<State>, py::arg("dim"),
            py::arg("name") = "Dopri54");
 }
 

--- a/Sources/GroundState/ground_state.hpp
+++ b/Sources/GroundState/ground_state.hpp
@@ -15,7 +15,6 @@
 #ifndef NETKET_GROUND_STATE_HPP
 #define NETKET_GROUND_STATE_HPP
 
-#include "imaginary_time.hpp"
 #include "variational_montecarlo.hpp"
 
 #endif

--- a/Sources/GroundState/py_exact.hpp
+++ b/Sources/GroundState/py_exact.hpp
@@ -71,7 +71,7 @@ void AddExactModule(py::module &m) {
                >>> hilbert = nk.hilbert.Spin(graph, 0.5)
                >>> n_states = hilbert.n_states
                >>> hamiltonian = nk.operator.Ising(hilbert, h=1.0)
-               >>> stepper = nk.dynamics.create_timestepper(n_states, rel_tol=1e-10, abs_tol=1e-10)
+               >>> stepper = nk.dynamics.timestepper(n_states, rel_tol=1e-10, abs_tol=1e-10)
                >>> output = nk.output.JsonOutputWriter('test.log', 'test.wf')
                >>> psi0 = np.random.rand(n_states)
                >>> driver = nk.exact.ExactTimePropagation(hamiltonian, stepper, t0=0,

--- a/Sources/GroundState/py_exact.hpp
+++ b/Sources/GroundState/py_exact.hpp
@@ -39,7 +39,7 @@ void AddExactModule(py::module &m) {
       .def(py::init<const AbstractOperator &, ExactTimePropagation::Stepper &,
                     double, ExactTimePropagation::StateVector,
                     const std::string &, const std::string &>(),
-           py::keep_alive<1, 2>(), py::arg("hamiltonian"), py::arg("stepper"),
+           py::keep_alive<1, 2>(), py::keep_alive<1, 3>(), py::arg("hamiltonian"), py::arg("stepper"),
            py::arg("t0"), py::arg("initial_state"),
            py::arg("matrix_type") = "sparse",
            py::arg("propagation_type") = "real", R"EOF(

--- a/Sources/GroundState/py_exact.hpp
+++ b/Sources/GroundState/py_exact.hpp
@@ -106,13 +106,11 @@ void AddExactModule(py::module &m) {
       .def_property("t", &ExactTimePropagation::GetTime,
                     &ExactTimePropagation::SetTime,
                     R"EOF(double: Time in the simulation.)EOF")
+      .def_property("state", &ExactTimePropagation::GetState,
+                   &ExactTimePropagation::SetState,
+                   "Current state.")
       .def(
-          "get_observable_stats",
-          [](const ExactTimePropagation &self) {
-            py::dict data;
-            self.GetObsManager().InsertAllStats(data);
-            return data;
-          },
+          "get_observable_stats", &ExactTimePropagation::GetObservableStats,
           R"EOF(
         Calculate and return the value of the operators stored as observables.
 

--- a/Sources/GroundState/py_exact.hpp
+++ b/Sources/GroundState/py_exact.hpp
@@ -57,7 +57,7 @@ void AddExactModule(py::module &m) {
                    other choices are `dense` and `direct`.
 
            Examples:
-               Solving 1D ising model with imagniary time propagation.
+               Solving 1D ising model with imaginary time propagation.
 
                ```python
                >>> import netket as nk

--- a/Sources/Hilbert/abstract_hilbert.hpp
+++ b/Sources/Hilbert/abstract_hilbert.hpp
@@ -101,8 +101,8 @@ class AbstractHilbert {
   @param newconf contains the value that those quantum numbers should take
   */
   virtual void UpdateConf(Eigen::Ref<Eigen::VectorXd> v,
-                          const std::vector<int> &tochange,
-                          const std::vector<double> &newconf) const = 0;
+                          nonstd::span<const int> tochange,
+                          nonstd::span<const double> newconf) const = 0;
 
   virtual const AbstractGraph &GetGraph() const noexcept = 0;
 

--- a/Sources/Hilbert/bosons.cc
+++ b/Sources/Hilbert/bosons.cc
@@ -98,8 +98,8 @@ bool Boson::CheckConstraint(Eigen::Ref<const Eigen::VectorXd> v) const {
 }
 
 void Boson::UpdateConf(Eigen::Ref<Eigen::VectorXd> v,
-                       const std::vector<int> &tochange,
-                       const std::vector<double> &newconf) const {
+                       nonstd::span<const int> tochange,
+                       nonstd::span<const double> newconf) const {
   assert(v.size() == nsites_);
 
   int i = 0;

--- a/Sources/Hilbert/bosons.hpp
+++ b/Sources/Hilbert/bosons.hpp
@@ -44,8 +44,8 @@ class Boson : public AbstractHilbert {
                   netket::default_random_engine &rgen) const override;
 
   void UpdateConf(Eigen::Ref<Eigen::VectorXd> v,
-                  const std::vector<int> &tochange,
-                  const std::vector<double> &newconf) const override;
+                  nonstd::span<const int> tochange,
+                  nonstd::span<const double> newconf) const override;
 
  private:
   void Init();

--- a/Sources/Hilbert/custom_hilbert.cc
+++ b/Sources/Hilbert/custom_hilbert.cc
@@ -44,8 +44,8 @@ void CustomHilbert::RandomVals(Eigen::Ref<Eigen::VectorXd> state,
 }
 
 void CustomHilbert::UpdateConf(Eigen::Ref<Eigen::VectorXd> v,
-                               const std::vector<int> &tochange,
-                               const std::vector<double> &newconf) const {
+                               nonstd::span<const int> tochange,
+                               nonstd::span<const double> newconf) const {
   assert(v.size() == size_);
 
   int i = 0;

--- a/Sources/Hilbert/custom_hilbert.hpp
+++ b/Sources/Hilbert/custom_hilbert.hpp
@@ -46,8 +46,8 @@ class CustomHilbert : public AbstractHilbert {
                   netket::default_random_engine &rgen) const override;
 
   void UpdateConf(Eigen::Ref<Eigen::VectorXd> v,
-                  const std::vector<int> &tochange,
-                  const std::vector<double> &newconf) const override;
+                  nonstd::span<const int> tochange,
+                  nonstd::span<const double> newconf) const override;
 };
 
 }  // namespace netket

--- a/Sources/Hilbert/py_hilbert.cc
+++ b/Sources/Hilbert/py_hilbert.cc
@@ -241,7 +241,7 @@ void AddHilbertModule(py::module m) {
 
       Args:
           v: The vector of visible units to be modified.
-          to_change: A list of which qunatum numbers will be modified.
+          to_change: A list of which quantum numbers will be modified.
           new_conf: Contains the value that those quantum numbers should take.
       )EOF");
 

--- a/Sources/Hilbert/spins.cc
+++ b/Sources/Hilbert/spins.cc
@@ -131,8 +131,8 @@ void Spin::RandomVals(Eigen::Ref<Eigen::VectorXd> state,
 }
 
 void Spin::UpdateConf(Eigen::Ref<Eigen::VectorXd> v,
-                      const std::vector<int> &tochange,
-                      const std::vector<double> &newconf) const {
+                      nonstd::span<const int> tochange,
+                      nonstd::span<const double> newconf) const {
   assert(v.size() == nspins_);
 
   int i = 0;

--- a/Sources/Hilbert/spins.hpp
+++ b/Sources/Hilbert/spins.hpp
@@ -44,8 +44,8 @@ class Spin : public AbstractHilbert {
                   netket::default_random_engine &rgen) const override;
 
   void UpdateConf(Eigen::Ref<Eigen::VectorXd> v,
-                  const std::vector<int> &tochange,
-                  const std::vector<double> &newconf) const override;
+                  nonstd::span<const int> tochange,
+                  nonstd::span<const double> newconf) const override;
 
  private:
   void Init();

--- a/Sources/Machine/py_machine.cc
+++ b/Sources/Machine/py_machine.cc
@@ -642,7 +642,7 @@ void AddAbstractMachine(py::module m) {
            )EOF")
       .def(
           "to_array",
-          [](AbstractMachine &self) -> AbstractMachine::VectorType {
+          [](AbstractMachine &self, bool normalize) -> AbstractMachine::VectorType {
             const auto &hind = self.GetHilbert().GetIndex();
             AbstractMachine::VectorType vals(hind.NStates());
 
@@ -660,9 +660,11 @@ void AddAbstractMachine(py::module m) {
               vals(i) = std::exp(vals(i));
             }
 
-            vals /= vals.norm();
+            if (normalize) {
+                vals.normalize();
+            }
             return vals;
-          },
+          }, py::arg("normalize") = true,
           R"EOF(
                 Returns a numpy array representation of the machine.
                 The returned array is normalized to 1 in L2 norm.

--- a/Test/Dynamics/test_dynamics.py
+++ b/Test/Dynamics/test_dynamics.py
@@ -1,0 +1,76 @@
+import numpy as np
+from pytest import approx
+from scipy.integrate import solve_ivp
+from scipy.linalg import norm
+
+import netket as nk
+from netket.dynamics import create_timestepper
+from netket.exact import ExactTimePropagation
+
+
+ATOL = 1e-9
+RTOL = 1e-9
+TIME = 20.0
+
+
+def _setup_model():
+    g = nk.graph.Hypercube(8, 1)
+    hi = nk.hilbert.Spin(g, 0.5)
+    ham = nk.operator.Heisenberg(hi)
+
+    ts = create_timestepper(hi.n_states, abs_tol=ATOL, rel_tol=RTOL)
+    psi0 = np.random.rand(hi.n_states) + 1j * np.random.rand(hi.n_states)
+    psi0 /= norm(psi0)
+
+    return hi, ham, ts, psi0
+
+
+def overlap(phi, psi):
+    return np.abs(np.vdot(phi, psi)) ** 2 / (np.vdot(phi, phi) * np.vdot(psi, psi)).real
+
+
+def test_real_time_evolution():
+    hi, ham, ts, psi0 = _setup_model()
+    ham_matrix = ham.to_dense()
+
+    driver = ExactTimePropagation(
+        ham, ts, t0=0.0, initial_state=psi0, propagation_type="real"
+    )
+
+    assert overlap(driver.state, psi0) == approx(1.0)
+
+    driver.advance(TIME)
+    assert driver.t == TIME
+
+    def rhs_real(t, x):
+        return -1.0j * ham_matrix @ x
+
+    res = solve_ivp(rhs_real, (0.0, TIME), psi0, atol=ATOL, rtol=RTOL)
+    psi_scipy = res.y[:, -1]
+
+    assert driver.t == approx(res.t[-1])
+    assert overlap(driver.state, psi_scipy) == approx(1.0)
+
+
+def test_imag_time_evolution():
+    hi, ham, ts, psi0 = _setup_model()
+    ham_matrix = ham.to_dense()
+
+    driver = ExactTimePropagation(
+        ham, ts, t0=0.0, initial_state=psi0, propagation_type="imaginary"
+    )
+
+    assert overlap(driver.state, psi0) == approx(1.0)
+
+    driver.advance(TIME)
+    assert driver.t == TIME
+
+    def rhs_imag(t, x):
+        mean = np.vdot(x, ham_matrix.dot(x))
+        return -ham_matrix.dot(x) + mean * x
+
+    res = solve_ivp(rhs_imag, (0.0, TIME), psi0, atol=ATOL, rtol=RTOL)
+    psi_scipy = res.y[:, -1]
+
+    assert driver.t == approx(res.t[-1])
+    assert overlap(driver.state, psi_scipy) == approx(1.0)

--- a/Test/Dynamics/test_dynamics.py
+++ b/Test/Dynamics/test_dynamics.py
@@ -31,7 +31,7 @@ def overlap(phi, psi):
 
 def test_real_time_evolution():
     hi, ham, ts, psi0 = _setup_model()
-    ham_matrix = ham.to_dense()
+    ham_matrix = ham.to_sparse()
 
     driver = ExactTimePropagation(
         ham, ts, t0=0.0, initial_state=psi0, propagation_type="real"
@@ -43,7 +43,7 @@ def test_real_time_evolution():
     assert driver.t == TIME
 
     def rhs_real(t, x):
-        return -1.0j * ham_matrix @ x
+        return -1.0j * ham_matrix.dot(x)
 
     res = solve_ivp(rhs_real, (0.0, TIME), psi0, atol=ATOL, rtol=RTOL)
     psi_scipy = res.y[:, -1]
@@ -54,7 +54,7 @@ def test_real_time_evolution():
 
 def test_imag_time_evolution():
     hi, ham, ts, psi0 = _setup_model()
-    ham_matrix = ham.to_dense()
+    ham_matrix = ham.to_sparse()
 
     driver = ExactTimePropagation(
         ham, ts, t0=0.0, initial_state=psi0, propagation_type="imaginary"

--- a/Test/Dynamics/test_dynamics.py
+++ b/Test/Dynamics/test_dynamics.py
@@ -4,7 +4,7 @@ from scipy.integrate import solve_ivp
 from scipy.linalg import norm
 
 import netket as nk
-from netket.dynamics import create_timestepper
+from netket.dynamics import timestepper
 from netket.exact import ExactTimePropagation
 
 
@@ -18,7 +18,7 @@ def _setup_model():
     hi = nk.hilbert.Spin(g, 0.5)
     ham = nk.operator.Heisenberg(hi)
 
-    ts = create_timestepper(hi.n_states, abs_tol=ATOL, rel_tol=RTOL)
+    ts = timestepper(hi.n_states, abs_tol=ATOL, rel_tol=RTOL)
     psi0 = np.random.rand(hi.n_states) + 1j * np.random.rand(hi.n_states)
     psi0 /= norm(psi0)
 

--- a/Test/GroundState/test_groundstate.py
+++ b/Test/GroundState/test_groundstate.py
@@ -99,7 +99,7 @@ def test_imag_time_propagation():
     hi = nk.hilbert.Spin(s=0.5, graph=g)
     ha = nk.operator.Ising(h=0.0, hilbert=hi)
 
-    stepper = nk.dynamics.create_timestepper(hi.n_states, rel_tol=1e-10, abs_tol=1e-10)
+    stepper = nk.dynamics.timestepper(hi.n_states, rel_tol=1e-10, abs_tol=1e-10)
     psi0 = np.random.rand(hi.n_states)
     driver = nk.exact.ExactTimePropagation(
         ha, stepper, t0=0, initial_state=psi0, propagation_type="imaginary"

--- a/Test/GroundState/test_groundstate.py
+++ b/Test/GroundState/test_groundstate.py
@@ -101,7 +101,9 @@ def test_imag_time_propagation():
 
     stepper = nk.dynamics.create_timestepper(hi.n_states, rel_tol=1e-10, abs_tol=1e-10)
     psi0 = np.random.rand(hi.n_states)
-    driver = nk.exact.ImagTimePropagation(ha, stepper, t0=0, initial_state=psi0)
+    driver = nk.exact.ExactTimePropagation(
+        ha, stepper, t0=0, initial_state=psi0, propagation_type="imaginary"
+    )
 
     for step in driver.iter(dt=0.1, n_iter=1000):
         pass

--- a/netket/dynamics.py
+++ b/netket/dynamics.py
@@ -1,1 +1,7 @@
 from ._C_netket.dynamics import *
+from . import _core
+
+
+@_core.deprecated("function has been renamed to `timestepper`")
+def create_timestepper(*args, **kwargs):
+    return timestepper(*args, **kwargs)

--- a/netket/exact.py
+++ b/netket/exact.py
@@ -12,15 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import itertools
+import itertools as _itertools
 
 from . import _core
 from ._C_netket.exact import *
 
 
-def _ImagTimePropagation_iter(self, dt, n_iter=None):
+def _ExactTimePropagation_iter(self, dt, n_iter=None):
     """
-    iter(self: ImagTimePropagation, dt: float, n_iter: int=None) -> int
+    iter(self: ExactTimePropagation, dt: float, n_iter: int=None) -> int
 
     Returns a generator which advances the time evolution by dt,
     yielding after every step.
@@ -32,14 +32,11 @@ def _ImagTimePropagation_iter(self, dt, n_iter=None):
     Yields:
         int: The current step.
     """
-    for i in itertools.count():
+    for i in _itertools.count():
         if n_iter and i >= n_iter:
             return
         self.advance(dt)
         yield i
-
-
-ImagTimePropagation.iter = _ImagTimePropagation_iter
 
 
 @_core.deprecated()
@@ -173,3 +170,21 @@ def full_ed(operator, first_n=1, compute_eigenvectors=False):
         first_n=first_n,
         compute_eigenvectors=compute_eigenvectors,
     )
+
+
+ExactTimePropagation.iter = _ExactTimePropagation_iter
+
+
+@_core.deprecated(
+    "`ImagTimePropagation` is deprecated. Please use "
+    '`ExactTimePropagation(..., propagation_type="imaginary")` instead.'
+)
+def ImagTimePropagation(*args, **kwargs):
+    """
+    Returns `ExactTimePropagation(..., propagation_type="imaginary")` for
+    backwards compatibility.
+
+    Deprecated (NetKet 2.0): Use `ExactTimePropagation` directly.
+    """
+    kwargs["propagation_type"] = "imaginary"
+    return ExactTimePropagation(*args, **kwargs)

--- a/netket/machine.py
+++ b/netket/machine.py
@@ -96,4 +96,3 @@ class CxxMachine(Machine):
             p: New variational parameters as a 1D complex vector.
         """
         raise NotImplementedError
-


### PR DESCRIPTION
This PR contains a bunch of mostly minor changes, mostly related to time evolution:

* The most noticeable one: Rename `ImagTimePropagation` to `ExactTimePropagation` and add option for solving the real-time Schrödinger equation. (In light of #235 this change may not be relevant for much longer, but since #235 is marked as version 2.1 and the work is already done, I think it still makes sense to merge it for now.)
* A fix for #234.
* Removing some typos from the docs.

* Making `UpdateConf` take `span`s, which removes the need for additional copies of data in a few cases.