### PR TITLE
netket.machine.Torch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,9 +190,10 @@ endif()
 if (NETKET_USE_TORCH)
     add_library(Torch INTERFACE)
     find_package(PythonInterp ${NETKET_PYTHON_VERSION} REQUIRED)
-    execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c"
-        "from torch.utils.cpp_extension import include_paths;
-print(';'.join(include_paths()), end='')"
+    execute_process(COMMAND "${PYTHON_EXECUTABLE}" -c
+        "from __future__ import print_function;
+from torch.utils.cpp_extension import include_paths;
+print(';'.join(include_paths()), end='')" 2>/dev/null | tail -n 1
         RESULT_VARIABLE _PYTHON_SUCCESS
         OUTPUT_VARIABLE _PYTHON_VALUE
         ERROR_VARIABLE _PYTHON_ERROR_VALUE)
@@ -204,9 +205,10 @@ print(';'.join(include_paths()), end='')"
     target_include_directories(Torch SYSTEM INTERFACE ${_PYTHON_VALUE})
     target_include_directories(Torch SYSTEM INTERFACE ${PYTHON_INCLUDE_DIRS})
     message(STATUS "[Torch] include directories: ${_PYTHON_VALUE}")
-    execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c"
-        "from torch.utils.cpp_extension import library_paths;
-print(';'.join(library_paths()), end='')"
+    execute_process(COMMAND "${PYTHON_EXECUTABLE}" -c
+        "from __future__ import print_function;
+from torch.utils.cpp_extension import library_paths;
+print(';'.join(library_paths()), end='')" 2>/dev/null | tail -n 1
         RESULT_VARIABLE _PYTHON_SUCCESS
         OUTPUT_VARIABLE _PYTHON_VALUE
         ERROR_VARIABLE _PYTHON_ERROR_VALUE)
@@ -216,6 +218,7 @@ print(';'.join(library_paths()), end='')"
         return()
     endif()
     target_link_libraries(Torch INTERFACE ${_PYTHON_VALUE})
+    message(STATUS "[Torch] libraries: ${_PYTHON_VALUE}")
 endif()
 
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ option(NETKET_USE_OPENMP "Use OpenMP for multithreading" ON)
 option(NETKET_USE_SANITIZER "Build test suite with Clang sanitizer" OFF)
 option(NETKET_USE_BLAS "Use system BLAS instead of Eigen's implementation" ON)
 option(NETKET_USE_LAPACK "Use system LAPACK instead of Eigen's implementation" ON)
+option(NETKET_USE_TORCH "Use PyTorch" ON)
 
 option(NETKET_USE_SLEEF "Use Sleef vector math library" ON)
 set(NETKET_PYTHON_VERSION "" CACHE STRING "Python version to use for compiling modules")
@@ -184,6 +185,38 @@ if (BUILD_TESTING AND NETKET_BUILD_TESTING)
         INTERFACE "${CMAKE_BINARY_DIR}/External/Catch2/catch2")
 endif()
 
+# PyTorch
+################################################################################
+if (NETKET_USE_TORCH)
+    add_library(Torch INTERFACE)
+    find_package(PythonInterp ${NETKET_PYTHON_VERSION} REQUIRED)
+    execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c"
+        "from torch.utils.cpp_extension import include_paths;
+print(';'.join(include_paths()), end='')"
+        RESULT_VARIABLE _PYTHON_SUCCESS
+        OUTPUT_VARIABLE _PYTHON_VALUE
+        ERROR_VARIABLE _PYTHON_ERROR_VALUE)
+    if(NOT _PYTHON_SUCCESS MATCHES 0)
+        message(FATAL_ERROR
+            "Could not find PyTorch include directories:\n${_PYTHON_ERROR_VALUE}")
+        return()
+    endif()
+    target_include_directories(Torch SYSTEM INTERFACE ${_PYTHON_VALUE})
+    target_include_directories(Torch SYSTEM INTERFACE ${PYTHON_INCLUDE_DIRS})
+    message(STATUS "[Torch] include directories: ${_PYTHON_VALUE}")
+    execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c"
+        "from torch.utils.cpp_extension import library_paths;
+print(';'.join(library_paths()), end='')"
+        RESULT_VARIABLE _PYTHON_SUCCESS
+        OUTPUT_VARIABLE _PYTHON_VALUE
+        ERROR_VARIABLE _PYTHON_ERROR_VALUE)
+    if(NOT _PYTHON_SUCCESS MATCHES 0)
+        message(FATAL_ERROR
+            "Could not find PyTorch library paths:\n${_PYTHON_ERROR_VALUE}")
+        return()
+    endif()
+    target_link_libraries(Torch INTERFACE ${_PYTHON_VALUE})
+endif()
 
 #
 # NetKet
