### PR TITLE
Remove `is_holomorphic` and replace with `has_complex_weights` (+ R->C bug fix)

### DIFF
--- a/Examples/CustomMachine/rbm.py
+++ b/Examples/CustomMachine/rbm.py
@@ -42,7 +42,7 @@ class PyRbm(netket.machine.CxxMachine):
             use_hidden_bias: specifies whether to use a bias for hidden spins.
         """
         # NOTE: The following call to __init__ is important!
-        super(PyRbm, self).__init__(hilbert)
+        super(PyRbm, self).__init__(hilbert, dtype=complex)
         n = hilbert.size
         if alpha < 0:
             raise ValueError("`alpha` should be non-negative")
@@ -98,11 +98,6 @@ class PyRbm(netket.machine.CxxMachine):
         t = out[:, i : i + self._w.size]
         t.shape = (batch_size, self._w.shape[0], self._w.shape[1])
         _np.einsum("ij,il->ijl", r, x, out=t)
-
-    def _is_holomorphic(self):
-        r"""Complex valued RBM a holomorphic function.
-        """
-        return True
 
     def state_dict(self):
         from collections import OrderedDict

--- a/Test/Machine/test_machine.py
+++ b/Test/Machine/test_machine.py
@@ -181,7 +181,7 @@ def test_set_get_parameters():
         machine.init_random_parameters()
         randpars = flatten(machine.parameters)
 
-        if machine.has_complex_weights:
+        if machine.has_complex_parameters:
             assert np.array_equal(flatten(machine.parameters), randpars)
             assert not all(randpars.real == 0)
             assert not all(randpars.imag == 0)
@@ -216,7 +216,7 @@ def test_save_load_parameters(tmpdir):
 
         os.remove(filename)
         os.rmdir(fn.dirname)
-        if machine.has_complex_weights:
+        if machine.has_complex_parameters:
             assert np.array_equal(flatten(machine.parameters), randpars)
         else:
             assert np.array_equal(flatten(machine.parameters).real, randpars.real)

--- a/Test/Machine/test_machine.py
+++ b/Test/Machine/test_machine.py
@@ -64,6 +64,8 @@ if test_jax:
         dtype=complex,
     )
 
+    machines["Jax RbmSpinPhase (R->C)"] = nk.machine.JaxRbmSpinPhase(hi, alpha=1)
+
     dm_machines["Jax NDM"] = nk.machine.density_matrix.NdmSpinPhase(hi, alpha=1, beta=1)
 
 

--- a/Test/Machine/test_machine.py
+++ b/Test/Machine/test_machine.py
@@ -170,12 +170,6 @@ def central_diff_grad(func, x, eps, *args):
     return grad
 
 
-def check_holomorphic(func, x, eps, *args):
-    gr = central_diff_grad(func, x, eps, *args)
-    gi = central_diff_grad(func, x, eps * 1.0j, *args)
-    same_derivatives(gr, gi)
-
-
 def test_set_get_parameters():
     for name, machine in merge_dicts(machines, dm_machines).items():
         unflatten = machine.numpy_unflatten
@@ -187,7 +181,7 @@ def test_set_get_parameters():
         machine.init_random_parameters()
         randpars = flatten(machine.parameters)
 
-        if machine.is_holomorphic:
+        if machine.has_complex_weights:
             assert np.array_equal(flatten(machine.parameters), randpars)
         else:
             assert np.array_equal(flatten(machine.parameters).real, randpars.real)
@@ -219,7 +213,7 @@ def test_save_load_parameters(tmpdir):
 
         os.remove(filename)
         os.rmdir(fn.dirname)
-        if machine.is_holomorphic:
+        if machine.has_complex_weights:
             assert np.array_equal(flatten(machine.parameters), randpars)
         else:
             assert np.array_equal(flatten(machine.parameters).real, randpars.real)
@@ -263,8 +257,6 @@ def test_log_derivative():
             # print(np.linalg.norm(der_log - num_der_log))
             # Check if machine is correctly set to be holomorphic
             # The check is done only on smaller subset of parameters, for speed
-            if i % 10 == 0 and machine.is_holomorphic:
-                check_holomorphic(log_val_f, randpars, 1.0e-8, machine, v)
 
 
 def test_vector_jacobian():

--- a/Test/Operator/test_der_local_operator.py
+++ b/Test/Operator/test_der_local_operator.py
@@ -164,7 +164,9 @@ def test_der_log_val_jax():
         )
 
         nk._trees2_map(
-            lambda x, y: np.testing.assert_array_almost_equal(x.flatten(), y.flatten()),
+            lambda x, y: np.testing.assert_array_almost_equal(
+                x.flatten(), y.flatten(), decimal=3
+            ),
             grad_all,
             der_loc_vals,
         )
@@ -184,7 +186,9 @@ def test_der_log_val_jax():
         )
 
         nk._trees2_map(
-            lambda x, y: np.testing.assert_array_almost_equal(x.flatten(), y.flatten()),
+            lambda x, y: np.testing.assert_array_almost_equal(
+                x.flatten(), y.flatten(), decimal=3
+            ),
             grad_all,
             der_loc_vals,
         )
@@ -211,7 +215,6 @@ def test_der_log_val_batched_jax():
     )
 
     for i in range(0, states.shape[0]):
-        print("doing ", i)
         state = jax.numpy.array(np.atleast_2d(states[i, :]))
 
         grad_all = nk.operator.der_local_values(

--- a/netket/_qsr.py
+++ b/netket/_qsr.py
@@ -70,7 +70,8 @@ class Qsr(AbstractVariationalDriver):
         self._sampler = sampler
         self._sr = sr
         if sr is not None:
-            self._sr.is_holomorphic = sampler.machine.is_holomorphic
+            self._sr.has_complex_weights = sampler.machine.has_complex_weights
+            self._sr.machine = sampler.machine
 
         self._rotations = rotations
         self._t_samples = _np.asarray(samples)

--- a/netket/_qsr.py
+++ b/netket/_qsr.py
@@ -70,7 +70,7 @@ class Qsr(AbstractVariationalDriver):
         self._sampler = sampler
         self._sr = sr
         if sr is not None:
-            self._sr.has_complex_weights = sampler.machine.has_complex_weights
+            self._sr.has_complex_parameters = sampler.machine.has_complex_parameters
             self._sr.machine = sampler.machine
 
         self._rotations = rotations

--- a/netket/_steadystate.py
+++ b/netket/_steadystate.py
@@ -68,7 +68,7 @@ class SteadyState(AbstractVariationalDriver):
 
         self._sr = sr
         if sr is not None:
-            self._sr.has_complex_weights = sampler.machine.has_complex_weights
+            self._sr.has_complex_parameters = sampler.machine.has_complex_parameters
             self._sr.machine = sampler.machine
 
         self._npar = self._machine.n_par
@@ -251,7 +251,7 @@ class SteadyState(AbstractVariationalDriver):
             #  if Real pars but complex gradient, take only real part
             # not necessary for SR because sr already does it.
             if (
-                not self._machine.has_complex_weights
+                not self._machine.has_complex_parameters
                 and self._machine.outdtype is complex
             ):
                 self._dp = tree_map(lambda x: x.real, self._grads)

--- a/netket/_steadystate.py
+++ b/netket/_steadystate.py
@@ -69,6 +69,7 @@ class SteadyState(AbstractVariationalDriver):
         self._sr = sr
         if sr is not None:
             self._sr.is_holomorphic = sampler.machine.is_holomorphic
+            self._sr.machine = sampler.machine
 
         self._npar = self._machine.n_par
 
@@ -233,7 +234,6 @@ class SteadyState(AbstractVariationalDriver):
             grad = _mean(der_loc_vals.conjugate() * _lloc_r, axis=0) - (
                 der_logs_ave.conjugate() * self._loss_stats.mean
             )
-
             return grad
 
         self._grads = trees2_map(gradfun, self._der_loc_vals, self._der_logs_ave)
@@ -247,8 +247,14 @@ class SteadyState(AbstractVariationalDriver):
 
             self._dp = self._sr.compute_update(self._jac, self._grads, self._dp)
 
+            if self._machine._dtype is float:
+                self._dp = tree_map(lambda x: x.real, self._dp)
+
         else:
             self._dp = self._grads
+
+            if self._machine._dtype is float:
+                self._dp = tree_map(lambda x: x.real, self._dp)
 
         return self._dp
 

--- a/netket/_steadystate.py
+++ b/netket/_steadystate.py
@@ -68,7 +68,7 @@ class SteadyState(AbstractVariationalDriver):
 
         self._sr = sr
         if sr is not None:
-            self._sr.is_holomorphic = sampler.machine.is_holomorphic
+            self._sr.has_complex_weights = sampler.machine.has_complex_weights
             self._sr.machine = sampler.machine
 
         self._npar = self._machine.n_par

--- a/netket/_steadystate.py
+++ b/netket/_steadystate.py
@@ -247,14 +247,16 @@ class SteadyState(AbstractVariationalDriver):
 
             self._dp = self._sr.compute_update(self._jac, self._grads, self._dp)
 
-            if self._machine._dtype is float:
-                self._dp = tree_map(lambda x: x.real, self._dp)
-
         else:
-            self._dp = self._grads
-
-            if self._machine._dtype is float:
-                self._dp = tree_map(lambda x: x.real, self._dp)
+            #  if Real pars but complex gradient, take only real part
+            # not necessary for SR because sr already does it.
+            if (
+                not self._machine.has_complex_weights
+                and self._machine.outdtype is complex
+            ):
+                self._dp = tree_map(lambda x: x.real, self._grads)
+            else:
+                self._dp = self._grads
 
         return self._dp
 

--- a/netket/_vmc.py
+++ b/netket/_vmc.py
@@ -159,10 +159,7 @@ class Vmc(AbstractVariationalDriver):
 
             self._grads = tree_map(_sum_inplace, self._grads)
 
-            if self._machine._dtype is complex:
-                self._dp = self._grads
-            else:
-                self._dp = tree_map(lambda x: x.real, self._grads)
+            self._dp = self._grads
 
         return self._dp
 

--- a/netket/_vmc.py
+++ b/netket/_vmc.py
@@ -159,7 +159,15 @@ class Vmc(AbstractVariationalDriver):
 
             self._grads = tree_map(_sum_inplace, self._grads)
 
-            self._dp = self._grads
+            #  if Real pars but complex gradient, take only real part
+            # not necessary for SR because sr already does it.
+            if (
+                not self._machine.has_complex_weights
+                and self._machine.outdtype is complex
+            ):
+                self._dp = tree_map(lambda x: x.real, self._grads)
+            else:
+                self._dp = self._grads
 
         return self._dp
 

--- a/netket/_vmc.py
+++ b/netket/_vmc.py
@@ -61,7 +61,7 @@ class Vmc(AbstractVariationalDriver):
         self._sampler = sampler
         self._sr = sr
         if sr is not None:
-            self._sr.has_complex_weights = sampler.machine.has_complex_weights
+            self._sr.has_complex_parameters = sampler.machine.has_complex_parameters
             self._sr.machine = sampler.machine
 
         self._npar = self._machine.n_par
@@ -162,7 +162,7 @@ class Vmc(AbstractVariationalDriver):
             #  if Real pars but complex gradient, take only real part
             # not necessary for SR because sr already does it.
             if (
-                not self._machine.has_complex_weights
+                not self._machine.has_complex_parameters
                 and self._machine.outdtype is complex
             ):
                 self._dp = tree_map(lambda x: x.real, self._grads)

--- a/netket/_vmc.py
+++ b/netket/_vmc.py
@@ -61,7 +61,7 @@ class Vmc(AbstractVariationalDriver):
         self._sampler = sampler
         self._sr = sr
         if sr is not None:
-            self._sr.is_holomorphic = sampler.machine.is_holomorphic
+            self._sr.has_complex_weights = sampler.machine.has_complex_weights
             self._sr.machine = sampler.machine
 
         self._npar = self._machine.n_par

--- a/netket/_vmc.py
+++ b/netket/_vmc.py
@@ -159,7 +159,10 @@ class Vmc(AbstractVariationalDriver):
 
             self._grads = tree_map(_sum_inplace, self._grads)
 
-            self._dp = self._grads
+            if self._machine._dtype is complex:
+                self._dp = self._grads
+            else:
+                self._dp = tree_map(lambda x: x.real, self._grads)
 
         return self._dp
 

--- a/netket/machine/__init__.py
+++ b/netket/machine/__init__.py
@@ -6,7 +6,7 @@ from ..utils import jax_available, torch_available
 
 
 if jax_available:
-    from .jax import Jax, JaxRbm
+    from .jax import Jax, JaxRbm, JaxRbmSpinPhase
 
 
 if torch_available:

--- a/netket/machine/abstract_machine.py
+++ b/netket/machine/abstract_machine.py
@@ -167,7 +167,7 @@ class AbstractMachine(abc.ABC):
         return self._outdtype
 
     @property
-    def has_complex_weights(self):
+    def has_complex_parameters(self):
         return self._dtype is complex
 
     @property

--- a/netket/machine/abstract_machine.py
+++ b/netket/machine/abstract_machine.py
@@ -5,9 +5,21 @@ import numpy as _np
 class AbstractMachine(abc.ABC):
     """Abstract class for NetKet machines"""
 
-    def __init__(self, hilbert):
+    def __init__(self, hilbert, dtype=complex, outdtype=None):
         super().__init__()
         self.hilbert = hilbert
+
+        if dtype is not float and dtype is not complex:
+            raise TypeError("dtype must be either float or complex")
+
+        if outdtype is None:
+            outdtype = dtype
+
+        elif outdtype is not float and outdtype is not complex:
+            raise TypeError("outdtype must be either float or complex or None")
+
+        self._outdtype = outdtype
+        self._dtype = dtype
 
     @abc.abstractmethod
     def log_val(self, x, out=None):
@@ -147,10 +159,16 @@ class AbstractMachine(abc.ABC):
             raise RuntimeError("The hilbert space is not indexable")
 
     @property
-    @abc.abstractmethod
-    def is_holomorphic(self):
-        r"""Returns whether the wave function is holomorphic."""
-        raise NotImplementedError
+    def dtype(self):
+        return self._dtype
+
+    @property
+    def outdtype(self):
+        return self._outdtype
+
+    @property
+    def has_complex_weights(self):
+        return self._dtype is complex
 
     @property
     def n_par(self):

--- a/netket/machine/density_matrix/__init__.py
+++ b/netket/machine/density_matrix/__init__.py
@@ -6,4 +6,4 @@ from ...utils import jax_available
 
 
 if jax_available:
-    from .jax import Jax, NdmSpin, NdmSpinPhase
+    from .jax import Jax, NdmSpin, NdmSpinPhase, JaxRbmSpin

--- a/netket/machine/density_matrix/abstract_density_matrix.py
+++ b/netket/machine/density_matrix/abstract_density_matrix.py
@@ -7,8 +7,8 @@ import numpy as _np
 class AbstractDensityMatrix(AbstractMachine):
     """Abstract class for NetKet density matrices"""
 
-    def __init__(self, hilbert):
-        super().__init__(hilbert)
+    def __init__(self, hilbert, dtype, outdtype=complex):
+        super().__init__(hilbert, dtype, outdtype)
 
     @abc.abstractmethod
     def log_val(self, xr, xc=None, out=None):

--- a/netket/machine/density_matrix/diagonal.py
+++ b/netket/machine/density_matrix/diagonal.py
@@ -5,7 +5,11 @@ import numpy as _np
 class Diagonal(AbstractMachine):
     def __init__(self, density_matrix):
         self._rho = density_matrix
-        super().__init__(density_matrix.hilbert)
+        super().__init__(
+            density_matrix.hilbert,
+            dtype=density_matrix.dtype,
+            outdtype=density_matrix.outdtype,
+        )
 
     def log_val(self, x, out=None):
         r"""Computes the logarithm of the wave function for a batch of visible
