### PR TITLE
Fix warnings due to unescaped LaTeX in docstrings

### DIFF
--- a/netket/_qsr.py
+++ b/netket/_qsr.py
@@ -286,7 +286,7 @@ class Qsr(AbstractVariationalDriver):
         return "\n  ".join([str(self)] + lines)
 
     def nll(self, rotations, samples, bases, log_norm=0):
-        """
+        r"""
         Negative log-likelihood, :math:`\langle log(|Psi_b(x)|^2) \rangle`,
         where the average is over the given samples, and :math:`b` denotes
         the given bases associated to the samples.

--- a/netket/operator/local_values.py
+++ b/netket/operator/local_values.py
@@ -50,7 +50,7 @@ def _local_values_op_op_impl(op, machine, v, log_vals, out):
 
 
 def local_values(op, machine, v, log_vals=None, out=None):
-    """
+    r"""
     Computes local values of the operator `op` for all `samples`.
 
     The local value is defined as
@@ -202,7 +202,7 @@ def _der_local_values_notcentered_impl(op, machine, v, log_vals, out):
 def der_local_values(
     op, machine, v, log_vals=None, der_log_vals=None, out=None, center_derivative=True
 ):
-    """
+    r"""
     Computes the derivative of local values of the operator `op` for all `samples`.
 
     The local value is defined as


### PR DESCRIPTION
Otherwise, `DeprecationWarning`s like this occur:
```
netket/hilbert/doubled_hilbert.py:29: DeprecationWarning: invalid escape sequence \o
```