@@ -207,7 +240,16 @@ if(NETKET_USE_OPENMP)
 endif()
 if(NETKET_USE_SLEEF)
     target_link_libraries(netket_lib INTERFACE Sleef)
-    target_compile_definitions(netket_lib INTERFACE NETKET_USE_SLEEF)
+    target_compile_definitions(netket_lib INTERFACE NETKET_USE_SLEEF=1)
+endif()
+if(NETKET_USE_TORCH)
+    target_link_libraries(netket_lib INTERFACE Torch)
+    target_compile_definitions(netket_lib INTERFACE
+        NETKET_USE_TORCH=1
+        TORCH_API_INCLUDE_EXTENSION_H=1
+        TORCH_EXTENSION_NAME="_C_netket"
+        _GLIBCXX_USE_CXX11_ABI=0
+    )
 endif()
 
 set(NETKET_WARNING_FLAGS
@@ -307,6 +349,21 @@ if (NETKET_USE_SLEEF)
     ExternalProject_Get_Property(eigen_project SOURCE_DIR)
     target_include_directories(log_cosh_avx2 SYSTEM PUBLIC ${SOURCE_DIR})
     target_sources(netket PRIVATE $<TARGET_OBJECTS:log_cosh_avx2>)
+endif()
+
+if (NETKET_USE_TORCH)
+    add_library(torch_machine OBJECT Sources/Machine/py_torch.cc Sources/Machine/torch.cc)
+    set_property(TARGET torch_machine PROPERTY POSITION_INDEPENDENT_CODE ON)
+    target_compile_definitions(torch_machine PUBLIC
+        $<TARGET_PROPERTY:netket_lib,INTERFACE_COMPILE_DEFINITIONS>)
+    target_compile_options(torch_machine PUBLIC
+        $<TARGET_PROPERTY:netket_lib,INTERFACE_COMPILE_OPTIONS>)
+    target_include_directories(torch_machine SYSTEM PUBLIC
+        $<TARGET_PROPERTY:netket_lib,INTERFACE_INCLUDE_DIRECTORIES>)
+    target_include_directories(torch_machine SYSTEM PUBLIC
+        $<TARGET_PROPERTY:Torch,INTERFACE_INCLUDE_DIRECTORIES>)
+    add_dependencies(torch_machine eigen_project pybind11_project)
+    target_sources(netket PRIVATE $<TARGET_OBJECTS:torch_machine>)
 endif()
 
 # A workaround for missing __cpu_model bug in gcc-5 and Clangs earlier than 6

--- a/Sources/Machine/abstract_machine.cc
+++ b/Sources/Machine/abstract_machine.cc
@@ -101,6 +101,22 @@ AbstractMachine::VectorType AbstractMachine::DerLogChanged(
   return DerLogSingle(vp);
 }
 
+void AbstractMachine::JvpLog(Eigen::Ref<const RowMatrix<double>> v,
+                             Eigen::Ref<const VectorXcd> delta,
+                             Eigen::Ref<VectorXcd> out) {
+  // Other shapes are checked in DerLog
+  CheckShape(__FUNCTION__, "delta", delta.size(), v.rows());
+  CheckShape(__FUNCTION__, "out", out.size(), Npar());
+  out.noalias() = DerLog(v).transpose() * delta;
+}
+
+VectorXcd AbstractMachine::JvpLog(Eigen::Ref<const RowMatrix<double>> v,
+                                  Eigen::Ref<const VectorXcd> delta) {
+  VectorXcd out(Npar());
+  JvpLog(v, delta, out);
+  return out;
+}
+
 AbstractMachine::VectorType AbstractMachine::LogValDiff(
     VisibleConstType v, const std::vector<std::vector<int>> &tochange,
     const std::vector<std::vector<double>> &newconf) {

--- a/Sources/Machine/abstract_machine.hpp
+++ b/Sources/Machine/abstract_machine.hpp
@@ -101,6 +101,17 @@ class AbstractMachine {
                                     const any &cache = any{});
 
   /**
+   * Computes the `J · delta` product where `J` is the Jacobian matrix of the
+   * logarithm of the wavefunction at points `v`. Result is written to `out`.
+   */
+  virtual void JvpLog(Eigen::Ref<const RowMatrix<double>> v,
+                      Eigen::Ref<const VectorXcd> delta,
+                      Eigen::Ref<VectorXcd> out);
+
+  virtual VectorXcd JvpLog(Eigen::Ref<const RowMatrix<double>> v,
+                           Eigen::Ref<const VectorXcd> delta);
+
+  /**
   Member function computing the logarithm of the wave function for a given
   visible vector. Given the current set of parameters, this function should
   comput the value of the logarithm of the wave function using the information

--- a/Sources/Machine/py_machine.cc
+++ b/Sources/Machine/py_machine.cc
@@ -41,6 +41,10 @@
 #include "Machine/rbm_spin_v2.hpp"
 #include "Utils/log_cosh.hpp"
 
+#if defined(NETKET_USE_TORCH)
+#include "Machine/py_torch.hpp"
+#endif
+
 namespace py = pybind11;
 
 namespace netket {
@@ -680,7 +684,7 @@ void AddAbstractMachine(py::module m) {
            )EOF")
       .def(
           "load_state_dict",
-          [](AbstractMachine &self, py::dict state) {
+          [](AbstractMachine &self, py::object state) {
             self.StateDict(state.ptr());
           },
           R"EOF(Loads machine's state from `state`.
@@ -771,6 +775,9 @@ void AddMachineModule(py::module m) {
   AddFFNN(subm);
   AddLayerModule(m);
   AddDensityMatrixModule(subm);
+#if defined(NETKET_USE_TORCH)
+  AddPyTorchMachine(subm.ptr());
+#endif
 }
 
 }  // namespace netket

--- a/Sources/Machine/py_machine.cc
+++ b/Sources/Machine/py_machine.cc
@@ -650,6 +650,14 @@ void AddAbstractMachine(py::module m) {
                  Args:
                      v: Input vector to machine.
            )EOF")
+      .def(
+          "jvp_log",
+          [](AbstractMachine &self, Eigen::Ref<const RowMatrix<double>> v,
+             Eigen::Ref<const VectorXcd> delta) {
+            return self.JvpLog(v, delta);
+          },
+          R"EOF( Pong! )EOF", py::arg{"v"}.noconvert(),
+          py::arg{"delta"}.noconvert())
       .def_property_readonly(
           "n_visible", &AbstractMachine::Nvisible,
           R"EOF(int: The number of inputs into the machine aka visible units in

--- a/Sources/Machine/py_torch.cc
+++ b/Sources/Machine/py_torch.cc
@@ -14,6 +14,7 @@
 
 #include "Machine/py_torch.hpp"
 
+#include <ATen/Parallel.h>
 #include <pybind11/complex.h>
 #include <pybind11/eigen.h>
 #include <pybind11/pybind11.h>
@@ -27,6 +28,9 @@ namespace py = pybind11;
 namespace netket {
 
 void AddPyTorchMachine(PyObject* raw) {
+  // at::set_num_threads(1);
+  // at::set_num_interop_threads(1);
+
   auto m = py::module{py::reinterpret_borrow<py::object>(raw)};
   py::class_<PyTorchMachine, AbstractMachine>(m, "Torch",
                                               R"EOF(

--- a/Sources/Machine/py_torch.cc
+++ b/Sources/Machine/py_torch.cc
@@ -1,0 +1,50 @@
+// Copyright 2019 The Simons Foundation, Inc. - All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "Machine/py_torch.hpp"
+
+#include <pybind11/complex.h>
+#include <pybind11/eigen.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+
+#include "Machine/torch.hpp"
+
+namespace py = pybind11;
+
+namespace netket {
+
+void AddPyTorchMachine(PyObject* raw) {
+  auto m = py::module{py::reinterpret_borrow<py::object>(raw)};
+  py::class_<PyTorchMachine, AbstractMachine>(m, "Torch",
+                                              R"EOF(
+    A wrapper which allows one to use a `torch.jit.ScriptModule` as a NetKet machine.
+
+    *Note:* Backprop is not yet supported pending implementation of SR in terms
+    of Jacobian vector products.
+    )EOF")
+      .def(py::init<std::shared_ptr<const AbstractHilbert>, std::string>(),
+           R"EOF(
+           Wraps a `torch.jit.ScriptModule` into a NetKet machine.
+
+           Args:
+               hilbert: Hilbert space on which to define the machine.
+               filename: Name of the file where PyTorch machine was saved to
+                   using `torch.jit.ScriptModule.save`.
+           )EOF",
+           py::arg{"hilbert"}, py::arg{"filename"});
+}
+
+}  // namespace netket

--- a/Sources/Machine/py_torch.hpp
+++ b/Sources/Machine/py_torch.hpp
@@ -1,0 +1,26 @@
+// Copyright 2019 The Simons Foundation, Inc. - All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NETKET_SOURCES_MACHINE_PY_TORCH_HPP
+#define NETKET_SOURCES_MACHINE_PY_TORCH_HPP
+
+#include <Python.h>
+
+namespace netket {
+
+void AddPyTorchMachine(PyObject *m);
+
+}  // namespace netket
+
+#endif  // NETKET_SOURCES_MACHINE_PY_TORCH_HPP

--- a/Sources/Machine/rbm_spin_v2.hpp
+++ b/Sources/Machine/rbm_spin_v2.hpp
@@ -57,38 +57,11 @@ class RbmSpinV2 : public AbstractMachine {
   void DerLog(Eigen::Ref<const RowMatrix<double>> v,
               Eigen::Ref<RowMatrix<Complex>> out, const any & /*unused*/) final;
 
-  /// Simply calls `LogVal` with a batch size of 1.
-  ///
-  /// \note performance of this function is pretty bad. Please, use `LogVal`
-  /// with batch sizes greater than 1 if at all possible.
-  Complex LogValSingle(Eigen::Ref<const Eigen::VectorXd> v,
-                       const any &cache) final {
-    Complex data;
-    auto out = Eigen::Map<Eigen::VectorXcd>(&data, 1);
-    LogVal(v.transpose(), out, cache);
-    return data;
-  }
-
-  /// Simply calls `DerLog` with a batch size of 1.
-  ///
-  /// \note performance of this function is pretty bad. Please, use `DerLog`
-  /// with batch sizes greater than 1 if at all possible.
-  Eigen::VectorXcd DerLogSingle(Eigen::Ref<const Eigen::VectorXd> v,
-                                const any &cache) final {
-    Eigen::VectorXcd out(Npar());
-    DerLog(v.transpose(),
-           Eigen::Map<RowMatrix<Complex>>{out.data(), 1, out.size()}, cache);
-    return out;
-  }
-
-  // Look-up stuff
-  any InitLookup(VisibleConstType) final { return {}; }
-  void UpdateLookup(VisibleConstType, const std::vector<int> &,
-                    const std::vector<double> &, any &) final {}
-
   PyObject *StateDict() final;
 
   bool IsHolomorphic() const noexcept final { return true; }
+
+  NETKET_MACHINE_DISABLE_LOOKUP
 
  private:
   /// Performs `out := log(cosh(out + b))`.

--- a/Sources/Machine/torch.cc
+++ b/Sources/Machine/torch.cc
@@ -1,0 +1,191 @@
+// Copyright 2019 The Simons Foundation, Inc. - All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "torch.hpp"
+
+#include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+namespace netket {
+
+namespace detail {
+
+/// Runs a Depth-First Search on \p module.
+///
+/// \note \p function is copied on every recursive call so make sure you wrap
+/// your function in a `std::reference_wrapper` if it is expensive to copy.
+template <class T>
+void ForEveryParameter(const torch::jit::script::Module& module, T function) {
+  for (const auto& slot : module.get_parameters()) {
+    function(slot);
+  }
+  for (const auto& child : module.get_modules()) {
+    ForEveryParameter(*child, function);
+  }
+}
+
+// NOTE: This function will probably fail if some of the parameters are not
+// Tensors. Not sure if this is actually possible though
+Index CountParameters(const torch::jit::script::Module& module) {
+  auto n = Index{0};
+  auto acc = [&n](const torch::jit::script::Slot& x) {
+    n += x.value().toTensor().numel();
+  };
+  ForEveryParameter(module, std::cref(acc));
+  return n;
+}
+
+torch::Tensor AsTensor(Eigen::Ref<const RowMatrix<double>> x) {
+  return torch::from_blob(
+      /*data=*/const_cast<double*>(x.data()),
+      /*sizes=*/{x.rows(), x.cols()},
+      /*strides=*/{x.cols(), 1}, torch::kFloat64);
+}
+
+std::shared_ptr<torch::jit::script::Module> LoadScriptModule(
+    const std::string& filename) {
+  auto m = torch::jit::load(filename);
+  NETKET_CHECK(
+      m != nullptr, RuntimeError,
+      "Failed to load torch::jit::script::Module from '" << filename << "'");
+  return m;
+}
+
+}  // namespace detail
+
+PyTorchMachine::PyTorchMachine(std::shared_ptr<const AbstractHilbert> hilbert,
+                               const std::string& filename)
+    : PyTorchMachine{std::move(hilbert), detail::LoadScriptModule(filename)} {}
+
+PyTorchMachine::PyTorchMachine(
+    std::shared_ptr<const AbstractHilbert> hilbert,
+    std::shared_ptr<torch::jit::script::Module> module)
+    : AbstractMachine{std::move(hilbert)},
+      module_{std::move(module)},
+      forward_{module_->get_method("forward")},
+      n_par_{detail::CountParameters(*module_)} {}
+
+void PyTorchMachine::LogVal(Eigen::Ref<const RowMatrix<double>> v,
+                            Eigen::Ref<Eigen::VectorXcd> out,
+                            const any& /*unused*/) {
+  CheckShape(__FUNCTION__, "v", {v.rows(), v.cols()},
+             {std::ignore, this->Nvisible()});
+  CheckShape(__FUNCTION__, "out", out.size(), v.rows());
+  auto r = forward_({detail::AsTensor(v)}).toTensor();
+  const auto sizes = r.sizes();
+  const auto strides = r.strides();
+  const auto dtype = r.dtype();
+  NETKET_CHECK((sizes == torch::IntArrayRef{v.rows(), 2}), RuntimeError,
+               "user-defined network returned a tensor of wrong shape: "
+                   << sizes << "; expected [" << v.rows() << ", 2]");
+  NETKET_CHECK(r.scalar_type() == torch::kFloat64, RuntimeError,
+               "user-defined network returned a tensor of wrong dtype: "
+                   << dtype << "; expected Float64");
+  NETKET_CHECK((strides == torch::IntArrayRef{2, 1}), RuntimeError,
+               "it is assumed that by defaylt PyTorch creates row-major "
+               "tensors; strides are"
+                   << strides << "; expected [2, 1]");
+  std::memcpy(out.data(), r.data_ptr(), 2 * out.size() * sizeof(double));
+}
+
+void PyTorchMachine::DerLog(Eigen::Ref<const RowMatrix<double>> /*unused*/,
+                            Eigen::Ref<RowMatrix<Complex>> /*unused*/,
+                            const any& /*unused*/) {
+  NETKET_CHECK(false, RuntimeError, "not yet implemented");
+}
+
+VectorXcd PyTorchMachine::GetParameters() {
+  // First of all, we construct a list of all the parameters by running DFS on
+  // the model
+  std::vector<torch::Tensor> parameters;
+  parameters.reserve(128);
+  auto acc = [&parameters](const torch::jit::script::Slot& x) {
+    parameters.emplace_back(x.value().toTensor().flatten());
+  };
+  torch::NoGradGuard no_grad;
+  detail::ForEveryParameter(*module_, std::cref(acc));
+  // The we ask PyTorch concatenate them
+  VectorXcd out(Npar());
+  auto out_tensor =
+      torch::from_blob(out.data(), {out.size()}, {2}, torch::kFloat64);
+  torch::cat_out(out_tensor, parameters);
+  return out;
+}
+
+void PyTorchMachine::SetParameters(Eigen::Ref<const Eigen::VectorXcd> pars) {
+  CheckShape(__FUNCTION__, "parameters", pars.size(), Npar());
+  NETKET_CHECK((pars.imag().array() == 0.0).all(), InvalidInputError,
+               "TorchMachine supports only real parameters; received a "
+               "parameter with non-zero imaginary part");
+  torch::NoGradGuard no_grad;
+  auto* ptr = const_cast<double*>(reinterpret_cast<const double*>(pars.data()));
+  auto go = [&ptr](const torch::jit::script::Slot& slot) {
+    auto dst = slot.value().toTensor().flatten();
+    auto src = torch::from_blob(ptr, dst.sizes(), {2}, torch::kFloat64);
+    dst.copy_(src);
+    ptr += 2 * dst.numel();
+  };
+  detail::ForEveryParameter(*module_, std::cref(go));
+}
+
+namespace detail {
+namespace {
+/// \brief Converts a Tensor into a NumPy array.
+///
+/// Kind of what `torch.Tensor.numpy` does in Python.
+py::array AsNumPy(torch::Tensor const& x) {
+  return AT_DISPATCH_ALL_TYPES(x.scalar_type(), "AsNumPy", [&]() -> py::array {
+    const auto torch_strides = x.strides();
+    // NumPy strides are in bytes rather than in counts of sizeof(scalar_t)
+    std::vector<ssize_t> numpy_strides;
+    numpy_strides.reserve(torch_strides.size());
+    for (const auto s : torch_strides) {
+      numpy_strides.push_back(sizeof(scalar_t) * s);
+    }
+    return py::array{pybind11::dtype::of<scalar_t>(), x.sizes(),
+                     std::move(numpy_strides), x.data_ptr(), py::none()};
+  });
+}
+
+/// \brief Builds a state dictionary for \p module.
+///
+/// See the implementation of `torch.nn.Module.state_dict` in PyTorch repo for /
+/// more info.
+py::object StateDict(const torch::jit::script::Module& module,
+                     py::object destination = py::none(),
+                     const std::string& prefix = "") {
+  if (destination.is_none()) {
+    destination = py::module::import("collections").attr("OrderedDict")();
+  }
+  for (const auto& slot : module.get_parameters()) {
+    destination[py::str(prefix + slot.name())] =
+        AsNumPy(slot.value().toTensor());
+  }
+  for (const auto& m : module.get_modules()) {
+    StateDict(*m, destination, prefix + m->name() + '.');
+  }
+  return destination;
+}
+}  // namespace
+}  // namespace detail
+
+PyObject* PyTorchMachine::StateDict() {
+  return detail::StateDict(*module_).release().ptr();
+}
+
+}  // namespace netket
+
+// PYBIND11_MODULE(_C_netket_torch, m) { netket::AddPyTorchMachine(m); }