@@ -20,11 +24,6 @@ class Diagonal(AbstractMachine):
             matrix.
         """
         return self._rho.log_val(x, x, out)
-
-    @property
-    def is_holomorphic(self):
-        r"""Returns whether the wave function is holomorphic."""
-        return self._rho.is_holomorphic
 
     @property
     def n_par(self):

--- a/netket/machine/density_matrix/jax.py
+++ b/netket/machine/density_matrix/jax.py
@@ -34,7 +34,7 @@ class Jax(JaxPure, AbstractDensityMatrix):
             dtype: either complex or float, is the type used for the weights.
                 In both cases the module must have a single output.
         """
-        AbstractDensityMatrix.__init__(self, hilbert)
+        AbstractDensityMatrix.__init__(self, hilbert, dtype, outdtype)
         JaxPure.__init__(self, hilbert, module, dtype, outdtype)
 
         assert self.input_size == self.hilbert.size * 2

--- a/netket/machine/density_matrix/jax.py
+++ b/netket/machine/density_matrix/jax.py
@@ -51,19 +51,12 @@ class Jax(JaxPure, AbstractDensityMatrix):
     def log_val(self, xr, xc=None, out=None):
         x = self._dminput(xr, xc)
 
-        if out is None:
-            out = self._forward_fn(self._params, x).reshape(x.shape[0],)
-        else:
-            out[:] = self._forward_fn(self._params, x).reshape(x.shape[0],)
-
-        return out
+        return JaxPure.log_val(self, x, out=out)
 
     def der_log(self, xr, xc=None, out=None):
         x = self._dminput(xr, xc)
 
