### PR TITLE
Set lapack off by default because of Eigen bug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ option(NETKET_BUILD_TESTING "Build unit tests." OFF)
 option(NETKET_USE_OPENMP "Use OpenMP for multithreading" ON)
 option(NETKET_USE_SANITIZER "Build test suite with Clang sanitizer" OFF)
 option(NETKET_USE_BLAS "Use system BLAS instead of Eigen's implementation" ON)
-option(NETKET_USE_LAPACK "Use system LAPACK instead of Eigen's implementation" ON)
+option(NETKET_USE_LAPACK "Use system LAPACK instead of Eigen's implementation" OFF)
 set(NETKET_PYTHON_VERSION "" CACHE STRING "Python version to use for compiling modules")
 
 if(NOT CMAKE_BUILD_TYPE)


### PR DESCRIPTION
Eigen still has a bug with the Lapack interface, because of the infamous ``I`` used in templates. This will cause netket installation to fail, thus it is wise to set the lapack option OFF by default.  