### PR TITLE
Add test for MCMC statistics

### DIFF
--- a/Sources/Utils/py_utils.cc
+++ b/Sources/Utils/py_utils.cc
@@ -43,10 +43,11 @@ void AddUtilsModule(py::module m) {
   py::class_<Lookup<Complex>>(m, "LookupComplex").def(py::init<>());
 
   py::class_<MPIHelpers>(m, "MPI")
-      .def("rank", &MPIHelpers::MPIRank,
-           R"EOF(int: The MPI rank for the current process.  )EOF")
-      .def("size", &MPIHelpers::MPISize,
-           R"EOF(int: The total number of MPI ranks currently active.  )EOF");
+      .def_static("rank", &MPIHelpers::MPIRank,
+                  R"EOF(int: The MPI rank for the current process.  )EOF")
+      .def_static(
+          "size", &MPIHelpers::MPISize,
+          R"EOF(int: The total number of MPI ranks currently active.  )EOF");
 }
 
 }  // namespace netket

--- a/Test/Stats/test_stats.py
+++ b/Test/Stats/test_stats.py
@@ -20,7 +20,7 @@ def _setup():
 
 
 def _test_stats_mean_std(hi, ham, ma, batch_size):
-    sampler = nk.sampler.MetropolisLocalV2(ma, batch_size=batch_size)
+    sampler = nk.sampler.MetropolisLocal(ma, batch_size=batch_size)
 
     n_samples = 16000
     num_samples_per_chain = n_samples // batch_size
@@ -38,8 +38,10 @@ def _test_stats_mean_std(hi, ham, ma, batch_size):
 
     assert stats.mean == pytest.approx(np.mean(eloc))
     if batch_size > 1:
-        # error of mean == stdev of sample mean between chains
-        assert stats.error_of_mean == pytest.approx(eloc.mean(axis=0).std(ddof=1))
+        # error of mean == stdev of sample mean between chains / sqrt(#chains)
+        assert stats.error_of_mean == pytest.approx(
+            eloc.mean(axis=0).std(ddof=0) / np.sqrt(batch_size)
+        )
         # variance == average sample variance over chains
         assert stats.variance == pytest.approx(eloc.var(axis=0).mean())
         # R estimate
@@ -55,4 +57,3 @@ def test_stats_mean_std():
 
     for bs in (1, 2, 16, 32):
         _test_stats_mean_std(hi, ham, ma, bs)
-

--- a/Test/Stats/test_stats.py
+++ b/Test/Stats/test_stats.py
@@ -1,0 +1,58 @@
+import numpy as np
+import pytest
+
+import netket as nk
+import netket.variational as vmc
+from netket.operator import local_values
+from netket.stats import statistics
+
+
+def _setup():
+    g = nk.graph.Hypercube(3, 2)
+    hi = nk.hilbert.Spin(g, 0.5)
+
+    ham = nk.operator.Heisenberg(hi)
+
+    ma = nk.machine.RbmSpinV2(hi, alpha=2)
+    ma.init_random_parameters()
+
+    return hi, ham, ma
+
+
+def _test_stats_mean_std(hi, ham, ma, batch_size):
+    sampler = nk.sampler.MetropolisLocalV2(ma, batch_size=batch_size)
+
+    n_samples = 16000
+    num_samples_per_chain = n_samples // batch_size
+
+    res = vmc.compute_samples(sampler, n_samples=n_samples, n_discard=6400)
+    assert res.samples.shape == (num_samples_per_chain, batch_size, hi.size)
+
+    eloc = local_values(res.samples, res.log_values, ma, ham)
+    assert eloc.shape == (num_samples_per_chain, batch_size)
+
+    stats = statistics(eloc)
+
+    # These tests only work for one MPI process
+    assert nk.MPI.size() == 1
+
+    assert stats.mean == pytest.approx(np.mean(eloc))
+    if batch_size > 1:
+        # error of mean == stdev of sample mean between chains
+        assert stats.error_of_mean == pytest.approx(eloc.mean(axis=0).std(ddof=1))
+        # variance == average sample variance over chains
+        assert stats.variance == pytest.approx(eloc.var(axis=0).mean())
+        # R estimate
+        B_over_n = stats.error_of_mean ** 2
+        W = stats.variance
+        assert stats.R == pytest.approx(
+            np.sqrt((n_samples - 1.0) / n_samples + B_over_n / W), abs=1e-3
+        )
+
+
+def test_stats_mean_std():
+    hi, ham, ma = _setup()
+
+    for bs in (1, 2, 16, 32):
+        _test_stats_mean_std(hi, ham, ma, bs)
+


### PR DESCRIPTION
This PR adds a test that checks the MC statistics computed by `netket.stats.statistics` for the case of one MPI process and several different batch sizes (i.e., different numbers of Markov chains).