-        out = self._perex_grads(self._params_ascomplex, x)
-
-        return out
+        return JaxPure.der_log(self, x, out=out)
 
     def diagonal(self):
         from .diagonal import Diagonal

--- a/netket/machine/density_matrix/jax.py
+++ b/netket/machine/density_matrix/jax.py
@@ -370,3 +370,12 @@ def NdmSpinPhase(hilbert, alpha, beta, use_hidden_bias=True, use_visible_bias=Tr
         )
 
     return Jax(hilbert, net, dtype=float, outdtype=complex)
+
+
+def JaxRbmSpin(hilbert, alpha, dtype=complex):
+    return Jax(
+        hilbert,
+        stax.serial(stax.Dense(alpha * hilbert.size * 2), LogCoshLayer, SumLayer()),
+        dtype=dtype,
+        outdtype=dtype,
+    )

--- a/netket/machine/density_matrix/rbm.py
+++ b/netket/machine/density_matrix/rbm.py
@@ -14,7 +14,7 @@ class RbmSpin(AbstractDensityMatrix):
         symmetry=None,
         dtype=complex,
     ):
-        super().__init__(hilbert)
+        super().__init__(hilbert, dtype=dtype, outdtype=complex)
 
         if symmetry is True:
             autom = hilbert.graph.automorphisms
