### PR TITLE
Improve display formatting of Stats and fix overflow error

### DIFF
--- a/Test/GroundState/test_vmc.py
+++ b/Test/GroundState/test_vmc.py
@@ -114,7 +114,7 @@ def test_vmc_progress_bar():
     pbar = f.getvalue().split("\r")[-1]
     assert re.match(r"100%\|#*\| (\d+)/\1", pbar)
     assert re.search(r"Energy=[-+]?[0-9]*\.?[0-9]*", pbar)
-    assert re.search(r"var=[-+]?[0-9]*\.?[0-9]*", pbar)
+    assert re.search(r"σ²=[-+]?[0-9]*\.?[0-9]*", pbar)
 
     f = StringIO()
     with redirect_stderr(f):

--- a/Test/Stats/test_stats.py
+++ b/Test/Stats/test_stats.py
@@ -141,17 +141,15 @@ def test_tau_corr():
 def test_decimal_format():
     from netket.stats import Stats
 
-    assert str(Stats(1.0, 1e-3)) == "1.0000 ± 0.0010 [var=nan]"
-    assert str(Stats(1.0, 1e-6)) == "1.0000000 ± 0.0000010 [var=nan]"
-    assert str(Stats(1.0, 1e-7)) == "1.000e+00 ± 1.000e-07 [var=nan]"
+    assert str(Stats(1.0, 1e-3)) == "1.0000 ± 0.0010 [σ²=nan]"
+    assert str(Stats(1.0, 1e-6)) == "1.0000000 ± 0.0000010 [σ²=nan]"
+    assert str(Stats(1.0, 1e-7)) == "1.000e+00 ± 1.000e-07 [σ²=nan]"
 
-    assert str(Stats(float("nan"), float("inf"))) == "nan ± inf [var=nan]"
-    assert str(Stats(1.0, float("nan"))) == "1.000e+00 ± nan [var=nan]"
-    assert str(Stats(1.0, float("inf"))) == "1.000e+00 ± inf [var=nan]"
-    assert str(Stats(float("inf"), 0.0)) == "inf ± 0.000e+00 [var=nan]"
-    assert str(Stats(1.0, 0.0)) == "1.000e+00 ± 0.000e+00 [var=nan]"
+    assert str(Stats(float("nan"), float("inf"))) == "nan ± inf [σ²=nan]"
+    assert str(Stats(1.0, float("nan"))) == "1.000e+00 ± nan [σ²=nan]"
+    assert str(Stats(1.0, float("inf"))) == "1.000e+00 ± inf [σ²=nan]"
+    assert str(Stats(float("inf"), 0.0)) == "inf ± 0.000e+00 [σ²=nan]"
+    assert str(Stats(1.0, 0.0)) == "1.000e+00 ± 0.000e+00 [σ²=nan]"
 
-    assert str(Stats(1.0, 0.12, 0.5)) == "1.00 ± 0.12 [var=0.50]"
-    assert (
-        str(Stats(1.0, 0.12, 0.5, R_hat=1.01)) == "1.00 ± 0.12 [var=0.50, R_hat=1.0100]"
-    )
+    assert str(Stats(1.0, 0.12, 0.5)) == "1.00 ± 0.12 [σ²=0.50]"
+    assert str(Stats(1.0, 0.12, 0.5, R_hat=1.01)) == "1.00 ± 0.12 [σ²=0.50, R̂=1.0100]"

--- a/Test/Stats/test_stats.py
+++ b/Test/Stats/test_stats.py
@@ -138,9 +138,15 @@ def test_tau_corr():
         _test_tau_corr(bs, sig_corr)
 
 
-def test_irregular_floats():
+def test_decimal_format():
     from netket.stats import Stats
 
+    assert str(Stats(1.0, 1e-3)) == "1.0000 ± 0.0010 [var=nan, R_hat=nan]"
+    assert str(Stats(1.0, 1e-6)) == "1.0000000 ± 0.0000010 [var=nan, R_hat=nan]"
+    assert str(Stats(1.0, 1e-7)) == "1.000e+00 ± 1.000e-07 [var=nan, R_hat=nan]"
+
     assert str(Stats(float("nan"), float("inf"))) == "nan ± inf [var=nan, R_hat=nan]"
