### PR TITLE
Also check benchmarks, tests, and examples with black

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -131,4 +131,5 @@ script:
   - python -m pytest --durations=0 -n 2 --verbose ../Test/
   - mpirun -np 2 python -m pytest --durations=0 --verbose ../Test_MPI
   - black --check ../netket/
+  - black --check ../Test ../Test_MPI
   # - python -m pytest --durations=0 --verbose --doctest-glob='*.md' ../Docs/

--- a/.travis.yml
+++ b/.travis.yml
@@ -132,4 +132,5 @@ script:
   - mpirun -np 2 python -m pytest --durations=0 --verbose ../Test_MPI
   - black --check ../netket/
   - black --check ../Test ../Test_MPI
+  - black --check ../Examples ../Benchmarks
   # - python -m pytest --durations=0 --verbose --doctest-glob='*.md' ../Docs/

--- a/Benchmarks/sampler.py
+++ b/Benchmarks/sampler.py
@@ -37,8 +37,7 @@ py_ma.parameters = ma.parameters
 # Metropolis Local Sampling
 batch_size = 32
 sa = nk.sampler.MetropolisLocal(machine=ma, n_chains=batch_size)
-py_sa = nk.sampler.MetropolisLocal(
-    machine=py_ma, n_chains=batch_size)
+py_sa = nk.sampler.MetropolisLocal(machine=py_ma, n_chains=batch_size)
 
 n_samples = 500
 samples = np.zeros((n_samples, sa.sample_shape[0], sa.sample_shape[1]))

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,3 +81,16 @@ pytest Test --verbose
 
 this will highlight cases where tests are failing. These must be addressed before any pull request can be merged on stable branches.
  
+#### Test MPI code
+
+For code that relies on MPI operations, there are units tests in the `Test_MPI` subfolder.
+If you add MPI-related code, please also add corresponding unit tests to that directory.
+
+The MPI tests can be run with
+```bash
+mpirun -np 2 pytest Test_MPI --verbose
+```
+Note that this will print the test output twice, as `pytest` itself is not aware of being run with MPI.
+Running these tests also provides a quick way to check if your MPI setup is working.
+If `test_is_running_with_multiple_procs` or `test_mpi_setup` is failing, you should check your MPI configuration,
+for example whether `mpi4py` is compiled against the correct MPI libraries for your machine.

--- a/Examples/CustomGraph/plot_ising.py
+++ b/Examples/CustomGraph/plot_ising.py
@@ -14,7 +14,6 @@ while True:
     energy = []
     sigma = []
     evar = []
-    
 
     data = json.load(open("test.log"))
     for iteration in data["Output"]:
@@ -22,7 +21,6 @@ while True:
         energy.append(iteration["Energy"]["Mean"])
         sigma.append(iteration["Energy"]["Sigma"])
         evar.append(iteration["Energy"]["Variance"])
-        
 
     plt.semilogy()
     plt.errorbar(iters, evar, yerr=evarsig, color="red")

--- a/Examples/CustomHamiltonian/plot_ising.py
+++ b/Examples/CustomHamiltonian/plot_ising.py
@@ -16,7 +16,6 @@ while True:
     energy = []
     sigma = []
     evar = []
-    
 
     data = json.load(open("test.log"))
     for iteration in data["Output"]:
@@ -24,7 +23,6 @@ while True:
         energy.append(iteration["Energy"]["Mean"])
         sigma.append(iteration["Energy"]["Sigma"])
         evar.append(iteration["Energy"]["Variance"])
-        
 
     nres = len(iters)
     cut = 200

--- a/Examples/CustomMachine/plot_ising.py
+++ b/Examples/CustomMachine/plot_ising.py
@@ -19,7 +19,6 @@ while True:
     energy = []
     sigma = []
     evar = []
-    
 
     data = json.load(open("test.log"))
     for iteration in data["Output"]:

--- a/Examples/CustomSampler/plot_heis.py
+++ b/Examples/CustomSampler/plot_heis.py
@@ -17,7 +17,6 @@ while True:
     energy = []
     sigma = []
     evar = []
-    
 
     data = json.load(open("test.log"))
     for iteration in data["Output"]:
