### PR TITLE
Add __repr__ and asdict() to Stats

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -191,7 +191,7 @@ install:
   - python -m pip install -U pip
   - python -m pip --version
   - python -m easy_install -U setuptools
-  - python -m pip install numpy scipy networkx pytest python-igraph mpi4py jax jaxlib
+  - python -m pip install numpy scipy networkx pytest python-igraph jax jaxlib
   - python -m pip install -U pytest
   - python -m pip install pytest-xdist
   - python -m pytest --version
@@ -199,7 +199,6 @@ install:
   - mkdir workdir && cd workdir
 
 script:
-  - python -c 'from mpi4py import MPI; print(MPI.get_vendor())'
   - python -c 'import netket'
   - python -c 'import netket; g = netket.graph.Hypercube(4, 1); h = netket.hilbert.Spin(g, 0.5); m = netket.machine.RbmSpin(h, 10)'
   - python -m pytest --durations=0 -n 2 --verbose ../Test/

--- a/Sources/Stats/py_stats.cc
+++ b/Sources/Stats/py_stats.cc
@@ -66,15 +66,16 @@ void AddStatsModule(py::module m) {
       .def_readonly("R", &Stats::R)
       .def("__repr__",
            [](const Stats& self) {
-             std::stringstream stream;
+             std::ostringstream stream;
+             const double imag = self.mean.imag();
              // clang-format off
              stream << std::setprecision(4)
-                    << self.mean.real()
-                    << " ± " << self.error_of_mean
-                    << " (Im=" << self.mean.imag()
-                    << ", var=" << self.variance
+                    << "(" << self.mean.real()
+                    << (imag >= 0 ? " + " : " - ") << std::abs(imag)
+                    << "i) ± " << self.error_of_mean
+                    << " [var=" << self.variance
                     << ", R=" << std::setprecision(6) << self.R
-                    << ")";
+                    << "]";
              // clang-format on
              return stream.str();
            })


### PR DESCRIPTION
Provides more useful `__repr__` output for `Stats` objects in Python and add `asdict` method:

```python
>>> stats = netket.stats.statistics(local_energy)
>>> stats
-8.321 ± 0.8524 (Im=-0.01043, var=58.23, R=1.0056)
>>> stats.asdict()
{'Mean': (-8.320763354546632-0.010434343835340771j), 'Sigma': 0.8524036308501588, 'Variance': 58.231913842857885, 'R': 1.0055981084528502, 'TauCorr': nan}
````