### PR TITLE
New driver.run() syntax

### DIFF
--- a/Examples/BoseHubbard1d/bosehubbard1d.py
+++ b/Examples/BoseHubbard1d/bosehubbard1d.py
@@ -44,4 +44,4 @@ vmc = nk.variational.Vmc(
     method="Sr",
 )
 
-vmc.run(output_prefix="test", n_iter=4000)
+vmc.run(n_iter=4000, out="test")

--- a/Examples/BoseHubbard1d/bosehubbard1d_jastrow.py
+++ b/Examples/BoseHubbard1d/bosehubbard1d_jastrow.py
@@ -44,4 +44,4 @@ vmc = nk.variational.Vmc(
     method="Sr",
 )
 
-vmc.run(output_prefix="test", n_iter=4000)
+vmc.run(n_iter=4000, out="test")

--- a/Examples/CustomGraph/custom_graph.py
+++ b/Examples/CustomGraph/custom_graph.py
@@ -47,4 +47,4 @@ gs = nk.variational.Vmc(
     method="Sr",
 )
 
-gs.run(output_prefix="test", n_iter=500)
+gs.run(out="test", n_iter=500)

--- a/Examples/CustomHamiltonian/custom_hamiltonian.py
+++ b/Examples/CustomHamiltonian/custom_hamiltonian.py
@@ -56,4 +56,4 @@ gs = nk.variational.Vmc(
     method="Sr",
 )
 
-gs.run(output_prefix="test", n_iter=3000)
+gs.run(out="test", n_iter=3000)

--- a/Examples/CustomMachine/ising1d.py
+++ b/Examples/CustomMachine/ising1d.py
@@ -44,4 +44,4 @@ gs = nk.variational.Vmc(
     method="Sr",
 )
 
-gs.run(output_prefix="test", n_iter=300)
+gs.run(n_iter=300, out="test")

--- a/Examples/CustomSampler/customsampler_heisenberg1d.py
+++ b/Examples/CustomSampler/customsampler_heisenberg1d.py
@@ -66,4 +66,4 @@ gs = nk.variational.Vmc(
     method="Sr",
 )
 
-gs.run(output_prefix="test", n_iter=300)
+gs.run(n_iter=300, out="test")

--- a/Examples/CustomSampler/exchange_kernel.py
+++ b/Examples/CustomSampler/exchange_kernel.py
@@ -49,4 +49,4 @@ gs = nk.variational.Vmc(
     method="Sr",
 )
 
-gs.run(output_prefix="test", n_iter=300)
+gs.run(n_iter=300, out="test")

--- a/Examples/DissipativeIsing1d/ising1d.py
+++ b/Examples/DissipativeIsing1d/ising1d.py
@@ -77,9 +77,6 @@ op = nk.optimizer.Sgd(0.01)
 sr = nk.optimizer.SR(diag_shift=0.01, use_iterative=True)
 
 ss = nk.SteadyState(lind, sa, op, 2000, sampler_obs=sa_obs, n_samples_obs=500)
-ss.add_observable(obs_sx, "Sx")
-ss.add_observable(obs_sy, "Sy")
-ss.add_observable(obs_sz, "Sz")
+obs = {'Sx': obs_sx, 'Sy': obs_sy, 'Sz': obs_sz}
 
-
-ss.run(output_prefix="test", n_iter=200)
+ss.run(n_iter=200, out="test", obs=obs)

--- a/Examples/GraphOperator/Ising/ising.py
+++ b/Examples/GraphOperator/Ising/ising.py
@@ -54,4 +54,4 @@ gs = nk.variational.Vmc(
     method="Gd",
 )
 
-gs.run(output_prefix="test", n_iter=30000)
+gs.run(out="test", n_iter=30000)

--- a/Examples/GraphOperator/J1J2/j1j2.py
+++ b/Examples/GraphOperator/J1J2/j1j2.py
@@ -75,4 +75,4 @@ gs = nk.variational.Vmc(
     method="Sr",
 )
 
-gs.run(output_prefix="test", n_iter=10000)
+gs.run(out="test", n_iter=10000)

--- a/Examples/Heisenberg1d/heisenberg1d.py
+++ b/Examples/Heisenberg1d/heisenberg1d.py
@@ -45,4 +45,4 @@ gs = nk.Vmc(
     sr=nk.optimizer.SR(diag_shift=0.1)
 )
 
-gs.run(output_prefix="test", n_iter=300)
+gs.run(out="test", n_iter=300)

