### PR TITLE
jax samplers: allow passing rng_key via kwargs

### DIFF
--- a/netket/sampler/custom_sampler.py
+++ b/netket/sampler/custom_sampler.py
@@ -3,7 +3,7 @@ from ._kernels import _CustomKernel
 
 
 def CustomSampler(
-    machine, move_operators, move_weights=None, n_chains=16, sweep_size=None
+    machine, move_operators, move_weights=None, n_chains=16, sweep_size=None, **kwargs
 ):
     r"""
      Custom Sampler, where transition operators are specified by the user.
@@ -66,15 +66,12 @@ def CustomSampler(
         _CustomKernel(machine, move_operators, move_weights),
         n_chains,
         sweep_size,
+        **kwargs,
     )
 
 
 def CustomSamplerPt(
-    machine,
-    move_operators,
-    move_weights=None,
-    n_replicas=16,
-    sweep_size=None,
+    machine, move_operators, move_weights=None, n_replicas=16, sweep_size=None, **kwargs
 ):
     r"""
     This sampler performs parallel-tempering
@@ -99,4 +96,5 @@ def CustomSamplerPt(
         _CustomKernel(machine, move_operators, move_weights),
         n_replicas,
         sweep_size,
+        **kwargs,
     )

--- a/netket/sampler/jax/__init__.py
+++ b/netket/sampler/jax/__init__.py
@@ -9,7 +9,7 @@ def _JaxMetropolisHastings(machine, kernel, n_chains=16, sweep_size=None, **kwar
 
 
 @MetropolisHastingsPt.register(JaxMachine)
-def _JaxMetropolisHastingsPt(machine, kernel, n_replicas=32, sweep_size=None):
+def _JaxMetropolisHastingsPt(machine, kernel, n_replicas=32, sweep_size=None, **kwargs):
     raise NotImplementedError("Parallel tempering samplers not yet implemented in Jax")
 
 

--- a/netket/sampler/jax/__init__.py
+++ b/netket/sampler/jax/__init__.py
@@ -4,8 +4,8 @@ from .metropolis_hastings import MetropolisHastings as JaxMetropolisHastings
 
 
 @MetropolisHastings.register(JaxMachine)
-def _JaxMetropolisHastings(machine, kernel, n_chains=16, sweep_size=None):
-    return JaxMetropolisHastings(machine, kernel, n_chains, sweep_size)
+def _JaxMetropolisHastings(machine, kernel, n_chains=16, sweep_size=None, **kwargs):
+    return JaxMetropolisHastings(machine, kernel, n_chains, sweep_size, **kwargs)
 
 
 @MetropolisHastingsPt.register(JaxMachine)

--- a/netket/sampler/jax/__init__.py
+++ b/netket/sampler/jax/__init__.py
@@ -4,12 +4,14 @@ from .metropolis_hastings import MetropolisHastings as JaxMetropolisHastings
 
 
 @MetropolisHastings.register(JaxMachine)
-def _JaxMetropolisHastings(machine, kernel, n_chains=16, sweep_size=None, **kwargs):
-    return JaxMetropolisHastings(machine, kernel, n_chains, sweep_size, **kwargs)
+def _JaxMetropolisHastings(machine, kernel, n_chains=16, sweep_size=None, rng_key=None):
+    return JaxMetropolisHastings(machine, kernel, n_chains, sweep_size, rng_key)
 
 
 @MetropolisHastingsPt.register(JaxMachine)
-def _JaxMetropolisHastingsPt(machine, kernel, n_replicas=32, sweep_size=None, **kwargs):
+def _JaxMetropolisHastingsPt(
+    machine, kernel, n_replicas=32, sweep_size=None, rng_key=None
+):
     raise NotImplementedError("Parallel tempering samplers not yet implemented in Jax")
 
 

--- a/netket/sampler/metropolis_exchange.py
+++ b/netket/sampler/metropolis_exchange.py
@@ -2,7 +2,7 @@ from .metropolis_hastings import *
 from ._kernels import _ExchangeKernel
 
 
-def MetropolisExchange(machine, d_max=1, n_chains=16, sweep_size=None):
+def MetropolisExchange(machine, d_max=1, n_chains=16, sweep_size=None, **kwargs):
     r"""
     This sampler acts locally only on two local degree of freedom :math:`s_i` and :math:`s_j`,
     and proposes a new state: :math:`s_1 \dots s^\prime_i \dots s^\prime_j \dots s_N`,
@@ -57,14 +57,11 @@ def MetropolisExchange(machine, d_max=1, n_chains=16, sweep_size=None):
     transition_kernel = _ExchangeKernel(machine, d_max)
 
     return MetropolisHastings(
-        machine,
-        transition_kernel,
-        n_chains,
-        sweep_size,
+        machine, transition_kernel, n_chains, sweep_size, **kwargs
     )
 
 
-def MetropolisExchangePt(machine, d_max=1, n_replicas=16, sweep_size=None):
+def MetropolisExchangePt(machine, d_max=1, n_replicas=16, sweep_size=None, **kwargs):
     r"""
     This sampler performs parallel-tempering
     moves in addition to the local moves implemented in `MetropolisExchange`.
@@ -100,8 +97,5 @@ def MetropolisExchangePt(machine, d_max=1, n_replicas=16, sweep_size=None):
     transition_kernel = _ExchangeKernel(machine, d_max)
 
     return MetropolisHastingsPt(
-        machine,
-        transition_kernel,
-        n_replicas,
-        sweep_size,
+        machine, transition_kernel, n_replicas, sweep_size, **kwargs
     )

--- a/netket/sampler/metropolis_hamiltonian.py
+++ b/netket/sampler/metropolis_hamiltonian.py
@@ -2,7 +2,7 @@ from .metropolis_hastings import *
 from ._kernels import _HamiltonianKernel
 
 
-def MetropolisHamiltonian(machine, hamiltonian, n_chains=16, sweep_size=None):
+def MetropolisHamiltonian(machine, hamiltonian, n_chains=16, sweep_size=None, **kwargs):
     r"""
     Sampling based on the off-diagonal elements of a Hamiltonian (or a generic Operator).
     In this case, the transition matrix is taken to be:
@@ -51,10 +51,13 @@ def MetropolisHamiltonian(machine, hamiltonian, n_chains=16, sweep_size=None):
         _HamiltonianKernel(machine, hamiltonian),
         n_chains,
         sweep_size,
+        **kwargs,
     )
 
 
-def MetropolisHamiltonianPt(machine, hamiltonian, n_replicas=16, sweep_size=None):
+def MetropolisHamiltonianPt(
+    machine, hamiltonian, n_replicas=16, sweep_size=None, **kwargs
+):
     r"""
     This sampler performs parallel-tempering
     moves in addition to the local moves implemented in `MetropolisLocal`.
@@ -77,4 +80,5 @@ def MetropolisHamiltonianPt(machine, hamiltonian, n_replicas=16, sweep_size=None
         _HamiltonianKernel(machine, hamiltonian),
         n_replicas,
         sweep_size,
+        **kwargs,
     )

--- a/netket/sampler/metropolis_local.py
+++ b/netket/sampler/metropolis_local.py
@@ -60,7 +60,7 @@ def MetropolisLocal(machine, n_chains=16, sweep_size=None, **kwargs):
     )
 
 
