### PR TITLE
Implement `__repr__` for various NetKet classes

### DIFF
--- a/netket/_vmc.py
+++ b/netket/_vmc.py
@@ -211,10 +211,10 @@ class Vmc(AbstractVariationalDriver):
         lines = [
             "{}: {}".format(name, info(obj, depth=depth + 1))
             for name, obj in [
-                ("Hamiltonian", self._ham),
-                ("Machine", self._machine),
-                ("Optimizer", self._optimizer),
-                ("SR solver", self._sr),
+                ("Hamiltonian ", self._ham),
+                ("Machine     ", self._machine),
+                ("Optimizer   ", self._optimizer),
+                ("SR solver   ", self._sr),
             ]
         ]
-        return "\n  ".join([str(self)] + lines)
+        return "\n{}".format(" " * 3 * (depth + 1)).join([str(self)] + lines)

--- a/netket/graph/graph.py
+++ b/netket/graph/graph.py
@@ -88,13 +88,18 @@ class NetworkX(AbstractGraph):
             self._automorphisms = _automorphisms
             return _automorphisms
 
+    def __repr__(self):
+        return "{}(n_nodes={})".format(
+            str(type(self)).split(".")[-1][:-2], self.n_nodes
+        )
 
-def Graph(nodes=[], edges=[]):
-    r"""A Custom Graph provided nodes or edges.
-    Constructs a Custom Graph given a list of nodes and edges.
-    Args:
-        nodes: A list of ints that index nodes of a graph
-        edges: A list of 2- or 3-tuples that denote an edge with an optional color
+
+class Graph(NetworkX):
+    r""" A Custom Graph provided nodes or edges.
+        Constructs a Custom Graph given a list of nodes and edges.
+        Args:
+            nodes: A list of ints that index nodes of a graph
+            edges: A list of 2- or 3-tuples that denote an edge with an optional color
 
     The Graph can be constructed specifying only the edges and the nodes will be deduced from the edges.
 
@@ -108,44 +113,46 @@ def Graph(nodes=[], edges=[]):
         10
 
     """
-    if not isinstance(nodes, list):
-        raise TypeError("nodes must be a list")
 
-    if not isinstance(edges, list):
-        raise TypeError("edges must be a list")
+    def __init__(self, nodes=[], edges=[]):
+        if not isinstance(nodes, list):
+            raise TypeError("nodes must be a list")
 
-    if edges:
-        type_condition = [
-            isinstance(edge, list) or isinstance(edge, tuple) for edge in edges
-        ]
-        if False in type_condition:
-            raise ValueError("edges must be a list of lists or tuples")
+        if not isinstance(edges, list):
+            raise TypeError("edges must be a list")
 
-        edges_array = _np.array(edges, dtype=_np.int32)
-        if edges_array.ndim != 2:
-            raise ValueError(
-                "edges must be a list of lists or tuples of the same length (2 or 3)"
-            )
+        if edges:
+            type_condition = [
+                isinstance(edge, list) or isinstance(edge, tuple) for edge in edges
+            ]
+            if False in type_condition:
+                raise ValueError("edges must be a list of lists or tuples")
 
-        if not (edges_array.shape[1] == 2 or edges_array.shape[1] == 3):
-            raise ValueError(
-                "edges must be a list of lists or tuples of the same length (2 or 3), where the third column indicates the color"
-            )
+            edges_array = _np.array(edges, dtype=_np.int32)
+            if edges_array.ndim != 2:
+                raise ValueError(
+                    "edges must be a list of lists or tuples of the same length (2 or 3)"
+                )
 
-    # Sort node names for ordering reasons:
-    if nodes:
-        node_names = sorted(nodes)
-    elif edges:
-        node_names = sorted(set((node for edge in edges_array for node in edge)))
+            if not (edges_array.shape[1] == 2 or edges_array.shape[1] == 3):
+                raise ValueError(
+                    "edges must be a list of lists or tuples of the same length (2 or 3), where the third column indicates the color"
+                )
 
-    graph = _nx.MultiGraph()
-    graph.add_nodes_from(node_names)
-    if edges:
-        graph.add_edges_from(edges_array)
-    return NetworkX(graph)
+        # Sort node names for ordering reasons:
+        if nodes:
+            node_names = sorted(nodes)
+        elif edges:
+            node_names = sorted(set((node for edge in edges_array for node in edge)))
+
+        graph = _nx.MultiGraph()
+        graph.add_nodes_from(node_names)
+        if edges:
+            graph.add_edges_from(edges_array)
+        super().__init__(graph)
 
 
-def Edgeless(nodes):
+class Edgeless(NetworkX):
     """A set graph (collection of unconnected vertices).
     Args:
         nodes: An integer number of nodes or a list of ints that index nodes of a graph
