### PR TITLE
add is_holomorphic to c++ SR

### DIFF
--- a/Sources/Optimizer/py_stochastic_reconfiguration.cc
+++ b/Sources/Optimizer/py_stochastic_reconfiguration.cc
@@ -45,6 +45,8 @@ void AddSR(py::module& m) {
           )EOF")
       .def_property("store_rank_enabled", &SR::StoreRankEnabled,
                     &SR::SetStoreRank)
+      .def_property("is_holomorphic", &SR::IsHolomorphic,
+                    &SR::SetIsHolomorphic)
       .def_property(
           "scale_invariant_regularization_enabled",
           &SR::ScaleInvariantRegularizationEnabled,

--- a/Sources/Optimizer/stochastic_reconfiguration.hpp
+++ b/Sources/Optimizer/stochastic_reconfiguration.hpp
@@ -142,6 +142,13 @@ class SR {
   bool StoreFullSMatrixEnabled() const { return store_full_S_matrix_; }
   void SetStoreFullSMatrix(bool enabled);
 
+  /**
+   * Returns the is_holomorphic parameter
+   * @return
+   */
+  bool IsHolomorphic() { return is_holomorphic_; };
+  void SetIsHolomorphic(bool is_holomorphic) {is_holomorphic_ = is_holomorphic;};
+
  private:
   LSQSolver solver_;
   double sr_diag_shift_;

--- a/netket/_qsr.py
+++ b/netket/_qsr.py
@@ -68,6 +68,8 @@ class Qsr(AbstractVariationalDriver):
 
         self._sampler = sampler
         self._sr = sr
+        if sr is not None:
+            self._sr.is_holomorphic = sampler.machine.is_holomorphic
 
         self._rotations = rotations
         self._t_samples = _np.asarray(samples)

--- a/netket/_steadystate.py
+++ b/netket/_steadystate.py
@@ -65,6 +65,8 @@ class SteadyState(AbstractVariationalDriver):
         self._sampler = sampler
         self._sampler_obs = sampler_obs
         self._sr = sr
+        if sr is not None:
+            self._sr.is_holomorphic = sampler.machine.is_holomorphic
 
         self._npar = self._machine.n_par
 

--- a/netket/_vmc.py
+++ b/netket/_vmc.py
@@ -62,6 +62,8 @@ class Vmc(AbstractVariationalDriver):
         self._ham = hamiltonian
         self._sampler = sampler
         self._sr = sr
+        if sr is not None:
+            self._sr.is_holomorphic = sampler.machine.is_holomorphic
 
         self._npar = self._machine.n_par
 


### PR DESCRIPTION
And automatically set it during driver initialization, so that users don't have to set it.
The new python drivers where not doing this and the user was supposed to do it (but that's boring).