### PR TITLE
Stats/binning.hpp: fix not actually adding the value after merging bins

### DIFF
--- a/Sources/Stats/binning.hpp
+++ b/Sources/Stats/binning.hpp
@@ -104,6 +104,12 @@ class Binning {
         }
       } else {
         Merge();
+        // finally, add the value
+        nb1_ = bins1_[0].N();
+        bins2_[last2_] << val;
+        if (bins2_[last2_].N() == nb1_) {
+          last2_++;
+        }
       }
     }
   }


### PR DESCRIPTION
...which meant every 32th value in the sum was disgarded.

This bug is noticeable f.e. when summing over a specific set of states, where the result might be quite different if there are summands missing. 