@@ -158,14 +165,17 @@ def Edgeless(nodes):
         >>> print(g.n_nodes)
         4
     """
-    if not isinstance(nodes, list):
-        if not isinstance(nodes, int):
-            raise TypeError("nodes must be either an integer or a list")
-        nodes = range(nodes)
 
-    edgelessgraph = _nx.MultiGraph()
-    edgelessgraph.add_nodes_from(nodes)
-    return NetworkX(edgelessgraph)
+    def __init__(self, nodes):
+        if not isinstance(nodes, list):
+            if not isinstance(nodes, int):
+                raise TypeError("nodes must be either an integer or a list")
+            nodes = range(nodes)
+
+        edgelessgraph = _nx.MultiGraph()
+        edgelessgraph.add_nodes_from(nodes)
+
+        super().__init__(edgelessgraph)
 
 
 def DoubledGraph(graph):

--- a/netket/graph/graph.py
+++ b/netket/graph/graph.py
@@ -95,7 +95,7 @@ class NetworkX(AbstractGraph):
 
 
 class Graph(NetworkX):
-    r""" A Custom Graph provided nodes or edges.
+    r"""A Custom Graph provided nodes or edges.
         Constructs a Custom Graph given a list of nodes and edges.
         Args:
             nodes: A list of ints that index nodes of a graph

--- a/netket/graph/grid.py
+++ b/netket/graph/grid.py
@@ -45,10 +45,16 @@ class Grid(NetworkX):
         if not isinstance(pbc, bool):
             raise TypeError("pbc must be a boolean")
 
+        self.length = length
+        self.pbc = pbc
+
         graph = _nx.generators.lattice.grid_graph(length, periodic=pbc)
         newnames = {old: new for new, old in enumerate(graph.nodes)}
         graph = _nx.relabel_nodes(graph, newnames)
         super().__init__(graph)
+
+    def __repr__(self):
+        return "Grid(length={}, pbc={})".format(self.length, self.pbc)
 
 
 def Hypercube(length, n_dim=1, pbc=True):

--- a/netket/graph/lattice.py
+++ b/netket/graph/lattice.py
@@ -166,6 +166,7 @@ class Lattice(NetworkX):
             self._pbc = pbc
 
         extent = _np.asarray(extent)
+        self.extent = extent
 
         atoms, cellANDlabel_to_site = create_points(
             self._basis_vectors, extent, atoms_coord_fractional, pbc
@@ -210,3 +211,8 @@ class Lattice(NetworkX):
 
     def vector_to_coord(self, vector):
         return _np.matmul(self._basis_vectors, vector)
+
+    def __repr__(self):
+        return "Lattice(n_nodes={})\n  extent={}\n  basis_vectors={}".format(
+            self.n_nodes, self.extent.tolist(), self.basis_vectors.tolist()
+        )

--- a/netket/hilbert/boson.py
+++ b/netket/hilbert/boson.py
@@ -136,3 +136,10 @@ class Boson(CustomHilbert):
     @jit(nopython=True)
     def _sum_constraint(x, n_bosons):
         return _np.sum(x, axis=1) == n_bosons
+
+    def __repr__(self):
+        nbosons = (
+            ", n_bosons={}".format(self._n_bosons) if self._n_bosons is not None else ""
+        )
+        nmax = self._n_max if self._n_max < _np.iinfo(_np.intp).max else "INT_MAX"
+        return "Boson(n_max={}{}; N={})".format(nmax, nbosons, self._size)

--- a/netket/hilbert/custom_hilbert.py
+++ b/netket/hilbert/custom_hilbert.py
@@ -205,3 +205,13 @@ class CustomHilbert(AbstractHilbert):
                     "The required state does not satisfy the given constraints."
                 )
             return found
+
+    def __repr__(self):
+        constr = (
+            ", #contraints={}".format(len(self._constraints))
+            if self._do_constraints
+            else ""
+        )
+        return "CustomHilbert(local_size={}{}; N={})".format(
+            len(self.local_states), constr, self.size
+        )

--- a/netket/hilbert/doubled_hilbert.py
+++ b/netket/hilbert/doubled_hilbert.py
@@ -118,3 +118,6 @@ class DoubledHilbert(AbstractHilbert):
         self.physical.random_state(out=out[n : 2 * n], rgen=rgen)
 
         return out
+
+    def __repr__(self):
+        return "DoubledHilbert({})".format(self.physical)

--- a/netket/hilbert/qubit.py
+++ b/netket/hilbert/qubit.py
@@ -28,3 +28,6 @@ class Qubit(CustomHilbert):
         if graph is None:
             graph = Edgeless(size)
         super().__init__(graph, [0, 1])
+
+    def __repr__(self):
+        return "Qubit(N={})".format(self._size)

--- a/netket/hilbert/spin.py
+++ b/netket/hilbert/spin.py
@@ -1,5 +1,7 @@
 from .custom_hilbert import CustomHilbert
 
+from fractions import Fraction
+
 import numpy as _np
 from netket import random as _random
 from numba import jit
@@ -120,3 +122,9 @@ class Spin(CustomHilbert):
             raise Exception(
                 "Cannot fix the total magnetization: Nspins + " "totalSz must be even."
             )
+
+    def __repr__(self):
+        total_sz = (
+            ", total_sz={}".format(self._total_sz) if self._total_sz is not None else ""
+        )
+        return "Spin(s={}{}; N={})".format(Fraction(self._s), total_sz, self._size)

--- a/netket/machine/abstract_machine.py
+++ b/netket/machine/abstract_machine.py
@@ -236,3 +236,11 @@ class AbstractMachine(abc.ABC):
     @property
     def input_size(self):
         return self.hilbert.size
+
+    def __repr__(self):
+        return "{}(input_size={}, n_par={}, complex_parameters={})".format(
+            type(self).__name__,
+            self.input_size,
+            self.n_par,
+            self.has_complex_parameters,
+        )

--- a/netket/machine/torch.py
+++ b/netket/machine/torch.py
@@ -191,6 +191,11 @@ class Torch(AbstractMachine):
             [(k, v.detach().numpy()) for k, v in self._module.state_dict().items()]
         )
 
+    def __repr__(self):
+        head = super().__repr__()
+        module = "\n│  ".join([""] + repr(self._module).split("\n"))
+        return head + module + "\n└"
+
 
 class TorchLogCosh(_torch.nn.Module):
     """

