### PR TITLE
Change sweep size to be odd by default

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -20,7 +20,7 @@ AlwaysBreakBeforeMultilineStrings: true
 AlwaysBreakTemplateDeclarations: Yes
 BinPackArguments: true
 BinPackParameters: true
-BraceWrapping:   
+BraceWrapping:
   AfterClass:      false
   AfterControlStatement: false
   AfterEnum:       false
@@ -56,12 +56,12 @@ DerivePointerAlignment: true
 DisableFormat:   false
 ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: true
-ForEachMacros:   
+ForEachMacros:
   - foreach
   - Q_FOREACH
   - BOOST_FOREACH
 IncludeBlocks:   Preserve
-IncludeCategories: 
+IncludeCategories:
   - Regex:           '^<ext/.*\.h>'
     Priority:        2
   - Regex:           '^<.*\.h>'
@@ -95,9 +95,9 @@ PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 200
 PointerAlignment: Left
-RawStringFormats: 
+RawStringFormats:
   - Language:        Cpp
-    Delimiters:      
+    Delimiters:
       - cc
       - CC
       - cpp
@@ -108,12 +108,12 @@ RawStringFormats:
     CanonicalDelimiter: ''
     BasedOnStyle:    google
   - Language:        TextProto
-    Delimiters:      
+    Delimiters:
       - pb
       - PB
       - proto
       - PROTO
-    EnclosingFunctions: 
+    EnclosingFunctions:
       - EqualsProto
       - EquivToProto
       - PARSE_PARTIAL_TEXT_PROTO
@@ -142,10 +142,9 @@ SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
 Standard:        Auto
-StatementMacros: 
-  - Q_UNUSED
-  - QT_REQUIRE_VERSION
+# StatementMacros:
+  # - Q_UNUSED
+  # - QT_REQUIRE_VERSION
 TabWidth:        8
 UseTab:          Never
 ...
-

--- a/Sources/Sampler/abstract_sampler.hpp
+++ b/Sources/Sampler/abstract_sampler.hpp
@@ -61,13 +61,9 @@ class AbstractSampler {
     return hilbert_;
   }
 
-  const AbstractHilbert &GetHilbert() const noexcept {
-    return *hilbert_;
-  }
+  const AbstractHilbert& GetHilbert() const noexcept { return *hilbert_; }
 
