### PR TITLE
bugfix: constrained hilbert spaces

### DIFF
--- a/netket/hilbert/custom_hilbert.py
+++ b/netket/hilbert/custom_hilbert.py
@@ -191,7 +191,7 @@ class CustomHilbert(AbstractHilbert):
     @staticmethod
     @jit(nopython=True)
     def _gen_to_bare_numbers(conditions):
-        return _np.argwhere(conditions).reshape(-1)
+        return _np.nonzero(conditions)[0]
 
     @staticmethod
     @jit(nopython=True)


### PR DESCRIPTION
Numba np.argwhere is badly supported and returns a non contiguous array that reshape does not like.
Use nonzero instead.

I think it's a recent Numba change.

In any case argwhere is internally implemented by Numba with nonzero so... does not change much.