### PR TITLE
Correctly initialize optimizer in Python VMC driver

### DIFF
--- a/Sources/Optimizer/py_optimizer.hpp
+++ b/Sources/Optimizer/py_optimizer.hpp
@@ -39,12 +39,14 @@ namespace netket {
 void AddOptimizerModule(py::module &m) {
   auto subm = m.def_submodule("optimizer");
 
+  using Init = void (AbstractOptimizer::*)(int, bool);
   using UpdateReal =
       void (AbstractOptimizer::*)(const VectorXd &, Eigen::Ref<VectorXd>);
   using UpdateCplx =
       void (AbstractOptimizer::*)(const VectorXcd &, Eigen::Ref<VectorXcd>);
 
   py::class_<AbstractOptimizer>(subm, "Optimizer")
+      .def("init", static_cast<Init>(&AbstractOptimizer::Init))
       .def("reset", &AbstractOptimizer::Reset, R"EOF(
        Member function resetting the internal state of the optimizer.)EOF")
       .def("update", static_cast<UpdateReal>(&AbstractOptimizer::Update),

--- a/netket/_vmc_driver.py
+++ b/netket/_vmc_driver.py
@@ -18,7 +18,7 @@ def info(obj, depth=None):
         return str(obj)
 
 
-def make_optimizer_fn(arg):
+def make_optimizer_fn(arg, ma):
     """
     Utility function to create the optimizer step function for VMC drivers.
 
@@ -49,6 +49,8 @@ def make_optimizer_fn(arg):
         return optimize_fn, desc
 
     elif issubclass(type(arg), _nk.optimizer.Optimizer):
+
+        arg.init(ma.n_par, ma.is_holomorphic)
 
         def optimize_fn(_, grad, p):
             arg.update(grad, p)
@@ -125,7 +127,9 @@ class VmcDriver(object):
         self._sampler = sampler
         self._sr = sr
 
-        self._optimizer_step, self._optimizer_desc = make_optimizer_fn(optimizer)
+        self._optimizer_step, self._optimizer_desc = make_optimizer_fn(
+            optimizer, self._machine
+        )
 
         self._npar = self._machine.n_par
         self._mc_data = None


### PR DESCRIPTION
NetKet optimizers need to be initialized before use by calling `init`.