### PR TITLE
Add options for mixed PBC/OBC and direction-colored edges to Grid

### DIFF
--- a/Test/Graph/test_graph.py
+++ b/Test/Graph/test_graph.py
@@ -5,11 +5,15 @@ import math
 
 from netket.graph import *
 
+import pytest
+
 nxg = nx.star_graph(10)
 graphs = [
     Hypercube(length=10, n_dim=1, pbc=True),
     Hypercube(length=4, n_dim=2, pbc=True),
     Hypercube(length=5, n_dim=1, pbc=False),
+    Grid(length=[2, 2], pbc=False),
+    Grid(length=[4, 2], pbc=[True, False]),
     Graph(edges=list(nxg.edges())),
     Lattice(
         basis_vectors=[[1.0, 0.0], [1.0 / 2.0, math.sqrt(3) / 2.0]],
@@ -189,6 +193,32 @@ def test_adjacency_list():
 
         for i in range(dim):
             assert set(adl[i]) in neigh
+
+
+def test_grid_color_pbc():
+    g = Grid([4, 4], pbc=True, color_edges=True)
+    assert len(g.edges(color=0)) == 16
+    assert len(g.edges(color=1)) == 16
+    assert len(g.edges()) == 32
+
+    g = Grid([4, 2], pbc=True, color_edges=True)
+    assert len(g.edges(color=0)) == 8
+    assert len(g.edges(color=1)) == 4
+
+    g = Grid([4, 2], pbc=False, color_edges=True)
+    assert len(g.edges(color=0)) == 6
+    assert len(g.edges(color=1)) == 4
+
+    with pytest.raises(ValueError, match="Directions with length <= 2 cannot have PBC"):
+        g = Grid([2, 4], pbc=[True, True])
+
+    g1 = Grid([7, 5], pbc=False)
+    g2 = Grid([7, 5], pbc=[False, False])
+    assert sorted(g1.edges()) == sorted(g2.edges())
+
+    g1 = Grid([7, 5], pbc=True)
+    g2 = Grid([7, 5], pbc=[True, True])
+    assert sorted(g1.edges()) == sorted(g2.edges())
 
 
 def test_automorphisms():

--- a/netket/graph/graph.py
+++ b/netket/graph/graph.py
@@ -65,11 +65,8 @@ class NetworkX(AbstractGraph):
         #       be a duplicated edge with two different colors.
 
         # For the moment, if there are colors, the method returns a NotImplementedError:
-        if self.edges():
-            colors = _np.unique(_np.array(self.edges(color=True))[:, 2])
-        else:
-            colors = _np.array([])
-        if colors.size >= 2:
+        colors = set(c for _, _, c in self.edges(color=True))
+        if len(colors) >= 2:
             raise NotImplementedError(
                 "automorphisms is not yet implemented for colored edges"
             )
@@ -152,6 +149,8 @@ class Graph(NetworkX):
             if edges_array.shape[1] == 3:  # edges with color
                 colors = {tuple(e): e[-1] for e in edges}
                 _nx.set_edge_attributes(graph, colors, name="color")
+            else:  # only one color
+                _nx.set_edge_attributes(graph, 0, name="color")
         super().__init__(graph)
 
 

--- a/netket/graph/graph.py
+++ b/netket/graph/graph.py
@@ -44,11 +44,11 @@ class NetworkX(AbstractGraph):
 
     def edges(self, color=False):
         if color is True:
-            return list(self.graph.edges(keys=True))
+            return list(self.graph.edges(data="color"))
         elif color is not False:
-            return [(u, v) for u, v, k in self.graph.edges if k == color]
-        else:
-            return list(self.graph.edges(keys=False))
+            return [(u, v) for u, v, k in self.graph.edges(data="color") if k == color]
+        else:  # color is False
+            return list(self.graph.edges())
 
     def distances(self):
         return _nx.floyd_warshall_numpy(self.graph).tolist()
@@ -149,6 +149,9 @@ class Graph(NetworkX):
         graph.add_nodes_from(node_names)
         if edges:
             graph.add_edges_from(edges_array)
+            if edges_array.shape[1] == 3:  # edges with color
+                colors = {tuple(e): e[-1] for e in edges}
+                _nx.set_edge_attributes(graph, colors, name="color")
         super().__init__(graph)
 
 

--- a/netket/graph/grid.py
+++ b/netket/graph/grid.py
@@ -83,6 +83,8 @@ class Grid(NetworkX):
                 color = int(_np.argwhere(diff[::-1] != 0))
                 edges[e] = color
             _nx.set_edge_attributes(graph, edges, name="color")
+        else:
+            _nx.set_edge_attributes(graph, 0, name="color")
 
         newnames = {old: new for new, old in enumerate(graph.nodes)}
         graph = _nx.relabel_nodes(graph, newnames)

--- a/netket/graph/grid.py
+++ b/netket/graph/grid.py
@@ -8,17 +8,18 @@ class Grid(NetworkX):
     r"""A Grid lattice of d dimensions, and possibly different sizes of each dimension.
     Periodic boundary conditions can also be imposed"""
 
-    def __init__(self, length, pbc=True):
+    def __init__(self, length, pbc=True, color_edges=False):
         """
         Constructs a new `Grid` given its length vector.
 
         Args:
             length: Side length of the Grid. It must be a list with integer components >= 1.
             pbc: If `True`, the grid will have periodic boundary conditions (PBC);
-            if `False`, the grid will have open boundary conditions (OBC).
-            This parameter can also be a list of booleans with same length as 
-            the parameter `length`, in which case each dimension will have
-            PBC/OBC depending on the corresponding entry of `pbc`.
+                if `False`, the grid will have open boundary conditions (OBC).
+                This parameter can also be a list of booleans with same length as
+                the parameter `length`, in which case each dimension will have
+                PBC/OBC depending on the corresponding entry of `pbc`.
+            color_edges: If `True`, the edges will be colored by their grid direction.
         Examples:
             A 5x10 lattice with periodic boundary conditions can be
             constructed as follows:
@@ -72,6 +73,16 @@ class Grid(NetworkX):
                     v1, v2 = sorted([e[0][i], e[1][i]])
                     if v1 == 0 and v2 == l - 1 and not is_per:
                         graph.remove_edge(*e)
+
+        if color_edges:
+            edges = {}
+            for e in graph.edges:
+                # color is the first (and only) dimension in which
+                # the edge coordinates differ
+                diff = _np.array(e[0]) - _np.array(e[1])
+                color = int(_np.argwhere(diff[::-1] != 0))
+                edges[e] = color
+            _nx.set_edge_attributes(graph, edges, name="color")
 
         newnames = {old: new for new, old in enumerate(graph.nodes)}
         graph = _nx.relabel_nodes(graph, newnames)

--- a/netket/graph/grid.py
+++ b/netket/graph/grid.py
@@ -10,13 +10,15 @@ class Grid(NetworkX):
 
     def __init__(self, length, pbc=True):
         """
-        Constructs a new ``Grid`` given its length vector.
+        Constructs a new `Grid` given its length vector.
 
         Args:
             length: Side length of the Grid. It must be a list with integer components >= 1.
-            pbc: If ``True```then the constructed Grid will have
-                periodic boundary conditions, otherwise open boundary conditions
-                are imposed.
+            pbc: If `True`, the grid will have periodic boundary conditions (PBC);
+            if `False`, the grid will have open boundary conditions (OBC).
+            This parameter can also be a list of booleans with same length as 
+            the parameter `length`, in which case each dimension will have
+            PBC/OBC depending on the corresponding entry of `pbc`.
         Examples:
             A 5x10 lattice with periodic boundary conditions can be
             constructed as follows:
@@ -42,15 +44,38 @@ class Grid(NetworkX):
         except TypeError:
             raise ValueError("Components of length must be integers greater than 1")
 
-        if not isinstance(pbc, bool):
-            raise TypeError("pbc must be a boolean")
+        if not (isinstance(pbc, bool) or isinstance(pbc, list)):
+            raise TypeError("pbc must be a boolean or list")
+        if isinstance(pbc, list):
+            if len(pbc) != len(length):
+                raise ValueError("len(pbc) must be equal to len(length)")
+            for l, p in zip(length, pbc):
+                if l <= 2 and p:
+                    raise ValueError("Directions with length <= 2 cannot have PBC")
+            periodic = any(pbc)
+        else:
+            periodic = pbc
 
         self.length = length
         self.pbc = pbc
 
-        graph = _nx.generators.lattice.grid_graph(length, periodic=pbc)
+        graph = _nx.generators.lattice.grid_graph(length, periodic=periodic)
+
+        # Remove unwanted periodic edges:
+        if isinstance(pbc, list) and periodic:
+            for e in graph.edges:
+                for i, (l, is_per) in enumerate(zip(length[::-1], pbc[::-1])):
+                    if l <= 2:
+                        # Do not remove for short directions, because there is
+                        # only one edge in that case.
+                        continue
+                    v1, v2 = sorted([e[0][i], e[1][i]])
+                    if v1 == 0 and v2 == l - 1 and not is_per:
+                        graph.remove_edge(*e)
+
         newnames = {old: new for new, old in enumerate(graph.nodes)}
         graph = _nx.relabel_nodes(graph, newnames)
+
         super().__init__(graph)
 
     def __repr__(self):


### PR DESCRIPTION
This PR extends `Grid` to support mixed boundary conditions by passing a list of booleans to `pbc=`. It also adds an option to color the edges by direction in order to make it easier to define anisotropic models.

```python
Grid(length=[8, 8], pbc=[True, False])  # cylinder
Grid(length=[8, 8], color_edges=True)   # differently colored x/y edges
```

Under the hood, this PR also changes how the color is stored in `NetworkX` graphs: Previously, it was stored as the _key_ of an edge, which is a `networkx.MultiGraph`-feature meant to distinguish multiple edges between the same node. Now, I use an extra attribute `"color"` on each edge. This makes the implementation easier (attributes can be added and changed more easily than edge keys) and could allow us to use normal graphs where a multigraph is not needed in the future.