### PR TITLE
Stochastic Reconfiguration in Jax

### DIFF
--- a/Examples/Jax/jax_sr_example.py
+++ b/Examples/Jax/jax_sr_example.py
@@ -1,0 +1,39 @@
+import netket as nk
+import numpy as np
+import jax
+from jax.experimental.optimizers import sgd as JaxSgd
+import cProfile
+
+# 1D Lattice
+L = 20
+g = nk.graph.Hypercube(length=L, n_dim=1, pbc=True)
+
+# Hilbert space of spins on the graph
+hi = nk.hilbert.PySpin(s=0.5, graph=g)
+
+ha = nk.operator.Ising(h=1.0, hilbert=hi)
+
+alpha = 1
+ma = nk.machine.JaxRbm(hi, alpha, dtype=complex)
+ma.init_random_parameters(seed=1232)
+
+# Jax Sampler
+sa = nk.sampler.jax.MetropolisLocal(machine=ma, n_chains=8)
+
+# Using a Jax Optimizer
+j_op = JaxSgd(0.01)
+op = nk.optimizer.Jax(ma, j_op)
+
+
+# Stochastic Reconfiguration
+sr = nk.optimizer.SR(lsq_solver="jaxcg",diag_shift=0.1)
+
+# Create the optimization driver
+gs = nk.Vmc(
+    hamiltonian=ha, sampler=sa, optimizer=op, n_samples=1000, sr=sr, n_discard=0
+)
+
+# The first iteration is slower because of start-up jit times
+gs.run(out="test", n_iter=1)
+
+gs.run(out="test", n_iter=300)

--- a/Examples/Jax/jax_sr_example.py
+++ b/Examples/Jax/jax_sr_example.py
@@ -26,7 +26,7 @@ op = nk.optimizer.Jax(ma, j_op)
 
 
 # Stochastic Reconfiguration
-sr = nk.optimizer.SR(lsq_solver="jaxcg",diag_shift=0.1)
+sr = nk.optimizer.JaxSR(diag_shift=0.1)
 
 # Create the optimization driver
 gs = nk.Vmc(

--- a/Test/Optimizer/test_sr.py
+++ b/Test/Optimizer/test_sr.py
@@ -23,23 +23,3 @@ def test_svd_threshold():
         match="The svd_threshold option is available only for non-sparse solvers.",
     ):
         SR(use_iterative=True, svd_threshold=1e-3)
-
-    a = np.diag([1e0 + 0j, 1e-3, 1e-6])
-    b = np.array([1.0 + 0j, 1.0, 1.0])
-
-    def SR_with_threshold(t):
-        return SR(lsq_solver="SVD", svd_threshold=t, diag_shift=0, is_holomorphic=True)
-
-    def solve(sr, a, b):
-        a1 = np.sqrt(a) * np.sqrt(a.shape[0])
-        out = sr.compute_update(a1, b)
-        return out
-
-    sr = SR_with_threshold(1e-1)
-    assert np.allclose(solve(sr, a, b), [1.0, 0.0, 0.0])
-
-    sr = SR_with_threshold(1e-4)
-    assert np.allclose(solve(sr, a, b), [1.0, 1e3, 0.0])
-
-    sr = SR_with_threshold(1e-7)
-    assert np.allclose(solve(sr, a, b), [1.0, 1e3, 1e6])

--- a/netket/_vmc.py
+++ b/netket/_vmc.py
@@ -12,9 +12,6 @@ from netket.stats import (
 from netket.vmc_common import info, tree_map
 from netket.abstract_variational_driver import AbstractVariationalDriver
 
-from netket.utils import jax_available
-if jax_available:
-    from netket.vmc_common import shape_for_sr, shape_for_update
 
 class Vmc(AbstractVariationalDriver):
     """
@@ -65,6 +62,7 @@ class Vmc(AbstractVariationalDriver):
         self._sr = sr
         if sr is not None:
             self._sr.is_holomorphic = sampler.machine.is_holomorphic
+            self._sr.machine = sampler.machine
 
         self._npar = self._machine.n_par
 
@@ -150,11 +148,8 @@ class Vmc(AbstractVariationalDriver):
             )
             
             self._grads = tree_map(_sum_inplace, self._grads)
-            self._grads, self._jac = shape_for_sr(self._grads,self._jac)
-            
-            self._dp = self._sr.compute_update(self._jac, self._grads, self._dp)
 
-            self._dp = shape_for_update(self._dp,self._machine.parameters) 
+            self._dp = self._sr.compute_update(self._jac, self._grads, self._dp)
 
         else:
             # Computing updates using the simple gradient

--- a/netket/_vmc.py
+++ b/netket/_vmc.py
@@ -146,7 +146,7 @@ class Vmc(AbstractVariationalDriver):
             self._grads, self._jac = self._machine.vector_jacobian_prod(
                 samples_r, eloc_r / self._n_samples, self._grads, return_jacobian=True
             )
-            
+
             self._grads = tree_map(_sum_inplace, self._grads)
 
             self._dp = self._sr.compute_update(self._jac, self._grads, self._dp)
@@ -156,7 +156,7 @@ class Vmc(AbstractVariationalDriver):
             self._grads = self._machine.vector_jacobian_prod(
                 samples_r, eloc_r / self._n_samples, self._grads
             )
-            
+
             self._grads = tree_map(_sum_inplace, self._grads)
 
             self._dp = self._grads

--- a/netket/_vmc.py
+++ b/netket/_vmc.py
@@ -11,8 +11,10 @@ from netket.stats import (
 
 from netket.vmc_common import info, tree_map
 from netket.abstract_variational_driver import AbstractVariationalDriver
-import jax
 
+from netket.utils import jax_available
+if jax_available:
+    from netket.vmc_common import shape_for_sr, shape_for_update
 
 class Vmc(AbstractVariationalDriver):
     """
@@ -148,24 +150,18 @@ class Vmc(AbstractVariationalDriver):
             )
             
             self._grads = tree_map(_sum_inplace, self._grads)
+            self._grads, self._jac = shape_for_sr(self._grads,self._jac)
             
-            self._grads = self._machine.jax_flatten(self._grads)
-            self._jac = self._machine.jacobian_flatten(self._jac)
-
-            # Center the log derivatives
-            # self._jac -= _mean(self._jac, axis=0)
-            self._jac -= jax.numpy.mean(self._jac,axis=0)
-
             self._dp = self._sr.compute_update(self._jac, self._grads, self._dp)
 