@@ -75,11 +75,6 @@ class RbmSpin(AbstractDensityMatrix):
             return self._pder_log(xr, out)
         else:
             return self._pder_log(_np.hstack((xr, xc)), out)
-
-    @property
-    def is_holomorphic(self):
-        r"""Returns whether the density matrix is holomorphic."""
-        return self._prbm.is_holomorphic
 
     @property
     def state_dict(self):

--- a/netket/machine/jastrow.py
+++ b/netket/machine/jastrow.py
@@ -103,7 +103,7 @@ class Jastrow(AbstractMachine):
 
         self._npar = n_sym + (self._a.size if self._a is not None else 0)
 
-        super().__init__(hilbert)
+        super().__init__(hilbert, dtype)
 
     @property
     def n_par(self):
@@ -184,12 +184,6 @@ class Jastrow(AbstractMachine):
                     out[b, Smap[i, j] + k] += x[b, i] * x[b, j]
 
         return out
-
-    @property
-    def is_holomorphic(self):
-        r"""Complex valued Jastrow is a holomorphic function.
-        """
-        return self._dtype is complex
 
     @property
     def state_dict(self):

--- a/netket/machine/jax.py
+++ b/netket/machine/jax.py
@@ -243,13 +243,6 @@ class Jax(AbstractMachine):
     def parameters(self):
         return self._params
 
-    @property
-    def _params_ascomplex(self):
-        if self._dtype is not complex:
-            return tree_map(lambda v: v.astype(jax.numpy.complex128), self._params)
-        else:
-            return self._params
-
     @parameters.setter
     def parameters(self, p):
         self._params = p

--- a/netket/machine/jax.py
+++ b/netket/machine/jax.py
@@ -149,9 +149,11 @@ class Jax(AbstractMachine):
 
     def init_random_parameters(self, seed=None, sigma=0.01):
         rgen = _np.random.RandomState(seed)