-    assert str(Stats(1.0, float("nan"))) == "1.00000000 ± nan [var=nan, R_hat=nan]"
-    assert str(Stats(1.0, float("inf"))) == "1.00000000 ± inf [var=nan, R_hat=nan]"
+    assert str(Stats(1.0, float("nan"))) == "1.000e+00 ± nan [var=nan, R_hat=nan]"
+    assert str(Stats(1.0, float("inf"))) == "1.000e+00 ± inf [var=nan, R_hat=nan]"
+    assert str(Stats(float("inf"), 0.0)) == "inf ± 0.000e+00 [var=nan, R_hat=nan]"
+    assert str(Stats(1.0, 0.0)) == "1.000e+00 ± 0.000e+00 [var=nan, R_hat=nan]"

--- a/Test/Stats/test_stats.py
+++ b/Test/Stats/test_stats.py
@@ -150,3 +150,5 @@ def test_decimal_format():
     assert str(Stats(1.0, float("inf"))) == "1.000e+00 ± inf [var=nan, R_hat=nan]"
     assert str(Stats(float("inf"), 0.0)) == "inf ± 0.000e+00 [var=nan, R_hat=nan]"
     assert str(Stats(1.0, 0.0)) == "1.000e+00 ± 0.000e+00 [var=nan, R_hat=nan]"
+
+    assert str(Stats(1.0, 0.12, 0.5)) == "1.00 ± 0.12 [var=0.50, R_hat=nan]"

--- a/Test/Stats/test_stats.py
+++ b/Test/Stats/test_stats.py
@@ -141,14 +141,17 @@ def test_tau_corr():
 def test_decimal_format():
     from netket.stats import Stats
 
-    assert str(Stats(1.0, 1e-3)) == "1.0000 ± 0.0010 [var=nan, R_hat=nan]"
-    assert str(Stats(1.0, 1e-6)) == "1.0000000 ± 0.0000010 [var=nan, R_hat=nan]"
-    assert str(Stats(1.0, 1e-7)) == "1.000e+00 ± 1.000e-07 [var=nan, R_hat=nan]"
+    assert str(Stats(1.0, 1e-3)) == "1.0000 ± 0.0010 [var=nan]"
+    assert str(Stats(1.0, 1e-6)) == "1.0000000 ± 0.0000010 [var=nan]"
+    assert str(Stats(1.0, 1e-7)) == "1.000e+00 ± 1.000e-07 [var=nan]"
 
-    assert str(Stats(float("nan"), float("inf"))) == "nan ± inf [var=nan, R_hat=nan]"
-    assert str(Stats(1.0, float("nan"))) == "1.000e+00 ± nan [var=nan, R_hat=nan]"
-    assert str(Stats(1.0, float("inf"))) == "1.000e+00 ± inf [var=nan, R_hat=nan]"
-    assert str(Stats(float("inf"), 0.0)) == "inf ± 0.000e+00 [var=nan, R_hat=nan]"
-    assert str(Stats(1.0, 0.0)) == "1.000e+00 ± 0.000e+00 [var=nan, R_hat=nan]"
+    assert str(Stats(float("nan"), float("inf"))) == "nan ± inf [var=nan]"
+    assert str(Stats(1.0, float("nan"))) == "1.000e+00 ± nan [var=nan]"
+    assert str(Stats(1.0, float("inf"))) == "1.000e+00 ± inf [var=nan]"
+    assert str(Stats(float("inf"), 0.0)) == "inf ± 0.000e+00 [var=nan]"
+    assert str(Stats(1.0, 0.0)) == "1.000e+00 ± 0.000e+00 [var=nan]"
 
-    assert str(Stats(1.0, 0.12, 0.5)) == "1.00 ± 0.12 [var=0.50, R_hat=nan]"
+    assert str(Stats(1.0, 0.12, 0.5)) == "1.00 ± 0.12 [var=0.50]"
+    assert (
+        str(Stats(1.0, 0.12, 0.5, R_hat=1.01)) == "1.00 ± 0.12 [var=0.50, R_hat=1.0100]"
+    )

