### PR TITLE
Various minor fixes

### DIFF
--- a/netket/_qsr.py
+++ b/netket/_qsr.py
@@ -68,9 +68,7 @@ class Qsr(AbstractVariationalDriver):
         super(Qsr, self).__init__(sampler.machine, optimizer)
 
         self._sampler = sampler
-        self._sr = sr
-        if sr is not None:
-            self._sr.setup(sampler.machine)
+        self.sr = sr
 
         self._rotations = rotations
         self._t_samples = _np.asarray(samples)
@@ -94,6 +92,16 @@ class Qsr(AbstractVariationalDriver):
 
         assert self._bases.ndim == 1
         assert self._bases.size == self._n_training_samples
+
+    @property
+    def sr(self):
+        return self._sr
+
+    @sr.setter
+    def sr(self, sr):
+        self._sr = sr
+        if self._sr is not None:
+            self._sr.setup(self.machine)
 
     @property
     def n_samples(self):

--- a/netket/_steadystate.py
+++ b/netket/_steadystate.py
@@ -66,9 +66,7 @@ class SteadyState(AbstractVariationalDriver):
         self._sampler = sampler
         self._sampler_obs = sampler_obs
 
-        self._sr = sr
-        if sr is not None:
-            self._sr.setup(sampler.machine)
+        self.sr = sr
 
         self._npar = self._machine.n_par
 
@@ -93,6 +91,16 @@ class SteadyState(AbstractVariationalDriver):
         self._lloc = None
 
         self._dp = None
+
+    @property
+    def sr(self):
+        return self._sr
+
+    @sr.setter
+    def sr(self, sr):
+        self._sr = sr
+        if self._sr is not None:
+            self._sr.setup(self.machine)
 
     @property
     def n_samples(self):

--- a/netket/_vmc.py
+++ b/netket/_vmc.py
@@ -59,9 +59,7 @@ class Vmc(AbstractVariationalDriver):
 
         self._ham = hamiltonian
         self._sampler = sampler
-        self._sr = sr
-        if sr is not None:
-            self._sr.setup(sampler.machine)
+        self.sr = sr
 
         self._npar = self._machine.n_par
 
@@ -74,6 +72,16 @@ class Vmc(AbstractVariationalDriver):
         self.n_discard = n_discard
 
         self._dp = None
+
+    @property
+    def sr(self):
+        return self._sr
+
+    @sr.setter
+    def sr(self, sr):
+        self._sr = sr
+        if self._sr is not None:
+            self._sr.setup(self.machine)
 
     @property
     def n_samples(self):

--- a/netket/abstract_variational_driver.py
+++ b/netket/abstract_variational_driver.py
@@ -106,6 +106,31 @@ class AbstractVariationalDriver(abc.ABC):
         """
         return self._machine
 
+    @property
+    def optimizer(self):
+        return self._optimizer
+
+    @optimizer.setter
+    def optimizer(self, optimizer_new):
+        self._optimizer = optimizer_new
+
+    @property
+    def step_count(self):
+        """
+        Returns a monotonic integer labelling all the steps performed by this driver.
+        This can be used, for example, to identify the line in a log file.
+        """
+        return self._step_count
+
+    @property
+    def step_value(self):
+        """
+        Returns a monotonic value identifying the current step. This might be the 
+        step_count for a standard iterative optimizer, or the time for a time-evolution
+        integrator.
+        """
+        return self.step_count
+
     def iter(self, n_steps, step=1):
         """
         Returns a generator which advances the VMC optimization, yielding

--- a/netket/abstract_variational_driver.py
+++ b/netket/abstract_variational_driver.py
@@ -38,7 +38,7 @@ class AbstractVariationalDriver(abc.ABC):
         self._obs = {}  # to deprecate
         self._loss_stats = None
         self._loss_name = minimized_quantity_name
-        self.step_count = 0
+        self._step_count = 0
 
         self._machine = machine
         self._optimizer = optimizer
@@ -121,15 +121,6 @@ class AbstractVariationalDriver(abc.ABC):
         This can be used, for example, to identify the line in a log file.
         """
         return self._step_count
-
-    @property
-    def step_value(self):
-        """
-        Returns a monotonic value identifying the current step. This might be the 
-        step_count for a standard iterative optimizer, or the time for a time-evolution
-        integrator.
-        """
-        return self.step_count
 
     def iter(self, n_steps, step=1):
         """
