### PR TITLE
[RFC] Make MPI an Optional dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,24 @@ Those are not hard dependencies of netket, therefore they must be installed sepa
 To avoid potential bugs, we suggest to install those libraries using the same tool that you
 used for netket (pip or conda).
 
+### MPI Support
 Depending on the library you use to define your machines, distributed computing through MPI might
 or might not be supported. Please see below:
-  - **netket** : MPI is supported natively. No additional dependencies required.
-  - **jax**    : MPI is supported natively only if you don't use Stochastic Reconfiguration (SR). If you need SR, you must install [mpi4jax](https://github.com/PhilipVinc/mpi4jax). Please note that we advise to install mpi4jax  with the same tool (conda or pip) with which you installed netket.
-  - **pytorch** : MPI is supported natively only if you don't use Stochastic Reconfiguration (SR).
+  - **netket** : distributed computing through MPI support can be enabled by installing the package `mpi4py` through pip or conda.
+  - **jax**    : distributed computing through MPI is supported natively only if you don't use Stochastic Reconfiguration (SR). If you need SR, you must install [mpi4jax](https://github.com/PhilipVinc/mpi4jax). Please note that we advise to install mpi4jax  with the same tool (conda or pip) with which you installed netket.
+  - **pytorch** : distributed computing through MPI is enabled if the package `mpi4py` is isntalled. Stochastic Reconfiguration (SR) cannot be used when MPI is enabled. 
+
+To check whever MPI support is enabled, check the flags 
+```python
+# For standard MPI support
+>>> netket.utils.mpi_available
+True
+
+# For faster MPI support with jax and to enable SR + MPI with Jax machines
+>>> netket.utils.mpi4jax_available
+True
+
+```
 
 ## Major Features
 

--- a/README.md
+++ b/README.md
@@ -25,19 +25,37 @@ It is a Python library built on C++ primitives.
 - **Source code:** <https://github.com/netket/netket>
 
 ## Installation and Usage
-You can install on osx or linux with either
- - *pip*   : `pip install netket`
- - *conda* : `conda install conda-forge::netket`
+Netket supports MacOS and Linux. The reccomended way to install it in a non-conda python environment is: 
+```
+pip install netket[all]
+``` 
+The `[all]` after netket will install all extra dependencies of netket. 
+We reccomend to install netket with all it's extra dependencies, which are documented below. 
+However, if you do not have a working MPI compiler in your PATH this installation will most likely fail because
+it will attempt to install `mpi4py`, which enables MPI support in netket.
+If you are only starting to discover netket and won't be running extended simulations, you can forego MPI by 
+installing netket with the command
+```
+pip install netket # or pip install netket[jax] 
+```
 
+Netket is also available on conda-forge. To install netket in a conda-environment you can use:
+```
+conda install conda-forge::netket
+```
 Conda by default ships pre-built binaries for recent versions of python.
-The default blas library is openblas, but mkl can be enforced.
+The default blas library is openblas, but mkl can be enforced. 
+The conda library is linked to anaconda's `mpi4py`, therefore we do not reccomend to use this installation
+method on computer clusters with a custom MPI distribution.
 
