### PR TITLE
Adding Cholesky solver

### DIFF
--- a/netket/optimizer/stochastic_reconfiguration.py
+++ b/netket/optimizer/stochastic_reconfiguration.py
@@ -139,7 +139,7 @@ class SR:
                 self._apply_preconditioning(grad)
 
                 if self._lsq_solver == "Cholesky":
-                    c, low = _cho_factor(self._S)
+                    c, low = _cho_factor(self._S, check_finite=False)
                     out[:] = _cho_solve((c, low), grad)
 
                 else:


### PR DESCRIPTION
This PR adds the Cholesky (LLt) solver as a possible solver, by choosing lsq_solver="Cholesky"
(technically, this does not solve the least square problem but that doesn't matter).

 My experience on the Ising1d example with this version, and previous C++ versions, is that the Cholesky decomposition is always the faster exact solver. For intermediate system sizes, it is competitive with iterative solvers (but is no longer efficient for larger systems). There might be specific niche cases (e.g. with a lot of symmetries) where it is actually even faster and/or more stable than the iterative solver.