### PR TITLE
Remove `EdResult` and streamline ED interface

### DIFF
--- a/Examples/AKLT/AKLT_ed.py
+++ b/Examples/AKLT/AKLT_ed.py
@@ -45,16 +45,16 @@ g = nk.graph.Hypercube(length=10, n_dim=1, pbc=True)
 hi = nk.hilbert.Spin(s=1, graph=g)
 
 # AKLT model Hamiltonian as graph
-ha = nk.operator.GraphOperator(hilbert=hi, bondops=[P2_AKLT.tolist()])
+ha = nk.operator.GraphOperator(hilbert=hi, bond_ops=[P2_AKLT.tolist()])
 
 # Perform Lanczos Exact Diagonalization to get lowest three eigenvalues
-res = nk.exact.lanczos_ed(ha, first_n=3, compute_eigenvectors=True)
+w, v = nk.exact.lanczos_ed(ha, k=3, compute_eigenvectors=True)
 
 # Print eigenvalues
-print("eigenvalues:", res.eigenvalues)
+print("eigenvalues:", w)
 
 # Compute energy of ground state
-print("ground state energy:", res.mean(ha, 0))
+print("ground state energy:", np.vdot(v[:, 0], ha(v[:, 0])).real)
 
 # Compute energy of first excited state
-print("first excited energy:", res.mean(ha, 1))
+print("first excited energy:", np.vdot(v[:, 1], ha(v[:, 1])).real)

--- a/Test/GroundState/test_groundstate.py
+++ b/Test/GroundState/test_groundstate.py
@@ -164,37 +164,40 @@ def test_imag_time_propagation():
 
 def test_ed():
     first_n = 3
-    g = nk.graph.Hypercube(length=8, n_dim=1, pbc=True)
-    hi = nk.hilbert.Spin(s=0.5, graph=g)
+    g = nk.graph.Chain(8)
+    hi = nk.hilbert.Spin(s=1 / 2, graph=g)
     ha = nk.operator.Ising(h=1.0, hilbert=hi)
 
+    def expval(op, v):
+        return np.vdot(v, op(v))
+
     # Test Lanczos ED with eigenvectors
-    res = nk.exact.lanczos_ed(ha, first_n=first_n, compute_eigenvectors=True)
-    assert len(res.eigenvalues) == first_n
-    assert len(res.eigenvectors) == first_n
-    gse = res.mean(ha, 0)
-    fse = res.mean(ha, 1)
-    assert gse == approx(res.eigenvalues[0], rel=1e-12, abs=1e-12)
-    assert fse == approx(res.eigenvalues[1], rel=1e-12, abs=1e-12)
+    w, v = nk.exact.lanczos_ed(ha, k=first_n, compute_eigenvectors=True)
+    assert w.shape == (first_n,)
+    assert v.shape == (hi.n_states, first_n)
+    gse = expval(ha, v[:, 0])
+    fse = expval(ha, v[:, 1])
+    assert gse == approx(w[0], rel=1e-14, abs=1e-14)
+    assert fse == approx(w[1], rel=1e-14, abs=1e-14)
 
     # Test Lanczos ED without eigenvectors
-    res = nk.exact.lanczos_ed(ha, first_n=first_n, compute_eigenvectors=False)
-    assert len(res.eigenvalues) == first_n
-    assert len(res.eigenvectors) == 0
+    w = nk.exact.lanczos_ed(ha, k=first_n, compute_eigenvectors=False)
+    assert w.shape == (first_n,)
 
     # Test Full ED with eigenvectors
-    res = nk.exact.full_ed(ha, compute_eigenvectors=True)
-    assert len(res.eigenvalues) == hi.n_states
-    assert len(res.eigenvectors) == hi.n_states
-    gse = res.mean(ha, 0)
-    fse = res.mean(ha, 1)
-
-    assert gse == approx(res.eigenvalues[0], rel=1e-12, abs=1e-12)
-    assert fse == approx(res.eigenvalues[1], rel=1e-12, abs=1e-12)
+    w_full, v_full = nk.exact.full_ed(ha, compute_eigenvectors=True)
+    assert w_full.shape == (hi.n_states,)
+    assert v_full.shape == (hi.n_states, hi.n_states)
+    gse = expval(ha, v_full[:, 0])
+    fse = expval(ha, v_full[:, 1])
+    assert gse == approx(w_full[0], rel=1e-14, abs=1e-14)
+    assert fse == approx(w_full[1], rel=1e-14, abs=1e-14)
+    assert w == approx(w_full[:3], rel=1e-14, abs=1e-14)
 
     # Test Full ED without eigenvectors
