### PR TITLE
Change AbstractMachine PyBind wrapper to parametric

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -280,7 +280,6 @@ set(NETKET_SOURCES
     Sources/Machine/rbm_spin_real.cc
     Sources/Machine/rbm_spin_symm.cc
     Sources/Machine/py_machine.cc
-    Sources/Machine/py_abstract_machine.cc
     Sources/Machine/DensityMatrices/abstract_density_matrix.cc
     Sources/Operator/abstract_operator.cc
     Sources/Operator/pauli_strings.cc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -304,7 +304,6 @@ set(NETKET_SOURCES
     Sources/Utils/random_utils.cc
     Sources/Machine/DensityMatrices/diagonal_density_matrix.cc
     Sources/Machine/DensityMatrices/ndm_spin_phase.cc
-    Sources/Machine/DensityMatrices/py_abstract_density_matrix.cc
     Sources/Machine/DensityMatrices/py_abstract_density_matrix.hpp
     Sources/Machine/DensityMatrices/py_density_matrix.cc
     Sources/Operator/local_liouvillian.cc

--- a/Sources/Machine/DensityMatrices/abstract_density_matrix.hpp
+++ b/Sources/Machine/DensityMatrices/abstract_density_matrix.hpp
@@ -194,7 +194,7 @@ class AbstractDensityMatrix : public AbstractMachine {
                              Eigen::Ref<Eigen::VectorXcd> output);
 
   // Methods below are inherited from AbstractMachine
-  int Nvisible() const final override { return NvisiblePhysical() * 2; }
+  int Nvisible() const override { return NvisiblePhysical() * 2; }
 
   void LogVal(Eigen::Ref<const RowMatrix<double>> v, Eigen::Ref<VectorType> out,
               const any &lt) override;

--- a/Sources/Machine/DensityMatrices/diagonal_density_matrix.cc
+++ b/Sources/Machine/DensityMatrices/diagonal_density_matrix.cc
@@ -22,38 +22,7 @@ using VisibleConstType = DiagonalDensityMatrix::VisibleConstType;
 using VisibleType = DiagonalDensityMatrix::VisibleType;
 using VisibleChangeInfo = DiagonalDensityMatrix::VisibleChangeInfo;
 
-VisibleType DiagonalDensityMatrix::DoubleVisibleConfig(const VisibleConstType v) const {
-  VisibleType v2(2 * v.rows());
-  v2.head(v.rows()) = v;
-  v2.tail(v.rows()) = v;
-
-  return v2;
-}
-
-VisibleChangeInfo DiagonalDensityMatrix::DoubleVisibleChangeInfo(const std::vector<int> &tochange,
-                                          const std::vector<double> &newconf,
-                                          int offset) const {
-  std::vector<int> tochange_doubled(tochange.size() * 2);
-  std::vector<double> newconf_doubled(newconf.size() * 2);
-
-  // Copy tochange on the first half of tochange_doubled and copy + offset on
-  // the other half.
-  std::copy(tochange.begin(), tochange.end(), tochange_doubled.begin());
-  std::copy(tochange.begin(), tochange.end(),
-            tochange_doubled.begin() + tochange.size());
-  for (auto tcd = tochange_doubled.begin() + tochange.size();
-       tcd != tochange_doubled.end(); ++tcd) {
-    *tcd += offset;
-  }
-
-  std::copy(newconf.begin(), newconf.end(), newconf_doubled.begin());
-  std::copy(newconf.begin(), newconf.end(),
-            newconf_doubled.begin() + newconf.size());
-
-  return VisibleChangeInfo(tochange_doubled, newconf_doubled);
-};
-
-Complex DiagonalDensityMatrix::LogValSingle(VisibleConstType v, const any &lt)  {
+Complex DiagonalDensityMatrix::LogValSingle(VisibleConstType v, const any &lt) {
   return density_matrix_.LogValSingle(v, v, lt);
 }
 

--- a/Sources/Machine/DensityMatrices/diagonal_density_matrix.hpp
+++ b/Sources/Machine/DensityMatrices/diagonal_density_matrix.hpp
@@ -35,19 +35,6 @@ class DiagonalDensityMatrix : public AbstractMachine {
 
   using VisibleChangeInfo = std::pair<std::vector<int>, std::vector<double>>;
 
- private:
-  /**
-   * Doubles a visible configuration v so that it represents an element on the
-   * diagonal of a density matrix.
-   * @param v is a visible configuration
-   * @return the vertical concatentation of [v, v]
-   */
-  VisibleType DoubleVisibleConfig(const VisibleConstType v) const;
-
-  VisibleChangeInfo DoubleVisibleChangeInfo(const std::vector<int> &tochange,
-                                            const std::vector<double> &newconf,
-                                            int offset) const ;
-
  public:
   Complex LogValSingle(VisibleConstType vr, const any &lt) override;
 

--- a/Sources/Machine/DensityMatrices/py_abstract_density_matrix.ipp
+++ b/Sources/Machine/DensityMatrices/py_abstract_density_matrix.ipp
@@ -12,26 +12,29 @@
 
 namespace netket {
 
-Complex PyAbstractDensityMatrix::LogValSingle(VisibleConstType v,
+template <class ADM>
+Complex PyAbstractDensityMatrix<ADM>::LogValSingle(VisibleConstType v,
                                               const any& cache) {
   Complex data;
   auto out = Eigen::Map<Eigen::VectorXcd>(&data, 1);
-  AbstractMachine::LogVal(v.transpose(), out, cache);
+  ADM::AbstractMachine::LogVal(v.transpose(), out, cache);
   return data;
 }
 
-void PyAbstractDensityMatrix::LogVal(Eigen::Ref<const RowMatrix<double>> vr,
+template <class ADM>
+void PyAbstractDensityMatrix<ADM>::LogVal(Eigen::Ref<const RowMatrix<double>> vr,
                                      Eigen::Ref<const RowMatrix<double>> vc,
                                      Eigen::Ref<VectorXcd> out,
                                      const linb::any& cache) {
   PYBIND11_OVERLOAD_PURE_NAME(void,                  /* Return type */
-                              AbstractDensityMatrix, /* Parent class */
+                              ADM, /* Parent class */
                               "log_val", /* Name of the function in Python */
                               LogVal,    /* Name of function in C++ */
                               vr, vc, out, cache);
 }
 
-Complex PyAbstractDensityMatrix::LogValSingle(VisibleConstType vr,
+template <class ADM>
+Complex PyAbstractDensityMatrix<ADM>::LogValSingle(VisibleConstType vr,
                                               VisibleConstType vc,
                                               const any& cache) {
   Complex data;
@@ -40,23 +43,26 @@ Complex PyAbstractDensityMatrix::LogValSingle(VisibleConstType vr,
   return data;
 }
 
-void PyAbstractDensityMatrix::DerLog(Eigen::Ref<const RowMatrix<double>> vr,
+template <class ADM>
+void PyAbstractDensityMatrix<ADM>::DerLog(Eigen::Ref<const RowMatrix<double>> vr,
                                      Eigen::Ref<const RowMatrix<double>> vc,
                                      Eigen::Ref<RowMatrix<Complex>> out,
                                      const linb::any& cache) {
   PYBIND11_OVERLOAD_PURE_NAME(void,                  /* Return type */
-                              AbstractDensityMatrix, /* Parent class */
+                              ADM, /* Parent class */
                               "der_log", /* Name of the function in Python */
                               DerLog,    /* Name of function in C++ */
                               vr, vc, out, cache);
 }
 
+/*
+template <class ADM>
 PyAbstractDensityMatrix::VectorType PyAbstractDensityMatrix::DerLogSingle(
     VisibleConstType vr, VisibleConstType vc, const any& cache) {
   Eigen::VectorXcd out(Npar());
   DerLog(vr.transpose(), vc.transpose(),
          Eigen::Map<RowMatrix<Complex>>{out.data(), 1, out.size()}, cache);
   return out;
-}
+}*/
 
 }  // namespace netket

--- a/Sources/Machine/DensityMatrices/py_density_matrix.cc
+++ b/Sources/Machine/DensityMatrices/py_density_matrix.cc
@@ -17,6 +17,7 @@
 
 #include "Utils/messages.hpp"
 
+#include "Machine/py_machine.hpp"
 #include "abstract_density_matrix.hpp"
 #include "diagonal_density_matrix.hpp"
 #include "ndm_spin_phase.hpp"
@@ -94,8 +95,11 @@ void AddDiagonalDensityMatrix(py::module &subm) {
 }
 
 void AddAbstractDensityMatrix(py::module &subm) {
-  py::class_<AbstractDensityMatrix, AbstractMachine, PyAbstractDensityMatrix>(
-      subm, "DensityMatrix")
+  py::class_<AbstractDensityMatrix, AbstractMachine,
+             PyAbstractDensityMatrix<AbstractDensityMatrix>>(subm,
+                                                             "DensityMatrix")
+      .def(py::init<std::shared_ptr<AbstractHilbert const>>(),
+           py::arg{"hilbert"})
       .def_property_readonly(
           "hilbert_physical", &AbstractDensityMatrix::GetHilbertPhysical,
           R"EOF(netket.hilbert.Hilbert: The physical hilbert space object of the density matrix.)EOF")
@@ -108,7 +112,8 @@ void AddAbstractDensityMatrix(py::module &subm) {
             the case of Restricted Boltzmann Machines.)EOF")
       .def(
           "to_matrix",
-          [](AbstractDensityMatrix &self, bool normalize) -> AbstractDensityMatrix::MatrixType {
+          [](AbstractDensityMatrix &self,
+             bool normalize) -> AbstractDensityMatrix::MatrixType {
             const auto &hind = self.GetHilbertPhysical().GetIndex();
             AbstractMachine::MatrixType vals(hind.NStates(), hind.NStates());
 
@@ -133,7 +138,8 @@ void AddAbstractDensityMatrix(py::module &subm) {
               vals /= vals.trace();
             }
             return vals;
-          },py::arg("normalize") = true,
+          },
+          py::arg("normalize") = true,
           R"EOF(
                 Returns a numpy matrix representation of the machine.
                 The returned matrix has trace normalized to 1 if `normalize=True`

--- a/Sources/Machine/py_abstract_machine.ipp
+++ b/Sources/Machine/py_abstract_machine.ipp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "Machine/py_abstract_machine.hpp"
+//#include "Machine/py_abstract_machine.hpp"
 
 #include <cstdio>
 
@@ -75,7 +75,8 @@ auto ShouldNotThrow(Function &&function, Args &&... args) noexcept
 }  // namespace
 }  // namespace detail
 
-int PyAbstractMachine::Npar() const {
+template <class AMB>
+int PyAbstractMachine<AMB>::Npar() const {
   return detail::ShouldNotThrow([this]() {
     PYBIND11_OVERLOAD_PURE_NAME(int,             /* Return type */
                                 AbstractMachine, /* Parent class */
@@ -85,82 +86,85 @@ int PyAbstractMachine::Npar() const {
   });
 }
 
-bool PyAbstractMachine::IsHolomorphic() const noexcept {
+template <class AMB>
+bool PyAbstractMachine<AMB>::IsHolomorphic() const noexcept {
   return detail::ShouldNotThrow([this]() {
     PYBIND11_OVERLOAD_PURE_NAME(
         bool,              /* Return type */
-        AbstractMachine,   /* Parent class */
+        AMB,               /* Parent class */
         "_is_holomorphic", /* Name of the function in Python */
         IsHolomorphic,     /* Name of function in C++ */
     );
   });
 }
 
-PyAbstractMachine::VectorType PyAbstractMachine::GetParameters() {
+template <class AMB>
+typename AMB::VectorType PyAbstractMachine<AMB>::GetParameters() {
   PYBIND11_OVERLOAD_PURE_NAME(
       VectorType,        /* Return type */
-      AbstractMachine,   /* Parent class */
+      AMB,               /* Parent class */
       "_get_parameters", /* Name of the function in Python */
       GetParameters,     /* Name of function in C++ */
   );
 }
 
-void PyAbstractMachine::SetParameters(VectorConstRefType pars) {
+template <class AMB>
+void PyAbstractMachine<AMB>::SetParameters(VectorConstRefType pars) {
   PYBIND11_OVERLOAD_PURE_NAME(
       void,              /* Return type */
-      AbstractMachine,   /* Parent class */
+      AMB,               /* Parent class */
       "_set_parameters", /* Name of the function in Python */
       SetParameters,     /* Name of function in C++ */
       pars);
 }
 
-void PyAbstractMachine::LogVal(Eigen::Ref<const RowMatrix<double>> v,
-                               Eigen::Ref<Eigen::VectorXcd> out,
-                               const any & /*unused*/) {
-  PYBIND11_OVERLOAD_PURE_NAME(void,            /* Return type */
-                              AbstractMachine, /* Parent class */
+template <class AMB>
+void PyAbstractMachine<AMB>::LogVal(Eigen::Ref<const RowMatrix<double>> v,
+                                    Eigen::Ref<Eigen::VectorXcd> out,
+                                    const any & /*unused*/) {
+  PYBIND11_OVERLOAD_PURE_NAME(void,      /* Return type */
+                              AMB,       /* Parent class */
                               "log_val", /* Name of the function in Python */
                               LogVal,    /* Name of function in C++ */
                               v, out);
 }
 
-Complex PyAbstractMachine::LogValSingle(VisibleConstType v, const any &cache) {
+template <class AMB>
+Complex PyAbstractMachine<AMB>::LogValSingle(VisibleConstType v,
+                                             const any &cache) {
   Complex data;
   auto out = Eigen::Map<Eigen::VectorXcd>(&data, 1);
   LogVal(v.transpose(), out, cache);
   return data;
 }
 
-any PyAbstractMachine::InitLookup(VisibleConstType /*unused*/) { return {}; }
-
-void PyAbstractMachine::UpdateLookup(VisibleConstType /*unused*/,
-                                     const std::vector<int> & /*unused*/,
-                                     const std::vector<double> & /*unused*/,
-                                     any & /*unused*/) {}
-
-PyAbstractMachine::VectorType PyAbstractMachine::DerLogSingle(
-    VisibleConstType v, const any &cache) {
-  Eigen::VectorXcd out(Npar());
-  DerLog(v.transpose(),
-         Eigen::Map<RowMatrix<Complex>>{out.data(), 1, out.size()}, cache);
-  return out;
+template <class AMB>
+any PyAbstractMachine<AMB>::InitLookup(VisibleConstType /*unused*/) {
+  return {};
 }
 
-void PyAbstractMachine::DerLog(Eigen::Ref<const RowMatrix<double>> v,
-                               Eigen::Ref<RowMatrix<Complex>> out,
-                               const any & /*unused*/) {
-  PYBIND11_OVERLOAD_PURE_NAME(void,            /* Return type */
-                              AbstractMachine, /* Parent class */
+template <class AMB>
+void PyAbstractMachine<AMB>::UpdateLookup(
+    VisibleConstType /*unused*/, const std::vector<int> & /*unused*/,
+    const std::vector<double> & /*unused*/, any & /*unused*/) {}
+
+template <class AMB>
+void PyAbstractMachine<AMB>::DerLog(Eigen::Ref<const RowMatrix<double>> v,
+                                    Eigen::Ref<RowMatrix<Complex>> out,
+                                    const any & /*unused*/) {
+  PYBIND11_OVERLOAD_PURE_NAME(void,      /* Return type */
+                              AMB,       /* Parent class */
                               "der_log", /* Name of the function in Python */
                               DerLog,    /* Name of function in C++ */
                               v, out);
 }
 
-PyObject *PyAbstractMachine::StateDict() {
+template <class AMB>
+PyObject *PyAbstractMachine<AMB>::StateDict() {
   return [this]() {
     PYBIND11_OVERLOAD_PURE_NAME(
         pybind11::object, /* Return type */
-        AbstractMachine,  /* Parent class */
+        AMB,              /* Parent class */
         "state_dict",     /* Name of the function in Python */
         StateDict,        /* Name of function in C++ */
                           /*Arguments*/
@@ -170,21 +174,23 @@ PyObject *PyAbstractMachine::StateDict() {
              .ptr();
 }
 
-void PyAbstractMachine::Save(const std::string &filename) const {
-  PYBIND11_OVERLOAD_NAME(void,            /* Return type */
-                         AbstractMachine, /* Parent class */
-                         "save",          /* Name of the function in Python */
-                         Save,            /* Name of function in C++ */
-                         filename         /*Arguments*/
+template <class AMB>
+void PyAbstractMachine<AMB>::Save(const std::string &filename) const {
+  PYBIND11_OVERLOAD_NAME(void,    /* Return type */
+                         AMB,     /* Parent class */
+                         "save",  /* Name of the function in Python */
+                         Save,    /* Name of function in C++ */
+                         filename /*Arguments*/
   );
 }
 
-void PyAbstractMachine::Load(const std::string &filename) {
-  PYBIND11_OVERLOAD_NAME(void,            /* Return type */
-                         AbstractMachine, /* Parent class */
-                         "load",          /* Name of the function in Python */
-                         Load,            /* Name of function in C++ */
-                         filename         /*Arguments*/
+template <class AMB>
+void PyAbstractMachine<AMB>::Load(const std::string &filename) {
+  PYBIND11_OVERLOAD_NAME(void,    /* Return type */
+                         AMB,     /* Parent class */
+                         "load",  /* Name of the function in Python */
+                         Load,    /* Name of function in C++ */
+                         filename /*Arguments*/
   );
 }
 

--- a/Sources/Machine/py_machine.cc
+++ b/Sources/Machine/py_machine.cc
@@ -552,7 +552,7 @@ void AddLayerModule(py::module m) {
 }
 
 void AddAbstractMachine(py::module m) {
-  py::class_<AbstractMachine, PyAbstractMachine>(m, "Machine")
+  py::class_<AbstractMachine, PyAbstractMachine<>>(m, "Machine")
       .def(py::init<std::shared_ptr<AbstractHilbert const>>(),
            py::arg{"hilbert"})
       .def_property_readonly(


### PR DESCRIPTION
Even if we will eventually let go of the C++ core, for now it's with us to stay.
Right now we have the following class hierarchy: `AbstractMachine<:AbstractDensityMatrix<:Anything`.

The correct way to wrap those in pybind11 would be to create parametric trampoline classes `PyAbstractMachine<Machine> <: PyDensityMatrix<Machine> <: Machine`. 

This is well documented in [the docs](https://pybind11.readthedocs.io/en/stable/advanced/classes.html#combining-virtual-functions-and-inheritance).

This PR aims at fixing my previous implementation, wich works but prevents to create Python objects which subclass the correct C++ class.