### PR TITLE
Fix jax 0.2 bug

### DIFF
--- a/.github/workflows/formatting_check.yml
+++ b/.github/workflows/formatting_check.yml
@@ -19,10 +19,15 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
-      # Formats the code to with black
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Pip install python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -v black==20.8b1
+
       - name: Black Code Formatter
-        # You may pin to the exact commit or the version.
-        # uses: lgeiger/black-action@4379f39aa4b6a3bb1cceb46a7665b9c26647d82d
-        uses: lgeiger/black-action@v1.0.1
-        with: 
-          args:  . --check --verbose
+        run: black --check --diff --color .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: stable
+    rev: 20.8b1
     hooks:
       - id: black
-        language_version: python3.8
+        language_version: python3

--- a/Test/Machine/test_machine.py
+++ b/Test/Machine/test_machine.py
@@ -6,7 +6,7 @@ from pytest import approx
 import os
 from netket.hilbert import Spin
 
-test_jax = True
+test_jax = nk.utils.jax_available
 try:
     import torch
 

--- a/Test/Operator/test_der_local_operator.py
+++ b/Test/Operator/test_der_local_operator.py
@@ -22,7 +22,7 @@ import pytest
 from pytest import approx
 import os
 
-test_jax = True
+test_jax = nk.utils.jax_available
 
 np.set_printoptions(linewidth=180)
 

--- a/netket/sampler/jax/metropolis_hastings.py
+++ b/netket/sampler/jax/metropolis_hastings.py
@@ -36,7 +36,6 @@ class MetropolisHastings(AbstractSampler):
         machine_pow,
         rng_key,
     ):
-        @jax.jit
         def one_step(i, walker):
             key, state, log_prob = walker
 
@@ -54,13 +53,11 @@ class MetropolisHastings(AbstractSampler):
 
             return (keys[0], state, log_prob)
 
-        @jax.jit
         def one_sweep(walker, i):
             key, state, log_prob = walker
             walker = jax.lax.fori_loop(0, sweep_size, one_step, (key, state, log_prob))
             return walker, walker[1]
 
-        @jax.jit
         def single_chain_kernel(key, state):
             log_prob = machine_pow * logpdf(params, state).real
             walker, samples = jax.lax.scan(


### PR DESCRIPTION
Jax recently released v0.2, which enables new cool omnistaging stuff but it broke this code for some reason.

I think the double jitting was confusing a bit jax.

This should not affect performance, as the external block is jitted anyway, and it's backward compatible.