@@ -25,7 +24,6 @@ while True:
         energy.append(iteration["Energy"]["Mean"])
         sigma.append(iteration["Energy"]["Sigma"])
         evar.append(iteration["Energy"]["Variance"])
-        
 
     plt.errorbar(iters, energy, yerr=sigma, color="red")
     plt.axhline(y=exact, xmin=0, xmax=iters[-1], linewidth=2, color="k", label="Exact")

--- a/Examples/DissipativeIsing1d/ising1d.py
+++ b/Examples/DissipativeIsing1d/ising1d.py
@@ -49,8 +49,7 @@ obs_sz = nk.operator.LocalOperator(hi)
 
 for i in range(L):
     ha += (gp / 2.0) * nk.operator.LocalOperator(hi, sx, [i])
-    ha += (Vp / 4.0) * nk.operator.LocalOperator(hi,
-                                                 np.kron(sz, sz), [i, (i + 1) % L])
+    ha += (Vp / 4.0) * nk.operator.LocalOperator(hi, np.kron(sz, sz), [i, (i + 1) % L])
 
     # sigma_{-} dissipation on every site
     j_ops.append(nk.operator.LocalOperator(hi, sigmam, [i]))
@@ -77,6 +76,6 @@ op = nk.optimizer.Sgd(0.01)
 sr = nk.optimizer.SR(diag_shift=0.01, use_iterative=True)
 
 ss = nk.SteadyState(lind, sa, op, 2000, sampler_obs=sa_obs, n_samples_obs=500)
-obs = {'Sx': obs_sx, 'Sy': obs_sy, 'Sz': obs_sz}
+obs = {"Sx": obs_sx, "Sy": obs_sy, "Sz": obs_sz}
 
 ss.run(n_iter=200, out="test", obs=obs)

--- a/Examples/ExactDiag/dissipative_ising1.py
+++ b/Examples/ExactDiag/dissipative_ising1.py
@@ -44,7 +44,7 @@ for i in range(L):
     j_ops.append(nk.operator.LocalOperator(hi, sigmam, [i]))
 
 
-# Create the lindbladian with no jump operators
+#  Create the lindbladian with no jump operators
 lind = nk.operator.LocalLiouvillian(ha)
 
 # add the jump operators
@@ -52,4 +52,6 @@ for j_op in j_ops:
     lind.add_jump_op(j_op)
 
 
-rho = nk.exact.steady_state(lind, method='iterative', sparse=True, maxiter=1000, tol=1e-5)
+rho = nk.exact.steady_state(
+    lind, method="iterative", sparse=True, maxiter=1000, tol=1e-5
+)

--- a/Examples/GraphOperator/Ising/plot_ising.py
+++ b/Examples/GraphOperator/Ising/plot_ising.py
@@ -19,7 +19,6 @@ while True:
     energy = []
     sigma = []
     evar = []
-    
 
     data = json.load(open("test.log"))
     for iteration in data["Output"]:
@@ -27,7 +26,6 @@ while True:
         energy.append(iteration["Energy"]["Mean"])
         sigma.append(iteration["Energy"]["Sigma"])
         evar.append(iteration["Energy"]["Variance"])
-        
 
     nres = len(iters)
     cut = 200

--- a/Examples/GraphOperator/J1J2/plot_j1j2.py
+++ b/Examples/GraphOperator/J1J2/plot_j1j2.py
@@ -17,7 +17,6 @@ while True:
     energy = []
     sigma = []
     evar = []
-    
 
     data = json.load(open("test.log"))
     for iteration in data["Output"]:
@@ -25,7 +24,6 @@ while True:
         energy.append(iteration["Energy"]["Mean"])
         sigma.append(iteration["Energy"]["Sigma"])
         evar.append(iteration["Energy"]["Variance"])
-        
 
     plt.errorbar(iters, energy, yerr=sigma, color="red")
     plt.axhline(y=exact, xmin=0, xmax=iters[-1], linewidth=2, color="k", label="Exact")

--- a/Examples/Heisenberg1d/plot_heis.py
+++ b/Examples/Heisenberg1d/plot_heis.py
@@ -17,7 +17,6 @@ while True:
     energy = []
     sigma = []
     evar = []
