### PR TITLE
 Fix warning due to string comparison with `is` in Stats

### DIFF
--- a/netket/stats/mc_stats.py
+++ b/netket/stats/mc_stats.py
@@ -49,15 +49,15 @@ class Stats:
         )
 
     def __getitem__(self, name):
-        if name is "mean" or "Mean":
+        if name in ("mean", "Mean"):
             return self.mean
-        elif name is "variance" or "Variance":
+        elif name in ("variance", "Variance"):
             return self.variance
-        elif name is "error_of_mean" or "Sigma":
+        elif name in ("error_of_mean", "Sigma"):
             return self.error_of_mean
-        elif name is "R_hat":
+        elif name in ("R_hat",):
             return self.R_hat
-        elif name is "tau_corr" or "TauCorr":
+        elif name in ("tau_corr", "TauCorr"):
             return self.tau_corr
 
 

--- a/netket/stats/mc_stats.py
+++ b/netket/stats/mc_stats.py
@@ -55,7 +55,7 @@ class Stats:
             return self.variance
         elif name in ("error_of_mean", "Sigma"):
             return self.error_of_mean
-        elif name in ("R_hat",):
+        elif name in ("R_hat", "R"):
             return self.R_hat
         elif name in ("tau_corr", "TauCorr"):
             return self.tau_corr


### PR DESCRIPTION
Strings should be compared with `==`. Comparing with `is` checks for object identity. This works accidentally here but is not [guaranteed to](https://docs.python.org/3.8/whatsnew/3.8.html#changes-in-python-behavior), because equal strings are not necessarily the same object. For this reason, the code produces warnings in Python 3.8.

Further, `name is "mean" or "Mean"` evaluates to `True` if `name is "mean"` but to "Mean" otherwise because it is parsed as
```
	(name is "mean") or "Mean"
```
which, while not breaking the code, is also unexpected.

In contrast, checking for membership with `name in (...)` also checks for equality (`==`).

(This PR also adds "R" as alias key for "R_hat", so that now all keys are backwards compatible with the v2 names.)