### PR TITLE
Compatibility with upcoming numba

### DIFF
--- a/netket/random.py
+++ b/netket/random.py
@@ -17,7 +17,7 @@ def seed(seed=None):
 
     """
 
-    if seed is None:
+    if seed == None:
         seed = _np.random.randint(0, 1 << 32)
 
     _np.random.seed(seed)


### PR DESCRIPTION
The next version of numba (0.51) will remove support for python's `is` operation, and retain only equality testing with None.
Without this netket won't load.