### PR TITLE
Fix OverflowError when displaying Stats objects

### DIFF
--- a/Test/Stats/test_stats.py
+++ b/Test/Stats/test_stats.py
@@ -136,3 +136,11 @@ def test_tau_corr():
     sig_corr = 0.5
     for bs in (1, 2, 32, 64):
         _test_tau_corr(bs, sig_corr)
+
+
+def test_irregular_floats():
+    from netket.stats import Stats
+
+    assert str(Stats(float("nan"), float("inf"))) == "nan ± inf [var=nan, R_hat=nan]"
+    assert str(Stats(1.0, float("nan"))) == "1.00000000 ± nan [var=nan, R_hat=nan]"
+    assert str(Stats(1.0, float("inf"))) == "1.00000000 ± inf [var=nan, R_hat=nan]"

--- a/netket/stats/mc_stats.py
+++ b/netket/stats/mc_stats.py
@@ -8,7 +8,7 @@ from . import total_size as _total_size
 
 
 def _format_decimal(value, std):
-    if not math.isnan(std):
+    if math.isfinite(std):
         decimals = max(int(_np.ceil(-_np.log10(std))), 0)
     else:
         decimals = 8


### PR DESCRIPTION
This PR resolves issue #459.

The `OverflowError` occurred for Stats with infinite `error_of_mean`, as the formula for computing the output precision overflows in that case. Now, this case is treated in the same way as NaN. Arguably, the precision of a quantity with infinite error is zero, but just displaying the value with some default precision seems acceptable to me.