-            self._dp = self._machine.unflatten(self._dp, self._machine._params)
+            self._dp = shape_for_update(self._dp,self._machine.parameters) 
 
         else:
             # Computing updates using the simple gradient
             self._grads = self._machine.vector_jacobian_prod(
                 samples_r, eloc_r / self._n_samples, self._grads
             )
-
+            
             self._grads = tree_map(_sum_inplace, self._grads)
 
             self._dp = self._grads

--- a/netket/machine/jax.py
+++ b/netket/machine/jax.py
@@ -22,6 +22,7 @@ import numpy as _np
 from netket.random import randint as _randint
 from jax.tree_util import tree_flatten, tree_unflatten, tree_map
 
+
 class Jax(AbstractMachine):
     def __init__(self, hilbert, module, dtype=complex):
         """
@@ -54,7 +55,7 @@ class Jax(AbstractMachine):
 
         forward_scalar = jax.jit(lambda pars, x: self._forward_fn(pars, x).reshape(()))
         grad_fun = jax.jit(jax.grad(forward_scalar, holomorphic=self.is_holomorphic))
-        self._perex_grads = jax.jit(jax.vmap(grad_fun, in_axes=(None,0)))
+        self._perex_grads = jax.jit(jax.vmap(grad_fun, in_axes=(None, 0)))
 
         self.init_random_parameters()
 
@@ -152,15 +153,18 @@ class Jax(AbstractMachine):
         else:
 
             if conjugate and self._dtype is complex:
-                prodj = lambda j: jax.np.tensordot(vec.transpose(), j.conjugate(), axes=1)
+                prodj = lambda j: jax.np.tensordot(
+                    vec.transpose(), j.conjugate(), axes=1
+                )
             else:
-                prodj = lambda j: jax.np.tensordot(vec.transpose().conjugate(), j, axes=1)
+                prodj = lambda j: jax.np.tensordot(
+                    vec.transpose().conjugate(), j, axes=1
+                )
 
             jacobian = self._perex_grads(self._params, x)
             out = tree_map(prodj, jacobian)
-            
-            return out, jacobian
 
+            return out, jacobian
 
     @property
     def is_holomorphic(self):
@@ -222,6 +226,7 @@ class Jax(AbstractMachine):
 
         return tree_unflatten(tree, datalist)
 
+
 from jax.experimental import stax
 from jax.experimental.stax import Dense
 
@@ -246,10 +251,10 @@ def logcosh(x):
 
 LogCoshLayer = stax.elementwise(logcosh)
 
+
 def JaxRbm(hilbert, alpha, dtype=complex):
     return Jax(
         hilbert,
-        stax.serial(stax.Dense(alpha * hilbert.size),LogCoshLayer, SumLayer()),
+        stax.serial(stax.Dense(alpha * hilbert.size), LogCoshLayer, SumLayer()),
         dtype=dtype,
     )
-

--- a/netket/optimizer/__init__.py
+++ b/netket/optimizer/__init__.py
@@ -9,12 +9,12 @@ from .rms_prop import RmsProp
 from .sgd import Sgd
 
 from .stochastic_reconfiguration import SR
-from .jax_stochastic_reconfiguration import JaxSR
 
 from ..utils import jax_available, torch_available
 
 if jax_available:
     from .jax import Jax
+    from .jax_stochastic_reconfiguration import JaxSR
 
 if torch_available:
     from .torch import Torch

--- a/netket/optimizer/__init__.py
+++ b/netket/optimizer/__init__.py
@@ -9,6 +9,7 @@ from .rms_prop import RmsProp
 from .sgd import Sgd
 
 from .stochastic_reconfiguration import SR
+from .jax_stochastic_reconfiguration import JaxSR
 
 from ..utils import jax_available, torch_available
 

--- a/netket/optimizer/jax_stochastic_reconfiguration.py
+++ b/netket/optimizer/jax_stochastic_reconfiguration.py
@@ -14,7 +14,7 @@ if jax_available:
     import jax
     from jax.scipy.sparse.linalg import cg as jcg
 
-class SR:
+class JaxSR:
     r"""
     Performs stochastic reconfiguration (SR) updates.
     """

--- a/netket/optimizer/jax_stochastic_reconfiguration.py
+++ b/netket/optimizer/jax_stochastic_reconfiguration.py
@@ -65,6 +65,11 @@ class JaxSR:
             else:
                 raise RuntimeError("Unknown sparse lsq_solver " + lsq_solver + ".")
 
+        if self._use_iterative and self._svd_threshold is not None:
+            raise ValueError(
+                "The svd_threshold option is available only for non-sparse solvers."
+            )
+
     def compute_update(self, oks, grad, out=None):
         r"""
         Solves the SR flow equation for the parameter update ẋ.
@@ -112,7 +117,10 @@ class JaxSR:
                 if self._lsq_solver == "Cholesky":
                     c, low = cho_factor(self._S, check_finite=False)
                     out = cho_solve((c, low), grad)
-                if self._lsq_solver in ["QR", "ColPivHouseholder"]:
+                if (
+                    self._lsq_solver in ["QR", "ColPivHouseholder"]
+                    or self._lsq_solver == None
+                ):
                     Q, R = qr(self._S)
                     grad = jax.numpy.matmul(Q.transpose().conjugate(), grad)
                     out = solve_triangular(R, grad)
@@ -139,7 +147,10 @@ class JaxSR:
                 if self._lsq_solver == "Cholesky":
                     c, low = cho_factor(self._S.real, check_finite=False)
                     out = cho_solve((c, low), grad.real)
-                if self._lsq_solver in ["QR", "ColPivHouseholder"]:
+                if (
+                    self._lsq_solver in ["QR", "ColPivHouseholder"]
+                    or self._lsq_solver == None
+                ):
                     Q, R = qr(self._S.real)
                     grad = jax.numpy.matmul(Q.transpose().conjugate(), grad.real)
                     out = solve_triangular(R, grad)

--- a/netket/optimizer/jax_stochastic_reconfiguration.py
+++ b/netket/optimizer/jax_stochastic_reconfiguration.py
@@ -62,7 +62,7 @@ class JaxSR:
 
         if self._use_iterative:
             if lsq_solver is None:
-                lsq_solver = "gmres" if self._is_holomorphic else "minres"
+                lsq_solver = "jaxcg"
 
             if lsq_solver == "gmres":
                 self._sparse_solver = partial(gmres, atol="legacy")