--- a/Sources/Machine/torch.hpp
+++ b/Sources/Machine/torch.hpp
@@ -59,6 +59,10 @@ class PyTorchMachine final : public AbstractMachine {
               Eigen::Ref<RowMatrix<Complex>> out,
               const any & /*unused*/) override;
 
+  void JvpLog(Eigen::Ref<const RowMatrix<double>> v,
+              Eigen::Ref<const VectorXcd> delta,
+              Eigen::Ref<VectorXcd> out) override;
+
   Eigen::VectorXcd GetParameters() override;
   void SetParameters(Eigen::Ref<const Eigen::VectorXcd> pars) override;
   PyObject *StateDict() override;

--- a/Sources/Machine/torch.hpp
+++ b/Sources/Machine/torch.hpp
@@ -1,0 +1,71 @@
+// Copyright 2019 The Simons Foundation, Inc. - All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NETKET_SOURCES_MACHINE_TORCH_HPP
+#define NETKET_SOURCES_MACHINE_TORCH_HPP
+
+#include <torch/extension.h>
+#include <torch/script.h>
+
+#include "Machine/abstract_machine.hpp"
+
+namespace netket {
+
+class PyTorchMachine final : public AbstractMachine {
+  /// \brief PyTorch module we are wrapping.
+  ///
+  /// \note This will become `torch::jit::script::Module` (without
+  /// `std::shared_ptr`) when PyTorch v1.2 comes out.
+  std::shared_ptr<torch::jit::script::Module> module_;
+  /// \brief Cached `forward` method to avoid looking it up in a map every time.
+  torch::jit::script::Method &forward_;
+  /// \brief Total number of parameters in the machine.
+  ///
+  /// It is initialised during construction is never updated.
+  Index n_par_;
+
+  PyTorchMachine(std::shared_ptr<const AbstractHilbert> hilbert,
+                 std::shared_ptr<torch::jit::script::Module> module);
+
+ public:
+  PyTorchMachine(std::shared_ptr<const AbstractHilbert> hilbert,
+                 const std::string &filename);
+
+  PyTorchMachine(const PyTorchMachine &) = delete;
+  PyTorchMachine(PyTorchMachine &&) = delete;
+  PyTorchMachine &operator=(const PyTorchMachine &) = delete;
+  PyTorchMachine &operator=(PyTorchMachine &&) = delete;
+
+  int Npar() const override { return static_cast<int>(n_par_); }
+  bool IsHolomorphic() const noexcept override { return false; }
+
+  void LogVal(Eigen::Ref<const RowMatrix<double>> v,
+              Eigen::Ref<Eigen::VectorXcd> out,
+              const any & /*unused*/) override;
+
+  /// \brief Currently just throws a "not yet implemented" exception.
+  void DerLog(Eigen::Ref<const RowMatrix<double>> v,
+              Eigen::Ref<RowMatrix<Complex>> out,
+              const any & /*unused*/) override;
+
+  Eigen::VectorXcd GetParameters() override;
+  void SetParameters(Eigen::Ref<const Eigen::VectorXcd> pars) override;
+  PyObject *StateDict() override;
+
+  NETKET_MACHINE_DISABLE_LOOKUP
+};
+
+}  // namespace netket
+
+#endif  // NETKET_SOURCES_MACHINE_TORCH_HPP

