### PR TITLE
Add edge color property to AbstractGraph

### DIFF
--- a/Sources/Graph/py_graph.cc
+++ b/Sources/Graph/py_graph.cc
@@ -203,6 +203,21 @@ void AddAbstractGraph(py::module subm) {
                              R"EOF(
       list[list]: The distances between the nodes. The fact that some node
           may not be reachable from another is represented by -1.)EOF")
+      .def_property_readonly(
+          "edge_colors",
+          [](const AbstractGraph& self) {
+            auto& color_map = self.EdgeColors();
+            std::vector<py::tuple> result;
+            for (auto& it : color_map) {
+              result.push_back(
+                  py::make_tuple(it.first[0], it.first[1], it.second));
+            }
+            return result;
+          },
+          R"EOF(
+      list[tuple]: Returns a list of tuples of the form (i, j, col) containing each edge `(i,j)`
+      with its corresponding color `col`.
+      )EOF")
       .def_property_readonly("automorphisms", &AbstractGraph::SymmetryTable,
                              R"EOF(
       list[list]: The automorphisms of the graph,

--- a/Test/Graph/test_graph.py
+++ b/Test/Graph/test_graph.py
@@ -194,3 +194,14 @@ def test_automorphisms():
             dim = len(graph.automorphisms)
             for i in range(dim):
                 assert graph.automorphisms[i] in autom
+
+
+def test_edge_color_accessor():
+    edges = sorted([(0, 1, 0), (1, 2, 1), (2, 3, 0), (0, 3, 1)])
+    g = nk.graph.CustomGraph(edges)
+
+    assert edges == sorted(g.edge_colors)
+
+    g = nk.graph.Hypercube(4, 1)
+
+    assert [(i, j, 0) for (i, j, _) in edges] == sorted(g.edge_colors)


### PR DESCRIPTION
This PR makes `AbstractGraph::EdgeColors` available in Python.