### PR TITLE
[WIP] Add `run` function to VMC driver

### DIFF
--- a/Examples/Heisenberg1d/heisenberg1d.py
+++ b/Examples/Heisenberg1d/heisenberg1d.py
@@ -37,13 +37,12 @@ sa = nk.sampler.MetropolisExchange(machine=ma)
 op = nk.optimizer.Sgd(learning_rate=0.05)
 
 # Stochastic reconfiguration
-gs = nk.variational.Vmc(
+gs = nk.Vmc(
     hamiltonian=ha,
     sampler=sa,
     optimizer=op,
     n_samples=1000,
-    diag_shift=0.1,
-    method="Sr",
+    sr=nk.optimizer.SR(diag_shift=0.1)
 )
 
 gs.run(output_prefix="test", n_iter=300)

--- a/Examples/Observables/sigmax.py
+++ b/Examples/Observables/sigmax.py
@@ -35,19 +35,19 @@ sa = nk.sampler.MetropolisLocal(machine=ma)
 op = nk.optimizer.Sgd(learning_rate=0.1)
 
 # Stochastic reconfiguration
-gs = nk.variational.Vmc(
+gs = nk.Vmc(
     hamiltonian=ha,
     sampler=sa,
     optimizer=op,
     n_samples=1000,
-    diag_shift=0.1,
-    method="Sr",
+    sr=nk.optimizer.SR(diag_shift=0.1),
 )
 
 # Adding an observable
 # The sum of sigma_x on all sites
 X = [[0, 1], [1, 0]]
 sx = nk.operator.LocalOperator(hi, [X] * L, [[i] for i in range(L)])
-gs.add_observable(sx, "SigmaX")
+obs = {"SigmaX": sx}
 
-gs.run(output_prefix="test", n_iter=300)
+gs.run(output_prefix="test", n_iter=300, obs=obs)
+

--- a/Test/GroundState/test_vmc.py
+++ b/Test/GroundState/test_vmc.py
@@ -68,11 +68,11 @@ def test_vmc_functions():
         assert ex.mean.real == approx(exact_ex.real, abs=tol)
 
         stats = vmc.estimate_expectations(
-            [op], sampler, n_samples=n_samples, n_discard=10
+            op, sampler, n_samples=n_samples, n_discard=10
         )
 
-        assert stats[0].mean.real == approx(np.mean(local_values).real, rel=tol)
-        assert stats[0].mean.real == approx(exact_ex.real, abs=tol)
+        assert stats.mean.real == approx(np.mean(local_values).real, rel=tol)
+        assert stats.mean.real == approx(exact_ex.real, abs=tol)
 
     local_values = nk.operator.local_values(ha, ma, samples)
     grad = nk.stats.covariance_sv(local_values, der_logs)
@@ -80,11 +80,11 @@ def test_vmc_functions():
     assert np.mean(np.abs(grad) ** 2) == approx(0.0, abs=1e-8)
 
     _, grads = vmc.estimate_expectations(
-        [ha], sampler, n_samples, 10, compute_gradients=True
+        ha, sampler, n_samples, 10, compute_gradients=True
     )
 
-    assert grads[0].shape == (ma.n_par,)
-    assert np.mean(np.abs(grads[0]) ** 2) == approx(0.0, abs=1e-8)
+    assert grads.shape == (ma.n_par,)
+    assert np.mean(np.abs(grads) ** 2) == approx(0.0, abs=1e-8)
 
 
 def test_vmc_use_cholesky_compatibility():

--- a/netket/_vmc.py
+++ b/netket/_vmc.py
@@ -1,11 +1,13 @@
+import json
 import sys
 
 import numpy as _np
+import tqdm
+from jax.tree_util import tree_map
 
 import netket as _nk
 from netket._core import deprecated
 from netket.operator import local_values as _local_values
-
 from netket.stats import (
     statistics as _statistics,
     covariance_sv as _covariance_sv,
@@ -80,6 +82,41 @@ def make_optimizer_fn(arg, ma):
             "Expected netket.optimizer.Optimizer subclass, JAX optimizer, "
             + " or callable f(i, grad, p); got {}".format(arg)
         )
+
+
+class _JsonLog:
+    """
+    TODO
+    """
+
+    def __init__(
+        self, output_prefix, n_iter, obs=None, save_params_every=50, write_every=50
+    ):
+        self._json_out = {"Output": []}
+        self._prefix = output_prefix
+        self._write_every = write_every
+        self._save_params_every = save_params_every
+        self._n_iter = n_iter
+        self._obs = obs if obs else {}
+
+    def __call__(self, step, driver):
+        item = {"Iteration": step}
+        stats = driver.estimate(self._obs)
+        stats["Energy"] = driver.energy
+        for key, value in stats.items():
+            st = value.asdict()
+            st["Mean"] = st["Mean"].real
+            item[key] = st
+
+        self._json_out["Output"].append(item)
+
+        if step % self._write_every == 0 or step == self._n_iter - 1:
+            if _nk.MPI.rank() == 0:
+                with open(self._prefix + ".log", "w") as outfile:
+                    json.dump(self._json_out, outfile)
+        if step % self._save_params_every == 0 or step == self._n_iter - 1:
+            if _nk.MPI.rank() == 0:
+                driver._machine.save(self._prefix + ".wf")
 
 
 class Vmc(object):
@@ -254,6 +291,28 @@ class Vmc(object):
 
             self.step_count += 1
 
+    def run(
+        self,
+        n_iter,
+        output_prefix,
+        obs=None,
+        save_params_every=50,
+        write_every=50,
+        step_size=1,
+        show_progress=True,
+    ):
+        """
+        TODO
+        """
+        output = _JsonLog(output_prefix, n_iter, obs, save_params_every, write_every)
+
+        with tqdm.tqdm(
+            self.iter(n_iter, step_size), total=n_iter, disable=not show_progress
+        ) as itr:
+            for step in itr:
+                output(step, self)
+                itr.set_postfix(Energy=(str(self._stats)))
+
     def iter(self, n_steps, step=1):
         """
         Returns a generator which advances the VMC optimization, yielding
@@ -271,6 +330,33 @@ class Vmc(object):
             self.advance(step)
             yield self.step_count
 
+    @property
+    def energy(self):
+        """
+        Return MCMC statistics for the expectation value of observables in the
+        current state of the driver.
+        """
+        return self._stats
+
+    def estimate(self, observables):
+        """
+        Return MCMC statistics for the expectation value of observables in the
+        current state of the driver.
+
+        Args:
+            observables: A pytree of operators for which statistics should be computed.
+
+        Returns:
+            A pytree of the same structure as the input, containing MCMC statistics
+            for the corresponding operators as leaves.
+        """
+
+        def estimate(obs):
+            return self._get_mc_stats(obs)[1]
+
+        return tree_map(estimate, observables)
+
+    @deprecated()
     def add_observable(self, obs, name):
         """
         Add an observables to the set of observables that will be computed by default
@@ -278,6 +364,7 @@ class Vmc(object):
         """
         self._obs[name] = obs
 
+    @deprecated()
     def get_observable_stats(self, observables=None, include_energy=True):
         """
         Return MCMC statistics for the expectation value of observables in the
@@ -300,12 +387,10 @@ class Vmc(object):
         """
         if not observables:
             observables = self._obs
-        r = {"Energy": self._stats} if include_energy else {}
-
-        r.update(
-            {name: self._get_mc_stats(obs)[1] for name, obs in observables.items()}
-        )
-        return r
+        result = self.estimate(observables)
+        if include_energy:
+            result["Energy"] = self._stats
+        return result
 
     def reset(self):
         self.step_count = 0

--- a/netket/variational.py
+++ b/netket/variational.py
@@ -79,7 +79,6 @@ class Vmc(object):
         )
 
     def _add_to_json_log(self, step_count):
-
         stats = self.get_observable_stats()
         self._json_out["Output"].append({})
         self._json_out["Output"][-1] = {}


### PR DESCRIPTION
This PR contains a first work-in-progress version of the `Vmc.run` for the new VMC class.

There are a couple of differences to the old implementation, which we should discuss:

1. `vmc.add_observable` is deprecated. I do not see a need to store the observables as an attribute of the driver. It is just as easy-to-use to have the user create a dict of observables in their own code and pass it to `Vmc.run`:
```python
vmc = nk.Vmc(...)
obs = {"X": sigmax, "Y": sigmay, ...}
vmc.run(n_iter=1000, output_prefix="...", obs=obs)
```
2. Instead of `get_observable_stats` with a somewhat complicated interface (`include_energy`, the option of either using the stored obs or passing a dict of other ones) I've added the method `vmc.estimate(obs)` which takes just a dict of observables and uses the pre-compiled samples of the current step and `vmc.energy` (following the original suggrstion of @orialb in #344 ) returning the already computed energy.
`get_observable_stats` is thus also deprecated (but trivial to implement in terms of `vmc.estimate`).

3. When I was saying `vmc.estimate` accepts a `dict`, that was not the full story: I have experimented here with using a [JAX `pytree`](https://jax.readthedocs.io/en/latest/jax.tree_util.html), which is the JAX term for any type of list `[obs1, obs2]`, dict `{"Obs1": ..., "Obs2": ...}`, tuples, or nested structure thereof, i.e., you could pass a nested dict like `{0: {1: sigmax01, 2: sigmax02, ...}, 1: {0: sigmax10, 2: sigmax12, ...}, ...}`).
The `estimate` method will then return a pytree of the same structure with the observables replaced by their MC stats via the JAX `tree_map` function.
It seems a bit silly to depend on JAX only for that (maybe we could just extract the function we need, it's also Apache licensed), but I like the resulting interface. Users can just store the observables in any structure they like (be it a list, dict, tuple, or a nested structure of these) and NetKet will do the right thing with it.

4. The JSON output logic is now contained in an internal class `_JsonLog`. We should make sure to check how to generalize it so it can be used by all the drivers.

For now, let me know what you think of the general ideas here.