### PR TITLE
fix `to_dense` in `AbstractOperator`

### DIFF
--- a/Sources/Operator/abstract_operator.hpp
+++ b/Sources/Operator/abstract_operator.hpp
@@ -148,7 +148,7 @@ class AbstractOperator {
     matrix.resize(hilbert_index.NStates(), hilbert_index.NStates());
     matrix.setZero();
     ForEachMatrixElement([&matrix](const int i, const int j, const Complex x) {
-      matrix(i, j) = matrix(i, j) + x;
+      matrix(i, j) += x;
     });
     return matrix;
   }

--- a/Sources/Operator/abstract_operator.hpp
+++ b/Sources/Operator/abstract_operator.hpp
@@ -148,7 +148,7 @@ class AbstractOperator {
     matrix.resize(hilbert_index.NStates(), hilbert_index.NStates());
     matrix.setZero();
     ForEachMatrixElement([&matrix](const int i, const int j, const Complex x) {
-      matrix(i, j) = x;
+      matrix(i, j) = matrix(i, j) + x;
     });
     return matrix;
   }


### PR DESCRIPTION
(A minor change that I'll need for Lindblad)

The fact that there is only one entry per change is a  _silent_ assumption that holds true at the moment, 
but is not really enforced nor needed anywhere.

Moreover, with `to_sparse` you don't have this problem.

I came across this while working with Lindblad ME because there I have multiple entries with no changes.