### PR TITLE
Remove deprecated `Hilbert.index` property (fixes #251)

### DIFF
--- a/Sources/Hilbert/py_hilbert.cc
+++ b/Sources/Hilbert/py_hilbert.cc
@@ -176,10 +176,6 @@ void AddHilbertModule(py::module m) {
 
        Returns:
            bool: Whether the Hilbert space is indexable.)EOF")
-          .def_property_readonly("index", &AbstractHilbert::GetIndex,
-                                 R"EOF(
-       HilbertIndex: An object containing information on the states of an
-               indexable Hilbert space)EOF")
           .def_property_readonly(
               "local_size", &AbstractHilbert::LocalSize,
               R"EOF(int: Size of the local hilbert space.)EOF")


### PR DESCRIPTION
Adressing #251. In the Python interface, all functionality from `HilbertIndex` is exposed through methods of `Hilbert` directly.