### PR TITLE
Fix JaxSR

### DIFF
--- a/netket/_qsr.py
+++ b/netket/_qsr.py
@@ -70,8 +70,7 @@ class Qsr(AbstractVariationalDriver):
         self._sampler = sampler
         self._sr = sr
         if sr is not None:
-            self._sr.has_complex_parameters = sampler.machine.has_complex_parameters
-            self._sr.machine = sampler.machine
+            self._sr.setup(sampler.machine)
 
         self._rotations = rotations
         self._t_samples = _np.asarray(samples)

--- a/netket/_steadystate.py
+++ b/netket/_steadystate.py
@@ -68,8 +68,7 @@ class SteadyState(AbstractVariationalDriver):
 
         self._sr = sr
         if sr is not None:
-            self._sr.has_complex_parameters = sampler.machine.has_complex_parameters
-            self._sr.machine = sampler.machine
+            self._sr.setup(sampler.machine)
 
         self._npar = self._machine.n_par
 

--- a/netket/_vmc.py
+++ b/netket/_vmc.py
@@ -61,8 +61,7 @@ class Vmc(AbstractVariationalDriver):
         self._sampler = sampler
         self._sr = sr
         if sr is not None:
-            self._sr.has_complex_parameters = sampler.machine.has_complex_parameters
-            self._sr.machine = sampler.machine
+            self._sr.setup(sampler.machine)
 
         self._npar = self._machine.n_par
 

--- a/netket/optimizer/jax_stochastic_reconfiguration.py
+++ b/netket/optimizer/jax_stochastic_reconfiguration.py
@@ -4,10 +4,89 @@ from netket.utils import n_nodes
 from mpi4py import MPI
 
 import jax
+import jax.numpy as jnp
+
+from jax import jit
 from jax.scipy.sparse.linalg import cg
 from jax.tree_util import tree_flatten
 from netket.vmc_common import jax_shape_for_update
-import jax.numpy as jnp
+from netket.utils import jit_if_singleproc
+
+
+@jit
+def _S_grad_mul(oks, v, n_samp):
+    """
+    Computes y = 1/N * ( O^\dagger * O * v ) where v is a vector of
+    length n_parameters, and O is a matrix (n_samples, n_parameters)
+    """
+    v_tilde = jnp.matmul(oks, v) / n_samp
+    y = jnp.matmul(oks.conjugate().transpose(), v_tilde)
+    return y
+
+
+@jit
+def _compose_result_cmplx(v, y, diag_shift):
+    return v * diag_shift + y
+
+
+@jit
+def _compose_result_real(v, y, diag_shift):
+    return (v * diag_shift + y).real
+
+
+#  Note: n_samp must be the total number of samples across all MPI processes!
+# Note: _sum_inplace can only be jitted through if we are in single process.
+@jit_if_singleproc
+def _matvec_cmplx(v, oks, n_samp, diag_shift):
+    y = _S_grad_mul(oks, v, n_samp)
+    return _compose_result_cmplx(v, _sum_inplace(y), diag_shift)
+
+
+@jit_if_singleproc
+def _matvec_real(v, oks, n_samp, diag_shift):
+    y = _S_grad_mul(oks, v, n_samp)
+    return _compose_result_real(v, _sum_inplace(y), diag_shift)
+
+
+@partial(jit_if_singleproc, static_argnums=1)
+def _jax_cg_solve(
+    x0, mat_vec, oks, grad, diag_shift, n_samp, sparse_tol, sparse_maxiter
+):
+    """
+    Solves the SR flow equation using the conjugate gradient method
+    """
+
+    _mat_vec = partial(mat_vec, oks=oks, diag_shift=diag_shift, n_samp=n_samp)
+
+    out, _ = cg(_mat_vec, grad, x0=x0, tol=sparse_tol, maxiter=sparse_maxiter)
+
+    return out
+
+
+@jit
+def _shape_for_sr(grads, jac):
+    r"""Reshapes grads and jax from tree like structures to arrays if jax_available
+
+    Args:
+        grads,jac: pytrees of jax arrays or numpy array
+
+    Returns:
+        A 1D array of gradients and a 2D array of the jacobian
+    """
+
+    grads = jnp.concatenate(tuple(fd.reshape(-1) for fd in tree_flatten(grads)[0]))
+    jac = jnp.concatenate(
+        tuple(fd.reshape(len(fd), -1) for fd in tree_flatten(jac)[0]), -1
+    )
+
+    return grads, jac
+
+
+@jit
+def _flatten_grad_and_oks(grad, oks):
+    grad, oks = _shape_for_sr(grad, oks)
+    oks -= jnp.mean(oks, axis=0)
+    return grad, oks
 
 
 class JaxSR:
