### PR TITLE
Progress bar for VMC driver

### DIFF
--- a/Test/GroundState/test_vmc.py
+++ b/Test/GroundState/test_vmc.py
@@ -4,6 +4,10 @@ import numpy as np
 import netket as nk
 import netket.variational as vmc
 
+from io import StringIO
+from contextlib import redirect_stderr
+import tempfile
+import re
 
 SEED = 214748364
 nk.utils.seed(SEED)
@@ -94,3 +98,24 @@ def test_vmc_use_cholesky_compatibility():
         vmc = nk.variational.Vmc(
             ha, sampler, op, 1000, use_cholesky=True, sr_lsq_solver="BDCSVD"
         )
+
+
+def test_vmc_progress_bar():
+    ha, sx, ma, sampler, driver = _setup_vmc()
+    driver.add_observable(sx, "sx")
+    tempdir = tempfile.mkdtemp()
+    prefix = tempdir + "/vmc_progressbar_test"
+
+    f = StringIO()
+    with redirect_stderr(f):
+        driver.run(prefix, 5)
+    pbar = f.getvalue().split("\r")[-1]
+    assert re.match(r"100%\|#*\| (\d+)/\1", pbar)
+    assert re.search(r"Energy=\([-+]?[0-9]*\.?[0-9]*", pbar)
+    assert re.search(r"var=[-+]?[0-9]*\.?[0-9]*", pbar)
+
+    f = StringIO()
+    with redirect_stderr(f):
+        driver.run(prefix, 5, show_progress=None)
+    pbar = f.getvalue()
+    assert not len(pbar)

--- a/setup.py
+++ b/setup.py
@@ -167,5 +167,5 @@ setup(
          neural networks and machine learning techniques.""",
     cmdclass=dict(build_ext=CMakeBuild),
     zip_safe=False,
-    install_requires=["numpy>=1.16", "cmake>=3.12", "scipy>=1.2.1", "mpi4py>=3.0.1"],
+    install_requires=["numpy>=1.16", "cmake>=3.12", "scipy>=1.2.1", "mpi4py>=3.0.1", "tqdm>=4.42.1"],
 )


### PR DESCRIPTION
This PR implements a progress bar that can be displayed during the VMC run, as discussed in https://github.com/netket/netket/issues/341. The progress bar is implemented using [tqdm](https://github.com/tqdm/tqdm), which is now added as a dependency.

With this PR, one can call `vmc_driver.run` with an extra argument `show_progress` that is used to enable the progress bar. The options for `show_progress` are:
1. `None` (deafult) - progress bar is disabled.
2.  list/tuple containing names of observables (e.g. `["Energy", "Sx"]`)- the observables' mean values will be displayed in the progress bar. Observables which were not added to the driver using `add_obsrvable` will be ignored. 
3. `True`/`[]` or any other value not listed above- display the progress bar without any information about observables. 
(If wanted I could add a check that makes sure that `show_progress` is either `True`/`[]` or the values above and throws an error otherwise).

I also added an argument `show_progress_fmt` which allows controlling the formatting of the printed mean values (default is ".4f"). But if this is an overkill I can remove it. 

In a Jupyter notebook the progress bar looks like this: 
<img width="851" alt="image" src="https://user-images.githubusercontent.com/1208196/75091547-dbc36280-556e-11ea-900b-c0707d73dc1e.png">
