### PR TITLE
Report durations for all tests cases when running tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -202,5 +202,5 @@ script:
   - python -c 'from mpi4py import MPI; print(MPI.get_vendor())'
   - python -c 'import netket'
   - python -c 'import netket; g = netket.graph.Hypercube(4, 1); h = netket.hilbert.Spin(g, 0.5); m = netket.machine.RbmSpin(h, 10)'
-  - python -m pytest -n 2 --verbose ../Test/
-  - python -m pytest --verbose --doctest-glob='*.md' ../Docs/
+  - python -m pytest --durations=0 -n 2 --verbose ../Test/
+  - python -m pytest --durations=0 --verbose --doctest-glob='*.md' ../Docs/


### PR DESCRIPTION
Calling [`pytest --durations=0`](http://doc.pytest.org/en/latest/usage.html#profiling-test-execution-duration) will print the runtime of all test cases, which I think is nice to have (primarily to identify which tests are slow).