--- a/netket/__init__.py
+++ b/netket/__init__.py
@@ -13,6 +13,12 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+try:
+    # We need to import torch before we import _C_netket, because torch loads
+    # libtorch.so which we rely on.
+    import torch
+except ImportError:
+    pass
 from . import (
     _C_netket,
     dynamics,

--- a/netket/machine/__init__.py
+++ b/netket/machine/__init__.py
@@ -14,9 +14,20 @@ def _has_jax():
     except ImportError:
         return False
 
+def _has_torch():
+    try:
+        import torch
+
+        return True
+    except ImportError:
+        return False
+
 
 if _has_jax():
     from .jax import *
+
+if _has_torch():
+    from .torch import *
 
 
 def MPSPeriodicDiagonal(hilbert, bond_dim, symperiod=-1):

--- a/netket/machine/torch.py
+++ b/netket/machine/torch.py
@@ -1,0 +1,113 @@
+# Copyright 2019 The Simons Foundation, Inc. - All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from collections import OrderedDict
+import numpy as np
+import torch
+
+from .cxx_machine import CxxMachine
+
+__all__ = ["Torch"]
+
+
+def _get_number_parameters(m):
+    r"""Returns total number of variational parameters in a torch.nn.Module."""
+    return sum(
+        map(lambda p: p.numel(), filter(lambda p: p.requires_grad, m.parameters()))
+    )
+
+
+class Torch(CxxMachine):
+    def __init__(self, hilbert, module):
+        super(Torch, self).__init__(hilbert)
+        self._module = torch.jit.load(module) if isinstance(module, str) else module
+        self._module.double()
+        n_par = _get_number_parameters(self._module)
+
+        self._n_par = lambda: n_par
+
+    def _get_parameters(self):
+        return (
+            torch.cat(tuple(p.view(-1) for p in self._module.parameters()))
+            .detach()
+            .numpy()
+        )
+
+    def _is_holomorphic(self):
+        return False
+
+    def _set_parameters(self, p):
+        if not np.all(p.imag == 0.0):
+            raise ValueError("PyTorch machines have real parameters")
+        p = torch.from_numpy(p.real)
+        if p.numel() != self._n_par():
+            raise ValueError(
+                "p has wrong shape: {}; expected [{}]".format(p.size(), self._n_par())
+            )
+        i = 0
+        for x in map(lambda x: x.view(-1), self._module.parameters()):
+            x.copy_(p[i : i + len(x)])
+            i += len(x)
+
+    def _log_val(self, x, out=None):
+        out = torch.from_numpy(out.view(np.float64)).view(-1, 2)
+        out.copy_(self._module(torch.from_numpy(x)))
+
+    def _der_log(self, x, out=None):
+        raise NotImplementedError
+
+    def jvp_log(self, v, delta, out=None):
+        v = torch.from_numpy(v)
+        if out is None:
+            out = np.empty(self._n_par(), dtype=np.complex128)
+
+        def write_to(dst):
+            dst = torch.from_numpy(dst)
+            i = 0
+            for g in (
+                x.grad.flatten() for x in self._module.parameters() if x.requires_grad
+            ):
+                dst[i : i + g.numel()].copy_(g)
+                i += g.numel()
+
+        def zero_grad():
+            for g in (x.grad for x in self._module.parameters() if x.requires_grad):
+                if g is not None:
+                    g.zero_()
+
+        grad = torch.empty(v.size(0), 2, dtype=torch.float64)
+
+        def get_delta(is_real):
+            if is_real:
+                grad[:, 0] = torch.from_numpy(delta.real)
+                grad[:, 1] = 0
+            else:
+                grad[:, 0] = 0
+                grad[:, 1] = torch.from_numpy(delta.imag)
+            return grad
+
+        y = self._module(v)
+        zero_grad()
+        y.backward(get_delta(True), retain_graph=True)
+        write_to(out.real)
+        zero_grad()
+        y.backward(get_delta(False))
+        write_to(out.imag)
+        return out
+
+    def state_dict(self):
+        return OrderedDict(
+            [(k, v.detach().numpy()) for k, v in self._module.state_dict().items()]
+        )

--- a/setup.py
+++ b/setup.py
@@ -165,5 +165,5 @@ setup(
          neural networks and machine learning techniques.""",
     cmdclass=dict(build_ext=CMakeBuild),
     zip_safe=False,
-    install_requires=["numpy>=1.16", "cmake>=3.10.3", "scipy>=1.2.1"],
+    install_requires=["numpy>=1.16", "cmake>=3.10.3", "scipy>=1.2.1", "torch>=1.1"],
 )


### PR DESCRIPTION
Allows one to use a `torch.jit.ScriptModule` as a NetKet machine.

Backpropagation is not (yet) supported. The purpose of this PR is to access performance of PyTorch in the context of NQS and to decide whether it's worth it to depend on PyTorch by default.

Users who don't want to use PyTorch can simply pass `-DNETKET_USE_TORCH=off` to CMake. Compilation of `netket::PyTorchMachine` will be disabled, and, in Python, `torch.machine.Torch` will no longer be available.