--- a/netket/optimizer/jax_stochastic_reconfiguration.py
+++ b/netket/optimizer/jax_stochastic_reconfiguration.py
@@ -106,8 +106,8 @@ class JaxSR:
         gradient).
 
         Args:
-            oks: The matrix 𝕆 of centered log-derivatives,
-               𝕆_ij = O_i(v_j) - ⟨O_i⟩.
+            oks: The matrix of log-derivatives,
+		O_i(v_j)
             grad: The vector of forces f.
             out: Output array for the update ẋ.
         """

--- a/netket/optimizer/jax_stochastic_reconfiguration.py
+++ b/netket/optimizer/jax_stochastic_reconfiguration.py
@@ -1,0 +1,370 @@
+from functools import partial
+import numpy as _np
+from scipy.linalg import lstsq as _lstsq
+from scipy.linalg import cho_factor as _cho_factor
+from scipy.linalg import cho_solve as _cho_solve
+from scipy.sparse.linalg import LinearOperator
+from netket.stats import sum_inplace as _sum_inplace
+from scipy.sparse.linalg import cg, gmres, minres
+from mpi4py import MPI
+
+from netket.utils import jax_available
+
+if jax_available:
+    import jax
+    from jax.scipy.sparse.linalg import cg as jcg
+
+class SR:
+    r"""
+    Performs stochastic reconfiguration (SR) updates.
+    """
+
+    def __init__(
+        self,
+        lsq_solver=None,
+        diag_shift=0.01,
+        use_iterative=True,
+        is_holomorphic=None,
+        svd_threshold=None,
+        sparse_tol=None,
+        sparse_maxiter=None,
+    ):
+
+        self._lsq_solver = lsq_solver
+        self._diag_shift = diag_shift
+        self._use_iterative = use_iterative
+        self._is_holomorphic = is_holomorphic
+        self._svd_threshold = svd_threshold
+        self._scale_invariant_pc = False
+        self._S = None
+        self._last_rank = None
+
+        # Temporary arrays
+        self._v_tilde = None
+        self._res_t = None
+
+        # Quantities for sparse solver
+        self.sparse_tol = 1.0e-5 if sparse_tol is None else sparse_tol
+        self.sparse_maxiter = sparse_maxiter
+        self._lsq_solver = lsq_solver
+        self._x0 = None
+        self._init_solver()
+
+        self._comm = MPI.COMM_WORLD
+
+    def _init_solver(self):
+        lsq_solver = self._lsq_solver
+
+        if lsq_solver in ["gmres", "cg", "minres","jaxcg"]:
+            self._use_iterative = True
+        if lsq_solver in ["ColPivHouseholder", "QR", "SVD", "Cholesky"]:
+            self._use_iterative = False
+
+        if self._use_iterative:
+            if lsq_solver is None:
+                lsq_solver = "gmres" if self._is_holomorphic else "minres"
+
+            if lsq_solver == "gmres":
+                self._sparse_solver = partial(gmres, atol="legacy")
+            elif lsq_solver == "cg":
+                self._sparse_solver = partial(cg, atol="legacy")
+            elif lsq_solver == "minres":
+                if self._is_holomorphic:
+                    raise RuntimeError(
+                        "minres can be used only for real-valued parameters."
+                    )
+                self._sparse_solver = minres
+            elif not lsq_solver == 'jaxcg':
+                raise RuntimeError("Unknown sparse lsq_solver " + lsq_solver + ".")
+
+        else:
+            if (
+                lsq_solver is None
+                or "ColPivHouseholder" in lsq_solver
+                or "QR" in lsq_solver
+            ):
+                self._lapack_driver = "gelsy"
+            elif "SVD" in lsq_solver or "Cholesky" in lsq_solver:
+                self._lapack_driver = None
+            else:
+                self._lapack_driver = None
+                raise RuntimeError("Unknown lsq_solver" + lsq_solver + ".")
+
+        if self._use_iterative and self._svd_threshold is not None:
+            raise ValueError(
+                "The svd_threshold option is available only for non-sparse solvers."
+            )
+
+    def compute_update(self, oks, grad, out=None):
+        r"""
+        Solves the SR flow equation for the parameter update ẋ.
+
+        The SR update is computed by solving the linear equation
+           Sẋ = f
+        where S is the covariance matrix of the partial derivatives
+        O_i(v_j) = ∂/∂x_i log Ψ(v_j) and f is a generalized force (the loss
+        gradient).
+
+        Args:
+            oks: The matrix 𝕆 of centered log-derivatives,
+               𝕆_ij = O_i(v_j) - ⟨O_i⟩.
+            grad: The vector of forces f.
+            out: Output array for the update ẋ.
+        """
+
+        oks -= jax.numpy.mean(oks,axis=0)
+
+        if self.is_holomorphic is None:
+            raise ValueError(
+                "is_holomorphic not set: this SR object is not properly initialized."
+            )
+
+        n_samp = _sum_inplace(_np.atleast_1d(oks.shape[0]))
+
+        n_par = grad.shape[0]
+
+        if out is None:
+            out = _np.zeros(n_par, dtype=_np.complex128)
+
+        if self._is_holomorphic:
+            if self._use_iterative:
+                if self._lsq_solver == "jaxcg":
+                    out = self._jax_cg_solve(oks,grad,n_samp)
+                else:
+                    op = self._linear_operator(oks, n_samp)
+
+                    if self._x0 is None:
+                        self._x0 = _np.zeros(n_par, dtype=_np.complex128)
+
+                    out[:], info = self._sparse_solver(
+                        op,
+                        grad,
+                        x0=self._x0,
+                        tol=self.sparse_tol,
+                        maxiter=self.sparse_maxiter,
+                    )
+                    if info < 0:
+                        raise RuntimeError("SR sparse solver did not converge.")
+
+                self._x0 = out
+            else:
+                self._S = _np.matmul(oks.conj().T, oks, self._S)
+                self._S = _sum_inplace(self._S)
+                self._S /= float(n_samp)
+
+                self._apply_preconditioning(grad)
+
+                if self._lsq_solver == "Cholesky":
+                    c, low = _cho_factor(self._S, check_finite=False)
+                    out[:] = _cho_solve((c, low), grad)
+
+                else:
+                    out[:], residuals, self._last_rank, s_vals = _lstsq(
+                        self._S,
+                        grad,
+                        cond=self._svd_threshold,
+                        lapack_driver=self._lapack_driver,
+                    )
+
+                self._revert_preconditioning(out)
+
+        else:
+            if self._use_iterative:
+                if self._lsq_solver == "jaxcg":
+                    out.real = self._jax_cg_solve(oks,grad.real,n_samp)
+                else:
+                    op = self._linear_operator(oks, n_samp)
+
+                    if self._x0 is None:
+                        self._x0 = _np.zeros(n_par)
+
+                    out[:].real, info = self._sparse_solver(
+                        op,
+                        grad.real,
+                        x0=self._x0,
+                        tol=self.sparse_tol,
+                        maxiter=self.sparse_maxiter,
+                    )
+                if info < 0:
+                    raise RuntimeError("SR sparse solver did not converge.")
+                
+                self._x0 = out.real
+            else:
+                self._S = _np.matmul(oks.conj().T, oks, self._S)
+                self._S /= float(n_samp)
+
+                self._apply_preconditioning(grad)
+
+                if self._lsq_solver == "Cholesky":
+                    c, low = _cho_factor(self._S, check_finite=False)
+                    out[:].real = _cho_solve((c, low), grad)
+                else:
+                    out[:].real, residuals, self._last_rank, s_vals = _lstsq(
+                        self._S.real,
+                        grad.real,
+                        cond=self._svd_threshold,
+                        lapack_driver=self._lapack_driver,
+                    )
+
+                self._revert_preconditioning(out.real)
+
+            out.imag.fill(0.0)
+        self._comm.bcast(out, root=0)
+        self._comm.barrier()
+        return out
+
+    def _jax_cg_solve(self,oks,grad,n_samp):
+        """
+        Solves the SR flow equation using the conjugate gradient method 
+        """
+
+        n_par = grad.shape[0]
+        if self._x0 is None:
+            self._x0 = _np.zeros(n_par, dtype=_np.complex128)
+
+        cov_op = jax.jit(self._jax_linear_function(oks,n_samp))
+        
+        out, _ = jcg(cov_op,grad,x0=self._x0,tol=self.sparse_tol,maxiter=self.sparse_maxiter)
+
+        return out
+
+    def _jax_linear_function(self,oks,n_samp):
+        """
+        Outputs function A(x) = Ax needed for conjugate gradient
+        """
+        v_tilde = self._v_tilde
+        res = self._res_t 
+        shift = self._diag_shift
+        oks_conj = oks.conjugate()
+
+        def matvec(oks,oks_conj,x):
+            y = jax.numpy.matmul(oks,x)/n_samp
+            y = jax.numpy.matmul(y,oks_conj) 
+            y = x*shift + y 
+
+            return y
+
+        return partial(matvec,oks,oks_conj)
+
+    def _apply_preconditioning(self, grad):
+        if self._scale_invariant_pc:
+            # Even if S is complex, its diagonal elements should be real since it
+            # is Hermitian.
+            self._diag_S = _np.sqrt(self._S.diagonal().real)
+
+            cutoff = 1.0e-10
+
+            index = self._diag_S <= cutoff
+            self._diag_S[index] = 1.0
+            self._S[index, :].fill(0.0)
+            self._S[:, index].fill(0.0)
+            _np.fill_diagonal(self._S, 1.0)
+
+            self._S /= _np.vdot(self._diag_S, self._diag_S)
+
+            grad /= self._diag_S
+
+        # Apply diagonal shift
+        self._S += self._diag_shift * _np.eye(self._S.shape[0])
+
+    @property
+    def last_rank(self):
+        return self._last_rank
+
+    @property
+    def last_covariance_matrix(self):
+        return self._S
+
+    def _revert_preconditioning(self, out):
+        if self._scale_invariant_pc:
+            out /= self._diag_S
+        return out
+
+    @property
+    def scale_invariant_regularization(self):
+        r"""bool: Whether to use the scale-invariant regularization as described by
+                    Becca and Sorella (2017), pp. 143-144.
+                    https://doi.org/10.1017/9781316417041
+        """
+        return self._scale_invariant_pc
+
+    @scale_invariant_regularization.setter
+    def scale_invariant_regularization(self, activate):
+        assert activate is True or activate is False
+
+        if activate and self._use_iterative:
+            raise NotImplementedError(
+                """Scale-invariant regularization is
+                   not implemented for iterative solvers at the moment."""
+            )
+
+        self._scale_invariant_pc = activate
+
+    def __repr__(self):
+        rep = "SR(solver="
+
+        if self._use_iterative:
+            rep += "iterative"
+        else:
+            rep += self._lsq_solver + ", diag_shift=" + str(self._diag_shift)
+            if self._svd_threshold is not None:
+                rep += ", threshold=" << self._svd_threshold
+
+        rep += ", is_holomorphic=" + str(self._is_holomorphic) + ")"
+        return rep
+
+    def info(self, depth=0):
+        indent = " " * 4 * depth
+        rep = indent
+        rep += "Stochastic reconfiguration method for "
+        rep += "holomorphic" if self._is_holomorphic else "real-parameter"
+        rep += " wavefunctions\n"
+
+        rep += indent + "Solver: "
+
+        if self._use_iterative:
+            rep += "iterative (Conjugate Gradient)"
+        else:
+            rep += self._lsq_solver
+        rep += "\n"
+
+        return rep
+
+    def _linear_operator(self, oks, n_samp):
+        n_par = oks.shape[1]
+        shift = self._diag_shift
+        oks_conj = oks.conjugate()
+
+        if self._is_holomorphic:
+
+            def matvec(v):
+                v_tilde = self._v_tilde
+                res = self._res_t
+
+                v_tilde = _np.matmul(oks, v, v_tilde) / float(n_samp)
+                res = _np.matmul(v_tilde, oks_conj, res)
+                res = _sum_inplace(res) + shift * v
+                return res
+
+        else:
+
+            def matvec(v):
+                v_tilde = self._v_tilde
+                res = self._res_t
+
+                v_tilde = _np.matmul(oks, v, v_tilde) / float(n_samp)
+                res = _np.matmul(v_tilde, oks_conj, res)
+                res = _sum_inplace(res) + shift * v
+
+                return res.real
+
+        return LinearOperator((n_par, n_par), matvec=matvec, rmatvec=matvec)
+
+    @property
+    def is_holomorphic(self):
+        return self._is_holomorphic
+
+    @is_holomorphic.setter
+    def is_holomorphic(self, is_holo):
+        self._is_holomorphic = is_holo
+        self._init_solver()

--- a/netket/optimizer/jax_stochastic_reconfiguration.py
+++ b/netket/optimizer/jax_stochastic_reconfiguration.py
@@ -1,18 +1,11 @@
 from functools import partial
-import numpy as _np
-from scipy.linalg import lstsq as _lstsq
-from scipy.linalg import cho_factor as _cho_factor
-from scipy.linalg import cho_solve as _cho_solve
-from scipy.sparse.linalg import LinearOperator
 from netket.stats import sum_inplace as _sum_inplace
-from scipy.sparse.linalg import cg, gmres, minres
 from mpi4py import MPI
 
-from netket.utils import jax_available
-
-if jax_available:
-    import jax
-    from jax.scipy.sparse.linalg import cg as jcg
+import jax
+from jax.scipy.sparse.linalg import cg
+from netket.vmc_common import shape_for_sr, shape_for_update
+from jax.scipy.linalg import cho_factor,  cho_solve, svd, qr, solve_triangular
 
 class JaxSR:
     r"""