-    res = nk.exact.full_ed(ha, compute_eigenvectors=False)
-    assert len(res.eigenvectors) == 0
+    w_full = nk.exact.full_ed(ha, compute_eigenvectors=False)
+    assert w_full.shape == (hi.n_states,)
+    assert w == approx(w_full[:3], rel=1e-14, abs=1e-14)
 
 
 def test_ed_restricted():
@@ -208,10 +211,10 @@ def test_ed_restricted():
     assert ham1.to_linear_operator().shape == (70, 70)
     assert ham2.to_linear_operator().shape == (256, 256)
 
-    r1 = nk.exact.lanczos_ed(ham1, compute_eigenvectors=True)
-    r2 = nk.exact.lanczos_ed(ham2, compute_eigenvectors=True)
+    w1, v1 = nk.exact.lanczos_ed(ham1, compute_eigenvectors=True)
+    w2, v2 = nk.exact.lanczos_ed(ham2, compute_eigenvectors=True)
 
-    assert r1.eigenvalues[0] == approx(r2.eigenvalues[0])
+    assert w1[0] == approx(w2[0])
 
     def overlap(phi, psi):
         bare_overlap = np.abs(np.vdot(phi, psi)) ** 2
@@ -219,5 +222,5 @@ def test_ed_restricted():
 
     # Non-zero elements of ground state in full Hilbert space should equal the ground
     # state in the constrained Hilbert space
-    idx_nonzero = np.abs(r2.eigenvectors[0]) > 1e-4
-    assert overlap(r1.eigenvectors[0], r2.eigenvectors[0][idx_nonzero]) == approx(1.0)
+    idx_nonzero = np.abs(v2[:, 0]) > 1e-4
+    assert overlap(v1[:, 0], v2[:, 0][idx_nonzero]) == approx(1.0)

--- a/Test/GroundState/test_groundstate.py
+++ b/Test/GroundState/test_groundstate.py
@@ -184,6 +184,15 @@ def test_ed():
     w = nk.exact.lanczos_ed(ha, k=first_n, compute_eigenvectors=False)
     assert w.shape == (first_n,)
 
+    # Test Lanczos ED with custom options
+    w_tol = nk.exact.lanczos_ed(
+        ha,
+        k=first_n,
+        scipy_args={"tol": 1e-9, "maxiter": 1000},
+    )
+    assert w_tol.shape == (first_n,)
+    assert w_tol == approx(w)
+
     # Test Full ED with eigenvectors
     w_full, v_full = nk.exact.full_ed(ha, compute_eigenvectors=True)
     assert w_full.shape == (hi.n_states,)

--- a/Test/Operator/test_operator.py
+++ b/Test/Operator/test_operator.py
@@ -143,7 +143,7 @@ def test_Heisenberg():
     hi = nk.hilbert.Spin(g, 0.5)
 
     def gs_energy(ham):
-        return nk.exact.lanczos_ed(ham).eigenvalues[0]
+        return nk.exact.lanczos_ed(ham)
 
     ha1 = nk.operator.Heisenberg(hi)
     ha2 = nk.operator.Heisenberg(hi, J=2.0)