@@ -20,10 +99,10 @@ class JaxSR:
         lsq_solver=None,
         diag_shift=0.01,
         use_iterative=True,
-        has_complex_parameters=None,
         svd_threshold=None,
         sparse_tol=None,
         sparse_maxiter=None,
+        machine=None,
     ):
 
         self._lsq_solver = lsq_solver
@@ -36,14 +115,16 @@ class JaxSR:
         self.sparse_maxiter = sparse_maxiter
         self._lsq_solver = lsq_solver
         self._x0 = None
+        self._machine = None
+        self._has_complex_parameters = None
+        self._mat_vec = None
         self._init_solver()
-
-        # self._comm = MPI.COMM_WORLD
-        if n_nodes > 1:
-            raise NotImplementedError("JaxSR currently works only for serial CPU jobs")
 
         if not self._use_iterative:
             raise NotImplementedError("JaxSR supports only iterative solvers")
+
+        if machine is not None:
+            self.setup(machine)
 
     def _init_solver(self):
         lsq_solver = self._lsq_solver
@@ -64,7 +145,23 @@ class JaxSR:
             else:
                 raise RuntimeError("Unknown sparse lsq_solver " + lsq_solver + ".")
 
-    @partial(jax.jit, static_argnums=(0,))
+    def setup(self, machine):
+        """
+        Sets up this Sr object to work with the selected machine.
+        This mainly sets internal flags `has_complex_parameters` and the
+        method used to flatten/unflatten the gradients.
+
+        Args:
+            machine: the machine
+        """
+        self._machine = machine
+        self._has_complex_parameters = machine.has_complex_parameters
+
+        if self._has_complex_parameters:
+            self._mat_vec = _matvec_cmplx
+        else:
+            self._mat_vec = _matvec_real
+
     def compute_update(self, oks, grad, out=None):
         r"""
         Solves the SR flow equation for the parameter update ẋ.
@@ -78,84 +175,56 @@ class JaxSR:
         Args:
             oks: A pytree of the jacobians ∂/∂x_i log Ψ(v_j)
             grad: A pytree of the forces f
-            out: A pytree of the parameter updates
+            out: A pytree of the parameter updates that will be ignored
         """
 
-        grad, oks = self.shape_for_sr(grad, oks)
-
-        oks -= jnp.mean(oks, axis=0)
-
-        if self.has_complex_parameters is None or self.machine is None:
+        if self.has_complex_parameters is None or self._machine is None:
             raise ValueError("This SR object is not properly initialized.")
 
-        # n_samp = _sum_inplace(jnp.atleast_1d(oks.shape[0]))
-        n_samp = oks.shape[0]
+        grad, oks = _flatten_grad_and_oks(grad, oks)
+
+        n_samp = oks.shape[0] * n_nodes
 
         n_par = grad.shape[0]
 
-        if out is None:
-            out = jnp.zeros(n_par, dtype=jnp.complex128)
+        if self._x0 is None:
+            if self.has_complex_parameters:
+                self._x0 = jnp.zeros(n_par, dtype=jnp.complex128)
+            else:
+                self._x0 = jnp.zeros(n_par, dtype=jnp.float64)
 
         if self.has_complex_parameters:
             if self._use_iterative:
                 if self._lsq_solver == "cg":
-                    out = self._jax_cg_solve(oks, grad, n_samp)
+                    out = _jax_cg_solve(
+                        self._x0,
+                        self._mat_vec,
+                        oks,
+                        grad,
+                        self._diag_shift,
+                        n_samp,
+                        self.sparse_tol,
+                        self.sparse_maxiter,
+                    )
                 self._x0 = out
         else:
             if self._use_iterative:
                 if self._lsq_solver == "cg":
-                    out = self._jax_cg_solve(oks, grad.real, n_samp)
-                self._x0 = jnp.real(out)
+                    out = _jax_cg_solve(
+                        self._x0,
+                        self._mat_vec,
+                        oks,
+                        grad.real,
+                        self._diag_shift,
+                        n_samp,
+                        self.sparse_tol,
+                        self.sparse_maxiter,
+                    )
+                self._x0 = out
 