@@ -61,39 +54,15 @@ class JaxSR:
             self._use_iterative = False
 
         if self._use_iterative:
-            if lsq_solver is None:
-                lsq_solver = "jaxcg"
-
-            if lsq_solver == "gmres":
-                self._sparse_solver = partial(gmres, atol="legacy")
-            elif lsq_solver == "cg":
-                self._sparse_solver = partial(cg, atol="legacy")
-            elif lsq_solver == "minres":
-                if self._is_holomorphic:
-                    raise RuntimeError(
-                        "minres can be used only for real-valued parameters."
+            if lsq_solver is None or lsq_solver == "cg":
+                self._lsq_solver = "cg"
+            elif lsq_solver in ["gmres","minres"]:
+                raise Warning(
+                    "Conjugate gradient is the only sparse solver currently implemented in Jax. Defaulting to cg"
                     )
-                self._sparse_solver = minres
-            elif not lsq_solver == 'jaxcg':
-                raise RuntimeError("Unknown sparse lsq_solver " + lsq_solver + ".")
-
-        else:
-            if (
-                lsq_solver is None
-                or "ColPivHouseholder" in lsq_solver
-                or "QR" in lsq_solver
-            ):
-                self._lapack_driver = "gelsy"
-            elif "SVD" in lsq_solver or "Cholesky" in lsq_solver:
-                self._lapack_driver = None
+                self._lsq_solver = "cg"
             else:
-                self._lapack_driver = None
-                raise RuntimeError("Unknown lsq_solver" + lsq_solver + ".")
-
-        if self._use_iterative and self._svd_threshold is not None:
-            raise ValueError(
-                "The svd_threshold option is available only for non-sparse solvers."
-            )
+                raise RuntimeError("Unknown sparse lsq_solver " + lsq_solver + ".")
 
     def compute_update(self, oks, grad, out=None):
         r"""
@@ -106,12 +75,13 @@ class JaxSR:
         gradient).
 
         Args:
-            oks: The matrix of log-derivatives,
-		O_i(v_j)
-            grad: The vector of forces f.
-            out: Output array for the update ẋ.
+            oks: A pytree of the jacobians ∂/∂x_i log Ψ(v_j)
+            grad: A pytree of the forces f
+            out: A pytree of the parameter updates
         """
 
+        grad, oks = shape_for_sr(grad,oks)    
+        
         oks -= jax.numpy.mean(oks,axis=0)
 
         if self.is_holomorphic is None:
@@ -119,96 +89,73 @@ class JaxSR:
                 "is_holomorphic not set: this SR object is not properly initialized."
             )
 
