### PR TITLE
Add test for MPI Markov chain statistics and fix Rhat

### DIFF
--- a/Test/Stats/mpi_test_stats.py
+++ b/Test/Stats/mpi_test_stats.py
@@ -82,11 +82,11 @@ def test_mean():
 
 
 def test_var():
-    data = np.random.rand(size, 10, 11, 12)
+    data = np.random.rand(size, 10, 11, 12, 13)
     data = comm.bcast(data)
     mydata = data[rank]
 
-    for axis in None, 0, 1, 2:
+    for axis in None, 0, 1, 2, 3:
         if axis is not None:
             # Merge first "MPI axis" with target axis
             refdata = np.moveaxis(data, axis + 1, 0)

--- a/Test/Stats/mpi_test_stats.py
+++ b/Test/Stats/mpi_test_stats.py
@@ -1,0 +1,83 @@
+import netket as nk
+import numpy as np
+from mpi4py import MPI
+
+import pytest
+from pytest import approx
+
+comm = MPI.COMM_WORLD
+size = comm.Get_size()
+rank = comm.Get_rank()
+
+
+def reference_stats(data):
+    """
+    Computes the statistics on the full data, without MPI,
+    for reference.
+    """
+    M_par, M_loc, N = data.shape
+    M_full = M_par * M_loc
+    data_ = data.reshape(M_full, N)
+
+    chain_means = np.mean(data_, axis=1)
+    chain_vars = np.var(data_, axis=1, ddof=1)
+
+    mean_full = np.mean(data)
+    var_full = np.var(data, ddof=1)
+
+    var_mean = np.mean(chain_vars)
+    var_between = N * np.var(chain_means, ddof=1)
+
+    Rhat = np.sqrt((N - 1) / N + var_between / (N * var_mean))
+
+    return mean_full, var_full, Rhat
+
+
+def test_mc_stats():
+    # Test data of shape [MPI_size, n_chains, n_samples], same on all ranks
+    data = np.random.rand(size, 10, 1000)
+    data = comm.bcast(data)
+
+    ref_mean, ref_var, ref_R = reference_stats(data)
+
+    mydata = data[rank]
+
+    stats = nk.stats.statistics(mydata)
+
+    assert stats.mean == approx(ref_mean)
+    assert stats.variance == approx(ref_var)
+    assert stats.R == approx(ref_R)
+
+
+def test_mean():
+    data = np.random.rand(size, 10, 11, 12)
+    data = comm.bcast(data)
+    mydata = data[rank]
+
+    for axis in None, 0, 1, 2:
+        ref_mean = np.mean(data.mean(0), axis=axis)
+        nk_mean = nk.stats.mean(mydata, axis=axis)
+
+        assert nk_mean.shape == ref_mean.shape, "axis={}".format(axis)
+        assert nk_mean == approx(ref_mean), "axis={}".format(axis)
+
+
+def test_var():
+    data = np.random.rand(size, 10, 11, 12)
+    data = comm.bcast(data)
+    mydata = data[rank]
+
+    for axis in None, 0, 1, 2:
+        if axis is not None:
+            # Merge first "MPI axis" with target axis
+            refdata = np.moveaxis(data, axis + 1, 0)
+            refdata = refdata.reshape(-1, *refdata.shape[2:])
+            # Compute variance over merged axis
+            ref_var = np.var(refdata, axis=0, ddof=0)
+        else:
+            ref_var = np.var(data, ddof=0)
+
+        nk_var = nk.stats.var(mydata, axis=axis)
+
+        assert nk_var.shape == ref_var.shape, "axis={}".format(axis)
+        assert nk_var == approx(ref_var), "axis={}".format(axis)

--- a/Test/Stats/mpi_test_stats.py
+++ b/Test/Stats/mpi_test_stats.py
@@ -81,3 +81,15 @@ def test_var():
 
         assert nk_var.shape == ref_var.shape, "axis={}".format(axis)
         assert nk_var == approx(ref_var), "axis={}".format(axis)
+
+
+def test_sum():
+    data = np.arange(size * 10 * 11).reshape(size, 10, 11)
+    data = comm.bcast(data)
+    mydata = data[rank]
+
+    ref_sum = np.sum(data, axis=0)
+    ret = nk.stats.mpi_sum_inplace(mydata)
+    # mydata should be changed in place
+    assert mydata == approx(ref_sum)
+    assert np.all(ret == mydata)

--- a/Test/Stats/mpi_test_stats.py
+++ b/Test/Stats/mpi_test_stats.py
@@ -20,13 +20,13 @@ def reference_stats(data):
     data_ = data.reshape(M_full, N)
 
     chain_means = np.mean(data_, axis=1)
-    chain_vars = np.var(data_, axis=1, ddof=1)
+    chain_vars = np.var(data_, axis=1, ddof=0)
 
     mean_full = np.mean(data)
-    var_full = np.var(data, ddof=1)
+    var_full = np.var(data, ddof=0)
 
     var_mean = np.mean(chain_vars)
-    var_between = N * np.var(chain_means, ddof=1)
+    var_between = N * np.var(chain_means, ddof=0)
 
     Rhat = np.sqrt((N - 1) / N + var_between / (N * var_mean))
 

