### PR TITLE
Make J and use of sign rule configurable for Heisenberg Hamiltonian

### DIFF
--- a/netket/operator.py
+++ b/netket/operator.py
@@ -28,11 +28,17 @@ def Ising(hilbert, h, J=1.0):
     return GraphOperator(hilbert, siteops=[-h * sigma_x], bondops=[J * sz_sz])
 
 
-def Heisenberg(hilbert):
+def Heisenberg(hilbert, J=1, sign_rule=None):
     """
     Constructs a new ``Heisenberg`` given a hilbert space.
     Args:
         hilbert: Hilbert space the operator acts on.
+        J: The strength of the coupling. Default is 1.
+        sign_rule: If enabled, Marshal's sign rule will be used. On a bipartite
+            lattice, this corresponds to a basis change flipping the Sz direction
+            at every odd site of the lattice. For non-bipartite lattices, the
+            sign rule cannot be applied. Defaults to True if the lattice is
+            bipartite, False otherwise.
     Examples:
      Constructs a ``Heisenberg`` operator for a 1D system.
         ```python
@@ -43,10 +49,15 @@ def Heisenberg(hilbert):
         >>> print(op.hilbert.size)
         20
     """
+    if sign_rule is None:
+        sign_rule = hilbert.graph.is_bipartite
+
     sz_sz = _np.array([[1, 0, 0, 0], [0, -1, 0, 0], [0, 0, -1, 0], [0, 0, 0, 1]])
     exchange = _np.array([[0, 0, 0, 0], [0, 0, 2, 0], [0, 2, 0, 0], [0, 0, 0, 0]])
-    if hilbert.graph.is_bipartite:
+    if sign_rule:
+        if not hilbert.graph.is_bipartite:
+            raise ValueError("sign_rule=True specified for a non-bipartite lattice")
         heis_term = sz_sz - exchange
     else:
         heis_term = sz_sz + exchange
-    return GraphOperator(hilbert, bondops=[heis_term])
+    return GraphOperator(hilbert, bondops=[J * heis_term])


### PR DESCRIPTION
`Ising` has configurable `J`, so why not also make it configurable for `Heisenberg` (even though in the static case it's only is a rescaling of the energy).

Also, while for VMC on a bipartite lattice the sign rule is crucial, adding the option of disabling it can be useful (e.g., to see its influence).