@@ -273,7 +264,7 @@ class AbstractVariationalDriver(abc.ABC):
             :param dp: the gradient
         """
         self._machine.parameters = self._optimizer.update(dp, self._machine.parameters)
-        self.step_count += 1
+        self._step_count += 1
 
     @deprecated()
     def add_observable(self, obs, name):

--- a/netket/machine/__init__.py
+++ b/netket/machine/__init__.py
@@ -7,7 +7,7 @@ from ..utils import jax_available, torch_available
 
 if jax_available:
     from .jax import Jax, JaxRbm, MPSPeriodic, JaxRbmSpinPhase
-
+    from .jax import SumLayer, LogCoshLayer
 
 if torch_available:
     from .torch import Torch, TorchLogCosh, TorchView

--- a/netket/machine/density_matrix/jax.py
+++ b/netket/machine/density_matrix/jax.py
@@ -14,9 +14,10 @@
 
 import jax
 import jax.numpy as jnp
+from jax import random
 
 from .abstract_density_matrix import AbstractDensityMatrix
-from ..jax import Jax as JaxPure
+from ..jax import Jax as JaxPure, logcosh
 from functools import partial
 
 
@@ -164,7 +165,7 @@ def NdmSpin(hilbert, alpha, beta, use_hidden_bias=True):
                 alpha * hilbert.size, beta * hilbert.size, use_hidden_bias
             ),
             LogCoshLayer,
-            SumLayer(),
+            SumLayer,
         ),
         dtype=float,
         outdtype=complex,
@@ -342,19 +343,19 @@ def NdmSpinPhase(hilbert, alpha, beta, use_hidden_bias=True, use_visible_bias=Tr
     mod_pure = stax.serial(
         DensePureRowCol(alpha * hilbert.size, use_hidden_bias),
         stax.parallel(LogCoshLayer, LogCoshLayer),
-        stax.parallel(SumLayer(), SumLayer()),
+        stax.parallel(SumLayer, SumLayer),
         FanInSum2,
     )
 
     phs_pure = stax.serial(
         DensePureRowCol(alpha * hilbert.size, use_hidden_bias),
         stax.parallel(LogCoshLayer, LogCoshLayer),
-        stax.parallel(SumLayer(), SumLayer()),
+        stax.parallel(SumLayer, SumLayer),
         FanInSub2,
     )
 
     mixing = stax.serial(
-        DenseMixingReal(beta * hilbert.size, use_hidden_bias), LogCoshLayer, SumLayer(),
+        DenseMixingReal(beta * hilbert.size, use_hidden_bias), LogCoshLayer, SumLayer,
     )
 
     if use_visible_bias:
@@ -375,7 +376,7 @@ def NdmSpinPhase(hilbert, alpha, beta, use_hidden_bias=True, use_visible_bias=Tr
 def JaxRbmSpin(hilbert, alpha, dtype=complex):
     return Jax(
         hilbert,
-        stax.serial(stax.Dense(alpha * hilbert.size * 2), LogCoshLayer, SumLayer()),
+        stax.serial(stax.Dense(alpha * hilbert.size * 2), LogCoshLayer, SumLayer),
         dtype=dtype,
         outdtype=dtype,
     )

--- a/netket/machine/jax.py
+++ b/netket/machine/jax.py
@@ -329,6 +329,9 @@ def SumLayer():
     return init_fun, apply_fun
 
 
+SumLayer = SumLayer()
+
+
 @jax.jit
 def logcosh(x):
     x = x * jax.numpy.sign(x.real)
@@ -341,7 +344,7 @@ LogCoshLayer = stax.elementwise(logcosh)
 def JaxRbm(hilbert, alpha, dtype=complex):
     return Jax(
         hilbert,
-        stax.serial(stax.Dense(alpha * hilbert.size), LogCoshLayer, SumLayer()),
+        stax.serial(stax.Dense(alpha * hilbert.size), LogCoshLayer, SumLayer),
         dtype=dtype,
     )
 
@@ -523,8 +526,8 @@ def JaxRbmSpinPhase(hilbert, alpha, dtype=float):
         stax.serial(
             stax.FanOut(2),
             stax.parallel(
-                stax.serial(stax.Dense(alpha * hilbert.size), LogCoshLayer, SumLayer()),
-                stax.serial(stax.Dense(alpha * hilbert.size), LogCoshLayer, SumLayer()),
+                stax.serial(stax.Dense(alpha * hilbert.size), LogCoshLayer, SumLayer),
+                stax.serial(stax.Dense(alpha * hilbert.size), LogCoshLayer, SumLayer),
             ),
             FanInSum2ModPhase,
         ),

--- a/netket/optimizer/__init__.py
+++ b/netket/optimizer/__init__.py
@@ -9,11 +9,10 @@ from .rms_prop import RmsProp
 from .sgd import Sgd
 from .stochastic_reconfiguration import SR
 
-from ..utils import jax_available, torch_available
+from ..utils import jax_available as _jax_available, torch_available as _torch_available
 
-if jax_available:
+if _jax_available:
     from . import jax
 
-
-if torch_available:
+if _torch_available:
     from .torch import Torch

--- a/netket/optimizer/jax/wrap.py
+++ b/netket/optimizer/jax/wrap.py
@@ -5,7 +5,7 @@ class Wrap(AbstractOptimizer):
     r"""Wrapper for Jax optimizers.
     """
 
-    def __init__(self, machine, optimizer):
+    def __init__(self, machine, optimizer, repr_str=None):
         r"""
            Constructs a new ``Jax`` optimizer that can be used in NetKet drivers.
 