-        n_samp = _sum_inplace(_np.atleast_1d(oks.shape[0]))
+        n_samp = _sum_inplace(jax.numpy.atleast_1d(oks.shape[0]))
 
         n_par = grad.shape[0]
 
         if out is None:
-            out = _np.zeros(n_par, dtype=_np.complex128)
+            out = jax.numpy.zeros(n_par, dtype=jax.numpy.complex128)
 
         if self._is_holomorphic:
             if self._use_iterative:
-                if self._lsq_solver == "jaxcg":
+                if self._lsq_solver == "cg":
                     out = self._jax_cg_solve(oks,grad,n_samp)
-                else:
-                    op = self._linear_operator(oks, n_samp)
-
-                    if self._x0 is None:
-                        self._x0 = _np.zeros(n_par, dtype=_np.complex128)
-
-                    out[:], info = self._sparse_solver(
-                        op,
-                        grad,
-                        x0=self._x0,
-                        tol=self.sparse_tol,
-                        maxiter=self.sparse_maxiter,
-                    )
-                    if info < 0:
-                        raise RuntimeError("SR sparse solver did not converge.")
-
                 self._x0 = out
             else:
-                self._S = _np.matmul(oks.conj().T, oks, self._S)
+                self._S = jax.numpy.matmul(oks.conj().T, oks)
+                self._S = _sum_inplace(self._S)
+                self._S /= float(n_samp)
+
+                self._apply_preconditioning(grad)
+                
+                if self._lsq_solver == "Cholesky":
+                    c, low = cho_factor(self._S, check_finite=False)
+                    out = cho_solve((c, low), grad)
+                if self._lsq_solver in ["QR","ColPivHouseholder"]:
+                    Q, R = qr(self._S)
+                    grad = jax.numpy.matmul(Q.transpose().conjugate(),grad)
+                    out = solve_triangular(R,grad)
+                if self._lsq_solver == "SVD":
+                    U, S, V = svd(self._S)
+                    grad = jax.numpy.matmul(U.transpose().conjugate(),grad)/S 
+                    out = jax.numpy.matmul(V.transpose().conjugate(),grad)
+
+                self._revert_preconditioning(out)
+
+
+        else:
+            if self._use_iterative:
+                if self._lsq_solver == "cg":
+                    out = self._jax_cg_solve(oks,grad.real,n_samp)     
+                self._x0 = jax.numpy.real(out)  
+
+            else:
+                self._S = jax.numpy.matmul(oks.conj().T, oks)
                 self._S = _sum_inplace(self._S)
                 self._S /= float(n_samp)
 
                 self._apply_preconditioning(grad)
 
                 if self._lsq_solver == "Cholesky":
-                    c, low = _cho_factor(self._S, check_finite=False)
-                    out[:] = _cho_solve((c, low), grad)
+                    c, low = cho_factor(self._S.real, check_finite=False)
+                    out = cho_solve((c, low), grad.real)
+                if self._lsq_solver in ["QR","ColPivHouseholder"]:
+                    Q, R = qr(self._S.real)
+                    grad = jax.numpy.matmul(Q.transpose().conjugate(),grad.real)
+                    out = solve_triangular(R,grad)
+                if self._lsq_solver == "SVD":
+                    U, S, V = svd(self._S.real)
+                    grad = jax.numpy.matmul(U.transpose().conjugate(),grad.real)/S 
+                    out = jax.numpy.matmul(V.transpose().conjugate(),grad)
 