--- a/netket/optimizer/stochastic_reconfiguration.py
+++ b/netket/optimizer/stochastic_reconfiguration.py
@@ -3,7 +3,7 @@ from scipy.linalg import lstsq as _lstsq
 from scipy.linalg import cho_factor as _cho_factor
 from scipy.linalg import cho_solve as _cho_solve
 from scipy.sparse.linalg import LinearOperator
-from netket.stats import mpi_sum_inplace as _mpi_sum_inplace
+from netket.stats import sum_inplace as _sum_inplace
 from scipy.sparse.linalg import cg, gmres, minres
 from mpi4py import MPI
 
@@ -106,7 +106,7 @@ class SR:
             out: Output array for the update ẋ.
         """
 
-        n_samp = _mpi_sum_inplace(_np.atleast_1d(oks.shape[0]))
+        n_samp = _sum_inplace(_np.atleast_1d(oks.shape[0]))
 
         n_par = grad.shape[0]
 
@@ -133,7 +133,7 @@ class SR:
                 self._x0 = out
             else:
                 self._S = _np.matmul(oks.conj().T, oks, self._S)
-                self._S = _mpi_sum_inplace(self._S)
+                self._S = _sum_inplace(self._S)
                 self._S /= float(n_samp)
 
                 self._apply_preconditioning(grad)
@@ -290,7 +290,7 @@ class SR:
 
                 v_tilde = _np.matmul(oks, v, v_tilde) / float(n_samp)
                 res = _np.matmul(v_tilde, oks_conj, res)
-                res = _mpi_sum_inplace(res) + shift * v
+                res = _sum_inplace(res) + shift * v
                 return res
 
         else:
@@ -301,7 +301,7 @@ class SR:
 
                 v_tilde = _np.matmul(oks, v, v_tilde) / float(n_samp)
                 res = _np.matmul(v_tilde, oks_conj, res)
-                res = _mpi_sum_inplace(res) + shift * v
+                res = _sum_inplace(res) + shift * v
 
                 return res.real
 

--- a/netket/optimizer/stochastic_reconfiguration.py
+++ b/netket/optimizer/stochastic_reconfiguration.py
@@ -3,7 +3,7 @@ from scipy.linalg import lstsq as _lstsq
 from scipy.linalg import cho_factor as _cho_factor
 from scipy.linalg import cho_solve as _cho_solve
 from scipy.sparse.linalg import LinearOperator
-from netket.stats import sum_on_nodes as _sum_on_nodes
+from netket.stats import mpi_sum_inplace as _mpi_sum_inplace
 from scipy.sparse.linalg import cg, gmres, minres
 from mpi4py import MPI
 
@@ -106,7 +106,7 @@ class SR:
             out: Output array for the update ẋ.
         """
 
-        n_samp = _sum_on_nodes(_np.atleast_1d(oks.shape[0]))
+        n_samp = _mpi_sum_inplace(_np.atleast_1d(oks.shape[0]))
 
         n_par = grad.shape[0]
 
@@ -133,7 +133,7 @@ class SR:
                 self._x0 = out
             else:
                 self._S = _np.matmul(oks.conj().T, oks, self._S)
-                self._S = _sum_on_nodes(self._S)
+                self._S = _mpi_sum_inplace(self._S)
                 self._S /= float(n_samp)
 
                 self._apply_preconditioning(grad)
@@ -290,7 +290,7 @@ class SR:
 
                 v_tilde = _np.matmul(oks, v, v_tilde) / float(n_samp)
                 res = _np.matmul(v_tilde, oks_conj, res)
-                res = _sum_on_nodes(res) + shift * v
+                res = _mpi_sum_inplace(res) + shift * v
                 return res
 
         else:
@@ -301,7 +301,7 @@ class SR:
 
                 v_tilde = _np.matmul(oks, v, v_tilde) / float(n_samp)
                 res = _np.matmul(v_tilde, oks_conj, res)
-                res = _sum_on_nodes(res) + shift * v
+                res = _mpi_sum_inplace(res) + shift * v
 
                 return res.real
 

--- a/netket/stats/mc_stats.py
+++ b/netket/stats/mc_stats.py
@@ -12,6 +12,7 @@ def _format_decimal(value, std):
         "{0:.{1}f}".format(std, decimals + 1),
     )
 
+
 class Stats:
     """A dict-compatible class containing the result of the statistics function."""
 

--- a/netket/stats/mc_stats.py
+++ b/netket/stats/mc_stats.py
@@ -78,7 +78,7 @@ def _block_variance(data, l):
 def _batch_variance(data):
     b_means = _np.mean(data, axis=1)
     ts = _total_size(b_means)
-    return _var(b_means) / float(ts), ts
+    return _var(b_means), ts
 
 
 def statistics(data):
@@ -116,7 +116,7 @@ def statistics(data):
 
     ts = _total_size(data)
 
-    bare_var = stats.variance / float(ts)
+    bare_var = stats.variance / ts
 
     batch_var, n_batches = _batch_variance(data)
 