-    
 
     data = json.load(open("test.log"))
     for iteration in data["Output"]:
@@ -25,7 +24,6 @@ while True:
         energy.append(iteration["Energy"]["Mean"])
         sigma.append(iteration["Energy"]["Sigma"])
         evar.append(iteration["Energy"]["Variance"])
-        
 
     plt.errorbar(iters, energy, yerr=sigma, color="red")
     plt.axhline(y=exact, xmin=0, xmax=iters[-1], linewidth=2, color="k", label="Exact")

--- a/Examples/ImaginaryTime/plot_ising_imag.py
+++ b/Examples/ImaginaryTime/plot_ising_imag.py
@@ -17,7 +17,6 @@ while True:
     energy = []
     sigma = []
     evar = []
-    
 
     data = json.load(open("ising_imag.log"))
     for iteration in data["Output"]:
@@ -26,7 +25,6 @@ while True:
         energy.append(iteration["Energy"]["Mean"])
         sigma.append(iteration["Energy"]["Sigma"])
         evar.append(iteration["Energy"]["Variance"])
-        
 
     nres = len(iters)
     cut = 100

--- a/Examples/Ising1d/ising1d.py
+++ b/Examples/Ising1d/ising1d.py
@@ -35,17 +35,10 @@ sa = nk.sampler.MetropolisLocal(ma, n_chains=32)
 op = nk.optimizer.Sgd(learning_rate=0.1)
 
 # Stochastic Reconfiguration
-sr = nk.optimizer.SR(diag_shift=0.1, use_iterative=False,
-                     lsq_solver="LLT")
+sr = nk.optimizer.SR(diag_shift=0.1, use_iterative=False, lsq_solver="LLT")
 
 # Create the optimization driver
-gs = nk.Vmc(
-    hamiltonian=ha,
-    sampler=sa,
-    optimizer=op,
-    n_samples=1000,
-    sr=sr,
-)
+gs = nk.Vmc(hamiltonian=ha, sampler=sa, optimizer=op, n_samples=1000, sr=sr)
 
 # Run the optimization for 300 iterations
 gs.run(n_iter=100)

--- a/Examples/Ising1d/plot_ising.py
+++ b/Examples/Ising1d/plot_ising.py
@@ -19,7 +19,6 @@ while True:
     energy = []
     sigma = []
     evar = []
-    
 
     data = json.load(open("test.log"))
     for iteration in data["Output"]:

--- a/Examples/Ising2d/ising2d.py
+++ b/Examples/Ising2d/ising2d.py
@@ -34,20 +34,13 @@ sa = nk.sampler.MetropolisLocal(machine=ma)
 op = nk.optimizer.Sgd(learning_rate=0.1)
 
 # Stochastic Reconfiguration
-sr = nk.optimizer.SR(diag_shift=0.1, use_iterative=False,
-                     lsq_solver="LLT")
+sr = nk.optimizer.SR(diag_shift=0.1, use_iterative=False, lsq_solver="LLT")
 
 # Stochastic reconfiguration
-gs = nk.Vmc(
-    hamiltonian=ha,
-    sampler=sa,
-    optimizer=op,
-    sr=sr,
-    n_samples=1000,
-)
+gs = nk.Vmc(hamiltonian=ha, sampler=sa, optimizer=op, sr=sr, n_samples=1000)
 
 # Create a JSON output file, and overwrite if file exists
-logger = nk.logging.JsonLog("test", 'w')
+logger = nk.logging.JsonLog("test", "w")
 
 # Run the optimization
 gs.run(n_iter=1000, out=logger)

--- a/Examples/Ising2d/plot_ising.py
+++ b/Examples/Ising2d/plot_ising.py
@@ -20,7 +20,6 @@ while True:
     energy = []
     sigma = []
     evar = []
-    
 
     data = json.load(open("test.log"))
     for iteration in data["Output"]:
@@ -28,7 +27,6 @@ while True:
         energy.append(iteration["Energy"]["Mean"])
         sigma.append(iteration["Energy"]["Sigma"])
         evar.append(iteration["Energy"]["Variance"])
-        
 
     nres = len(iters)
     cut = 60