-                else:
-                    out[:], residuals, self._last_rank, s_vals = _lstsq(
-                        self._S,
-                        grad,
-                        cond=self._svd_threshold,
-                        lapack_driver=self._lapack_driver,
-                    )
 
                 self._revert_preconditioning(out)
+ 
+            out = jax.numpy.real(out)
 
-        else:
-            if self._use_iterative:
-                if self._lsq_solver == "jaxcg":
-                    out.real = self._jax_cg_solve(oks,grad.real,n_samp)
-                else:
-                    op = self._linear_operator(oks, n_samp)
 
-                    if self._x0 is None:
-                        self._x0 = _np.zeros(n_par)
+        out = shape_for_update(out,self.machine.parameters) 
 
-                    out[:].real, info = self._sparse_solver(
-                        op,
-                        grad.real,
-                        x0=self._x0,
-                        tol=self.sparse_tol,
-                        maxiter=self.sparse_maxiter,
-                    )
-                if info < 0:
-                    raise RuntimeError("SR sparse solver did not converge.")
-                
-                self._x0 = out.real
-            else:
-                self._S = _np.matmul(oks.conj().T, oks, self._S)
-                self._S /= float(n_samp)
-
-                self._apply_preconditioning(grad)
-
-                if self._lsq_solver == "Cholesky":
-                    c, low = _cho_factor(self._S, check_finite=False)
-                    out[:].real = _cho_solve((c, low), grad)
-                else:
-                    out[:].real, residuals, self._last_rank, s_vals = _lstsq(
-                        self._S.real,
-                        grad.real,
-                        cond=self._svd_threshold,
-                        lapack_driver=self._lapack_driver,
-                    )
-
-                self._revert_preconditioning(out.real)
-
-            out.imag.fill(0.0)
         self._comm.bcast(out, root=0)
         self._comm.barrier()
         return out
@@ -220,11 +167,11 @@ class JaxSR:
 
         n_par = grad.shape[0]
         if self._x0 is None:
-            self._x0 = _np.zeros(n_par, dtype=_np.complex128)
+            self._x0 = jax.numpy.zeros(n_par, dtype=jax.numpy.complex128)
 
-        cov_op = jax.jit(self._jax_linear_function(oks,n_samp))
+        cov_op = self._jax_linear_function(oks,n_samp)
         
-        out, _ = jcg(cov_op,grad,x0=self._x0,tol=self.sparse_tol,maxiter=self.sparse_maxiter)
+        out, _ = cg(cov_op,grad,x0=self._x0,tol=self.sparse_tol,maxiter=self.sparse_maxiter)
 
         return out
 
@@ -250,7 +197,7 @@ class JaxSR:
         if self._scale_invariant_pc:
             # Even if S is complex, its diagonal elements should be real since it
             # is Hermitian.
-            self._diag_S = _np.sqrt(self._S.diagonal().real)
+            self._diag_S = jax.numpy.sqrt(self._S.diagonal().real)
 
             cutoff = 1.0e-10
 
@@ -258,14 +205,12 @@ class JaxSR:
             self._diag_S[index] = 1.0
             self._S[index, :].fill(0.0)
             self._S[:, index].fill(0.0)
-            _np.fill_diagonal(self._S, 1.0)
-
-            self._S /= _np.vdot(self._diag_S, self._diag_S)
-
+            self._S[range(len(self._S)),range(len(self._S))]
+            self._S /= jax.numpy.vdot(self._diag_S, self._diag_S)
             grad /= self._diag_S
 
         # Apply diagonal shift
-        self._S += self._diag_shift * _np.eye(self._S.shape[0])
+        self._S += self._diag_shift * jax.numpy.eye(self._S.shape[0])
 
     @property
     def last_rank(self):
@@ -329,36 +274,6 @@ class JaxSR:
         rep += "\n"
 
         return rep
-
-    def _linear_operator(self, oks, n_samp):
-        n_par = oks.shape[1]
-        shift = self._diag_shift
-        oks_conj = oks.conjugate()
-
-        if self._is_holomorphic:
-
-            def matvec(v):
-                v_tilde = self._v_tilde
-                res = self._res_t
-
-                v_tilde = _np.matmul(oks, v, v_tilde) / float(n_samp)
-                res = _np.matmul(v_tilde, oks_conj, res)
-                res = _sum_inplace(res) + shift * v
-                return res
-
-        else:
-
-            def matvec(v):
-                v_tilde = self._v_tilde
-                res = self._res_t
-
-                v_tilde = _np.matmul(oks, v, v_tilde) / float(n_samp)
-                res = _np.matmul(v_tilde, oks_conj, res)
-                res = _sum_inplace(res) + shift * v
-
-                return res.real
-
-        return LinearOperator((n_par, n_par), matvec=matvec, rmatvec=matvec)
 
     @property
     def is_holomorphic(self):

--- a/netket/optimizer/stochastic_reconfiguration.py
+++ b/netket/optimizer/stochastic_reconfiguration.py
@@ -4,7 +4,7 @@ from scipy.linalg import lstsq as _lstsq
 from scipy.linalg import cho_factor as _cho_factor
 from scipy.linalg import cho_solve as _cho_solve
 from scipy.sparse.linalg import LinearOperator
-from netket.stats import (sum_inplace as _sum_inplace, mean as  _mean)
+from netket.stats import sum_inplace as _sum_inplace, mean as _mean
 from scipy.sparse.linalg import cg, gmres, minres
 from mpi4py import MPI
 
@@ -107,7 +107,7 @@ class SR:
             out: Output array for the update ẋ.
         """
 
-        oks -= _mean(oks,axis=0)
+        oks -= _mean(oks, axis=0)
 
         if self.is_holomorphic is None:
             raise ValueError(

--- a/netket/optimizer/stochastic_reconfiguration.py
+++ b/netket/optimizer/stochastic_reconfiguration.py
@@ -107,7 +107,7 @@ class SR:
             out: Output array for the update ẋ.
         """
 
