### PR TITLE
Improvements & fixes for v2.1.1

### DIFF
--- a/Examples/Ising1d/ising1d.py
+++ b/Examples/Ising1d/ising1d.py
@@ -34,7 +34,7 @@ sa = nk.sampler.MetropolisLocal(machine=ma, n_chains=8)
 op = nk.optimizer.Sgd(learning_rate=0.1)
 
 # Stochastic Reconfiguration
-sr = nk.optimizer.SR()
+sr = nk.optimizer.SR(diag_shift=0.1)
 
 # Create the optimization driver
 gs = nk.Vmc(

--- a/Examples/Ising1d/ising1d.py
+++ b/Examples/Ising1d/ising1d.py
@@ -47,4 +47,4 @@ gs = nk.Vmc(
 )
 
 # Run the optimization for 300 iterations
-gs.run(n_iter=100)
+gs.run(n_iter=100, out="test")

--- a/Examples/Ising1d/ising1d.py
+++ b/Examples/Ising1d/ising1d.py
@@ -34,8 +34,7 @@ sa = nk.sampler.MetropolisLocal(machine=ma, n_chains=8)
 op = nk.optimizer.Sgd(learning_rate=0.1)
 
 # Stochastic Reconfiguration
-sr = nk.optimizer.SR(diag_shift=0.1, use_iterative=False,
-                     lsq_solver="LLT")
+sr = nk.optimizer.SR()
 
 # Create the optimization driver
 gs = nk.Vmc(
@@ -47,4 +46,4 @@ gs = nk.Vmc(
 )
 
 # Run the optimization for 300 iterations
-gs.run(n_iter=100, out="test")
+gs.run(n_iter=300, out="test")

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-<img src="https://www.netket.org/_static/logo_simple.jpg" alt="logo" width="200"></img>
+<img src="https://www.netket.org/_static/logo_simple.jpg" alt="logo" width="400"></img>
 </div>
 
 # __NetKet__ 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,37 @@
+<div align="center">
+<img src="https://www.netket.org/_static/logo_simple.jpg" alt="logo" width="200"></img>
+</div>
 
-# <img src="http://www.netket.org/img/logo_simple.jpg" width="400"> <img src="http://www.netket.org/img/logo_simple.jpg" width="400">
+# __NetKet__ 
 
 [![Release](https://img.shields.io/github/release/netket/netket.svg)](https://github.com/netket/netket/releases)
+[![Anaconda-Server Badge](https://anaconda.org/conda-forge/netket/badges/installer/conda.svg)](https://conda.anaconda.org/conda-forge)
 [![Build Status](https://travis-ci.org/netket/netket.svg?branch=master)](https://travis-ci.org/netket/netket)
 [![GitHub Issues](https://img.shields.io/github/issues/netket/netket.svg)](http://github.com/netket/netket/issues)
 [![Paper](https://img.shields.io/badge/paper-arXiv%3A1904.00031-B31B1B.svg)](https://arxiv.org/abs/1904.00031)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/netket/netket/v.2.0)
 
-
-# __NetKet__
-
 NetKet is an open-source project delivering cutting-edge methods for the study
 of many-body quantum systems with artificial neural networks and machine learning techniques.
 It is a Python library built on C++ primitives.
 
+- **Homepage:** <https://netket.org>
+- **Citing:** <https://www.netket.org/citing>
+- **Documentation:** <https://netket.org/documentation>
+- **Tutorials:** <https://www.netket.org/tutorials>
+- **Examples:** <https://github.com/netket/netket/tree/master/Examples> 
+- **Source code:** <https://github.com/netket/netket>
+
+## Installation and Usage
+You can install on osx or linux with either
+ - *pip*   : `pip install netket`
+ - *conda* : `conda install conda-forge::netket`
+
+Conda by default ships pre-built binaries for recent versions of python.
+The default blas library is openblas, but mkl can be enforced.
+
+To learn more, check out the website or the examples.
 
 ## Major Features
 
@@ -99,10 +116,6 @@ It is a Python library built on C++ primitives.
 * Interface
   * Python Library
   * JSON output  
-
-## Installation and Usage
-
-Please visit our [homepage](https://www.netket.org) for further information.
 
 ## License
 

--- a/netket/_jitclass.py
+++ b/netket/_jitclass.py
@@ -1,0 +1,26 @@
+# Copyright 2019 The Simons Foundation, Inc. - All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file permits loading numba's jitclass without throwing deprecation
+# warnings in v > 0.49.
+
+# TODO if numba's minimum version is raised to 0.49, remove this file and
+# change all usages to from numba.experimental import jitclass
+
+from pkg_resources import get_distribution
+
+if get_distribution("numba").version < '0.49':
+    from numba import jitclass
+else:
+    from numba.experimental import jitclass

--- a/netket/abstract_variational_driver.py
+++ b/netket/abstract_variational_driver.py
@@ -200,9 +200,17 @@ class AbstractVariationalDriver(abc.ABC):
             raise ValueError(
                 "Invalid out and output_prefix arguments. Only one of the two can be passed. Note that output_prefix is deprecated and you should use out."
             )
-        elif out is None:
-            warn_deprecation("The output_prefix argument is deprecated. Use out instead.")
+        elif out is None and output_prefix is not None:
+            warn_deprecation(
+                "The output_prefix argument is deprecated. Use out instead."
+            )
             out = output_prefix
+
+        if out is None:
+            print(
+                "No output specified (out=[apath|nk.logging.JsonLogger(...)])."
+                "Running the optimization but not saving the output."
+            )
 
         # Log only non-root nodes
         if self._mynode == 0:

--- a/netket/sampler/metropolis_exchange.py
+++ b/netket/sampler/metropolis_exchange.py
@@ -5,9 +5,13 @@ from .abstract_sampler import AbstractSampler
 from .metropolis_hastings import *
 from .._C_netket import sampler as c_sampler
 
-from numba import jit, jitclass
-from numba import int64, float64
 
+from numba import jit, int64, float64
+from pkg_resources import get_distribution
+if get_distribution("numba").version < '0.49':
+    from numba import jitclass
+else:
+    from numba.experimental import jitclass
 
 @jitclass([("clusters", int64[:, :])])
 class _exchange_kernel:

--- a/netket/sampler/metropolis_exchange.py
+++ b/netket/sampler/metropolis_exchange.py
@@ -5,13 +5,8 @@ from .abstract_sampler import AbstractSampler
 from .metropolis_hastings import *
 from .._C_netket import sampler as c_sampler
 
-
 from numba import jit, int64, float64
-from pkg_resources import get_distribution
-if get_distribution("numba").version < '0.49':
-    from numba import jitclass
-else:
-    from numba.experimental import jitclass
+from .._jitclass import jitclass
 
 @jitclass([("clusters", int64[:, :])])
 class _exchange_kernel:

--- a/netket/sampler/metropolis_hastings.py
+++ b/netket/sampler/metropolis_hastings.py
@@ -5,9 +5,14 @@ from .._C_netket import sampler as c_sampler
 from .._C_netket.utils import random_engine
 from ..stats import mean as _mean
 
-from numba import jit, jitclass
-from numba import int64, float64
 from netket import random as _random
+
+from numba import jit, int64, float64
+from pkg_resources import get_distribution
+if get_distribution("numba").version < '0.49':
+    from numba import jitclass
+else:
+    from numba.experimental import jitclass
 
 
 class PyMetropolisHastings(AbstractSampler):

--- a/netket/sampler/metropolis_hastings.py
+++ b/netket/sampler/metropolis_hastings.py
@@ -8,11 +8,7 @@ from ..stats import mean as _mean
 from netket import random as _random
 
 from numba import jit, int64, float64
-from pkg_resources import get_distribution
-if get_distribution("numba").version < '0.49':
-    from numba import jitclass
-else:
-    from numba.experimental import jitclass
+from .._jitclass import jitclass
 
 
 class PyMetropolisHastings(AbstractSampler):

--- a/netket/sampler/metropolis_local.py
+++ b/netket/sampler/metropolis_local.py
@@ -6,11 +6,7 @@ from .metropolis_hastings import *
 from .._C_netket import sampler as c_sampler
 
 from numba import jit, int64, float64
-from pkg_resources import get_distribution
-if get_distribution("numba").version < '0.49':
-    from numba import jitclass
-else:
-    from numba.experimental import jitclass
+from .._jitclass import jitclass
 
 
 @jitclass([("local_states", float64[:]), ("size", int64), ("n_states", int64)])

--- a/netket/sampler/metropolis_local.py
+++ b/netket/sampler/metropolis_local.py
@@ -5,8 +5,12 @@ from .abstract_sampler import AbstractSampler
 from .metropolis_hastings import *
 from .._C_netket import sampler as c_sampler
 
-from numba import jit, jitclass
-from numba import int64, float64
+from numba import jit, int64, float64
+from pkg_resources import get_distribution
+if get_distribution("numba").version < '0.49':
+    from numba import jitclass
+else:
+    from numba.experimental import jitclass
 
 
 @jitclass([("local_states", float64[:]), ("size", int64), ("n_states", int64)])


### PR DESCRIPTION
- Stop Numba from displaying deprecation warnings 
- Warn if no output variable is passed to a driver, but run the optimization anyway.
- Fix an example that was missing the out variable

this should be back ported to v3.0