-        pars = rgen.normal(scale=sigma, size=self.n_par,) + 1.0j * rgen.normal(
-            scale=sigma, size=self.n_par
-        )
+
+        pars = rgen.normal(scale=sigma, size=self.n_par)
+
+        if self.has_complex_parameters:
+            pars = pars + 1.0j * rgen.normal(scale=sigma, size=self.n_par)
 
         self.parameters = self.numpy_unflatten(pars, self.parameters)
 

--- a/netket/machine/jax.py
+++ b/netket/machine/jax.py
@@ -37,21 +37,9 @@ class Jax(AbstractMachine):
             dtype: either complex or float, is the type used for the weights.
                 In both cases the network must have a single output.
         """
-        super().__init__(hilbert)
+        super().__init__(hilbert=hilbert, dtype=dtype, outdtype=outdtype)
 
-        if dtype is not float and dtype is not complex:
-            raise TypeError("dtype must be either float or complex")
-
-        if outdtype is None:
-            outdtype = dtype
-
-        elif outdtype is not float and outdtype is not complex:
-            raise TypeError("outdtype must be either float or complex or None")
-
-        self._dtype = dtype
         self._npdtype = _np.complex128 if dtype is complex else _np.float64
-
-        self._outdtype = outdtype
 
         self._init_fn, self._forward_fn = module
 
@@ -226,10 +214,6 @@ class Jax(AbstractMachine):
             out = tree_map(prodj, jacobian)
 
             return out, jacobian
-
-    @property
-    def is_holomorphic(self):
-        return self._dtype is complex
 
     @property
     def state_dict(self):

--- a/netket/machine/rbm.py
+++ b/netket/machine/rbm.py
@@ -92,12 +92,13 @@ class RbmSpin(AbstractMachine):
             860
         """
 
+        super().__init__(hilbert, dtype=dtype)
+
         n = hilbert.size
 
         if dtype is not float and dtype is not complex:
             raise TypeError("dtype must be either float or complex")
 
