### PR TITLE
Fix deadlock when calling InitRandomPars without seed

### DIFF
--- a/Sources/Machine/abstract_machine.cc
+++ b/Sources/Machine/abstract_machine.cc
@@ -38,13 +38,12 @@ void AbstractMachine::InitRandomPars(double sigma,
 
   default_random_engine generator;
 
+  if (seed.has_value()) {
+    generator = default_random_engine(*seed);
+  } else {
+    generator = GetRandomEngine();
+  }
   if (rank == root) {
-    if (seed.has_value()) {
-      generator = default_random_engine(*seed);
-    } else {
-      generator = GetRandomEngine();
-    }
-
     std::generate(parameters.data(), parameters.data() + parameters.size(),
                   [&generator, sigma]() {
                     std::normal_distribution<double> dist{0.0, sigma};


### PR DESCRIPTION
Calling `GetRandomEngine` may create a new `DistributedRandomEngine`. This operation, through `GetDerivedSeed`, performs an MPI broadcast. Thus, `GetRandomEngine` needs to be called from all MPI processes in order to prevent a deadlock.