### PR TITLE
Remove unneeded `assert` in complex*LocalOperator

### DIFF
--- a/Sources/Operator/local_operator.hpp
+++ b/Sources/Operator/local_operator.hpp
@@ -396,7 +396,6 @@ class LocalOperator : public AbstractOperator {
 
   template <class T>
   friend LocalOperator operator*(T lhs, const LocalOperator &rhs) {
-    assert(std::imag(lhs) == 0.);
     auto mat = rhs.mat_;
     auto sites = rhs.sites_;
 


### PR DESCRIPTION
I'm mostly sure this assert is not needed.