-	    oks -= _mean(oks,axis=0)
+        oks -= _mean(oks,axis=0)
 
         if self.is_holomorphic is None:
             raise ValueError(
@@ -140,7 +140,6 @@ class SR:
 
                 self._x0 = out
             else:
-
                 self._S = _np.matmul(oks.conj().T, oks, self._S)
                 self._S = _sum_inplace(self._S)
                 self._S /= float(n_samp)

--- a/netket/optimizer/stochastic_reconfiguration.py
+++ b/netket/optimizer/stochastic_reconfiguration.py
@@ -101,8 +101,8 @@ class SR:
         gradient).
 
         Args:
-            oks: The matrix 𝕆 of centered log-derivatives,
-               𝕆_ij = O_i(v_j) - ⟨O_i⟩.
+            oks: The matrix of log-derivatives,
+           	O_i(v_j)
             grad: The vector of forces f.
             out: Output array for the update ẋ.
         """

--- a/netket/optimizer/stochastic_reconfiguration.py
+++ b/netket/optimizer/stochastic_reconfiguration.py
@@ -4,12 +4,9 @@ from scipy.linalg import lstsq as _lstsq
 from scipy.linalg import cho_factor as _cho_factor
 from scipy.linalg import cho_solve as _cho_solve
 from scipy.sparse.linalg import LinearOperator
-from netket.stats import sum_inplace as _sum_inplace
+from netket.stats import (sum_inplace as _sum_inplace, mean as  _mean)
 from scipy.sparse.linalg import cg, gmres, minres
 from mpi4py import MPI
-
-import jax
-from jax.scipy.sparse.linalg import cg as jcg
 
 
 class SR:
@@ -53,7 +50,7 @@ class SR:
     def _init_solver(self):
         lsq_solver = self._lsq_solver
 
-        if lsq_solver in ["gmres", "cg", "minres","jaxcg"]:
+        if lsq_solver in ["gmres", "cg", "minres"]:
             self._use_iterative = True
         if lsq_solver in ["ColPivHouseholder", "QR", "SVD", "Cholesky"]:
             self._use_iterative = False
@@ -72,8 +69,6 @@ class SR:
                         "minres can be used only for real-valued parameters."
                     )
                 self._sparse_solver = minres
-            elif lsq_solver == "jaxcg":
-                self._is_holomorphic = True
             else:
                 raise RuntimeError("Unknown sparse lsq_solver " + lsq_solver + ".")
 
@@ -112,6 +107,8 @@ class SR:
             out: Output array for the update ẋ.
         """
 
+	oks -= _mean(oks,axis=0)
+
         if self.is_holomorphic is None:
             raise ValueError(
                 "is_holomorphic not set: this SR object is not properly initialized."
@@ -126,24 +123,20 @@ class SR:
 
         if self._is_holomorphic:
             if self._use_iterative:
-                if self._lsq_solver == "jaxcg":
-                    out = self._jax_cg_solve(oks,grad,n_samp)
+                op = self._linear_operator(oks, n_samp)
 
-                else:
-                    op = self._linear_operator(oks, n_samp)
+                if self._x0 is None:
+                    self._x0 = _np.zeros(n_par, dtype=_np.complex128)
 
-                    if self._x0 is None:
-                        self._x0 = _np.zeros(n_par, dtype=_np.complex128)
-
-                    out[:], info = self._sparse_solver(
-                        op,
-                        grad,
-                        x0=self._x0,
-                        tol=self.sparse_tol,
-                        maxiter=self.sparse_maxiter,
-                    )
-                    if info < 0:
-                        raise RuntimeError("SR sparse solver did not converge.")
+                out[:], info = self._sparse_solver(
+                    op,
+                    grad,
+                    x0=self._x0,
+                    tol=self.sparse_tol,
+                    maxiter=self.sparse_maxiter,
+                )
+                if info < 0:
+                    raise RuntimeError("SR sparse solver did not converge.")
 
                 self._x0 = out
             else:
@@ -207,39 +200,6 @@ class SR:
         self._comm.bcast(out, root=0)
         self._comm.barrier()
         return out
-
-    def _jax_cg_solve(self,oks,grad,n_samp):
-        """
-        Solves the SR flow equation using the conjugate gradient method 
-        """
-
-        n_par = grad.shape[0]
-        if self._x0 is None:
-            self._x0 = _np.zeros(n_par, dtype=_np.complex128)
-
-        cov_op = self._jax_linear_function(oks,n_samp)
-        
-        out, _ = jcg(cov_op,grad,x0=self._x0,tol=self.sparse_tol,maxiter=self.sparse_maxiter)
-
-        return out
-
-    def _jax_linear_function(self,oks,n_samp):
-        """
-        Outputs function A(x) = Ax needed for conjugate gradient
-        """
-        v_tilde = self._v_tilde
-        res = self._res_t 
-        shift = self._diag_shift
-        oks_conj = oks.conjugate()
-
-        def matvec(oks,oks_conj,x):
-            y = jax.numpy.matmul(oks,x)/n_samp
-            y = jax.numpy.matmul(y,oks_conj) 
-            y = x*shift + y 
-
-            return y
-
-        return partial(matvec,oks,oks_conj)
 
     def _apply_preconditioning(self, grad):
         if self._scale_invariant_pc:

--- a/netket/optimizer/stochastic_reconfiguration.py
+++ b/netket/optimizer/stochastic_reconfiguration.py
@@ -107,7 +107,7 @@ class SR:
             out: Output array for the update ẋ.
         """
 
-	oks -= _mean(oks,axis=0)
+	    oks -= _mean(oks,axis=0)
 
         if self.is_holomorphic is None:
             raise ValueError(
@@ -140,6 +140,7 @@ class SR:
 
                 self._x0 = out
             else:
+
                 self._S = _np.matmul(oks.conj().T, oks, self._S)
                 self._S = _sum_inplace(self._S)
                 self._S /= float(n_samp)

--- a/netket/vmc_common.py
+++ b/netket/vmc_common.py
@@ -17,14 +17,16 @@ def tree_map(fun, tree):
     else:
         return fun(tree)
 
+
 import numpy as np
 from netket.utils import jax_available
+
 if jax_available:
     from jax.tree_util import tree_flatten, tree_unflatten, tree_map
     import jax.numpy as jnp
 
 
-def shape_for_sr(grads,jac):
+def shape_for_sr(grads, jac):
     r"""Reshapes grads and jax from tree like structures to arrays if jax_available 
 
     Args:
@@ -33,14 +35,16 @@ def shape_for_sr(grads,jac):
     Returns:
         A 1D array of gradients and a 2D array of the jacobian
     """
-    
-    grads = jnp.concatenate(tuple(fd.reshape(-1) for fd in tree_flatten(grads)[0]))
-    jac = jnp.concatenate(tuple(fd.reshape(len(fd),-1) for fd in tree_flatten(jac)[0]),-1)
-    
-    return grads, jac 
-    
 
-def shape_for_update(update,shape_like):
+    grads = jnp.concatenate(tuple(fd.reshape(-1) for fd in tree_flatten(grads)[0]))
+    jac = jnp.concatenate(
+        tuple(fd.reshape(len(fd), -1) for fd in tree_flatten(jac)[0]), -1
+    )
+
+    return grads, jac
+
+
+def shape_for_update(update, shape_like):
     r"""Reshapes grads from array to tree like structure if neccesary for update 
 
     Args:
@@ -52,8 +56,7 @@ def shape_for_update(update,shape_like):
         A possibly non-flat structure of jax arrays containing a copy of data
         compatible with the given shape if jax_available and a copy of update otherwise
     """
-    
-    
+
     shf, tree = tree_flatten(shape_like)
 
     updatelist = []
@@ -64,4 +67,3 @@ def shape_for_update(update,shape_like):
         k += size
 
     return tree_unflatten(tree, updatelist)
-    

--- a/netket/vmc_common.py
+++ b/netket/vmc_common.py
@@ -20,7 +20,7 @@ def tree_map(fun, tree):
 import numpy as np
 from netket.utils import jax_available
 if jax_available:
-    from jax.tree_util import tree_flatten, tree_unflatten
+    from jax.tree_util import tree_flatten, tree_unflatten, tree_map
     import jax.numpy as jnp
 
 
@@ -33,15 +33,11 @@ def shape_for_sr(grads,jac):
     Returns:
         A 1D array of gradients and a 2D array of the jacobian
     """
-
-    if isinstance(grads,np.ndarray):
-        return grads, jac
-    else:
-        from jax.tree_util import tree_flatten
-        import jax.numpy as jnp
-        grads = jnp.concatenate(tuple(fd.reshape(-1) for fd in tree_flatten(grads)[0]))
-        jac = jnp.concatenate(tuple(fd.reshape(len(fd),-1) for fd in tree_flatten(jac)[0]),-1)
-        return grads, jac
+    
+    grads = jnp.concatenate(tuple(fd.reshape(-1) for fd in tree_flatten(grads)[0]))
+    jac = jnp.concatenate(tuple(fd.reshape(len(fd),-1) for fd in tree_flatten(jac)[0]),-1)
+    
+    return grads, jac 
     
 
 def shape_for_update(update,shape_like):
@@ -56,17 +52,16 @@ def shape_for_update(update,shape_like):
         A possibly non-flat structure of jax arrays containing a copy of data
         compatible with the given shape if jax_available and a copy of update otherwise
     """
-    if isinstance(shape_like, np.ndarray):
-        return update
-    else:
-        shf, tree = tree_flatten(shape_like)
+    
+    
+    shf, tree = tree_flatten(shape_like)
 
-        updatelist = []
-        k = 0
-        for s in shf:
-            size = s.size
-            updatelist.append(jnp.asarray(update[k : k + size]).reshape(s.shape))
-            k += size
+    updatelist = []
+    k = 0
+    for s in shf:
+        size = s.size
+        updatelist.append(jnp.asarray(update[k : k + size]).reshape(s.shape))
+        k += size
 
-        return tree_unflatten(tree, updatelist)
+    return tree_unflatten(tree, updatelist)
     

--- a/netket/vmc_common.py
+++ b/netket/vmc_common.py
@@ -25,7 +25,6 @@ if jax_available:
     from jax.tree_util import tree_flatten, tree_unflatten, tree_map
     import jax.numpy as jnp
 
-
     def shape_for_sr(grads, jac):
         r"""Reshapes grads and jax from tree like structures to arrays if jax_available 
 
@@ -42,7 +41,6 @@ if jax_available:
         )
 
         return grads, jac
