### PR TITLE
Fix Jax complex weight initialization

### DIFF
--- a/Test/Machine/test_machine.py
+++ b/Test/Machine/test_machine.py
@@ -187,8 +187,11 @@ def test_set_get_parameters():
 
         if machine.is_holomorphic:
             assert np.array_equal(flatten(machine.parameters), randpars)
+            assert not all(randpars.real == 0)
+            assert not all(randpars.imag == 0)
         else:
             assert np.array_equal(flatten(machine.parameters).real, randpars.real)
+            assert not all(randpars.real == 0)
 
         machine.parameters = unflatten(np.zeros(npar), machine.parameters)
         assert np.count_nonzero(np.abs(flatten(machine.parameters))) == 0

--- a/netket/machine/jax.py
+++ b/netket/machine/jax.py
@@ -132,13 +132,21 @@ class Jax(AbstractMachine):
         else:
             raise ValueError("We do not support C->R wavefunctions.")
 
-        self.init_random_parameters()
+        self.jax_init_parameters()
 
         # Computes total number of parameters
         weights, _ = tree_flatten(self._params)
         self._npar = sum([w.size for w in weights])
+        self.init_random_parameters()
 
-    def init_random_parameters(self, seed=None, sigma=None):
+    def jax_init_parameters(self, seed=None):
+        """
+        Uses the init function of the jax networks to generate a set of parameters.
+        Beware that usually jax does not correctly set the imaginary part of
+        networks, so for complex networks it MUST be followed by a call to
+        init_random_parameters, unless your network correctly initialised the 
+        imaginary part.
+        """
         if seed is None:
             seed = _randint(0, 2 ** 32 - 2)
 
@@ -149,6 +157,14 @@ class Jax(AbstractMachine):
 
         if output_shape != (-1, 1):
             raise ValueError("A valid network must have 1 output.")
+
+    def init_random_parameters(self, seed=None, sigma=0.01):
+        rgen = _np.random.RandomState(seed)
+        pars = rgen.normal(scale=sigma, size=self.n_par,) + 1.0j * rgen.normal(
+            scale=sigma, size=self.n_par
+        )
+
+        self.parameters = self.numpy_unflatten(pars, self.parameters)
 
     def _cast(self, p):
         if self._dtype is complex:


### PR DESCRIPTION
Fix the fact that jax networks with complex weights have zero imaginary part.

Adds a test