### PR TITLE
Simplify netket.graph

### DIFF
--- a/Test/Graph/test_graph.py
+++ b/Test/Graph/test_graph.py
@@ -91,6 +91,17 @@ def check_edges(length, n_dim, pbc):
     assert x_edges == y_edges
 
 
+def test_graph_wrong():
+    with pytest.raises(TypeError):
+        nk.graph.Graph(5)
+
+    with pytest.raises(TypeError):
+        nk.graph.Graph([1, 2, 3], True)
+
+    with pytest.raises(ValueError):
+        nk.graph.Graph([1, 2, 3], [1, 2, 3])
+
+
 def test_edges_are_correct():
     check_edges(1, 1, False)
     check_edges(1, 2, False)

--- a/Test/Graph/test_graph.py
+++ b/Test/Graph/test_graph.py
@@ -241,3 +241,13 @@ def test_automorphisms():
 #     g = Hypercube(4, 1)
 #
 #     assert [(i, j, 0) for (i, j, _) in edges] == sorted(g.edge_colors)
+
+
+def test_union():
+    graph1 = lattices[0]
+
+    for graph in lattices:
+        ug = nk.graph.disjoint_union(graph, graph1)
+
+        assert ug.n_nodes == graph1.n_nodes + graph.n_nodes
+        assert len(ug.edges()) == len(graph1.edges()) + len(graph.edges())

--- a/netket/graph/graph.py
+++ b/netket/graph/graph.py
@@ -194,3 +194,18 @@ def DoubledGraph(graph):
     dedges += [(edge[0] + n_v, edge[1] + n_v) for edge in graph.edges()]
 
     return Graph(edges=dedges)
+
+
+def disjoint_union(graph_1, graph_2):
+    """
+    disjoint_union(graph_1, graph_2)
+
+    Args:
+        graph_1: a NetworkX graph
+        graph_2: a NetworkX graph
+
+    Returns:
+        The Disjoint union of the two graphs. See NetworkX documentation for more informations.
+    """
+    union_graph = _nx.disjoint_union(graph_1.graph, graph_2.graph)
+    return NetworkX(union_graph)


### PR DESCRIPTION
As Edgeless and Graph where simply wrappers around the base class NetworkX with a custom constructor.
I implemented them as simple functions that create a NetworkX graph instead of full fledged-classes. 

I also added a function to perform the disjoint union of two graphs, which might come in handy in the future, and it's test.