### PR TITLE
Speed up JaxSR and simplify it

### DIFF
--- a/Examples/Jax/jax_sr_example.py
+++ b/Examples/Jax/jax_sr_example.py
@@ -34,6 +34,6 @@ gs = nk.Vmc(
 )
 
 # The first iteration is slower because of start-up jit times
-gs.run(out="test", n_iter=1)
+gs.run(out="test", n_iter=2)
 
 gs.run(out="test", n_iter=300)

--- a/netket/vmc_common.py
+++ b/netket/vmc_common.py
@@ -18,32 +18,16 @@ def tree_map(fun, tree):
         return fun(tree)
 
 
-import numpy as np
 from netket.utils import jax_available
 
 if jax_available:
+    import jax
     from jax.tree_util import tree_flatten, tree_unflatten, tree_map
     import jax.numpy as jnp
 
-    def shape_for_sr(grads, jac):
-        r"""Reshapes grads and jax from tree like structures to arrays if jax_available 
-
-        Args:
-            grads,jac: pytrees of jax arrays or numpy array
-
-        Returns:
-            A 1D array of gradients and a 2D array of the jacobian
-        """
-
-        grads = jnp.concatenate(tuple(fd.reshape(-1) for fd in tree_flatten(grads)[0]))
-        jac = jnp.concatenate(
-            tuple(fd.reshape(len(fd), -1) for fd in tree_flatten(jac)[0]), -1
-        )
-
-        return grads, jac
-
-    def shape_for_update(update, shape_like):
-        r"""Reshapes grads from array to tree like structure if neccesary for update 
+    @jax.jit
+    def jax_shape_for_update(update, shape_like):
+        r"""Reshapes grads from array to tree like structure if neccesary for update
 
         Args:
             grads: a 1d jax/numpy array


### PR DESCRIPTION
I sped up JaxSR using a couple of well placed jit decorators + some luck with exchanging the order of one matmul. I have removed the non iterative solvers, since they perform quite poorly. The situation might change as they become more stable in jax. 

In my tests on the standard ising benchmark, JaxSr is now about 40% faster than the corresponding Numpy version, whereas the pure gradient descent (no SR) is about 60% faster. 

This version is still purely serial, since there is an issue with jitting calls to MPI (that should be solvable, but maybe @PhilipVinc knows better). 