--- a/netket/exact.py
+++ b/netket/exact.py
@@ -60,7 +60,7 @@ def lanczos_ed(
         >>> hamiltonian = nk.operator.Ising(hi, h=1.0)
         >>> w = nk.exact.lanczos_ed(hamiltonian, k=3)
         >>> w
-        array([ -8.69093921, -10.05467898, -10.25166179])
+        array([-10.25166179, -10.05467898,  -8.69093921])
         ```
     """
     from scipy.sparse.linalg import eigsh

--- a/netket/exact.py
+++ b/netket/exact.py
@@ -18,117 +18,99 @@ import numpy as np
 from scipy.sparse.linalg import LinearOperator, bicgstab
 
 from . import _core
+from .operator import AbstractOperator
 from ._exact_dynamics import PyExactTimePropagation
 
 
-class EdResult(object):
-    def __init__(self, eigenvalues, eigenvectors):
-        # NOTE: These conversions are required because our old C++ code stored
-        # eigenvalues and eigenvectors as Python lists :(
-        self._eigenvalues = eigenvalues.tolist()
-        self._eigenvectors = (
-            [np.asarray(eigenvectors[:, i]) for i in range(eigenvectors.shape[1])]
-            if eigenvectors is not None
-            else []
-        )
-
-    @property
-    def eigenvalues(self):
-        r"""Eigenvalues of the Hamiltonian."""
-        return self._eigenvalues
-
-    @property
-    def eigenvectors(self):
-        r"""Eigenvectors of the Hamiltonian."""
-        return self._eigenvectors
-
-    def mean(self, operator, which):
-        import numpy
-
-        x = self._eigenvectors[which]
-
-        return numpy.vdot(x, operator(x))
-
-
 def lanczos_ed(
-    operator,
-    matrix_free=False,
-    first_n=1,
-    max_iter=1000,
-    seed=None,
-    precision=1e-14,
-    compute_eigenvectors=False,
+    operator: AbstractOperator,
+    *,
+    k: int = 1,
+    compute_eigenvectors: bool = False,
+    matrix_free: bool = False,
+    scipy_args: dict = None,
 ):
     r"""Computes `first_n` smallest eigenvalues and, optionally, eigenvectors
-    of a Hermitian operator using the Lanczos method.
+    of a Hermitian operator using `scipy.sparse.linalg.eigsh`.
 
     Args:
-        operator: The operator to diagnolize.
-        matrix_free: If true, matrix elements are computed on the fly.
-            Otherwise, the operator is first converted to a sparse matrix.
-        first_n: The number of eigenvalues to compute.
-        max_iter: The maximum number of iterations.
-        seed: **Ignored**. Accepted for backward compatibility only.
-        precision: The precision to which the eigenvalues will be
-            computed.
+        operator: NetKet operator to diagonalize.
+        k: The number of eigenvalues to compute.
         compute_eigenvectors: Whether or not to return the
             eigenvectors of the operator. With ARPACK, not requiring the
             eigenvectors has almost no performance benefits.
+        matrix_free: If true, matrix elements are computed on the fly.
+            Otherwise, the operator is first converted to a sparse matrix.
+        scipy_args: Additional keyword arguments passed to `scipy.sparse.linalg.eigvalsh`.
+            See the Scipy documentation for further information.
 
+    Returns:
+        Either `w` or the tuple `(w, v)` depending on whether
+            `compute_eigenvectors` is True.
+
+        w: Array containing the lowest `first_n` eigenvalues.
+        v: Array containing the eigenvectors as columns, such that
+            `v[:, i]` corresponds to `w[i]`.
 
     Examples:
-        Testing the number of eigenvalues saved when solving a simple
-        1D Ising problem.
-
+        Test for 1D Ising chain with 8 sites.
         ```python
         >>> import netket as nk
-        >>> hilbert = nk.hilbert.Spin(
-        ...     nk.graph.Hypercube(length=8, n_dim=1, pbc=True), s=0.5)
-        >>> hamiltonian = nk.operator.Ising(h=1.0, hilbert=hilbert)
-        >>> r = nk.exact.lanczos_ed(
-        ...     hamiltonian, first_n=3, compute_eigenvectors=True)
-        >>> r.eigenvalues
-        [-10.251661790966047, -10.054678984251746, -8.690939214837037]
+        >>> hi = nk.hilbert.Spin(nk.graph.Chain(8), s=1/2)
+        >>> hamiltonian = nk.operator.Ising(hi, h=1.0)
+        >>> w = nk.exact.lanczos_ed(hamiltonian, k=3)
+        >>> w
+        array([ -8.69093921, -10.05467898, -10.25166179])
         ```
-
     """
     from scipy.sparse.linalg import eigsh
 
+    actual_scipy_args = {}
+    if scipy_args:
+        actual_scipy_args.update(scipy_args)
+    actual_scipy_args["which"] = "SA"
+    actual_scipy_args["k"] = k
+    actual_scipy_args["return_eigenvectors"] = compute_eigenvectors
+
     result = eigsh(
         operator.to_linear_operator() if matrix_free else operator.to_sparse(),
-        k=first_n,
-        which="SA",
-        maxiter=max_iter,
-        tol=precision,
-        return_eigenvectors=compute_eigenvectors,
+        **actual_scipy_args,
     )
-    if compute_eigenvectors:
-        return EdResult(*result)
-    return EdResult(result, None)
+    if not compute_eigenvectors:
+        # The sort order of eigenvalues returned by scipy changes based on
+        # `return_eigenvalues`. Therefore we invert the order here so that the
+        # smallest eigenvalue is still the first one.
+        return result[::-1]
+    else:
+        return result
 
 
-def full_ed(operator, compute_eigenvectors=False):
-    r"""Computes `first_n` smallest eigenvalues and, optionally, eigenvectors
+def full_ed(operator: AbstractOperator, *, compute_eigenvectors: bool = False):
+    r"""Computes all eigenvalues and, optionally, eigenvectors
     of a Hermitian operator by full diagonalization.
 
     Args:
-        operator: Operator to diagnolize.
-        compute_eigenvectors: Whether or not to return the
-            eigenvectors of the operator.
+        operator: NetKet operator to diagonalize.
+        compute_eigenvectors: Whether or not to return the eigenvectors
+            of the operator.
+
+    Returns:
+        Either `w` or the tuple `(w, v)` depending on whether
+            `compute_eigenvectors` is True.
+
+        w: Array containing the lowest `first_n` eigenvalues.
+        v: Array containing the eigenvectors as columns, such that
+            `v[:, i]` corresponds to `w[i]`.
 
     Examples:
-        Testing the numer of eigenvalues saved when solving a simple
-        1D Ising problem.
-
         ```python
+        Test for 1D Ising chain with 8 sites.
         >>> import netket as nk
-        >>> hilbert = nk.hilbert.Spin(
-        ...     nk.graph.Hypercube(length=8, n_dim=1, pbc=True), s=0.5)
-        >>> hamiltonian = nk.operator.Ising(h=1.0, hilbert=hilbert)
-        >>> r = nk.exact.lanczos_ed(
-        ...     hamiltonian, compute_eigenvectors=True)
-        >>> len(r.eigenvalues)
-        3
+        >>> hi = nk.hilbert.Spin(nk.graph.Chain(8), s=1/2)
+        >>> hamiltonian = nk.operator.Ising(hi, h=1.0)
+        >>> w = nk.exact.full_ed(hamiltonian)
+        >>> w.shape
+        (256,)
         ```
     """
     from numpy.linalg import eigh, eigvalsh
@@ -136,11 +118,9 @@ def full_ed(operator, compute_eigenvectors=False):
     dense_op = operator.to_dense()
 
     if compute_eigenvectors:
-        w, v = eigh(dense_op)
-        return EdResult(w, v)
+        return eigh(dense_op)
     else:
-        w = eigvalsh(dense_op)
-        return EdResult(w, None)
+        return eigvalsh(dense_op)
 
 
 def steady_state(lindblad, sparse=False, method="ed", rho0=None, **kwargs):

--- a/netket/operator/_abstract_operator.py
+++ b/netket/operator/_abstract_operator.py
@@ -138,7 +138,7 @@ class AbstractOperator(abc.ABC):
         This method requires an indexable Hilbert space.
 
         Returns:
-            numpy.matrix: The dense matrix representation of the operator.
+            numpy.ndarray: The dense matrix representation of the operator as a Numpy array.
         """
         return self.to_sparse().todense().A
 

--- a/netket/operator/_abstract_operator.py
+++ b/netket/operator/_abstract_operator.py
@@ -140,7 +140,7 @@ class AbstractOperator(abc.ABC):
         Returns:
             numpy.matrix: The dense matrix representation of the operator.
         """
-        return self.to_sparse().todense()
+        return self.to_sparse().todense().A
 
     def apply(self, v):
         return self.to_sparse().dot(v)


### PR DESCRIPTION
The existence of the `EdResult` class was purely for reasons of backwards compatibility with the old C++ interface. The step to version 3.0 provides the ideal oportunity to remove it.

Directly returning the array of eigenvalues and, optionally, eigenvectors is in line with Numpy and Scipy and makes the NetKet interface more comfortable to use. (It is just a thin convenience wrapper anyways.)

Further, `AbstractOperator.to_dense` returns `numpy.ndarray` now, instead of `numpy.matrix`, because the use of `numpy.matrix` is no longer recommended according to the official documentation and can lead to surprising errors when used in code that expects to deal with `ndarray`s. (For example: Using `numpy.vdot(v[:, 0], op(v[:, 0]))` to compute an expectation value of the `0`th eigenvector works with `ndarray` but not with `matrix` due to differences in how slicing works.)