### PR TITLE
Remove workaround for flushing jax queue

### DIFF
--- a/netket/optimizer/jax/wrap.py
+++ b/netket/optimizer/jax/wrap.py
@@ -35,10 +35,6 @@ class Wrap(AbstractOptimizer):
         self._step += 1
         pars = self._params_fun(self._opt_state)
 
-        # Force jax to execute all buffered operations, so that pending MPI operations on all
-        # ranks are executed. Otherwise it is possible that only rank0 executed
-        tree_map(lambda x: x.block_until_ready(), pars)
-
         return pars
 
     def reset(self):

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,6 @@ setup(
     python_requires=">=3.6",
     extras_require={
         "dev": ["pytest", "python-igraph", "pre-commit", "black==20.8b1"],
-        "jax": ["jax", "mpi4jax>=0.2.5"],
+        "jax": ["jax", "mpi4jax>=0.2.6"],
     },
 )


### PR DESCRIPTION
Following [mpi4jax#25](https://github.com/PhilipVinc/mpi4jax/pull/25) mpi4jax automatically flushes jax queues at exit, so we don't need the workaround anymore in netket itself
.
The same mechanism will be used to flush GPU operation queues in the future.