-def MetropolisLocalPt(machine, n_replicas=16, sweep_size=None):
+def MetropolisLocalPt(machine, n_replicas=16, sweep_size=None, **kwargs):
     r"""
     This sampler performs parallel-tempering
     moves in addition to the local moves implemented in `MetropolisLocal`.
@@ -76,4 +76,6 @@ def MetropolisLocalPt(machine, n_replicas=16, sweep_size=None):
                      If None, sweep_size is equal to the number of degrees of freedom (n_visible).
 
     """
-    return MetropolisHastingsPt(machine, _LocalKernel(machine), n_replicas, sweep_size)
+    return MetropolisHastingsPt(
+        machine, _LocalKernel(machine), n_replicas, sweep_size, **kwargs
+    )

--- a/netket/sampler/metropolis_local.py
+++ b/netket/sampler/metropolis_local.py
@@ -2,7 +2,7 @@ from .metropolis_hastings import *
 from ._kernels import _LocalKernel
 
 
-def MetropolisLocal(machine, n_chains=16, sweep_size=None):
+def MetropolisLocal(machine, n_chains=16, sweep_size=None, **kwargs):
     r"""
     Sampler acting on one local degree of freedom.
 
@@ -55,7 +55,9 @@ def MetropolisLocal(machine, n_chains=16, sweep_size=None):
         100
     """
 
-    return MetropolisHastings(machine, _LocalKernel(machine), n_chains, sweep_size)
+    return MetropolisHastings(
+        machine, _LocalKernel(machine), n_chains, sweep_size, **kwargs
+    )
 
 
 def MetropolisLocalPt(machine, n_replicas=16, sweep_size=None):


### PR DESCRIPTION
Currently there is no way to pass a rng_key to the jax version of nk.sampler.MetropolisLocal.
This PR tries to add that functionality.

The same could also be done for the other samplers (MetropolisExchange, ...)