--- a/Examples/J1J2/j1j2.py
+++ b/Examples/J1J2/j1j2.py
@@ -69,12 +69,7 @@ sr = nk.optimizer.SR(diag_shift=0.01, use_iterative=True)
 
 # Variational Monte Carlo
 gs = nk.Vmc(
-    hamiltonian=op,
-    sampler=sa,
-    optimizer=opt,
-    sr=sr,
-    n_samples=4000,
-    n_discard=5
+    hamiltonian=op, sampler=sa, optimizer=opt, sr=sr, n_samples=4000, n_discard=5
 )
 
 vmc.run(n_iter=300, out="test")

--- a/Examples/J1J2/plot_j1j2.py
+++ b/Examples/J1J2/plot_j1j2.py
@@ -17,7 +17,6 @@ while True:
     energy = []
     sigma = []
     evar = []
-    
 
     data = json.load(open("test.log"))
     for iteration in data["Output"]:
@@ -25,7 +24,6 @@ while True:
         energy.append(iteration["Energy"]["Mean"])
         sigma.append(iteration["Energy"]["Sigma"])
         evar.append(iteration["Energy"]["Variance"])
-        
 
     plt.errorbar(iters, energy, yerr=sigma, color="red")
     plt.axhline(y=exact, xmin=0, xmax=iters[-1], linewidth=2, color="k", label="Exact")

--- a/Examples/Observables/sigmax.py
+++ b/Examples/Observables/sigmax.py
@@ -50,4 +50,3 @@ sx = nk.operator.LocalOperator(hi, [X] * L, [[i] for i in range(L)])
 obs = {"SigmaX": sx}
 
 gs.run(n_iter=300, out="test", obs=obs)
-

--- a/Examples/PyNetKet/plot_heis.py
+++ b/Examples/PyNetKet/plot_heis.py
@@ -17,7 +17,6 @@ while True:
     energy = []
     sigma = []
     evar = []
-    
 
     data = json.load(open("test.log"))
     for iteration in data["Output"]:
@@ -25,7 +24,6 @@ while True:
         energy.append(iteration["Energy"]["Mean"])
         sigma.append(iteration["Energy"]["Sigma"])
         evar.append(iteration["Energy"]["Variance"])
-        
 
     plt.errorbar(iters, energy, yerr=sigma, color="red")
     plt.axhline(y=exact, xmin=0, xmax=iters[-1], linewidth=2, color="k", label="Exact")

--- a/Examples/PyNetKet/plot_ising.py
+++ b/Examples/PyNetKet/plot_ising.py
@@ -19,7 +19,6 @@ while True:
     energy = []
     sigma = []
     evar = []
-    
 
     data = json.load(open("test.log"))
     for iteration in data["Output"]:
@@ -27,7 +26,6 @@ while True:
         energy.append(iteration["Energy"]["Mean"])
         sigma.append(iteration["Energy"]["Sigma"])
         evar.append(iteration["Energy"]["Variance"])
-        
 
     nres = len(iters)
     cut = 60

--- a/Examples/RealMachines/plot_ising.py
+++ b/Examples/RealMachines/plot_ising.py
@@ -19,7 +19,6 @@ while True:
     energy = []
     sigma = []
     evar = []
-    
 
     data = json.load(open("test.log"))
     for iteration in data["Output"]:
@@ -27,7 +26,6 @@ while True:
         energy.append(iteration["Energy"]["Mean"])
         sigma.append(iteration["Energy"]["Sigma"])
         evar.append(iteration["Energy"]["Variance"])
-        
 
     nres = len(iters)
     cut = 60

--- a/Examples/RealMachines/plot_j1j2.py
+++ b/Examples/RealMachines/plot_j1j2.py
@@ -28,7 +28,6 @@ while True:
     energy = []
     sigma = []
     evar = []
-    
 
     data = json.load(open("test.log"))
     for iteration in data["Output"]:
@@ -36,7 +35,6 @@ while True:
         energy.append(iteration["Energy"]["Mean"])
         sigma.append(iteration["Energy"]["Sigma"])
         evar.append(iteration["Energy"]["Variance"])
