### PR TITLE
WIP: state_dict

### DIFF
--- a/Sources/Machine/abstract_machine.hpp
+++ b/Sources/Machine/abstract_machine.hpp
@@ -20,6 +20,7 @@
 #include <memory>
 #include <vector>
 
+#include <Python.h>
 #include <Eigen/Core>
 
 #include "Hilbert/abstract_hilbert.hpp"
@@ -205,6 +206,14 @@ class AbstractMachine {
                                    const std::vector<double> &newconf);
 
   virtual bool IsHolomorphic() const noexcept = 0;
+
+  virtual PyObject *StateDict() const {
+    throw std::runtime_error{"Not implemented!"};
+  }
+
+  virtual void StateDict(PyObject *state) {
+    throw std::runtime_error{"Not implemented!"};
+  }
 
   virtual void Save(const std::string &filename) const = 0;
   virtual void Load(const std::string &filename) = 0;

--- a/Sources/Machine/py_machine.cc
+++ b/Sources/Machine/py_machine.cc
@@ -641,6 +641,20 @@ void AddAbstractMachine(py::module m) {
                      filename: name of file to load parameters from.
            )EOF")
       .def(
+          "state_dict",
+          [](AbstractMachine const &self) {
+            return py::reinterpret_steal<py::dict>(self.StateDict());
+          },
+          R"EOF(Returns machine's state as a dictionary. Similar to `torch.nn.Module.state_dict`.
+           )EOF")
+      .def(
+          "load_state_dict",
+          [](AbstractMachine &self, py::dict state) {
+            self.StateDict(state.ptr());
+          },
+          R"EOF(Loads machine's state from `state`.
+           )EOF")
+      .def(
           "to_array",
           [](AbstractMachine &self) -> AbstractMachine::VectorType {
             const auto &hind = self.GetHilbert().GetIndex();

--- a/Sources/Machine/rbm_spin.cc
+++ b/Sources/Machine/rbm_spin.cc
@@ -14,6 +14,11 @@
 
 #include "rbm_spin.hpp"
 
+#include <pybind11/complex.h>
+#include <pybind11/eigen.h>
+#include <pybind11/eval.h>
+#include <pybind11/pybind11.h>
+
 #include "Utils/json_utils.hpp"
 #include "Utils/messages.hpp"
 
@@ -21,62 +26,85 @@ namespace netket {
 
 RbmSpin::RbmSpin(std::shared_ptr<const AbstractHilbert> hilbert, int nhidden,
                  int alpha, bool usea, bool useb)
-    : AbstractMachine(hilbert), nv_(hilbert->Size()), usea_(usea), useb_(useb) {
-  nh_ = std::max(nhidden, alpha * nv_);
-  Init();
+    : AbstractMachine(hilbert),
+      W_{},
+      a_{},
+      b_{},
+      thetas_{},
+      lnthetas_{},
+      thetasnew_{},
+      lnthetasnew_{} {
+  const auto nvisible = hilbert->Size();
+  assert(nvisible >= 0 && "AbstractHilbert::Size is broken");
+  if (nhidden < 0) {
+    std::ostringstream msg;
+    msg << "invalid number of hidden units: " << nhidden
+        << "; expected a non-negative number";
+    throw InvalidInputError{msg.str()};
+  }
+  if (alpha < 0) {
+    std::ostringstream msg;
+    msg << "invalid density of hidden units: " << alpha
+        << "; expected a non-negative number";
+    throw InvalidInputError{msg.str()};
+  }
+  if (nhidden > 0 && alpha > 0 && nhidden != alpha * nvisible) {
+    std::ostringstream msg;
+    msg << "number and density of hidden units are incompatible: " << nhidden
+        << " != " << alpha << " * " << nvisible;
+    throw InvalidInputError{msg.str()};
+  }
+  nhidden = std::max(nhidden, alpha * nvisible);
+
+  W_.resize(nvisible, nhidden);
+  if (usea) {
+    a_.emplace(nvisible);
+  }
+  if (useb) {
+    b_.emplace(nhidden);
+  }
+
+  thetas_.resize(nhidden);
+  lnthetas_.resize(nhidden);
+  thetasnew_.resize(nhidden);
+  lnthetasnew_.resize(nhidden);
 }
 
-int RbmSpin::Nvisible() const { return nv_; }
+int RbmSpin::Nvisible() const { return W_.rows(); }
 
-int RbmSpin::Npar() const { return npar_; }
-
-void RbmSpin::Init() {
-  W_.resize(nv_, nh_);
-  a_.resize(nv_);
-  b_.resize(nh_);
-
-  thetas_.resize(nh_);
-  lnthetas_.resize(nh_);
-  thetasnew_.resize(nh_);
-  lnthetasnew_.resize(nh_);
-
-  npar_ = nv_ * nh_;
-
-  if (usea_) {
-    npar_ += nv_;
-  } else {
-    a_.setZero();
-  }
-
-  if (useb_) {
-    npar_ += nh_;
-  } else {
-    b_.setZero();
-  }
-
-  InfoMessage() << "RBM Initizialized with nvisible = " << nv_
-                << " and nhidden = " << nh_ << std::endl;
-  InfoMessage() << "Using visible bias = " << usea_ << std::endl;
-  InfoMessage() << "Using hidden bias  = " << useb_ << std::endl;
+int RbmSpin::Npar() const {
+  return W_.size() + (a_.has_value() ? a_->size() : 0) +
+         (b_.has_value() ? b_->size() : 0);
 }
 
 void RbmSpin::InitRandomPars(int seed, double sigma) {
-  VectorType par(npar_);
+  VectorType par(Npar());
 
   netket::RandomGaussian(par, seed, sigma);
 
   SetParameters(par);
 }
 
+namespace detail {
+namespace {
+VectorXcd DenseFwd(AbstractMachine::MatrixType const &weights,
+                   AbstractMachine::VisibleConstType x,
+                   nonstd::optional<AbstractMachine::VectorType> const &bias) {
+  return bias.has_value() ? (weights.transpose() * x + *bias).eval()
+                          : (weights.transpose() * x).eval();
+}
+}  // namespace
+}  // namespace detail
+
 void RbmSpin::InitLookup(VisibleConstType v, LookupType &lt) {
   if (lt.VectorSize() == 0) {
-    lt.AddVector(b_.size());
+    lt.AddVector(Nhidden());
   }
-  if (lt.V(0).size() != b_.size()) {
-    lt.V(0).resize(b_.size());
+  if (lt.V(0).size() != Nhidden()) {
+    lt.V(0).resize(Nhidden());
   }
 
-  lt.V(0) = (W_.transpose() * v + b_);
+  lt.V(0) = detail::DenseFwd(W_, v, b_);
 }
 
 void RbmSpin::UpdateLookup(VisibleConstType v, const std::vector<int> &tochange,
@@ -96,59 +124,59 @@ RbmSpin::VectorType RbmSpin::DerLog(VisibleConstType v) {
 }
 
 RbmSpin::VectorType RbmSpin::DerLog(VisibleConstType v, const LookupType &lt) {
-  VectorType der(npar_);
+  VectorType der(Npar());
 
-  if (usea_) {
-    der.head(nv_) = v;
+  if (a_.has_value()) {
+    der.head(Nvisible()) = v;
   }
 
   RbmSpin::tanh(lt.V(0), lnthetas_);
 
-  if (useb_) {
-    der.segment(usea_ * nv_, nh_) = lnthetas_;
+  if (b_.has_value()) {
+    der.segment(a_.has_value() * Nvisible(), Nhidden()) = lnthetas_;
   }
 
   MatrixType wder = (v * lnthetas_.transpose());
-  der.tail(nv_ * nh_) = Eigen::Map<VectorType>(wder.data(), nv_ * nh_);
+  der.tail(W_.size()) = Eigen::Map<VectorType>(wder.data(), W_.size());
 
   return der;
 }
 
 RbmSpin::VectorType RbmSpin::GetParameters() {
-  VectorType pars(npar_);
+  VectorType pars(Npar());
 
-  if (usea_) {
-    pars.head(nv_) = a_;
+  if (a_.has_value()) {
+    pars.head(Nvisible()) = *a_;
   }
 
-  if (useb_) {
-    pars.segment(usea_ * nv_, nh_) = b_;
+  if (b_.has_value()) {
+    pars.segment(a_.has_value() * Nvisible(), Nhidden()) = *b_;
   }
 
-  pars.tail(nv_ * nh_) = Eigen::Map<VectorType>(W_.data(), nv_ * nh_);
+  pars.tail(W_.size()) = Eigen::Map<VectorType>(W_.data(), W_.size());
 
   return pars;
 }
 
 void RbmSpin::SetParameters(VectorConstRefType pars) {
-  if (usea_) {
-    a_ = pars.head(nv_);
+  if (a_.has_value()) {
+    a_ = pars.head(Nvisible());
   }
 
-  if (useb_) {
-    b_ = pars.segment(usea_ * nv_, nh_);
+  if (b_.has_value()) {
+    b_ = pars.segment(a_.has_value() * Nvisible(), Nhidden());
   }
 
-  VectorType Wpars = pars.tail(nv_ * nh_);
+  VectorType Wpars = pars.tail(W_.size());
 
-  W_ = Eigen::Map<MatrixType>(Wpars.data(), nv_, nh_);
+  W_ = Eigen::Map<MatrixType>(Wpars.data(), Nvisible(), Nhidden());
 }
 
 // Value of the logarithm of the wave-function
 Complex RbmSpin::LogVal(VisibleConstType v) {
-  RbmSpin::lncosh(W_.transpose() * v + b_, lnthetas_);
+  RbmSpin::lncosh(detail::DenseFwd(W_, v, b_), lnthetas_);
 
-  return (v.dot(a_) + lnthetas_.sum());
+  return (a_.has_value() ? v.dot(*a_) : 0) + lnthetas_.sum();
 }
 
 // Value of the logarithm of the wave-function
@@ -156,7 +184,7 @@ Complex RbmSpin::LogVal(VisibleConstType v) {
 Complex RbmSpin::LogVal(VisibleConstType v, const LookupType &lt) {
   RbmSpin::lncosh(lt.V(0), lnthetas_);
 
-  return (v.dot(a_) + lnthetas_.sum());
+  return (a_.has_value() ? v.dot(*a_) : 0) + lnthetas_.sum();
 }
 
 // Difference between logarithms of values, when one or more visible variables
@@ -167,25 +195,35 @@ RbmSpin::VectorType RbmSpin::LogValDiff(
   const std::size_t nconn = tochange.size();
   VectorType logvaldiffs = VectorType::Zero(nconn);
 
-  thetas_ = (W_.transpose() * v + b_);
+  thetas_ = detail::DenseFwd(W_, v, b_);
   RbmSpin::lncosh(thetas_, lnthetas_);
 
   Complex logtsum = lnthetas_.sum();
 
-  for (std::size_t k = 0; k < nconn; k++) {
-    if (tochange[k].size() != 0) {
-      thetasnew_ = thetas_;
-
-      for (std::size_t s = 0; s < tochange[k].size(); s++) {
-        const int sf = tochange[k][s];
-
-        logvaldiffs(k) += a_(sf) * (newconf[k][s] - v(sf));
-
-        thetasnew_ += W_.row(sf) * (newconf[k][s] - v(sf));
+  if (a_.has_value()) {
+    for (std::size_t k = 0; k < nconn; k++) {
+      if (tochange[k].size() != 0) {
+        thetasnew_ = thetas_;
+        for (std::size_t s = 0; s < tochange[k].size(); s++) {
+          const int sf = tochange[k][s];
+          logvaldiffs(k) += (*a_)(sf) * (newconf[k][s] - v(sf));
+          thetasnew_ += W_.row(sf) * (newconf[k][s] - v(sf));
+        }
+        RbmSpin::lncosh(thetasnew_, lnthetasnew_);
+        logvaldiffs(k) += lnthetasnew_.sum() - logtsum;
       }
-
-      RbmSpin::lncosh(thetasnew_, lnthetasnew_);
-      logvaldiffs(k) += lnthetasnew_.sum() - logtsum;
+    }
+  } else {
+    for (std::size_t k = 0; k < nconn; k++) {
+      if (tochange[k].size() != 0) {
+        thetasnew_ = thetas_;
+        for (std::size_t s = 0; s < tochange[k].size(); s++) {
+          const int sf = tochange[k][s];
+          thetasnew_ += W_.row(sf) * (newconf[k][s] - v(sf));
+        }
+        RbmSpin::lncosh(thetasnew_, lnthetasnew_);
+        logvaldiffs(k) += lnthetasnew_.sum() - logtsum;
+      }
     }
   }
   return logvaldiffs;
@@ -199,84 +237,155 @@ Complex RbmSpin::LogValDiff(VisibleConstType v,
                             const std::vector<double> &newconf,
                             const LookupType &lt) {
   Complex logvaldiff = 0.;
-
   if (tochange.size() != 0) {
     RbmSpin::lncosh(lt.V(0), lnthetas_);
-
     thetasnew_ = lt.V(0);
-
-    for (std::size_t s = 0; s < tochange.size(); s++) {
-      const int sf = tochange[s];
-
-      logvaldiff += a_(sf) * (newconf[s] - v(sf));
-
-      thetasnew_ += W_.row(sf) * (newconf[s] - v(sf));
+    if (a_.has_value()) {
+      for (std::size_t s = 0; s < tochange.size(); s++) {
+        const int sf = tochange[s];
+        logvaldiff += (*a_)(sf) * (newconf[s] - v(sf));
+        thetasnew_ += W_.row(sf) * (newconf[s] - v(sf));
+      }
+    } else {
+      for (std::size_t s = 0; s < tochange.size(); s++) {
+        const int sf = tochange[s];
+        thetasnew_ += W_.row(sf) * (newconf[s] - v(sf));
+      }
     }
-
     RbmSpin::lncosh(thetasnew_, lnthetasnew_);
     logvaldiff += (lnthetasnew_.sum() - lnthetas_.sum());
   }
   return logvaldiff;
 }
 
+namespace detail {
+/// Saves Python object \par raw to a file \par filename using pickle.
+///
+/// \param raw reference to a Python object. It is borrowed, not stolen.
+///
+/// \note This is a hacky solution which should be implemented in pure Python.
+void WriteToFile(const std::string &filename, PyObject *raw) {
+  namespace py = pybind11;
+  auto object = py::reinterpret_borrow<py::object>(raw);
+  py::dict scope;
+  scope["dump"] = pybind11::module::import("pickle").attr("dump");
+  scope["filename"] = pybind11::cast(filename);
+  scope["x"] = object;
+  pybind11::exec(R"(
+    with open(filename, "wb") as output:
+        dump(x, output)
+    )",
+                 pybind11::module::import("__main__").attr("__dict__"), scope);
+}
+
+/// Loads a Python object from a file \par filename using pickle.
+//
+/// \return **new reference**.
+///
+/// \note This is a hacky solution which should be implemented in pure Python.
+PyObject *ReadFromFile(const std::string &filename) {
+  namespace py = pybind11;
+  py::dict scope;
+  scope["load"] = pybind11::module::import("pickle").attr("load");
+  scope["filename"] = pybind11::cast(filename);
+  scope["_return_value"] = pybind11::none();
+  pybind11::exec(R"(
+    with open(filename, "rb") as input:
+        _return_value = load(input)
+    )",
+                 pybind11::module::import("__main__").attr("__dict__"), scope);
+  return static_cast<py::object>(scope["_return_value"]).release().ptr();
+}
+}  // namespace detail
+
 void RbmSpin::Save(const std::string &filename) const {
-  json state;
-  state["Name"] = "RbmSpin";
-  state["Nvisible"] = nv_;
-  state["Nhidden"] = nh_;
-  state["UseVisibleBias"] = usea_;
-  state["UseHiddenBias"] = useb_;
-  state["a"] = a_;
-  state["b"] = b_;
-  state["W"] = W_;
-  WriteJsonToFile(state, filename);
+  auto state = pybind11::reinterpret_steal<pybind11::dict>(StateDict());
+  detail::WriteToFile(filename, state.ptr());
 }
 
 void RbmSpin::Load(const std::string &filename) {
-  auto const pars = ReadJsonFromFile(filename);
-  std::string name = FieldVal<std::string>(pars, "Name");
-  if (name != "RbmSpin") {
-    throw InvalidInputError(
-        "Error while constructing RbmSpin from input parameters");
-  }
-
-  if (FieldExists(pars, "Nvisible")) {
-    nv_ = FieldVal<int>(pars, "Nvisible");
-  }
-  if (nv_ != GetHilbert().Size()) {
-    throw InvalidInputError(
-        "Number of visible units is incompatible with given "
-        "Hilbert space");
-  }
-
-  if (FieldExists(pars, "Nhidden")) {
-    nh_ = FieldVal<int>(pars, "Nhidden");
-  } else {
-    nh_ = nv_ * double(FieldVal<double>(pars, "Alpha"));
-  }
-
-  usea_ = FieldOrDefaultVal(pars, "UseVisibleBias", true);
-  useb_ = FieldOrDefaultVal(pars, "UseHiddenBias", true);
-
-  Init();
-
-  // Loading parameters, if defined in the input
-  if (FieldExists(pars, "a")) {
-    a_ = FieldVal<VectorType>(pars, "a");
-  } else {
-    a_.setZero();
-  }
-
-  if (FieldExists(pars, "b")) {
-    b_ = FieldVal<VectorType>(pars, "b");
-  } else {
-    b_.setZero();
-  }
-  if (FieldExists(pars, "W")) {
-    W_ = FieldVal<MatrixType>(pars, "W");
-  }
+  // NOTE: conversion to dict is very important, since it performs error
+  // checking! So don't just change object's type to `pybind11::object`. The
+  // code will compile, but as soon as the user passes some weird type, the
+  // program will most likely crash.
+  auto const state =
+      pybind11::dict{pybind11::reinterpret_steal<pybind11::object>(
+          detail::ReadFromFile(filename))};
+  StateDict(state.ptr());
 }
 
 bool RbmSpin::IsHolomorphic() const noexcept { return true; }
+
+PyObject *RbmSpin::StateDict() const {
+  namespace py = pybind11;
+  py::dict state;
+  state["a"] = a_.has_value() ? py::cast(*a_) : py::none();
+  state["b"] = b_.has_value() ? py::cast(*b_) : py::none();
+  state["w"] = py::cast(W_);
+  return state.release().ptr();
+}
+
+namespace detail {
+namespace {
+/// Checks that \par src has the right shape to be written to \par dst.
+template <class T1, class T2>
+void CheckShape(char const *name, Eigen::EigenBase<T1> const &dst,
+                Eigen::EigenBase<T2> const &src) {
+  if (src.rows() != dst.rows() || src.cols() != dst.cols()) {
+    std::ostringstream msg;
+    msg << "field '" << name << "' has wrong shape: [" << src.rows() << ", "
+        << src.cols() << "]; expected [" << dst.rows() << ", " << dst.cols()
+        << "]";
+    throw InvalidInputError{msg.str()};
+  }
+}
+
+/// Loads some data from a Python object \par obj into an Eigen object
+/// \par parameter. \par name should be the name of the parameter and is used
+/// for error reporting.
+template <class T>
+void LoadImpl(char const *name, T &parameter, pybind11::object obj) {
+  auto new_parameter = obj.cast<T>();
+  CheckShape(name, parameter, new_parameter);
+  parameter = std::move(new_parameter);
+}
+
+/// Loads some data from a Python object \par obj into an Eigen object
+/// \par parameter. Very similar to #LoadImpl(char const*, T&, pybind11::object)
+/// except that \par parameter may be `nullopt` in which case \par obj is
+/// required to be `None`.
+template <class T>
+void LoadImpl(char const *name, nonstd::optional<T> &parameter,
+              pybind11::object obj) {
+  if (parameter.has_value()) {
+    LoadImpl(name, *parameter, obj);
+  } else if (!obj.is_none()) {
+    std::ostringstream msg;
+    msg << "expected field '" << name << "' to be None";
+    throw InvalidInputError{msg.str()};
+  }
+}
+
+/// Loads the `state[name]` into \par parameter.
+template <class T>
+void Load(char const *name, T &parameter, pybind11::dict state) {
+  auto py_name = pybind11::str{name};
+  if (!state.contains(py_name)) {
+    std::ostringstream msg;
+    msg << "state is missing required field '" << name << "'";
+    throw InvalidInputError{msg.str()};
+  }
+  LoadImpl(name, parameter, state[py_name]);
+}
+}  // namespace
+}  // namespace detail
+
+void RbmSpin::StateDict(PyObject *obj) {
+  namespace py = pybind11;
+  auto state = py::dict{py::reinterpret_borrow<py::object>(obj)};
+  detail::Load("a", a_, state);
+  detail::Load("b", b_, state);
+  detail::Load("w", W_, state);
+}
 
 }  // namespace netket

--- a/Sources/Machine/rbm_spin.hpp
+++ b/Sources/Machine/rbm_spin.hpp
@@ -17,6 +17,8 @@
 
 #include <cmath>
 
+#include <nonstd/optional.hpp>
+
 #include "Machine/abstract_machine.hpp"
 
 namespace netket {
@@ -25,31 +27,14 @@ namespace netket {
  *
  */
 class RbmSpin : public AbstractMachine {
-  // number of visible units
-  int nv_;
-
-  // number of hidden units
-  int nh_;
-
-  // number of parameters
-  int npar_;
-
-  // weights
-  MatrixType W_;
-
-  // visible units bias
-  VectorType a_;
-
-  // hidden units bias
-  VectorType b_;
-
+  MatrixType W_;                    ///< weights
+  nonstd::optional<VectorType> a_;  ///< visible units bias
+  nonstd::optional<VectorType> b_;  ///< hidden units bias
+  /// Caches
   VectorType thetas_;
   VectorType lnthetas_;
   VectorType thetasnew_;
   VectorType lnthetasnew_;
-
-  bool usea_;
-  bool useb_;
 
  public:
   RbmSpin(std::shared_ptr<const AbstractHilbert> hilbert, int nhidden = 0,
@@ -57,7 +42,7 @@ class RbmSpin : public AbstractMachine {
 
   int Nvisible() const override;
   int Npar() const override;
-  /*constexpr*/ int Nhidden() const noexcept { return nh_; }
+  /*constexpr*/ int Nhidden() const noexcept { return W_.cols(); }
 
   void InitRandomPars(int seed, double sigma) override;
   void InitLookup(VisibleConstType v, LookupType &lt) override;
@@ -89,6 +74,9 @@ class RbmSpin : public AbstractMachine {
   void Load(const std::string &filename) override;
 
   bool IsHolomorphic() const noexcept override;
+
+  PyObject *StateDict() const override;
+  void StateDict(PyObject *dict) override;
 
   static double lncosh(double x) {
     const double xp = std::abs(x);


### PR DESCRIPTION
We talked about using Python dictionaries for updating and saving parameters. This PR actually implements this functionality for RbmSpin.

Now we have
```python
>>> import netket
>>> import numpy
>>> h = netket.hilbert.Spin(netket.graph.Hypercube(5, n_dim=1, pbc=True), s=0.5)
>>> m = netket.machine.RbmSpin(h, n_hidden=4)
>>> m.init_random_parameters()
>>> m.state_dict()
{'a': array([ 0.06266416-0.08706595j,  0.05022808-0.00971853j,
        0.12287212+0.13265499j, -0.36866098-0.00968607j,
       -0.12293974-0.00809343j]), 'b': array([ 0.03828042-0.16867513j, -0.0536683 +0.00832681j,
        0.11986847-0.03270153j,  0.21675369-0.05061179j]), 'w': array([[ 0.10887414+9.25775000e-02j,  0.04988153+7.22126278e-03j,
        -0.00953845-3.61061884e-05j, -0.02722431-9.56652539e-02j],
       [ 0.17739797+2.67596957e-01j, -0.08609805+3.47115713e-02j,
         0.05762644-1.57047880e-02j,  0.06564118+5.19112256e-03j],
       [-0.01790749-1.57556098e-01j, -0.02993753+1.34490347e-01j,
         0.18646482-1.45914767e-01j, -0.04700775+6.12943165e-02j],
       [ 0.10217094+8.98425795e-02j,  0.04849756+1.80935579e-01j,
        -0.06182897-1.25392615e-02j,  0.04124381+1.00977662e-01j],
       [ 0.17383309+7.56729259e-02j, -0.01546016+1.61383038e-02j,
         0.13857972-3.74710975e-02j, -0.02467454+1.47849472e-01j]])}
```

There are also a few changes to the implementation of the RBM, namely using `optional`s instead of separate `bool` flags. Also, passing invalid arguments to RbmSpin constructor actually throws instead of crashing:
```python3
>>> # Before this PR (i.e. current master)
>>> m = netket.machine.RbmSpin(h, alpha=-2, n_hidden=-4)
python3: External/Eigen3/Eigen/src/Core/PlainObjectBase.h:285: void Eigen::PlainObjectBase<Eigen::Matrix<std::complex<double>, -1, -1, 0, -1, -1> >::resize(Eigen::Index, Eigen::Index) [Derived = Eigen::Matrix<std::complex<double>, -1, -1, 0, -1, -1>]: Assertion `(!(RowsAtCompileTime!=Dynamic) || (rows==RowsAtCompileTime)) && (!(ColsAtCompileTime!=Dynamic) || (cols==ColsAtCompileTime)) && (!(RowsAtCompileTime==Dynamic && MaxRowsAtCompileTime!=Dynamic) || (rows<=MaxRowsAtCompileTime)) && (!(ColsAtCompileTime==Dynamic && MaxColsAtCompileTime!=Dynamic) || (cols<=MaxColsAtCompileTime)) && rows>=0 && cols>=0 && "Invalid sizes when resizing a matrix or array."' failed.
[sccloan005:04474] *** Process received signal ***
[sccloan005:04474] Signal: Aborted (6)
[sccloan005:04474] Signal code:  (-6)
[sccloan005:04474] [ 0] /lib/x86_64-linux-gnu/libc.so.6(+0x43f60)[0x7f0ea7daff60]
[sccloan005:04474] [ 1] /lib/x86_64-linux-gnu/libc.so.6(gsignal+0xc7)[0x7f0ea7dafed7]
[sccloan005:04474] [ 2] /lib/x86_64-linux-gnu/libc.so.6(abort+0x121)[0x7f0ea7d91535]
[sccloan005:04474] [ 3] /lib/x86_64-linux-gnu/libc.so.6(+0x2540f)[0x7f0ea7d9140f]
[sccloan005:04474] [ 4] /lib/x86_64-linux-gnu/libc.so.6(+0x35012)[0x7f0ea7da1012]
[sccloan005:04474] [ 5] /home/twesterhout/src/netket/netket/_C_netket.cpython-37m-x86_64-linux-gnu.so(+0x11151e)[0x7f0ea662851e]
[sccloan005:04474] [ 6] /home/twesterhout/src/netket/netket/_C_netket.cpython-37m-x86_64-linux-gnu.so(+0x341991)[0x7f0ea6858991]
[sccloan005:04474] [ 7] /home/twesterhout/src/netket/netket/_C_netket.cpython-37m-x86_64-linux-gnu.so(+0x33e957)[0x7f0ea6855957]
[sccloan005:04474] [ 8] /home/twesterhout/src/netket/netket/_C_netket.cpython-37m-x86_64-linux-gnu.so(+0x3756d4)[0x7f0ea688c6d4]
[sccloan005:04474] [ 9] /home/twesterhout/src/netket/netket/_C_netket.cpython-37m-x86_64-linux-gnu.so(+0x3755ef)[0x7f0ea688c5ef]
[sccloan005:04474] [10] /home/twesterhout/src/netket/netket/_C_netket.cpython-37m-x86_64-linux-gnu.so(+0x375522)[0x7f0ea688c522]
[sccloan005:04474] [11] /home/twesterhout/src/netket/netket/_C_netket.cpython-37m-x86_64-linux-gnu.so(+0x374a36)[0x7f0ea688ba36]
[sccloan005:04474] [12] /home/twesterhout/src/netket/netket/_C_netket.cpython-37m-x86_64-linux-gnu.so(+0x374838)[0x7f0ea688b838]
[sccloan005:04474] [13] /home/twesterhout/src/netket/netket/_C_netket.cpython-37m-x86_64-linux-gnu.so(+0x374735)[0x7f0ea688b735]
[sccloan005:04474] [14] /home/twesterhout/src/netket/netket/_C_netket.cpython-37m-x86_64-linux-gnu.so(+0xde027)[0x7f0ea65f5027]
[sccloan005:04474] [15] python3(_PyMethodDef_RawFastCallDict+0x12b)[0x5d82db]
[sccloan005:04474] [16] python3[0x4d9dc7]
[sccloan005:04474] [17] python3(PyObject_Call+0x56)[0x5dbc76]
[sccloan005:04474] [18] python3[0x591298]
[sccloan005:04474] [19] python3(_PyObject_FastCallKeywords+0x129)[0x5d93c9]
[sccloan005:04474] [20] python3[0x54b0f1]
[sccloan005:04474] [21] python3(_PyEval_EvalFrameDefault+0x13ae)[0x54f0ee]
[sccloan005:04474] [22] python3(_PyEval_EvalCodeWithName+0x252)[0x54b9f2]
[sccloan005:04474] [23] python3(PyEval_EvalCode+0x23)[0x54dd33]
[sccloan005:04474] [24] python3[0x630f22]
[sccloan005:04474] [25] python3[0x480d87]
[sccloan005:04474] [26] python3(PyRun_InteractiveLoopFlags+0xd4)[0x480f09]
[sccloan005:04474] [27] python3(PyRun_AnyFileExFlags+0x53)[0x631e33]
[sccloan005:04474] [28] python3[0x65414e]
[sccloan005:04474] [29] python3(_Py_UnixMain+0x2e)[0x6544ae]
[sccloan005:04474] *** End of error message ***
Aborted (core dumped)
```
and
```python3
>>> # With this PR
>>> m = netket.machine.RbmSpin(h, n_hidden=-4)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: invalid number of hidden units: -4; expected a non-negative number
```


I'm looking for some early feedback. Can I go on and implement state_dict interface for other machines? This will greatly benefit interoperability with PyTorch later on.