-  AbstractMachine &GetMachine() const noexcept {
-    return psi_;
-  }
+  AbstractMachine& GetMachine() const noexcept { return psi_; }
 
   const MachineFunction& GetMachineFunc() const noexcept {
     return machine_func_;

--- a/Sources/Sampler/custom_sampler.hpp
+++ b/Sources/Sampler/custom_sampler.hpp
@@ -179,7 +179,7 @@ class CustomSampler : public AbstractSampler {
   }
 
   void SetSweepSize(int sweep_size) {
-    if (sweep_size_ <= 0) {
+    if (sweep_size <= 0) {
       throw InvalidInputError{"Sweep size should be a positive integer."};
     }
     sweep_size_ = sweep_size;

--- a/Sources/Sampler/custom_sampler.hpp
+++ b/Sources/Sampler/custom_sampler.hpp
@@ -55,6 +55,8 @@ class CustomSampler : public AbstractSampler {
   int nstates_;
   std::vector<double> localstates_;
 
+  int sweep_size_;
+
  public:
   CustomSampler(AbstractMachine &psi, const LocalOperator &move_operators,
                 const std::vector<double> &move_weights = {})
@@ -101,6 +103,13 @@ class CustomSampler : public AbstractSampler {
     nstates_ = GetHilbert().LocalSize();
     localstates_ = GetHilbert().LocalStates();
 
+    // Always use odd sweep size to avoid possible ergodicity problems
+    if (nv_ % 2 == 0) {
+      SetSweepSize(nv_ + 1);
+    } else {
+      SetSweepSize(nv_);
+    }
+
     Reset(true);
 
     InfoMessage() << "Custom Metropolis sampler is ready " << std::endl;
@@ -122,7 +131,7 @@ class CustomSampler : public AbstractSampler {
                                               operatorsweights_.end());
     std::uniform_real_distribution<double> distu;
 
-    for (int i = 0; i < nv_; i++) {
+    for (int i = 0; i < sweep_size_; i++) {
       // pick a random operator in possible ones according to the provided
       // weights
       int op = disc_dist(this->GetRandomEngine());
@@ -137,16 +146,17 @@ class CustomSampler : public AbstractSampler {
         cumulative_prob += std::real(mel_[exit_state]);
       }
 
-      auto exlog = std::exp(GetMachine().LogValDiff(v_, tochange_[exit_state],
-                                            newconfs_[exit_state], lt_));
+      auto exlog = std::exp(GetMachine().LogValDiff(
+          v_, tochange_[exit_state], newconfs_[exit_state], lt_));
       double ratio = this->GetMachineFunc()(exlog);
 
       // Metropolis acceptance test
       if (ratio > distu(this->GetRandomEngine())) {
         accept_[0] += 1;
-        GetMachine().UpdateLookup(v_, tochange_[exit_state], newconfs_[exit_state],
-                          lt_);
-        GetHilbert().UpdateConf(v_, tochange_[exit_state], newconfs_[exit_state]);
+        GetMachine().UpdateLookup(v_, tochange_[exit_state],
+                                  newconfs_[exit_state], lt_);
+        GetHilbert().UpdateConf(v_, tochange_[exit_state],
+                                newconfs_[exit_state]);
       }
       moves_[0] += 1;
     }
@@ -167,6 +177,15 @@ class CustomSampler : public AbstractSampler {
     }
     return acc;
   }
+
+  void SetSweepSize(int sweep_size) {
+    if (sweep_size_ <= 0) {
+      throw InvalidInputError{"Sweep size should be a positive integer."};
+    }
+    sweep_size_ = sweep_size;
+  }
+
+  int GetSweepSize() const { return sweep_size_; }
 
   static void CheckMoveOperators(const LocalOperator &move_operators) {
     if (move_operators.Size() == 0) {

--- a/Sources/Sampler/custom_sampler.hpp
+++ b/Sources/Sampler/custom_sampler.hpp
@@ -180,12 +180,15 @@ class CustomSampler : public AbstractSampler {
 
   void SetSweepSize(int sweep_size) {
     if (sweep_size <= 0) {
-      throw InvalidInputError{"Sweep size should be a positive integer."};
+      std::ostringstream msg;
+      msg << "invalid sweep size: " << sweep_size
+          << "; expected a positive integer";
+      throw InvalidInputError{msg.str()};
     }
     sweep_size_ = sweep_size;
   }
 
-  int GetSweepSize() const { return sweep_size_; }
+  int GetSweepSize() const noexcept { return sweep_size_; }
 
   static void CheckMoveOperators(const LocalOperator &move_operators) {
     if (move_operators.Size() == 0) {

--- a/Sources/Sampler/custom_sampler_pt.hpp
+++ b/Sources/Sampler/custom_sampler_pt.hpp
@@ -244,7 +244,7 @@ class CustomSamplerPt : public AbstractSampler {
   }
 
   void SetSweepSize(int sweep_size) {
-    if (sweep_size_ <= 0) {
+    if (sweep_size <= 0) {
       throw InvalidInputError{"Sweep size should be a positive integer."};
     }
     sweep_size_ = sweep_size;

--- a/Sources/Sampler/custom_sampler_pt.hpp
+++ b/Sources/Sampler/custom_sampler_pt.hpp
@@ -245,12 +245,15 @@ class CustomSamplerPt : public AbstractSampler {
 
   void SetSweepSize(int sweep_size) {
     if (sweep_size <= 0) {
-      throw InvalidInputError{"Sweep size should be a positive integer."};
+      std::ostringstream msg;
+      msg << "invalid sweep size: " << sweep_size
+          << "; expected a positive integer";
+      throw InvalidInputError{msg.str()};
     }
     sweep_size_ = sweep_size;
   }
 
-  int GetSweepSize() const { return sweep_size_; }
+  int GetSweepSize() const noexcept { return sweep_size_; }
 };
 }  // namespace netket
 

--- a/Sources/Sampler/custom_sampler_pt.hpp
+++ b/Sources/Sampler/custom_sampler_pt.hpp
@@ -58,6 +58,8 @@ class CustomSamplerPt : public AbstractSampler {
   int nrep_;
   std::vector<double> beta_;
 
+  int sweep_size_;
+
  public:
   CustomSamplerPt(AbstractMachine& psi, const LocalOperator& move_operators,
                   const std::vector<double>& move_weights = {},
@@ -116,6 +118,13 @@ class CustomSamplerPt : public AbstractSampler {
     accept_.resize(2 * nrep_);
     moves_.resize(2 * nrep_);
 
+    // Always use odd sweep size to avoid possible ergodicity problems
+    if (nv_ % 2 == 0) {
+      SetSweepSize(nv_ + 1);
+    } else {
+      SetSweepSize(nv_);
+    }
+
     Reset(true);
 
     InfoMessage() << "Custom Metropolis sampler with parallel tempering "
@@ -143,7 +152,7 @@ class CustomSamplerPt : public AbstractSampler {
     std::discrete_distribution<int> disc_dist(operatorsweights_.begin(),
                                               operatorsweights_.end());
     std::uniform_real_distribution<double> distu;
-    for (int i = 0; i < nv_; i++) {
+    for (int i = 0; i < sweep_size_; i++) {
       // pick a random operator in possible ones according to the provided
       // weights
       int op = disc_dist(this->GetRandomEngine());
@@ -157,19 +166,19 @@ class CustomSamplerPt : public AbstractSampler {
         cumulative_prob += std::real(mel_[exit_state]);
       }
 
-      auto explo = std::exp(beta_[rep] *
-                            GetMachine().LogValDiff(v_[rep], tochange_[exit_state],
-                                            newconfs_[exit_state], lt_[rep]));
+      auto explo = std::exp(beta_[rep] * GetMachine().LogValDiff(
+                                             v_[rep], tochange_[exit_state],
+                                             newconfs_[exit_state], lt_[rep]));
 
       double ratio = this->GetMachineFunc()(explo);
 
       // Metropolis acceptance test
       if (ratio > distu(this->GetRandomEngine())) {
         accept_(rep) += 1;
-        GetMachine().UpdateLookup(v_[rep], tochange_[exit_state], newconfs_[exit_state],
-                          lt_[rep]);
+        GetMachine().UpdateLookup(v_[rep], tochange_[exit_state],
+                                  newconfs_[exit_state], lt_[rep]);
         GetHilbert().UpdateConf(v_[rep], tochange_[exit_state],
-                            newconfs_[exit_state]);
+                                newconfs_[exit_state]);
       }
       moves_(rep) += 1;
     }
@@ -233,6 +242,15 @@ class CustomSamplerPt : public AbstractSampler {
     }
     return acc;
   }
+
+  void SetSweepSize(int sweep_size) {
+    if (sweep_size_ <= 0) {
+      throw InvalidInputError{"Sweep size should be a positive integer."};
+    }
+    sweep_size_ = sweep_size;
+  }
+
+  int GetSweepSize() const { return sweep_size_; }
 };
 }  // namespace netket
 

--- a/Sources/Sampler/py_custom_sampler.hpp
+++ b/Sources/Sampler/py_custom_sampler.hpp
@@ -86,7 +86,10 @@ void AddCustomSampler(py::module &subm) {
                  >>> sa = nk.sampler.CustomSampler(machine=ma, move_operators=move_op)
 
                  ```
-             )EOF");
+             )EOF")
+      .def_property("sweep_size", &CustomSampler::GetSweepSize,
+                    &CustomSampler::SetSweepSize, R"EOF(
+                      The size of the sweep. Extra caution should be put in making sure that the number of sweeps is sufficient to have an ergodic sampling.)EOF");
 }
 }  // namespace netket
 #endif

--- a/Sources/Sampler/py_custom_sampler_pt.hpp
+++ b/Sources/Sampler/py_custom_sampler_pt.hpp
@@ -63,7 +63,10 @@ void AddCustomSamplerPt(py::module &subm) {
                  >>> sa = nk.sampler.CustomSamplerPt(machine=ma, move_operators=move_op,n_replicas=10)
 
                  ```
-             )EOF");
+             )EOF")
+      .def_property("sweep_size", &CustomSamplerPt::GetSweepSize,
+                    &CustomSamplerPt::SetSweepSize, R"EOF(
+                             The size of the sweep. Extra caution should be put in making sure that the number of sweeps is sufficient to have an ergodic sampling.)EOF");
 }
 }  // namespace netket
 #endif

--- a/Test/Sampler/test_sampler.py
+++ b/Test/Sampler/test_sampler.py
@@ -181,6 +181,3 @@ def test_correct_sampling():
             eps = np.sqrt(1.0 / float(n_samples))
 
             assert z == approx(0.0, rel=10 * eps, abs=10 * eps)
-
-
-test_correct_sampling()


### PR DESCRIPTION
Correcting a potential ergodicity issue in samplers arising when the size of the sweep is even