-        
 
     plt.errorbar(iters, energy, yerr=sigma, color="red")
     plt.axhline(y=exact, xmin=0, xmax=iters[-1], linewidth=2, color="k", label="Exact")

--- a/Examples/Torch/plot.py
+++ b/Examples/Torch/plot.py
@@ -19,7 +19,6 @@ while True:
     energy = []
     sigma = []
     evar = []
-    
 
     data = json.load(open("test.log"))
     for iteration in data["Output"]:

--- a/Examples/Torch/torch_machine.py
+++ b/Examples/Torch/torch_machine.py
@@ -50,8 +50,6 @@ op = nk.optimizer.Sgd(0.1)
 sr = nk.optimizer.SR(diag_shift=0.1, use_iterative=True)
 
 # Driver
-gs = nk.Vmc(
-    hamiltonian=ha, sampler=sa, optimizer=op, n_samples=500, sr=sr
-)
+gs = nk.Vmc(hamiltonian=ha, sampler=sa, optimizer=op, n_samples=500, sr=sr)
 
 gs.run(n_iter=300, out="test")

--- a/Test/GroundState/test_groundstate.py
+++ b/Test/GroundState/test_groundstate.py
@@ -99,11 +99,7 @@ def test_vmc_iterator_iterative():
         for name in "Energy", "SigmaX":
             assert name in obs
             e = obs[name]
-            assert (
-                hasattr(e, "mean")
-                and hasattr(e, "variance")
-                and hasattr(e, "R_hat")
-            )
+            assert hasattr(e, "mean") and hasattr(e, "variance") and hasattr(e, "R_hat")
         last_obs = obs
 
     assert count == 300

--- a/Test/GroundState/test_vmc.py
+++ b/Test/GroundState/test_vmc.py
@@ -34,6 +34,7 @@ def _setup_vmc():
 
     return ha, sx, ma, sa, driver
 
+
 def test_vmc_functions():
     ha, sx, ma, sampler, driver = _setup_vmc()
     driver.advance(500)
@@ -121,10 +122,12 @@ def test_vmc_progress_bar():
     pbar = f.getvalue()
     assert not len(pbar)
 
+
 def _energy(par, machine, H):
     machine.parameters = np.copy(par)
     psi = machine.to_array()
-    return np.real(psi.conj()@H@psi)
+    return np.real(psi.conj() @ H @ psi)
+
 
 def central_diff_grad(func, x, eps, *args):
     grad = np.zeros(len(x), dtype=complex)
@@ -132,13 +135,14 @@ def central_diff_grad(func, x, eps, *args):
     epsd[0] = eps
     for i in range(len(x)):
         assert not np.any(np.isnan(x + epsd))
-        grad_r =  0.5 * (func(x + epsd, *args) - func(x - epsd, *args))
-        grad_i =  0.5 * (func(x + 1j*epsd, *args) - func(x - 1j*epsd, *args))
-        grad[i] = 0.5 * grad_r + 0.5j*grad_i
+        grad_r = 0.5 * (func(x + epsd, *args) - func(x - epsd, *args))
+        grad_i = 0.5 * (func(x + 1j * epsd, *args) - func(x - 1j * epsd, *args))
+        grad[i] = 0.5 * grad_r + 0.5j * grad_i
         assert not np.isnan(grad[i])
         grad[i] /= eps
         epsd = np.roll(epsd, 1)
     return grad
+
 
 def same_derivatives(der_log, num_der_log, eps=1.0e-6):
     assert np.max(np.real(der_log - num_der_log)) == approx(0.0, rel=eps, abs=eps)
@@ -146,6 +150,7 @@ def same_derivatives(der_log, num_der_log, eps=1.0e-6):
     assert np.max(np.exp(np.imag(der_log - num_der_log) * 1.0j) - 1.0) == approx(
         0.0, rel=eps, abs=eps
     )
+
 
 def test_vmc_gradient():
     ha, sx, ma, sampler, driver = _setup_vmc()
@@ -158,5 +163,5 @@ def test_vmc_gradient():
     driver.machine.parameters = np.copy(pars)
     grad_approx = driver._forward_and_backward()
 