--- a/netket/optimizer/numpy/sgd.py
+++ b/netket/optimizer/numpy/sgd.py
@@ -25,9 +25,12 @@ class Sgd(AbstractOptimizer):
         self._eta = self._learning_rate
 
     def __repr__(self):
-        rep = "Sgd optimizer with these parameters :"
-        rep += "\nLearning Rate = " + str(self._learning_rate)
-        rep += "\nCurrent learning Rate = " + str(self._eta)
-        rep += "\nL2 Regularization = " + str(self._l2reg)
-        rep += "\nDecay Factor = " + str(self._decay_factor)
-        return rep
+        if self._learning_rate != self._eta:
+            lr = "learning_rate[base]={}, learning_rate[current]={}".format(
+                self._learning_rate, self._eta
+            )
+        else:
+            lr = "learning_rate={}".format(self._learning_rate)
+        return ("Sgd({}, l2reg={}, decay_factor={})").format(
+            lr, self._l2reg, self._decay_factor
+        )

--- a/netket/optimizer/numpy/stochastic_reconfiguration.py
+++ b/netket/optimizer/numpy/stochastic_reconfiguration.py
@@ -281,30 +281,13 @@ class SR:
         rep = "SR(solver="
 
         if self._use_iterative:
-            rep += "iterative"
+            rep += "iterative:CG"
         else:
             rep += self._lsq_solver + ", diag_shift=" + str(self._diag_shift)
             if self._svd_threshold is not None:
                 rep += ", threshold=" << self._svd_threshold
 
         rep += ", has_complex_parameters=" + str(self._has_complex_parameters) + ")"
-        return rep
-
-    def info(self, depth=0):
-        indent = " " * 4 * depth
-        rep = indent
-        rep += "Stochastic reconfiguration method for "
-        rep += "holomorphic" if self._has_complex_parameters else "real-parameter"
-        rep += " wavefunctions\n"
-
-        rep += indent + "Solver: "
-
-        if self._use_iterative:
-            rep += "iterative (Conjugate Gradient)"
-        else:
-            rep += self._lsq_solver
-        rep += "\n"
-
         return rep
 
     def _linear_operator(self, oks, n_samp):


### PR DESCRIPTION
This PR implements `__repr__` for graphs, hilbert spaces, and machines, which makes it more comfortable to work with NetKet objects interactively.

For example:

**before:**
```python
>>> g = nk.graph.Hypercube(8, 2)
>>> g
<netket.graph.grid.Grid at 0x7f143c7eb070>
```
**after:**
```python
>>> g = nk.graph.Hypercube(8, 2)
>>> g
Grid(length=[8, 8], pbc=True)
```
Similarly for Hilbert spaces
```python
>>> hi = nk.hilbert.Spin(g, 1/2)
>>> hi
Spin(s=1/2; N=64)
```
or machines:
```python
>>> tnn = torch.nn.Sequential(torch.nn.Linear(64, 128), torch.nn.Tanh(), torch.nn.Linear(128, 2))
>>> nk.machine.Torch(tnn, hi)
Torch(input_size=64, n_par=8578, complex_parameters=False)
│  Sequential(
│    (0): Linear(in_features=64, out_features=128, bias=True)
│    (1): Tanh()
│    (2): Linear(in_features=128, out_features=2, bias=True)
│  )
└
```

This also vastly improves the utility of printing `vmc.info`:
```python
>>> print(vmc.info())                                                      
Vmc(step_count=0, n_samples=1008, n_discard=100)
   Hamiltonian : <netket.operator._hamiltonian.Ising object at 0x7fdc983d2460>
   Machine     : RbmSpin(input_size=64, n_par=131, complex_parameters=True)
   Optimizer   : Sgd(learning_rate=0.01, l2reg=0, decay_factor=1.0)
   SR solver   : SR(solver=iterative:CG, has_complex_parameters=True)
```
(As you can see, some things such as operators are still missing, but those can easily be added in a later PR.)

Let me know what you think.