-            out = out.real
-
-        out = jax_shape_for_update(out, self.machine.parameters)
-
-        # self._comm.bcast(out, root=0)
-        # self._comm.barrier()
-        return out
-
-    @partial(jax.jit, static_argnums=(0, 3))
-    def _jax_cg_solve(self, oks, grad, n_samp):
-        """
-        Solves the SR flow equation using the conjugate gradient method
-        """
-
-        n_par = grad.shape[0]
-        if self._x0 is None:
-            self._x0 = jnp.zeros(n_par, dtype=jnp.complex128)
-
-        def mat_vec(x):
-            y = jnp.matmul(oks, x) / n_samp
-            y = jnp.matmul(oks.conjugate().transpose(), y)
-            y = x * self._diag_shift + y
-
-            return y
-
-        out, _ = cg(
-            mat_vec, grad, x0=self._x0, tol=self.sparse_tol, maxiter=self.sparse_maxiter
-        )
+        out = jax_shape_for_update(out, self._machine.parameters)
 
         return out
-
-    @staticmethod
-    @jax.jit
-    def shape_for_sr(grads, jac):
-        r"""Reshapes grads and jax from tree like structures to arrays if jax_available
-
-        Args:
-            grads,jac: pytrees of jax arrays or numpy array
-
-        Returns:
-            A 1D array of gradients and a 2D array of the jacobian
-        """
-
-        grads = jnp.concatenate(tuple(fd.reshape(-1) for fd in tree_flatten(grads)[0]))
-        jac = jnp.concatenate(
-            tuple(fd.reshape(len(fd), -1) for fd in tree_flatten(jac)[0]), -1
-        )
-
-        return grads, jac
 
     def __repr__(self):
         rep = "SR(solver="
@@ -187,8 +256,3 @@ class JaxSR:
     @property
     def has_complex_parameters(self):
         return self._has_complex_parameters
-
-    @has_complex_parameters.setter
-    def has_complex_parameters(self, is_real):
-        self._has_complex_parameters = is_real
-        self._init_solver()

--- a/netket/optimizer/jax_stochastic_reconfiguration.py
+++ b/netket/optimizer/jax_stochastic_reconfiguration.py
@@ -108,15 +108,14 @@ class JaxSR:
         self._lsq_solver = lsq_solver
         self._diag_shift = diag_shift
         self._use_iterative = use_iterative
-        self._has_complex_parameters = has_complex_parameters
+        self._has_complex_parameters = None
+        self._machine = None
 
         # Quantities for sparse solver
         self.sparse_tol = 1.0e-5 if sparse_tol is None else sparse_tol
         self.sparse_maxiter = sparse_maxiter
         self._lsq_solver = lsq_solver
         self._x0 = None
-        self._machine = None
-        self._has_complex_parameters = None
         self._mat_vec = None
         self._init_solver()
 

--- a/netket/optimizer/stochastic_reconfiguration.py
+++ b/netket/optimizer/stochastic_reconfiguration.py
@@ -19,10 +19,10 @@ class SR:
         lsq_solver=None,
         diag_shift=0.01,
         use_iterative=True,
-        has_complex_parameters=None,
         svd_threshold=None,
         sparse_tol=None,
         sparse_maxiter=None,
+        machine=None,
     ):
 
         self._lsq_solver = lsq_solver
@@ -89,6 +89,19 @@ class SR:
             raise ValueError(
                 "The svd_threshold option is available only for non-sparse solvers."
             )
