### PR TITLE
Add iterative solvers for exact steadystate of open system

### DIFF
--- a/Examples/ExactDiag/dissipative_ising1.py
+++ b/Examples/ExactDiag/dissipative_ising1.py
@@ -52,4 +52,4 @@ for j_op in j_ops:
     lind.add_jump_op(j_op)
 
 
-rho = nk.exact.steady_state(lind, method='iterative', maxiter=1000, verbose=True)
+rho = nk.exact.steady_state(lind, method='iterative', sparse=True, maxiter=1000, tol=1e-5)

--- a/Examples/ExactDiag/dissipative_ising1.py
+++ b/Examples/ExactDiag/dissipative_ising1.py
@@ -19,7 +19,7 @@ np.set_printoptions(linewidth=180)
 rg = nk.utils.RandomEngine(seed=1234)
 
 # 1D Lattice
-L = 2
+L = 9
 g = nk.graph.Hypercube(length=L, n_dim=1, pbc=False)
 
 # Hilbert space of spins on the graph
@@ -45,11 +45,11 @@ for i in range(L):
 
 
 # Create the lindbladian with no jump operators
-lind = nk.operator.LocalLindbladian(ha)
+lind = nk.operator.LocalLiouvillian(ha)
 
 # add the jump operators
 for j_op in j_ops:
     lind.add_jump_op(j_op)
 
 
-rho = nk.exact.steady_state(lind)
+rho = nk.exact.steady_state(lind, method='iterative', maxiter=1000, verbose=True)


### PR DESCRIPTION
Uses a trickUses a trick from my PhD thesis to find the steadystate through `bicgstabl`.

Essentially iteratively solves the linear system 
L\rho = 0
Trace[\rho] = 1

In principle, in compiled languages I was able to push the method to handle up to 13-14 spins, but numpy does not seem to handle more than 10-11...

Still, it's much better than the diagonalization approach which cannot be used for more than 6-7 spins.