-To learn more, check out the website or the examples.
+### Extra dependencies
+When installing netket with pip, you can pass the following extra variants as square brakets. You can install several of them by separating them with a comma.
+ - '[dev]': installs development-related dependencies such as black, pytest and testing dependencies
+ - '[mpi]': Installs `mpi4py` to enable multi-process parallelism. Requires a working MPI compiler in your path
+ - '[jax]': Installs `jax` to enable jax-based neural networks
+ - '[all]': Installs `mpi`, `jax` and `mpi4jax` which is required to use mpi with jax machines.
 
 Since version 3, in addition to the built-in machines, you can also use [Jax](https://github.com/google/jax) and [PyTorch](https://pytorch.org) to define your custom neural networks.
-Those are not hard dependencies of netket, therefore they must be installed separately.
-To avoid potential bugs, we suggest to install those libraries using the same tool that you
-used for netket (pip or conda).
 
 ### MPI Support
 Depending on the library you use to define your machines, distributed computing through MPI might

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ black = { version = "^18.3-alpha.0", python = "^3.6" }
 pre-commit = ">= 2.7"
 pytest = ">= 5"
 
-
 [build-system]
 requires = ["setuptools", "wheel"]
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,10 @@
 from setuptools import setup, find_packages
 
+DEV_DEPENDENCIES = ["pytest>=5", "python-igraph", "pre-commit", "black==20.8b1"]
+MPI_DEPENDENCIES = ["mpi4py>=3.0.1"]
+JAX_DEPENDENCIES = ["jax"]
+
+MPIJAX_DEPENDENCIES = ["mpi4jax>=0.2.6"]
 
 setup(
     name="netket",
@@ -21,8 +26,12 @@ setup(
     ],
     python_requires=">=3.6",
     extras_require={
-        "dev": ["pytest", "python-igraph", "pre-commit", "black==20.8b1"],
-        "jax": ["jax"],
-        "mpi": ["mpi4py>=3.0.1"],
+        "dev": DEV_DEPENDENCIES,
+        "mpi": MPI_DEPENDENCIES,
+        "jax": JAX_DEPENDENCIES,
+        "all": DEV_DEPENDENCIES
+        + MPI_DEPENDENCIES
+        + JAX_DEPENDENCIES
+        + MPIJAX_DEPENDENCIES,
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
-from setuptools import setup
+from setuptools import setup, find_packages
+
 
 setup(
     name="netket",
@@ -7,29 +8,13 @@ setup(
     url="http://github.com/netket/netket",
     author_email="netket@netket.org",
     license="Apache 2.0",
-    packages=[
-        "netket",
-        "netket.graph",
-        "netket.hilbert",
-        "netket.logging",
-        "netket.callbacks",
-        "netket.machine",
-        "netket.machine.density_matrix",
-        "netket.sampler",
-        "netket.sampler.numpy",
-        "netket.sampler.jax",
-        "netket.stats",
-        "netket.operator",
-        "netket.optimizer",
-        "netket.optimizer.numpy",
-        "netket.optimizer.jax",
-    ],
+    packages=find_packages(),
     long_description="""NetKet is an open - source project delivering cutting - edge
          methods for the study of many - body quantum systems with artificial
          neural networks and machine learning techniques.""",
     install_requires=[
         "numpy>=1.16",
-        "scipy>=1.2.1",
+        "scipy>=1.5.2",
         "tqdm>=4.42.1",
         "numba>=0.49.0",
         "networkx>=2.4",
@@ -37,6 +22,7 @@ setup(
     python_requires=">=3.6",
     extras_require={
         "dev": ["pytest", "python-igraph", "pre-commit", "black==20.8b1"],
-        "jax": ["jax", "mpi4jax>=0.2.6"],
+        "jax": ["jax"],
+        "mpi": ["mpi4py>=3.0.1"],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ setup(
     install_requires=[
         "numpy>=1.16",
         "scipy>=1.2.1",
-        "mpi4py>=3.0.1",
         "tqdm>=4.42.1",
         "numba>=0.49.0",
         "networkx>=2.4",

--- a/setup.py
+++ b/setup.py
@@ -29,9 +29,6 @@ setup(
         "dev": DEV_DEPENDENCIES,
         "mpi": MPI_DEPENDENCIES,
         "jax": JAX_DEPENDENCIES,
-        "all": DEV_DEPENDENCIES
-        + MPI_DEPENDENCIES
-        + JAX_DEPENDENCIES
-        + MPIJAX_DEPENDENCIES,
+        "all": MPI_DEPENDENCIES + JAX_DEPENDENCIES + MPIJAX_DEPENDENCIES,
     },
 )


### PR DESCRIPTION
We could argue that MPI is necessary to achieve high performance with netket, but people trying out the library for the first time, or students, possibly don't have MPI installed.

As it's not trivial to install it if you don't have admin access to your machine, or if you have an old distro (on linux), making it optional might go a long way to help them meet netket.

This PR has no functional change, as I had already made mpi4py an optional dependency long ago.
However, while on mac it is possible to install mpi4py even without mpicc compiler (though you can't load it), on linux you cannot install mpi4py without the right compilers...

What this PR does is simply remove mpi4py from the direct dependencies of netket, and slightly reword the readme in order to say that if MPI is not installed, then it won't be used.

Still, i should add a check for mpi version>=3. in the init code. 

Please let me know if you think this is a good idea or not.