+
+    def setup(self, machine=None):
+        """
+        Sets up this Sr object to work with the selected machine.
+        This mainly sets internal flags `has_complex_parameters` and the
+        method used to flatten/unflatten the gradients.
+
+        Args:
+            machine: the machine
+
+        """
+
+        self._has_complex_parameters = has_complex_parameters
 
     def compute_update(self, oks, grad, out=None):
         r"""
@@ -318,8 +331,3 @@ class SR:
     @property
     def has_complex_parameters(self):
         return self._has_complex_parameters
-
-    @has_complex_parameters.setter
-    def has_complex_parameters(self, is_real):
-        self._has_complex_parameters = is_real
-        self._init_solver()

--- a/netket/optimizer/stochastic_reconfiguration.py
+++ b/netket/optimizer/stochastic_reconfiguration.py
@@ -28,7 +28,7 @@ class SR:
         self._lsq_solver = lsq_solver
         self._diag_shift = diag_shift
         self._use_iterative = use_iterative
-        self._has_complex_parameters = has_complex_parameters
+        self._has_complex_parameters = None
         self._svd_threshold = svd_threshold
         self._scale_invariant_pc = False
         self._S = None
@@ -46,6 +46,9 @@ class SR:
         self._init_solver()
 
         self._comm = MPI.COMM_WORLD
+
+        if machine is not None:
+            self.setup(machine)
 
     def _init_solver(self):
         lsq_solver = self._lsq_solver

--- a/netket/optimizer/stochastic_reconfiguration.py
+++ b/netket/optimizer/stochastic_reconfiguration.py
@@ -93,7 +93,7 @@ class SR:
                 "The svd_threshold option is available only for non-sparse solvers."
             )
 
-    def setup(self, machine=None):
+    def setup(self, machine):
         """
         Sets up this Sr object to work with the selected machine.
         This mainly sets internal flags `has_complex_parameters` and the
@@ -104,7 +104,7 @@ class SR:
 
         """
 
-        self._has_complex_parameters = has_complex_parameters
+        self._has_complex_parameters = machine.has_complex_parameters
 
     def compute_update(self, oks, grad, out=None):
         r"""

--- a/netket/optimizer/stochastic_reconfiguration.py
+++ b/netket/optimizer/stochastic_reconfiguration.py
@@ -103,8 +103,8 @@ class SR:
             machine: the machine
 
         """
-
         self._has_complex_parameters = machine.has_complex_parameters
+        self._init_solver()
 
     def compute_update(self, oks, grad, out=None):
         r"""

--- a/netket/stats/_sum_inplace.py
+++ b/netket/stats/_sum_inplace.py
@@ -119,3 +119,17 @@ if jax_available:
         _MPI_comm.Allreduce(_MPI.IN_PLACE, arr.reshape(-1), op=_MPI.SUM)
 
         return x
+
+    @define_sum_inplace(
+        atypes=(
+            jax.interpreters.partial_eval.JaxprTracer,
+            jax.interpreters.ad.JVPTracer,
+        )
+    )
+    def sum_inplace_jax_jittracer(x):
+        if _n_nodes == 1:
+            return x
+        else:
+            raise RuntimError(
+                "Cannot jit sum_inplace when running with multiple MPI processes."
+            )

--- a/netket/stats/mc_stats.py
+++ b/netket/stats/mc_stats.py
@@ -1,3 +1,5 @@
+import math
+
 from numba import jit
 import numpy as _np
 from . import mean as _mean
@@ -6,7 +8,11 @@ from . import total_size as _total_size
 
 
 def _format_decimal(value, std):
-    decimals = max(int(_np.ceil(-_np.log10(std))), 0)
+    if not math.isnan(std):
+        decimals = max(int(_np.ceil(-_np.log10(std))), 0)
+    else:
+        decimals = 8
+
     return (
         "{0:.{1}f}".format(value, decimals),
         "{0:.{1}f}".format(std, decimals + 1),

--- a/netket/utils.py
+++ b/netket/utils.py
@@ -5,7 +5,6 @@ MPI_comm = MPI.COMM_WORLD
 n_nodes = MPI_comm.Get_size()
 node_number = MPI_comm.Get_rank()
 
-
 try:
     import os
 
@@ -14,6 +13,14 @@ try:
     import jax
 
     jax_available = True
+
+    def jit_if_singleproc(f, *args, **kwargs):
+        if n_nodes == 1:
+            return jax.jit(f, *args, **kwargs)
+        else:
+            return f
+
+
 except ImportError:
     jax_available = False
 


### PR DESCRIPTION
Apparently the SR implementation for jax by @chrisrothUT did not work with R->C machines, because of jitting through non-pure functions.

This PR rewrites a big chunk of JaxSR to make it only use pure functions, and incidentally now works with MPI.

It also changes the way we initialise SR classes: instead of setting `has_complex_parameters` like we were doing before, I created a function `sr.setup(machine)` that sets this up (and methods to flatten/unflatten).

I'd like to add a few more test to check this case, but otherwise this can already be reviewed.

There is also a tiny bug fix in the last commit: now if `stats.error_of_mean` is a nan we don't crash upon display.