--- a/netket/stats/mc_stats.py
+++ b/netket/stats/mc_stats.py
@@ -8,15 +8,17 @@ from . import total_size as _total_size
 
 
 def _format_decimal(value, std):
-    if math.isfinite(std):
+    if math.isfinite(std) and std > 1e-7:
         decimals = max(int(_np.ceil(-_np.log10(std))), 0)
+        return (
+            "{0:.{1}f}".format(value, decimals + 1),
+            "{0:.{1}f}".format(std, decimals + 1),
+        )
     else:
-        decimals = 8
-
-    return (
-        "{0:.{1}f}".format(value, decimals),
-        "{0:.{1}f}".format(std, decimals + 1),
-    )
+        return (
+            "{0:.3e}".format(value),
+            "{0:.3e}".format(std),
+        )
 
 
 class Stats:

--- a/netket/stats/mc_stats.py
+++ b/netket/stats/mc_stats.py
@@ -49,10 +49,10 @@ class Stats:
     def __repr__(self):
         mean, err, var = _format_decimal(self.mean, self.error_of_mean, self.variance)
         if not math.isnan(self.R_hat):
-            ext = ", R_hat={:.4f}".format(self.R_hat)
+            ext = ", R̂={:.4f}".format(self.R_hat)
         else:
             ext = ""
-        return "{} ± {} [var={}{}]".format(mean, err, var, ext)
+        return "{} ± {} [σ²={}{}]".format(mean, err, var, ext)
 
     def __getitem__(self, name):
         if name in ("mean", "Mean"):

--- a/netket/stats/mc_stats.py
+++ b/netket/stats/mc_stats.py
@@ -48,7 +48,11 @@ class Stats:
 
     def __repr__(self):
         mean, err, var = _format_decimal(self.mean, self.error_of_mean, self.variance)
-        return "{} ± {} [var={}, R_hat={:.4f}]".format(mean, err, var, self.R_hat)
+        if not math.isnan(self.R_hat):
+            ext = ", R_hat={:.4f}".format(self.R_hat)
+        else:
+            ext = ""
+        return "{} ± {} [var={}{}]".format(mean, err, var, ext)
 
     def __getitem__(self, name):
         if name in ("mean", "Mean"):

--- a/netket/stats/mc_stats.py
+++ b/netket/stats/mc_stats.py
@@ -7,17 +7,19 @@ from . import var as _var
 from . import total_size as _total_size
 
 
-def _format_decimal(value, std):
+def _format_decimal(value, std, var):
     if math.isfinite(std) and std > 1e-7:
         decimals = max(int(_np.ceil(-_np.log10(std))), 0)
         return (
             "{0:.{1}f}".format(value, decimals + 1),
             "{0:.{1}f}".format(std, decimals + 1),
+            "{0:.{1}f}".format(var, decimals + 1),
         )
     else:
         return (
             "{0:.3e}".format(value),
             "{0:.3e}".format(std),
+            "{0:.3e}".format(var),
         )
 
 
@@ -45,10 +47,8 @@ class Stats:
         return jsd
 
     def __repr__(self):
-        mean, err = _format_decimal(self.mean, self.error_of_mean)
-        return "{} ± {} [var={:.1e}, R_hat={:.4f}]".format(
-            mean, err, self.variance, self.R_hat
-        )
+        mean, err, var = _format_decimal(self.mean, self.error_of_mean, self.variance)
+        return "{} ± {} [var={}, R_hat={:.4f}]".format(mean, err, var, self.R_hat)
 
     def __getitem__(self, name):
         if name in ("mean", "Mean"):


### PR DESCRIPTION
As observed in #459, the display issue in #460 also occurs when the error of mean is too small. With this PR, the decimal format is switched to scientific notation when the error is smaller than 1e-7, which makes the output more readable and also avoids this issue.

I've also added several other small changes to improve the output formatting since I was already making another PR here. (Using unicode such as `σ²` should be fine, we've already doing that with `±` for a while and this output is only meant for human consumption anyway).