-    err = 5/np.sqrt(driver.n_samples)
+    err = 5 / np.sqrt(driver.n_samples)
     same_derivatives(grad_approx, grad_exact, eps=err)

--- a/Test/Operator/test_liouvillian.py
+++ b/Test/Operator/test_liouvillian.py
@@ -51,34 +51,33 @@ for i in range(L):
     j_ops.append(nk.operator.LocalOperator(hi, sigmam, [i]))
 
 
-# Create the lindbladian with
+#  Create the lindbladian with
 lind = nk.operator.LocalLiouvillian(ha, j_ops)
+
 
 def test_lindblad_form():
     ## Construct the lindbladian by hand:
-    idmat = sparse.eye(2**L)
+    idmat = sparse.eye(2 ** L)
 
     # Build the non hermitian matrix
     hnh_mat = ha.to_sparse()
     for j_op in j_ops:
         j_mat = j_op.to_sparse()
-        hnh_mat -= 0.5j * j_mat.H*j_mat
-
+        hnh_mat -= 0.5j * j_mat.H * j_mat
 
     # Compute the left and right product with identity
-    lind_mat = -1j*sparse.kron(idmat, hnh_mat) + 1j*sparse.kron(hnh_mat.H, idmat) 
+    lind_mat = -1j * sparse.kron(idmat, hnh_mat) + 1j * sparse.kron(hnh_mat.H, idmat)
     # add jump operators
     for j_op in j_ops:
         j_mat = j_op.to_sparse()
         lind_mat += sparse.kron(j_mat.conj(), j_mat)
-
 
     assert (lind_mat.todense() == lind.to_dense()).all()
 
 
 def test_lindblad_zero_eigenvalue():
     lind_mat = lind.to_sparse()
-    w, v = linalg.eigsh(lind_mat.H*lind_mat, which='SM')
+    w, v = linalg.eigsh(lind_mat.H * lind_mat, which="SM")
     assert w[0] <= 10e-10
 
 
@@ -89,7 +88,9 @@ def test_der_log_val():
     # test single input
     for i in range(0, lind.hilbert.n_states):
         state = lind.hilbert.number_to_state(i)
-        der_loc_vals = nk.operator.der_local_values(lind, ma, state, center_derivative=False)
+        der_loc_vals = nk.operator.der_local_values(
+            lind, ma, state, center_derivative=False
+        )
 
         log_val_s = ma.log_val(state)
         der_log_s = ma.der_log(state)
@@ -102,39 +103,51 @@ def test_der_log_val():
         log_val_diff = mel * np.exp(log_val_p - log_val_s)
         log_val_diff = log_val_diff.reshape((log_val_diff.size, 1))
 
-        grad = log_val_diff * (der_log_p) #- der_log_s) because derivative not centered
+        grad = log_val_diff * (
+            der_log_p
+        )  # - der_log_s) because derivative not centered
         grad_all = grad.sum(axis=0)
 
         np.testing.assert_array_almost_equal(grad_all, der_loc_vals.flatten())
 
         # centered
         # not necessary for liouvillian but worth checking
-        der_loc_vals = nk.operator.der_local_values(lind, ma, state, center_derivative=True)
+        der_loc_vals = nk.operator.der_local_values(
+            lind, ma, state, center_derivative=True
+        )
         grad = log_val_diff * (der_log_p - der_log_s)
         grad_all = grad.sum(axis=0)
 
         np.testing.assert_array_almost_equal(grad_all, der_loc_vals.flatten())
 
+
 def test_der_log_val_batched():
     ma = nk.machine.NdmSpinPhase(hilbert=hi_c, alpha=1, beta=1)
     ma.init_random_parameters(seed=1234, sigma=0.01)
 
-    states = np.empty((5, hi_c.size*2), dtype=np.float64)
+    states = np.empty((5, hi_c.size * 2), dtype=np.float64)
     der_locs = np.empty((5, ma.n_par), dtype=np.complex128)
     der_locs_c = np.empty((5, ma.n_par), dtype=np.complex128)
     # test single input
     for i in range(0, 5):
         state = lind.hilbert.number_to_state(i)
