### PR TITLE
Add configurable SVD threshold to SR for BDCSVD method

### DIFF
--- a/Sources/Optimizer/py_stochastic_reconfiguration.cc
+++ b/Sources/Optimizer/py_stochastic_reconfiguration.cc
@@ -14,16 +14,18 @@ namespace py = pybind11;
 void AddSR(py::module& m) {
   py::class_<SR>(m, "SR", "Performs stochastic reconfiguration (SR) updates")
       .def(py::init([](const std::string& solver_name, double diag_shift,
-                       bool use_iterative, bool is_holomorphic) {
+                       bool use_iterative, bool is_holomorphic,
+                       nonstd::optional<double> svd_threshold) {
              const auto solver = SR::SolverFromString(solver_name);
              NETKET_CHECK(solver.has_value(), InvalidInputError,
                           "Invalid LSQ solver \"" << solver_name
                                                   << "\" specified for SR");
              return SR(solver.value(), diag_shift, use_iterative,
-                       is_holomorphic);
+                       is_holomorphic, svd_threshold);
            }),
            py::arg("lsq_solver") = "LLT", py::arg("diag_shift") = 0.01,
-           py::arg("use_iterative") = false, py::arg("is_holomorphic") = true)
+           py::arg("use_iterative") = false, py::arg("is_holomorphic") = true,
+           py::arg("svd_threshold") = nonstd::nullopt)
       .def("compute_update", &SR::ComputeUpdate, py::arg("Oks").noconvert(),
            py::arg("grad").noconvert(), py::arg("out").noconvert(),
            R"EOF(

--- a/Sources/Optimizer/stochastic_reconfiguration.cc
+++ b/Sources/Optimizer/stochastic_reconfiguration.cc
@@ -91,6 +91,9 @@ std::string SR::ShortDesc() const {
     str << "iterative";
   } else {
     str << SolverAsString(solver_) << ", diag_shift=" << sr_diag_shift_;
+    if (svd_threshold_.has_value()) {
+      str << ", threshold=" << *svd_threshold_;
+    }
   }
   str << ", is_holomorphic=" << (is_holomorphic_ ? "True" : "False") << ")";
   return str.str();

--- a/Test/Optimizer/test_sr.py
+++ b/Test/Optimizer/test_sr.py
@@ -1,9 +1,53 @@
 import netket as nk
+from netket.optimizer import SR
+
+import numpy as np
+
+import pytest
+
 
 def test_sr_no_segfault():
     """
     Tests the resolution of bug #317.
     """
-    sr = nk.optimizer.SR()
+    sr = SR()
     assert sr.last_covariance_matrix is None
 
+
+def test_svd_threshold():
+    """
+    Test SVD threshold option of BDCSVD
+    """
+    with pytest.raises(
+        ValueError, match="svd_threshold option only available for BDCSVD solver"
+    ):
+        SR(svd_threshold=1e-3)
+    with pytest.raises(
+        ValueError, match="svd_threshold option only available for BDCSVD solver"
+    ):
+        SR(use_iterative=True, svd_threshold=1e-3)
+    with pytest.raises(
+        ValueError, match="svd_threshold option only available for BDCSVD solver"
+    ):
+        SR(lsq_solver="LDLT", svd_threshold=1e-3)
+
+    a = np.diag([1e0 + 0j, 1e-3, 1e-6])
+    b = np.array([1.0 + 0j, 1.0, 1.0])
+
+    def SR_with_threshold(t):
+        return SR(lsq_solver="BDCSVD", svd_threshold=t, diag_shift=0)
+
+    def solve(sr, a, b):
+        a1 = np.sqrt(a) * np.sqrt(a.shape[0])
+        out = np.copy(b)
+        sr.compute_update(a1, b, out)
+        return out
+
+    sr = SR_with_threshold(1e-1)
+    assert np.allclose(solve(sr, a, b), [1.0, 0.0, 0.0])
+
+    sr = SR_with_threshold(1e-3)
+    assert np.allclose(solve(sr, a, b), [1.0, 1e3, 0.0])
+
+    sr = SR_with_threshold(1e-6)
+    assert np.allclose(solve(sr, a, b), [1.0, 1e3, 1e6])


### PR DESCRIPTION
This PR exposes the [`setThreshold`](https://eigen.tuxfamily.org/dox/classEigen_1_1SVDBase.html#a1c95d05398fc15e410a28560ef70a5a6) method of the Eigen BDCSVD solver on the SR class to Python.