### PR TITLE
Add option to disable JIT in Jax machines

### DIFF
--- a/Test/Machine/test_machine.py
+++ b/Test/Machine/test_machine.py
@@ -31,7 +31,6 @@ g = nk.graph.Hypercube(length=4, n_dim=1)
 # Hilbert space of spins from given graph
 hi = Spin(s=0.5, graph=g)
 
-
 if test_jax:
     import jax
     import jax.experimental
@@ -52,22 +51,20 @@ if test_jax:
     #     dtype=float,
     # )
 
-    machines["Jax Complex"] = nk.machine.Jax(
-        hi,
-        jax.experimental.stax.serial(
-            jax.experimental.stax.Dense(4, initializer, initializer),
-            jax.experimental.stax.Tanh,
-            jax.experimental.stax.Dense(2, initializer, initializer),
-            jax.experimental.stax.Tanh,
-            jax.experimental.stax.Dense(1, initializer, initializer),
-        ),
-        dtype=complex,
+    jax_net = jax.experimental.stax.serial(
+        jax.experimental.stax.Dense(4, initializer, initializer),
+        jax.experimental.stax.Tanh,
+        jax.experimental.stax.Dense(2, initializer, initializer),
+        jax.experimental.stax.Tanh,
+        jax.experimental.stax.Dense(1, initializer, initializer),
+    )
+    machines["Jax Complex"] = nk.machine.Jax(hi, jax_net, dtype=complex)
+    machines["Jax Complex (No JIT)"] = nk.machine.Jax(
+        hi, jax_net, dtype=complex, enable_jit=False
     )
 
     machines["Jax mps"] = nk.machine.MPSPeriodic(hi, bond_dim=4, dtype=complex)
-
     machines["Jax RbmSpinPhase (R->C)"] = nk.machine.JaxRbmSpinPhase(hi, alpha=1)
-
     dm_machines["Jax NDM"] = nk.machine.density_matrix.NdmSpinPhase(hi, alpha=1, beta=1)
 
 

--- a/netket/machine/density_matrix/jax.py
+++ b/netket/machine/density_matrix/jax.py
@@ -22,7 +22,15 @@ from functools import partial
 
 
 class Jax(JaxPure, AbstractDensityMatrix):
-    def __init__(self, hilbert, module, dtype=complex, outdtype=complex):
+    def __init__(
+        self,
+        hilbert,
+        module,
+        *,
+        dtype=complex,
+        outdtype=complex,
+        enable_jit: bool = True,
+    ):
         """
         Wraps a stax network (which is a tuple of `init_fn` and `predict_fn`)
         so that it can be used as a NetKet density matrix.
@@ -34,9 +42,25 @@ class Jax(JaxPure, AbstractDensityMatrix):
                 `jax.experimental.stax` for more info.
             dtype: either complex or float, is the type used for the weights.
                 In both cases the module must have a single output.
+            enable_jit: Controls whether jax.jit is used to just-in-time compile the
+                module. Disabling jit can be useful for debugging purposes, as it allows
+                the module to perform operations that would not be possible in JITed functions.
+                (Default: True)
         """
-        AbstractDensityMatrix.__init__(self, hilbert, dtype, outdtype)
-        JaxPure.__init__(self, hilbert, module, dtype, outdtype)
+        AbstractDensityMatrix.__init__(
+            self,
+            hilbert,
+            dtype=dtype,
+            outdtype=outdtype,
+        )
+        JaxPure.__init__(
+            self,
+            hilbert,
+            module,
+            dtype=dtype,
+            outdtype=outdtype,
+            enable_jit=enable_jit,
+        )
 
         assert self.input_size == self.hilbert.size * 2
 

--- a/netket/machine/jax.py
+++ b/netket/machine/jax.py
@@ -53,6 +53,7 @@ class Jax(AbstractMachine):
         self._init_fn, self._forward_fn = module
         self._forward_fn_nj = self._forward_fn
 
+        self._enable_jit = enable_jit
         maybe_jit = jax.jit if enable_jit else (lambda x, *_, **__: x)
 
         # Computes the Jacobian matrix using forward ad
@@ -219,6 +220,10 @@ class Jax(AbstractMachine):
     def n_par(self):
         r"""The number of variational parameters in the machine."""
         return self._npar
+
+    @property
+    def enable_jit(self):
+        return self._enable_jit
 
     def log_val(self, x, out=None):
         if x.ndim != 2:

--- a/netket/sampler/jax/metropolis_hastings.py
+++ b/netket/sampler/jax/metropolis_hastings.py
@@ -22,7 +22,9 @@ class MetropolisHastings(AbstractSampler):
         self.sweep_size = sweep_size
 
         if machine.enable_jit:
-            self._metropolis_kernel = jax.jit(self._metropolis_kernel, static_argnums=(0, 1, 2))
+            self._metropolis_kernel = jax.jit(
+                self._metropolis_kernel, static_argnums=(0, 1, 2)
+            )
 
     @staticmethod
     def _metropolis_kernel(

--- a/netket/sampler/jax/metropolis_hastings.py
+++ b/netket/sampler/jax/metropolis_hastings.py
@@ -18,13 +18,13 @@ class MetropolisHastings(AbstractSampler):
             self._rng_key = jax.random.PRNGKey(_random.randint(low=0, high=(2 ** 32)))
 
         self.machine_pow = 2
-
         self.n_chains = n_chains
-
         self.sweep_size = sweep_size
 
+        if machine.enable_jit:
+            self._metropolis_kernel = jax.jit(self._metropolis_kernel, static_argnums=(0, 1, 2))
+
     @staticmethod
-    @partial(jax.jit, static_argnums=(0, 1, 2))
     def _metropolis_kernel(
         logpdf,
         transition_kernel,


### PR DESCRIPTION
I've found it to be useful for debugging and development purposes to turn off `jax.jit` in machines sometimes. Thus, this PR adds an option `enable_jit` to `netket.machine.Jax`.

Beside making it possible to put a quick `print` statement in the machine code, this more importantly allows one to write proof-of-concept implementations that don't need to be `jit`-able right away. Since some things that are natural in normal Python require more effort to implement in JAX (e.g., control flow, ragged arrays), this can be helpful to test an idea before optimizing it for JAX.

Possible downside: Since `MetropolisHastings` decides whether to JIT its kernel based on the machine in this PR, the kernel is now recompiled every time the sampler is recreated. I think this is not much of a problem, as recompilation also happens, e.g., when the chain size changes or similar. I don't expect realistic code that re-creates the sampler often enough to see a performance impact to exists.