@@ -132,7 +132,7 @@ def statistics(data):
     batch_good = tau_batch < 6 * data.shape[1] and n_batches >= b_s
 
     if batch_good:
-        stats.error_of_mean = _np.sqrt(batch_var)
+        stats.error_of_mean = _np.sqrt(batch_var / ts)
         stats.tau_corr = max(0, tau_batch)
     elif block_good:
         stats.error_of_mean = _np.sqrt(block_var)
@@ -142,6 +142,7 @@ def statistics(data):
         stats.tau_corr = _np.nan
 
     if n_batches > 1:
-        stats.R = _np.sqrt(1.0 + batch_var / stats.variance)
+        N = data.shape[-1]
+        stats.R = _np.sqrt((N - 1) / N + batch_var / stats.variance)
 
     return stats

--- a/netket/stats/mpi_stats.py
+++ b/netket/stats/mpi_stats.py
@@ -60,23 +60,20 @@ def mpi_sum_inplace(a):
 def var(a, axis=None, dtype=None, out=None):
     """
     Compute the variance mean along the specified axis and over MPI processes.
-
-
     """
 
     m = mean(a, axis=axis, dtype=dtype, out=out)
+
     if axis is None or axis == 0:
-        out = mean(_np.abs(a - m) ** 2.0, axis=axis, dtype=dtype, out=out)
+        ssq = _np.abs(a - m) ** 2.0
     elif axis == 1:
-        out = mean(
-            _np.abs(a - m[:, _np.newaxis]) ** 2.0, axis=axis, dtype=dtype, out=out
-        )
+        ssq = _np.abs(a - m[:, _np.newaxis]) ** 2.0
     elif axis == 2:
-        out = mean(
-            _np.abs(a - m[:, :, _np.newaxis]) ** 2.0, axis=axis, dtype=dtype, out=out
-        )
+        ssq = _np.abs(a - m[:, :, _np.newaxis]) ** 2.0
     else:
         raise RuntimeError("var implemented only for ndim<=3.")
+
+    out = mean(ssq, axis=axis, dtype=dtype, out=out)
 
     return out
 

--- a/netket/stats/mpi_stats.py
+++ b/netket/stats/mpi_stats.py
@@ -21,7 +21,6 @@ def subtract_mean(x, axis=None, dtype=None, mean_out=None):
 
 
 _MPI_comm = MPI.COMM_WORLD
-
 _n_nodes = _MPI_comm.Get_size()
 
 
@@ -47,17 +46,15 @@ def mean(a, axis=None, dtype=None, out=None):
     return out.reshape(old_shape)
 
 
-def sum_on_nodes(a, out=None):
+def mpi_sum_inplace(a):
     """
-    Computes the sum of a numpy array over MPI processes.
+    Computes the elementwise sum of a numpy array over all MPI processes.
+
+    Args:
+        a (numpy.ndarray): The input array, which will be overwritten in place.
     """
-    if out is None:
-        _MPI_comm.Allreduce(MPI.IN_PLACE, a.reshape(-1), op=MPI.SUM)
-        return a
-    else:
-        out = _np.copy(a)
-        _MPI_comm.Allreduce(MPI.IN_PLACE, out.reshape(-1), op=MPI.SUM)
-        return out
+    _MPI_comm.Allreduce(MPI.IN_PLACE, a.reshape(-1), op=MPI.SUM)
+    return a
 
 
 def var(a, axis=None, dtype=None, out=None):

--- a/netket/stats/mpi_stats.py
+++ b/netket/stats/mpi_stats.py
@@ -55,14 +55,10 @@ def var(a, axis=None, out=None):
 
     m = mean(a, axis=axis)
 
-    if axis is None or axis == 0:
+    if axis is None:
         ssq = _np.abs(a - m) ** 2.0
-    elif axis == 1:
-        ssq = _np.abs(a - m[:, _np.newaxis]) ** 2.0
-    elif axis == 2:
-        ssq = _np.abs(a - m[:, :, _np.newaxis]) ** 2.0
     else:
-        raise RuntimeError("var implemented only for ndim<=3.")
+        ssq = _np.abs(a - _np.expand_dims(m, axis)) ** 2.0
 
     out = mean(ssq, axis=axis, out=out)
     return out


### PR DESCRIPTION
Complementing the discussion in #365, these are tests that I believe the NetKet statistics should satisfy.

Note that `test_var` currently uses `ddof=0` and passes. I believe we should have a `ddof` parameter on the NetKet functions as well, to apply the denominator corresction just as `np.var` does.

The `test_mc_stats` currently fails, due to the discrepancy in the computation of variance and `Rhat` with `ddof=1` we are discussing in #365. While for `Rhat`, we should definitely use `ddof=1`, I am not sure about `stats.variance`, though I believe the correction is also appropriate there.

Also note that these tests use MPI. I haven't yet figured out how to conveniently run them together with the others using `pytest` (at least not without producing duplicate output, as all processes print data with `pytest`), but they can be run manually using, e.g, `mpirun -np 2 python3 -m pytest -v Test/Stats/mpi_test_stats.py`.