-
 
     def shape_for_update(update, shape_like):
         r"""Reshapes grads from array to tree like structure if neccesary for update 

--- a/netket/vmc_common.py
+++ b/netket/vmc_common.py
@@ -16,3 +16,57 @@ def tree_map(fun, tree):
         return {key: tree_map(fun, value) for key, value in tree.items()}
     else:
         return fun(tree)
+
+import numpy as np
+from netket.utils import jax_available
+if jax_available:
+    from jax.tree_util import tree_flatten, tree_unflatten
+    import jax.numpy as jnp
+
+
+def shape_for_sr(grads,jac):
+    r"""Reshapes grads and jax from tree like structures to arrays if jax_available 
+
+    Args:
+        grads,jac: pytrees of jax arrays or numpy array
+
+    Returns:
+        A 1D array of gradients and a 2D array of the jacobian
+    """
+
+    if isinstance(grads,np.ndarray):
+        return grads, jac
+    else:
+        from jax.tree_util import tree_flatten
+        import jax.numpy as jnp
+        grads = jnp.concatenate(tuple(fd.reshape(-1) for fd in tree_flatten(grads)[0]))
+        jac = jnp.concatenate(tuple(fd.reshape(len(fd),-1) for fd in tree_flatten(jac)[0]),-1)
+        return grads, jac
+    
+
+def shape_for_update(update,shape_like):
+    r"""Reshapes grads from array to tree like structure if neccesary for update 
+
+    Args:
+        grads: a 1d jax/numpy array
+        shape_like: this as in instance having the same type and shape of
+                    the desired conversion.
+
+    Returns:
+        A possibly non-flat structure of jax arrays containing a copy of data
+        compatible with the given shape if jax_available and a copy of update otherwise
+    """
+    if isinstance(shape_like, np.ndarray):
+        return update
+    else:
+        shf, tree = tree_flatten(shape_like)
+
+        updatelist = []
+        k = 0
+        for s in shf:
+            size = s.size
+            updatelist.append(jnp.asarray(update[k : k + size]).reshape(s.shape))
+            k += size
+
+        return tree_unflatten(tree, updatelist)
+    


### PR DESCRIPTION
Hi everyone,

I fixed the code so that stochastic reconfiguration works with Jax. Right now the only SR solver that is implemented with Jax types is "jaxcg" which does conjugate gradient with Jax. I'll post a speed comparison shortly.

Unfortunately, the exact solvers in Jax are causing SIGBUS errors for systems of more than 10 electrons, so I have left their SciPy implementations currently. 

Now that Jax is working on CPUs, I will try to get it working on a GPU. Soon we may be able to train deep networks with stochastic reconfiguration.