-        self._dtype = dtype
         self._npdtype = _np.complex128 if dtype is complex else _np.float64
 
         self._autom, self.n_hidden, alpha_symm = self._get_hidden(
@@ -136,8 +137,6 @@ class RbmSpin(AbstractMachine):
             self._set_bare_parameters(
                 self._a, self._b, self._w, self._as, self._bs, self._ws, self._autom
             )
-
-        super().__init__(hilbert)
 
     @property
     def n_par(self):
@@ -232,12 +231,6 @@ class RbmSpin(AbstractMachine):
         _np.einsum("ij,il->ijl", x, r, out=t)
 
         return out
-
-    @property
-    def is_holomorphic(self):
-        r"""Complex valued RBM is a holomorphic function.
-        """
-        return self._dtype is complex
 
     @property
     def state_dict(self):
@@ -750,7 +743,7 @@ class RbmSpinPhase(AbstractMachine):
 
         self._n_par = self._rbm_a.n_par + self._rbm_p.n_par
 
-        super().__init__(hilbert)
+        super().__init__(hilbert, dtype=float, outdtype=complex)
 
     @property
     def n_par(self):
@@ -799,12 +792,6 @@ class RbmSpinPhase(AbstractMachine):
         out[:, n_par_a:] *= 1.0j
 
         return out
-
-    @property
-    def is_holomorphic(self):
-        r"""This machine is not holomorphic.
-        """
-        return False
 
     @property
     def state_dict(self):

--- a/netket/machine/torch.py
+++ b/netket/machine/torch.py
@@ -15,14 +15,14 @@ def _get_differentiable_parameters(m):
 
 
 class Torch(AbstractMachine):
-    def __init__(self, module, hilbert):
+    def __init__(self, module, hilbert, dtype, outdtype=None):
         self._module = _torch.jit.load(module) if isinstance(module, str) else module
         self._module.double()
         self._n_par = _get_number_parameters(self._module)
         self._parameters = list(_get_differentiable_parameters(self._module))
 
         # TODO check that module has input shape compatible with hilbert size
-        super().__init__(hilbert)
+        super().__init__(hilbert, dtype=dtype, outdtype=outdtype)
 
     @property
     def parameters(self):
@@ -155,12 +155,6 @@ class Torch(AbstractMachine):
         write_to(out.imag)
 
         return out
-
-    @property
-    def is_holomorphic(self):
-        r"""PyTorch models are real-valued only, thus non holomorphic.
-        """
-        return False
 
     @property
     def state_dict(self):

--- a/netket/optimizer/abstract_optimizer.py
+++ b/netket/optimizer/abstract_optimizer.py
@@ -5,12 +5,12 @@ import numpy as _np
 class AbstractOptimizer(abc.ABC):
     """Abstract class for NetKet optimizers"""
 
-    def init(self, n_par, has_complex_weights):
+    def init(self, n_par, has_complex_parameters):
         r""" Initializes the optimizer.
 
         Args:
             n_par (int): Number of parameters to be optimized.
-            has_complex_weights (bool): Whether the target function has complex weights.
+            has_complex_parameters (bool): Whether the target function has complex weights.
 
         """
         pass

--- a/netket/optimizer/abstract_optimizer.py
+++ b/netket/optimizer/abstract_optimizer.py
@@ -5,12 +5,12 @@ import numpy as _np
 class AbstractOptimizer(abc.ABC):
     """Abstract class for NetKet optimizers"""
 
-    def init(self, n_par, is_holomorphic):
+    def init(self, n_par, has_complex_weights):
         r""" Initializes the optimizer.
 
         Args:
             n_par (int): Number of parameters to be optimized.
-            is_holomorphic (bool): Whether the target function is holomorphic.
+            has_complex_weights (bool): Whether the target function has complex weights.
 
         """
         pass

--- a/netket/optimizer/jax_stochastic_reconfiguration.py
+++ b/netket/optimizer/jax_stochastic_reconfiguration.py
@@ -20,7 +20,7 @@ class JaxSR:
         lsq_solver=None,
         diag_shift=0.01,
         use_iterative=True,
-        has_complex_weights=None,
+        has_complex_parameters=None,
         svd_threshold=None,
         sparse_tol=None,
         sparse_maxiter=None,
@@ -29,7 +29,7 @@ class JaxSR:
         self._lsq_solver = lsq_solver
         self._diag_shift = diag_shift
         self._use_iterative = use_iterative
-        self._has_complex_weights = has_complex_weights
+        self._has_complex_parameters = has_complex_parameters
 
         # Quantities for sparse solver
         self.sparse_tol = 1.0e-5 if sparse_tol is None else sparse_tol
@@ -85,7 +85,7 @@ class JaxSR:
 
         oks -= jnp.mean(oks, axis=0)
 
-        if self.has_complex_weights is None or self.machine is None:
+        if self.has_complex_parameters is None or self.machine is None:
             raise ValueError("This SR object is not properly initialized.")
 
         # n_samp = _sum_inplace(jnp.atleast_1d(oks.shape[0]))
@@ -96,7 +96,7 @@ class JaxSR:
         if out is None:
             out = jnp.zeros(n_par, dtype=jnp.complex128)
 
-        if self.has_complex_weights:
+        if self.has_complex_parameters:
             if self._use_iterative:
                 if self._lsq_solver == "cg":
                     out = self._jax_cg_solve(oks, grad, n_samp)
@@ -163,14 +163,16 @@ class JaxSR:
         if self._use_iterative:
             rep += "iterative"
 
-        rep += ", has_complex_weights=" + str(self._has_complex_weights) + ")"
+        rep += ", has_complex_parameters=" + str(self._has_complex_parameters) + ")"
         return rep
 
     def info(self, depth=0):
         indent = " " * 4 * depth
         rep = indent
         rep += "Stochastic reconfiguration method for "
-        rep += "complex-parameters" if self._has_complex_weights else "real-parameters"
+        rep += (
+            "complex-parameters" if self._has_complex_parameters else "real-parameters"
+        )
         rep += " wavefunctions\n"
 
         rep += indent + "Solver: "
@@ -183,10 +185,10 @@ class JaxSR:
         return rep
 
     @property
-    def has_complex_weights(self):
-        return self._has_complex_weights
+    def has_complex_parameters(self):
+        return self._has_complex_parameters
 
-    @has_complex_weights.setter
-    def has_complex_weights(self, is_real):
-        self._has_complex_weights = is_real
+    @has_complex_parameters.setter
+    def has_complex_parameters(self, is_real):
+        self._has_complex_parameters = is_real
         self._init_solver()

--- a/netket/optimizer/jax_stochastic_reconfiguration.py
+++ b/netket/optimizer/jax_stochastic_reconfiguration.py
@@ -20,7 +20,7 @@ class JaxSR:
         lsq_solver=None,
         diag_shift=0.01,
         use_iterative=True,
-        is_holomorphic=None,
+        has_complex_weights=None,
         svd_threshold=None,
         sparse_tol=None,
         sparse_maxiter=None,
@@ -29,7 +29,7 @@ class JaxSR:
         self._lsq_solver = lsq_solver
         self._diag_shift = diag_shift
         self._use_iterative = use_iterative
-        self._is_holomorphic = is_holomorphic
+        self._has_complex_weights = has_complex_weights
 
         # Quantities for sparse solver
         self.sparse_tol = 1.0e-5 if sparse_tol is None else sparse_tol
@@ -85,7 +85,7 @@ class JaxSR:
 
         oks -= jnp.mean(oks, axis=0)
 
-        if self.is_holomorphic is None or self.machine is None:
+        if self.has_complex_weights is None or self.machine is None:
             raise ValueError("This SR object is not properly initialized.")
 
         # n_samp = _sum_inplace(jnp.atleast_1d(oks.shape[0]))
@@ -96,7 +96,7 @@ class JaxSR:
         if out is None:
             out = jnp.zeros(n_par, dtype=jnp.complex128)
 
-        if self._is_holomorphic:
+        if self.has_complex_weights:
             if self._use_iterative:
                 if self._lsq_solver == "cg":
                     out = self._jax_cg_solve(oks, grad, n_samp)
@@ -163,14 +163,14 @@ class JaxSR:
         if self._use_iterative:
             rep += "iterative"
 
-        rep += ", is_holomorphic=" + str(self._is_holomorphic) + ")"
+        rep += ", has_complex_weights=" + str(self._has_complex_weights) + ")"
         return rep
 
     def info(self, depth=0):
         indent = " " * 4 * depth
         rep = indent
         rep += "Stochastic reconfiguration method for "
-        rep += "holomorphic" if self._is_holomorphic else "real-parameter"
+        rep += "complex-parameters" if self._has_complex_weights else "real-parameters"
         rep += " wavefunctions\n"
 
         rep += indent + "Solver: "
@@ -183,10 +183,10 @@ class JaxSR:
         return rep
 
     @property
-    def is_holomorphic(self):
-        return self._is_holomorphic
+    def has_complex_weights(self):
+        return self._has_complex_weights
 
-    @is_holomorphic.setter
-    def is_holomorphic(self, is_holo):
-        self._is_holomorphic = is_holo
+    @has_complex_weights.setter
+    def has_complex_weights(self, is_real):
+        self._has_complex_weights = is_real
         self._init_solver()

--- a/netket/optimizer/stochastic_reconfiguration.py
+++ b/netket/optimizer/stochastic_reconfiguration.py
@@ -19,7 +19,7 @@ class SR:
         lsq_solver=None,
         diag_shift=0.01,
         use_iterative=True,
-        is_holomorphic=None,
+        has_complex_weights=None,
         svd_threshold=None,
         sparse_tol=None,
         sparse_maxiter=None,
@@ -28,7 +28,7 @@ class SR:
         self._lsq_solver = lsq_solver
         self._diag_shift = diag_shift
         self._use_iterative = use_iterative
-        self._is_holomorphic = is_holomorphic
+        self._has_complex_weights = has_complex_weights
         self._svd_threshold = svd_threshold
         self._scale_invariant_pc = False
         self._S = None
@@ -57,14 +57,14 @@ class SR:
 
         if self._use_iterative:
             if lsq_solver is None:
-                lsq_solver = "gmres" if self._is_holomorphic else "minres"
+                lsq_solver = "gmres" if self._has_complex_weights else "minres"
 
             if lsq_solver == "gmres":
                 self._sparse_solver = partial(gmres, atol="legacy")
             elif lsq_solver == "cg":
                 self._sparse_solver = partial(cg, atol="legacy")
             elif lsq_solver == "minres":
-                if self._is_holomorphic:
+                if self._has_complex_weights:
                     raise RuntimeError(
                         "minres can be used only for real-valued parameters."
                     )
@@ -109,9 +109,9 @@ class SR:
 
         oks -= _mean(oks, axis=0)
 
-        if self.is_holomorphic is None:
+        if self.has_complex_weights is None:
             raise ValueError(
-                "is_holomorphic not set: this SR object is not properly initialized."
+                "has_complex_weights not set: this SR object is not properly initialized."
             )
 
         n_samp = _sum_inplace(_np.atleast_1d(oks.shape[0]))
@@ -121,7 +121,7 @@ class SR:
         if out is None:
             out = _np.zeros(n_par, dtype=_np.complex128)
 
-        if self._is_holomorphic:
+        if self._has_complex_weights:
             if self._use_iterative:
                 op = self._linear_operator(oks, n_samp)
 
@@ -265,14 +265,14 @@ class SR:
             if self._svd_threshold is not None:
                 rep += ", threshold=" << self._svd_threshold
 
-        rep += ", is_holomorphic=" + str(self._is_holomorphic) + ")"
+        rep += ", has_complex_weights=" + str(self._has_complex_weights) + ")"
         return rep
 
     def info(self, depth=0):
         indent = " " * 4 * depth
         rep = indent
         rep += "Stochastic reconfiguration method for "
-        rep += "holomorphic" if self._is_holomorphic else "real-parameter"
+        rep += "holomorphic" if self._has_complex_weights else "real-parameter"
         rep += " wavefunctions\n"
 
         rep += indent + "Solver: "
@@ -290,7 +290,7 @@ class SR:
         shift = self._diag_shift
         oks_conj = oks.conjugate()
 
-        if self._is_holomorphic:
+        if self._has_complex_weights:
 
             def matvec(v):
                 v_tilde = self._v_tilde
@@ -316,10 +316,10 @@ class SR:
         return LinearOperator((n_par, n_par), matvec=matvec, rmatvec=matvec)
 
     @property
-    def is_holomorphic(self):
-        return self._is_holomorphic
+    def has_complex_weights(self):
+        return self._has_complex_weights
 
-    @is_holomorphic.setter
-    def is_holomorphic(self, is_holo):
-        self._is_holomorphic = is_holo
+    @has_complex_weights.setter
+    def has_complex_weights(self, is_real):
+        self._has_complex_weights = is_real
         self._init_solver()

--- a/netket/optimizer/stochastic_reconfiguration.py
+++ b/netket/optimizer/stochastic_reconfiguration.py
@@ -19,7 +19,7 @@ class SR:
         lsq_solver=None,
         diag_shift=0.01,
         use_iterative=True,
-        has_complex_weights=None,
+        has_complex_parameters=None,
         svd_threshold=None,
         sparse_tol=None,
         sparse_maxiter=None,
@@ -28,7 +28,7 @@ class SR:
         self._lsq_solver = lsq_solver
         self._diag_shift = diag_shift
         self._use_iterative = use_iterative
-        self._has_complex_weights = has_complex_weights
+        self._has_complex_parameters = has_complex_parameters
         self._svd_threshold = svd_threshold
         self._scale_invariant_pc = False
         self._S = None
@@ -57,14 +57,14 @@ class SR:
 
         if self._use_iterative:
             if lsq_solver is None:
-                lsq_solver = "gmres" if self._has_complex_weights else "minres"
+                lsq_solver = "gmres" if self._has_complex_parameters else "minres"
 
             if lsq_solver == "gmres":
                 self._sparse_solver = partial(gmres, atol="legacy")
             elif lsq_solver == "cg":
                 self._sparse_solver = partial(cg, atol="legacy")
             elif lsq_solver == "minres":
-                if self._has_complex_weights:
+                if self._has_complex_parameters:
                     raise RuntimeError(
                         "minres can be used only for real-valued parameters."
                     )
@@ -109,9 +109,9 @@ class SR:
 
         oks -= _mean(oks, axis=0)
 
-        if self.has_complex_weights is None:
+        if self.has_complex_parameters is None:
             raise ValueError(
-                "has_complex_weights not set: this SR object is not properly initialized."
+                "has_complex_parameters not set: this SR object is not properly initialized."
             )
 
         n_samp = _sum_inplace(_np.atleast_1d(oks.shape[0]))
@@ -121,7 +121,7 @@ class SR:
         if out is None:
             out = _np.zeros(n_par, dtype=_np.complex128)
 
-        if self._has_complex_weights:
+        if self._has_complex_parameters:
             if self._use_iterative:
                 op = self._linear_operator(oks, n_samp)
 
@@ -265,14 +265,14 @@ class SR:
             if self._svd_threshold is not None:
                 rep += ", threshold=" << self._svd_threshold
 
-        rep += ", has_complex_weights=" + str(self._has_complex_weights) + ")"
+        rep += ", has_complex_parameters=" + str(self._has_complex_parameters) + ")"
         return rep
 
     def info(self, depth=0):
         indent = " " * 4 * depth
         rep = indent
         rep += "Stochastic reconfiguration method for "
-        rep += "holomorphic" if self._has_complex_weights else "real-parameter"
+        rep += "holomorphic" if self._has_complex_parameters else "real-parameter"
         rep += " wavefunctions\n"
 
         rep += indent + "Solver: "
@@ -290,7 +290,7 @@ class SR:
         shift = self._diag_shift
         oks_conj = oks.conjugate()
 
-        if self._has_complex_weights:
+        if self._has_complex_parameters:
 
             def matvec(v):
                 v_tilde = self._v_tilde
@@ -316,10 +316,10 @@ class SR:
         return LinearOperator((n_par, n_par), matvec=matvec, rmatvec=matvec)
 
     @property
-    def has_complex_weights(self):
-        return self._has_complex_weights
+    def has_complex_parameters(self):
+        return self._has_complex_parameters
 
-    @has_complex_weights.setter
-    def has_complex_weights(self, is_real):
-        self._has_complex_weights = is_real
+    @has_complex_parameters.setter
+    def has_complex_parameters(self, is_real):
+        self._has_complex_parameters = is_real
         self._init_solver()

--- a/netket/optimizer/torch.py
+++ b/netket/optimizer/torch.py
@@ -32,7 +32,7 @@ class Torch(AbstractOptimizer):
         if not issubclass(optim, _torch.optim.Optimizer):
             raise ValueError("Not a valid Torch optimizer.")
 
-        if machine.is_holomorphic:
+        if machine.dtype is complex:
             raise ValueError(
                 "Torch optimizers work only for machines with real parameters."
             )

--- a/netket/variational.py
+++ b/netket/variational.py
@@ -49,7 +49,6 @@ def Vmc(
             lsq_solver=sr_lsq_solver,
             diag_shift=diag_shift,
             use_iterative=use_iterative,
-            is_holomorphic=sampler.machine.is_holomorphic,
         )
         return _Vmc(
             hamiltonian=hamiltonian,


### PR DESCRIPTION
After having harassed @gcarleo several times about our usage of `is_holomorphic`, I finally did a PR to fix (in my opinion) it.

In essence: 
 - In netket our usage of `is_holomorphic` was to check if the function had real parameters, to dispatch to a more efficient SR version.
 - While R->R functions are not holomorphic, R->C functions are holomorphic, even if the Cauchy conditions have to be reformulated (my favourite read is [this](http://dsp.ucsd.edu/~kreutz/PEI-05%20Support%20Files/Lecture%20Supplement%203%20on%20the%20Complex%20Derivative%20v1.3c%20F05%20.pdf)). 
 - If we have a C->C function that is not holomorphic netket breaks down anyways so...

I propose to change `is_holomorphic` to `has_complex_weights`. Now all machines specify their `dtype` (either float or complex) at construction.
Machines also  specify their output type, `outdtype`. this defaults to the same as the `dtype`, so if you don't specify it everything will stil work.

The main advantage in knowing the input and output type is that now we can correctly treat R->C wavefunctions during optimisation, and restrict the update to only the real part of the gradient. Previously this would fail (and was untested).

This is also used to speed up some jax gradients and vjp (from a previous PR).

This pr also:
 - Introduces a new Jax Pure machine that is R->C, and tests that der_log and vjp works 
 - I also add a bunch of density matrix machines
 - I fixed a bug with der log of jax R->C wavefunction that I missed in my last pr.