--- a/Examples/Heisenberg1d/heisenberg1d_conv.py
+++ b/Examples/Heisenberg1d/heisenberg1d_conv.py
@@ -81,4 +81,4 @@ gs = nk.variational.Vmc(
     method="Sr",
 )
 
-gs.run(output_prefix="test", n_iter=300)
+gs.run(out="test", n_iter=300)

--- a/Examples/Heisenberg1d/heisenberg1d_ffnn.py
+++ b/Examples/Heisenberg1d/heisenberg1d_ffnn.py
@@ -54,4 +54,4 @@ gs = nk.variational.Vmc(
     use_iterative=True,
 )
 
-gs.run(output_prefix="test", n_iter=300)
+gs.run(out="test", n_iter=300)

--- a/Examples/Heisenberg1d/heisenberg1d_jastrow.py
+++ b/Examples/Heisenberg1d/heisenberg1d_jastrow.py
@@ -46,4 +46,4 @@ gs = nk.variational.Vmc(
     method="Sr",
 )
 
-gs.run(output_prefix="test", n_iter=300)
+gs.run(out="test", n_iter=300)

--- a/Examples/Ising1d/ising1d.py
+++ b/Examples/Ising1d/ising1d.py
@@ -33,14 +33,18 @@ sa = nk.sampler.MetropolisLocal(machine=ma, n_chains=8)
 # Optimizer
 op = nk.optimizer.Sgd(learning_rate=0.1)
 
