### PR TITLE
Add MPI-enabled test cases for statistics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ matrix:
             - 'ninja-build'
             - 'g++-7'
             - 'libopenmpi-dev'
+            - 'openmpi-bin'
 
     # Modern toolsets
     - os: linux
@@ -44,6 +45,7 @@ matrix:
             - 'g++-9'
             - 'libomp-dev'
             - 'libmpich-dev'
+            - 'mpich'
             - 'libopenblas-dev'
 
     - os: linux
@@ -58,6 +60,7 @@ matrix:
             - 'ninja-build'
             - 'g++-9'
             - 'libopenmpi-dev'
+            - 'openmpi-bin'
             - 'libopenblas-dev'
 
 before_install:
@@ -126,4 +129,5 @@ script:
   - python -c 'import netket'
   - python -c 'import netket; g = netket.graph.Hypercube(4, 1); h = netket.hilbert.Spin(g, 0.5); m = netket.machine.RbmSpin(h, 10)'
   - python -m pytest --durations=0 -n 2 --verbose ../Test/
+  - mpirun -np 2 python -m pytest --durations=0 --verbose ../Test_MPI
   # - python -m pytest --durations=0 --verbose --doctest-glob='*.md' ../Docs/

--- a/Test_MPI/test_mpi.py
+++ b/Test_MPI/test_mpi.py
@@ -1,0 +1,20 @@
+from mpi4py import MPI
+import pytest
+
+comm = MPI.COMM_WORLD
+size = comm.Get_size()
+rank = comm.Get_rank()
+
+
+def test_is_running_with_multiple_procs():
+    msg = "The Test_MPI tests should be run with more than one MPI process"
+    assert size > 1, msg
+
+
+def test_mpi_setup():
+    recv = comm.bcast(rank)
+    assert recv == 0, "rank={}".format(rank)
+
+    ranks = comm.allgather(rank)
+    assert len(ranks) == size
+    assert ranks == list(range(size))

--- a/netket/machine/abstract_machine.py
+++ b/netket/machine/abstract_machine.py
@@ -44,7 +44,7 @@ class AbstractMachine(abc.ABC):
         Returns:
              `out`
         """
-        out = _np.dot(_np.asmatrix(self.der_log(x)).H, vec, out)
+        out = _np.dot(self.der_log(x).conjugate().transpose(), vec, out)
         return out
 
     def jacobian_vector_prod(self, v, vec, out=None):

--- a/netket/optimizer/stochastic_reconfiguration.py
+++ b/netket/optimizer/stochastic_reconfiguration.py
@@ -57,7 +57,7 @@ class SR:
 
         if self._use_iterative:
             if lsq_solver is None:
-                lsq_solver = "gmres" if self.is_holomorphic else "minres"
+                lsq_solver = "gmres" if self._is_holomorphic else "minres"
 
             if lsq_solver == "gmres":
                 self._sparse_solver = partial(gmres, atol="legacy")
@@ -65,13 +65,14 @@ class SR:
                 self._sparse_solver = partial(cg, atol="legacy")
             elif lsq_solver == "minres":
                 if self._is_holomorphic:
-                    self._sparse_solver = minres
-                else:
                     raise RuntimeError(
                         "minres can be used only for real-valued parameters."
                     )
+                self._sparse_solver = minres
             else:
-                raise RuntimeError("Unknown sparse lsq_solver " + lsq_solver + ".")
+                raise RuntimeError(
+                    "Unknown sparse lsq_solver " + lsq_solver + "."
+                )
 
         else:
             if (

--- a/netket/optimizer/stochastic_reconfiguration.py
+++ b/netket/optimizer/stochastic_reconfiguration.py
@@ -1,3 +1,4 @@
+from functools import partial
 import numpy as _np
 from scipy.linalg import lstsq as _lstsq
 from scipy.linalg import cho_factor as _cho_factor
@@ -56,11 +57,12 @@ class SR:
 
         if self._use_iterative:
             if lsq_solver is None:
-                self._sparse_solver = gmres if self.is_holomorphic else minres
-            elif lsq_solver == "gmres":
-                self._sparse_solver = gmres
+                lsq_solver = "gmres" if self.is_holomorphic else "minres"
+
+            if lsq_solver == "gmres":
+                self._sparse_solver = partial(gmres, atol="legacy")
             elif lsq_solver == "cg":
-                self._sparse_solver = cg
+                self._sparse_solver = partial(cg, atol="legacy")
             elif lsq_solver == "minres":
                 if self._is_holomorphic:
                     self._sparse_solver = minres

--- a/netket/stats/mpi_stats.py
+++ b/netket/stats/mpi_stats.py
@@ -28,8 +28,8 @@ def mean(a, axis=None, out=None):
     Returns the average of the array elements. The average is taken over the flattened array by default,
     otherwise over the specified axis. float64 intermediate and return values are used for integer inputs.
     """
-
-    out = _np.mean(a, axis=axis, out=out)
+    # asarray is necessary for the axis=None case to work, as the MPI call requires a NumPy array
+    out = _np.asarray(_np.mean(a, axis=axis, out=out))
 
     _MPI_comm.Allreduce(MPI.IN_PLACE, out.reshape(-1), op=MPI.SUM)
     out /= _n_nodes
@@ -41,7 +41,8 @@ def sum(a, axis=None, out=None):
     """
     Compute the arithmetic mean along the specified axis and over MPI processes.
     """
-    out = _np.sum(a, axis=axis, out=out)
+    # asarray is necessary for the axis=None case to work, as the MPI call requires a NumPy array
+    out = _np.asarray(_np.sum(a, axis=axis, out=out))
     _MPI_comm.Allreduce(MPI.IN_PLACE, out.reshape(-1), op=MPI.SUM)
     return out
 


### PR DESCRIPTION
In order to make sure our statistics functions work, I have added a couple of tests to be run with MPI.
Adding those tests also uncovered a bug I had overlooked in the MPI stats functions that is now fixed.

The tests are in a separate `Test_MPI` folder so that they are not automatically run with the other tests. As a side effect, this also provides a quick way to check that one's own MPI environment is correctly set up.