@@ -25,6 +25,8 @@ class Wrap(AbstractOptimizer):
 
         self._machine = machine
 
+        self._repr_str = repr_str
+
         self.reset()
 
     def update(self, grad, pars):
@@ -39,6 +41,18 @@ class Wrap(AbstractOptimizer):
         self._opt_state = self._init_fun(self._machine.parameters)
 
     def __repr__(self):
-        rep = "Wrapper for the following Jax optimizer :\n"
-        rep += str(self._j_opt)
-        return rep
+        repr_str = self._repr_str
+        if repr_str is None:
+            try:
+                module = self._update_fun.__module__
+                qname = self._update_fun.__qualname__
+                repr_str = module + "." + qname
+
+                if module.startswith("jax"):
+                    repr_str = repr_str.rsplit(".", 2)[0]
+            except:
+                repr_str = ""
+
+            rep = "Wrapper for the following Jax optimizer :\n  "
+            rep += str(repr_str)
+            return rep

--- a/netket/stats/__init__.py
+++ b/netket/stats/__init__.py
@@ -2,12 +2,4 @@ from ._sum_inplace import sum_inplace
 
 from .mpi_stats import *
 
-
 from .mc_stats import statistics, Stats
-
-
-# use_mpi = True
-# try:
-#     from mpi4py import MPI
-# except:
-#     use_mpi = False

--- a/netket/stats/_sum_inplace.py
+++ b/netket/stats/_sum_inplace.py
@@ -68,9 +68,12 @@ if jax_available:
 
     @sum_inplace.register(jax.interpreters.xla.DeviceArray)
     def sum_inplace_jax(x):
-        # if not isinstance(x, jax.interpreters.xla.DeviceArray):
-        #    raise TypeError("Argument to sum_inplace_jax must be a DeviceArray, got {}"
-        #            .format(type(x)))
+        if not isinstance(x, jax.interpreters.xla.DeviceArray):
+            raise TypeError(
+                "Argument to sum_inplace_jax must be a DeviceArray, got {}".format(
+                    type(x)
+                )
+            )
 
         if _n_nodes == 1:
             return x


### PR DESCRIPTION
- Make Optimizer a property that can be modified of an optimiser. In that way it can be changed live without having to recreate the optimiser object (which is not nice sometimes, as it means another output file unless you take extra precautions).
- idem for Sr

- For jax Machines, the `Sumlayer` which takes no argument is a function. I changed it to reflect the jax standard of using them as objects if they do not take any input (this often trips me when mixing netket layers and jax layers).
- Export logCosh and SumLayers 

- Fix printing of jax optimisers (there was some dead code). For jax optimisers I can recover their name (inside a try-catch statement, you never know...). otherwise I just print the fully qualified function name.
