### PR TITLE
V2.1 : Fix wrong factors in new McStats class

### DIFF
--- a/Sources/Stats/mc_stats.cc
+++ b/Sources/Stats/mc_stats.cc
@@ -153,7 +153,8 @@ Stats Statistics(Eigen::Ref<const Eigen::VectorXcd> values,
     const auto R =
         std::sqrt(static_cast<double>(n - 1) / static_cast<double>(n) +
                   var.first / var.second);
-    return {mean, std::sqrt(var.first), var.second, correlation, R};
+    return {mean, std::sqrt(var.first / static_cast<double>(m - 1)), var.second,
+            correlation, R};
   }
   return Stats{mean, NaN, NaN, NaN, NaN};
 }

--- a/Sources/Stats/mc_stats.cc
+++ b/Sources/Stats/mc_stats.cc
@@ -107,7 +107,7 @@ Stats Statistics(Eigen::Ref<const Eigen::VectorXcd> values,
   NETKET_CHECK(values.size() >= local_number_chains, InvalidInputError,
                "not enough samples to compute statistics");
   constexpr auto NaN = std::numeric_limits<double>::quiet_NaN();
-  constexpr auto iNaN = std::numeric_limits<int>::quiet_NaN();
+
   auto stats_local = StatisticsLocal(values, local_number_chains);
   // Number of samples in each Markov Chain
   const auto n = values.size() / local_number_chains;
@@ -156,9 +156,9 @@ Stats Statistics(Eigen::Ref<const Eigen::VectorXcd> values,
         std::sqrt(static_cast<double>(n - 1) / static_cast<double>(n) +
                   var.first / var.second);
     return {mean, std::sqrt(var.first / static_cast<double>(m)), var.second,
-            static_cast<int>(std::round(correlation)), R};
+            std::round(correlation), R};
   }
-  return Stats{mean, NaN, NaN, iNaN, NaN};
+  return Stats{mean, NaN, NaN, NaN, NaN};
 }
 
 }  // namespace netket

--- a/Sources/Stats/mc_stats.hpp
+++ b/Sources/Stats/mc_stats.hpp
@@ -28,7 +28,7 @@ struct Stats {
   /// Average of in-chain variances of the observable over all Markov Chains.
   double variance;
   /// Autocorrelation time
-  int correlation;
+  double correlation;
   /// Convergence estimator. The closer it is to 1, the better has the sampling
   /// converged.
   double R;

--- a/Sources/Stats/mc_stats.hpp
+++ b/Sources/Stats/mc_stats.hpp
@@ -27,8 +27,8 @@ struct Stats {
   double error_of_mean;
   /// Average of in-chain variances of the observable over all Markov Chains.
   double variance;
-  /// Autocorrelation
-  double correlation;
+  /// Autocorrelation time
+  int correlation;
   /// Convergence estimator. The closer it is to 1, the better has the sampling
   /// converged.
   double R;


### PR DESCRIPTION
The error on the mean was largely overestimated, because the factor 1/m was missing. I also fixed the calculation of the correlation time, that is now an integer by default. The estimate of the correlation time has large error bars +/-1 (at least) thus it makes sense to round it to just an integer 