-        states[i,:] = state
-        der_locs[i,:] = nk.operator.der_local_values(lind, ma, state, center_derivative=False)
-        der_locs_c[i,:] = nk.operator.der_local_values(lind, ma, state, center_derivative=True)
+        states[i, :] = state
+        der_locs[i, :] = nk.operator.der_local_values(
+            lind, ma, state, center_derivative=False
+        )
+        der_locs_c[i, :] = nk.operator.der_local_values(
+            lind, ma, state, center_derivative=True
+        )
 
-    der_locs_all = nk.operator.der_local_values(lind, ma, states, center_derivative=False)
-    der_locs_all_c = nk.operator.der_local_values(lind, ma, states, center_derivative=True)
+    der_locs_all = nk.operator.der_local_values(
+        lind, ma, states, center_derivative=False
+    )
+    der_locs_all_c = nk.operator.der_local_values(
+        lind, ma, states, center_derivative=True
+    )
 
     np.testing.assert_array_almost_equal(der_locs, der_locs_all)
     np.testing.assert_array_almost_equal(der_locs_c, der_locs_all_c)
-
 
 
 # Construct the operators for Sx, Sy and Sz
@@ -150,5 +163,3 @@ for i in range(L):
 sxmat = obs_sx.to_dense()
 symat = obs_sy.to_dense()
 szmat = obs_sz.to_dense()
-
-

--- a/Test/Operator/test_local_operator.py
+++ b/Test/Operator/test_local_operator.py
@@ -98,6 +98,7 @@ def test_local_operator_transpose_conjugation():
         math_h = oph.transpose().conjugate().to_dense()
         same_matrices(math_h, mat)
 
+
 def test_local_operator_add():
     sz0 = nk.operator.spin.sigmaz(hi, 0)
     sz1 = nk.operator.spin.sigmaz(hi, 1)
@@ -116,21 +117,21 @@ def test_local_operator_add():
     same_matrices(ha, ha2)
     same_matrices(ha, ham)
 
-    for i in range(1,3):
+    for i in range(1, 3):
         ha = ha + 0.2 * nk.operator.spin.sigmaz(hi, i)
         ha2 += 0.2 * nk.operator.spin.sigmaz(hi, i)
         ham += 0.2 * nk.operator.spin.sigmaz(hi, i).to_dense()
     same_matrices(ha, ha2)
     same_matrices(ha, ham)
 
-    for i in range(3,5):
+    for i in range(3, 5):
         ha = ha + 0.2 * nk.operator.spin.sigmax(hi, i)
         ha2 += 0.2 * nk.operator.spin.sigmax(hi, i)
         ham += 0.2 * nk.operator.spin.sigmax(hi, i).to_dense()
     same_matrices(ha, ha2)
     same_matrices(ha, ham)
 
-    for i in range(5,7):
+    for i in range(5, 7):
         ha = ha - 0.3 * nk.operator.spin.sigmam(hi, i)
         ha2 -= 0.3 * nk.operator.spin.sigmam(hi, i)
         ham -= 0.3 * nk.operator.spin.sigmam(hi, i).to_dense()
@@ -146,14 +147,15 @@ def test_local_operator_add():
     # test commutativity
     ha = LocalOperator(hi)
     ha2 = LocalOperator(hi)
-    for i in range(0,3):
-        ha += 0.3 * nk.operator.spin.sigmaz(hi, i)  * nk.operator.spin.sigmax(hi, i+1)
+    for i in range(0, 3):
+        ha += 0.3 * nk.operator.spin.sigmaz(hi, i) * nk.operator.spin.sigmax(hi, i + 1)
         ha += 0.4 * nk.operator.spin.sigmaz(hi, i)
         ha2 += 0.5 * nk.operator.spin.sigmay(hi, i)
 
     ha_ha2 = ha + ha2
     ha2_ha = ha2 + ha
     same_matrices(ha_ha2, ha2_ha)
+
 
 def test_simple_operators():
     L = 4


### PR DESCRIPTION
Based on #402, I propose also checking the code style of the unit tests, examples, and benchmarks with black as well. I have reformatted the code accordingly and added these checks to `.travis.yml`.

This PR also adds a subsection on `Test_MPI` to `CONTRIBUTING.md`.