-# Stochastic reconfiguration
-gs = nk.variational.Vmc(
+# Stochastic Reconfiguration
+sr = nk.optimizer.SR(diag_shift=0.1, use_iterative=False,
+                     lsq_solver="LLT")
+
+# Create the optimization driver
+gs = nk.Vmc(
     hamiltonian=ha,
     sampler=sa,
     optimizer=op,
     n_samples=1000,
-    method="Sr",
-    diag_shift=0.1,
+    sr=sr,
 )
 
-gs.run(output_prefix="test", n_iter=300)
+# Run the optimization for 300 iterations
+gs.run(n_iter=100)

--- a/Examples/Ising1d/ising1d_jastrow.py
+++ b/Examples/Ising1d/ising1d_jastrow.py
@@ -43,4 +43,4 @@ gs = nk.variational.Vmc(
     method="Sr",
 )
 
-gs.run(output_prefix="test", n_iter=300)
+gs.run(n_iter=300, out="test")

--- a/Examples/Ising2d/ising2d.py
+++ b/Examples/Ising2d/ising2d.py
@@ -33,14 +33,21 @@ sa = nk.sampler.MetropolisLocal(machine=ma)
 # Optimizer
 op = nk.optimizer.Sgd(learning_rate=0.1)
 
+# Stochastic Reconfiguration
+sr = nk.optimizer.SR(diag_shift=0.1, use_iterative=False,
+                     lsq_solver="LLT")
+
 # Stochastic reconfiguration
-gs = nk.variational.Vmc(
+gs = nk.Vmc(
     hamiltonian=ha,
     sampler=sa,
     optimizer=op,
+    sr=sr,
     n_samples=1000,
-    diag_shift=0.1,
-    method="Sr",
 )
 
-gs.run(output_prefix="test", n_iter=1000)
+# Create a JSON output file, and overwrite if file exists
+logger = nk.logging.JsonLog("test", 'w')
+
+# Run the optimization
+gs.run(n_iter=1000, out=logger)

--- a/Examples/J1J2/j1j2.py
+++ b/Examples/J1J2/j1j2.py
@@ -61,14 +61,16 @@ sa = nk.sampler.MetropolisHamiltonianPt(machine=ma, hamiltonian=op, n_replicas=1
 # Optimizer
 opt = nk.optimizer.Sgd(learning_rate=0.01)
 
+# Stochastic Reconfiguration
+sr = nk.optimizer.SR(diag_shift=0.01, use_iterative=True)
+
 # Variational Monte Carlo
-gs = nk.variational.Vmc(
+gs = nk.Vmc(
     hamiltonian=op,
     sampler=sa,
     optimizer=opt,
+    sr=sr,
     n_samples=1000,
-    use_iterative=True,
-    method="Sr",
 )
 
-gs.run(output_prefix="test", n_iter=10000)
+gs.run(n_iter=10000, out="test")

--- a/Examples/Observables/sigmax.py
+++ b/Examples/Observables/sigmax.py
@@ -49,5 +49,5 @@ X = [[0, 1], [1, 0]]
 sx = nk.operator.LocalOperator(hi, [X] * L, [[i] for i in range(L)])
 obs = {"SigmaX": sx}
 
-gs.run(output_prefix="test", n_iter=300, obs=obs)
+gs.run(n_iter=300, out="test", obs=obs)
 

--- a/Examples/QuantumStateReconstruction/ising1d.py
+++ b/Examples/QuantumStateReconstruction/ising1d.py
@@ -45,6 +45,6 @@ qst = nk.unsupervised.Qsr(
     method="Sr",
 )
 
-qst.add_observable(ha, "Energy")
+obs = {"Energy": ha}
 
-qst.run(n_iter=2000, output_prefix="output")
+qst.run(n_iter=2000, out="output", obs=obs)

--- a/Examples/RealMachines/j1j2.py
+++ b/Examples/RealMachines/j1j2.py
@@ -66,4 +66,4 @@ gs = nk.variational.Vmc(
     hamiltonian=op, sampler=sa, optimizer=opt, n_samples=1000, method="Sr"
 )
 
-gs.run(output_prefix="test", n_iter=10000)
+gs.run(out="test", n_iter=10000)

--- a/Examples/RealMachines/rbm_phase.py
+++ b/Examples/RealMachines/rbm_phase.py
@@ -44,4 +44,4 @@ gs = nk.variational.Vmc(
     method="Sr",
 )
 
-gs.run(output_prefix="test", n_iter=300)
+gs.run(out="test", n_iter=300)

--- a/Examples/RealMachines/rbm_real.py
+++ b/Examples/RealMachines/rbm_real.py
@@ -44,4 +44,4 @@ gs = nk.variational.Vmc(
     method="Sr",
 )
 
-gs.run(output_prefix="test", n_iter=300)
+gs.run(out="test", n_iter=300)

--- a/Examples/Torch/torch_machine.py
+++ b/Examples/Torch/torch_machine.py
@@ -47,8 +47,11 @@ sa = nk.sampler.MetropolisLocal(machine=ma, n_chains=8)
 op = nk.optimizer.Sgd(0.1)
 
 # Stochastic reconfiguration
-gs = nk.variational.Vmc(
-    hamiltonian=ha, sampler=sa, optimizer=op, n_samples=500, method="Sr", use_iterative=True
+sr = nk.optimizer.SR(diag_shift=0.1, use_iterative=True)
+
+# Driver
+gs = nk.Vmc(
+    hamiltonian=ha, sampler=sa, optimizer=op, n_samples=500, sr=sr
 )
 
-gs.run(output_prefix="test", n_iter=300)
+gs.run(n_iter=300, out="test")

--- a/netket/__init__.py
+++ b/netket/__init__.py
@@ -37,6 +37,7 @@ from . import (
     graph,
     hilbert,
     layer,
+    logging,
     machine,
     operator,
     optimizer,

--- a/netket/_core.py
+++ b/netket/_core.py
@@ -37,3 +37,14 @@ def deprecated(reason=None):
         return wrapper
 
     return decorator
+
+
+def warn_deprecation(message):
+    """
+    This is a function that sends a deprecation warning to the user about a
+    function that will is now deprecated and will be removed in a future
+    major release.
+
+    :param message: A mandatory message documenting the deprecation.
+    """
+    warnings.warn(message, category=FutureWarning, stacklevel=2)

--- a/netket/abstract_variational_driver.py
+++ b/netket/abstract_variational_driver.py
@@ -1,6 +1,6 @@
 import abc
 
-from netket._core import deprecated
+from netket._core import deprecated, warn_deprecation
 import netket as _nk
 
 from netket.logging import JsonLog as _JsonLog
@@ -142,24 +142,29 @@ class AbstractVariationalDriver(abc.ABC):
 
     def run(
         self,
-        output_prefix,
         n_iter,
+        out=None,
         obs=None,
-        save_params_every=50,
-        write_every=50,
-        step_size=1,
         show_progress=True,
+        save_params_every=50,  # for default logger
+        write_every=50,  # for default logger
+        step_size=1,  # for default logger
+        output_prefix=None,  # TODO: deprecated
     ):
         """
         Executes the Monte Carlo Variational optimization, updating the weights of the network
         stored in this driver for `n_iter` steps and dumping values of the observables `obs`
-        in the output. The output is a json file at `output_prefix`, overwriting files with
-        the same prefix.
+        in the output `logger`. If no logger is specified, creates a json file at `output_prefix`,
+        overwriting files with the same prefix.
+
+        !! Compatibility v2.1
+            Before v2.1 the order of the first two arguments, `n_iter` and `output_prefix` was
+            reversed. The reversed ordering will still be supported until v3.0, but is deprecated.
 
         Args:
-            :output_prefix: The prefix at which json output should be stored (ignored if logger
-              is provided).
             :n_iter: the total number of iterations
+            :out: A logger object to be used to store simulation log and data.
+                If this argument is a string, it will be used as output prefix for the standard JSON logger.
             :obs: An iterable containing all observables that should be computed
             :save_params_every: Every how many steps the parameters of the network should be
             serialized to disk (ignored if logger is provided)
@@ -167,7 +172,20 @@ class AbstractVariationalDriver(abc.ABC):
             logger is provided)
             :step_size: Every how many steps should observables be logged to disk (default=1)
             :show_progress: If true displays a progress bar (default=True)
+            :output_prefix: (Deprecated) The prefix at which json output should be stored (ignored if out
+              is provided).
         """
+
+        # TODO Remove this deprecated code in v3.0
+        # manage deprecated where argument names are not specified, and
+        # prefix is passed as the first positional argument and the number
+        # of iterations as a second argument.
+        if type(n_iter) is str and type(out) is int:
+            n_iter, out = out, n_iter
+            warn_deprecation(
+                "The positional syntax run(output_prefix, n_iter, **args) is deprecated, use run(n_iter, output_prefix, **args) instead."
+            )
+
         if obs is None:
             # TODO remove the first case after deprecation of self._obs in 3.0
             if len(self._obs) != 0:
@@ -175,10 +193,25 @@ class AbstractVariationalDriver(abc.ABC):
             else:
                 obs = {}
 
-        logger = _JsonLog(output_prefix, save_params_every, write_every)
+        # output_prefix is deprecated. out should be used and takes over
+        # error out if both are passed
+        # TODO: remove in v3.0
+        if out is not None and output_prefix is not None:
+            raise ValueError(
+                "Invalid out and output_prefix arguments. Only one of the two can be passed. Note that output_prefix is deprecated and you should use out."
+            )
+        elif out is None:
+            warn_deprecation("The output_prefix argument is deprecated. Use out instead.")
+            out = output_prefix
 
-        # Don't log on non-root nodes
-        if self._mynode != 0:
+        # Log only non-root nodes
+        if self._mynode == 0:
+            # if out is a path, create an overwriting Json Log for output
+            if isinstance(out, str):
+                logger = _JsonLog(out, "w", save_params_every, write_every)
+            else:
+                logger = out
+        else:
             logger = None
 
         with tqdm(

--- a/netket/logging/__init__.py
+++ b/netket/logging/__init__.py
@@ -1,0 +1,1 @@
+from ._json_log import JsonLog

--- a/netket/logging/_json_log.py
+++ b/netket/logging/_json_log.py
@@ -23,7 +23,7 @@ class JsonLog:
     """
 
     def __init__(
-        self, output_prefix, save_params_every=50, write_every=50, mode="write"
+        self, output_prefix, mode="write", save_params_every=50, write_every=50
     ):
         # Shorthands for mode
         if mode == "w":

--- a/setup.py
+++ b/setup.py
@@ -161,7 +161,7 @@ setup(
     url="http://github.com/netket/netket",
     author_email="netket@netket.org",
     license="Apache 2.0",
-    packages=["netket", "netket.machine", "netket.sampler", "netket.operator"],
+    packages=["netket", "netket.machine", "netket.sampler", "netket.operator", "netket.logging"],
     ext_modules=[CMakeExtension("netket._C_netket")],
     long_description="""NetKet is an open - source project delivering cutting - edge
          methods for the study of many - body quantum systems with artificial


### PR DESCRIPTION
This pr does two things in a non-breaking way:
 - sets a new order of arguments for the `run` function of drivers
 - allows to pass a logger object to `run`.
 - I also updated Ising1/2d and J1J2 and DissipativeIsing examples to use the non deprecated syntax

The new signature is 
```python     
def run(self, n_iter, output_prefix=None, obs=None, logger=None, etc...)
```
essentially switching the order of `n_iter` and `output_prefix`.
The rationale is that if one wants to use a different logger created by himself one can do 
`driver.run(300, logger=mylogger)`. Essentially, the first argument is now not the output folder (one might want no output, after all) but the number of iterations.

The reason why it's useful to pass a logger to run is so that one can append different runs, if you create the logger with `my logger = nk.logging.JsonLog('path', 'append')`.

In order to make this non breaking, there are a bunch of type checks on inputs. Later this PR should be back ported to v3.0 branch, removing those deprecation warnings.

### Note for merging
This PR is rebased on top of #381, so who merges #381 should possibly do a rebase and merge and then this can be merged without issues