### PR TITLE
WIP stochastic reconfiguration with jvp and vjp

### DIFF
--- a/Test/Optimizer/test_sr_onthefly.py
+++ b/Test/Optimizer/test_sr_onthefly.py
@@ -1,7 +1,9 @@
 import pytest
-from jax.config import config
+import netket as nk
 
-config.update("jax_enable_x64", True)
+if not nk.utils.jax_available:
+    pytest.skip("skipping jax-only SR-onthefly tests", allow_module_level=True)
+
 import jax
 import jax.numpy as jnp
 import jax.flatten_util

--- a/Test/Optimizer/test_sr_onthefly.py
+++ b/Test/Optimizer/test_sr_onthefly.py
@@ -54,10 +54,8 @@ def flatten(x):
 
 def toreal(x):
     if jnp.iscomplexobj(x):
-        # workaround for
-        # NotImplementedError: Transpose rule (for reverse-mode differentiation) for 'imag' not implemented
         return jnp.array(
-            [x.real, (-1j * x).real]
+            [x.real, x.imag]
         )  # need to use sth which jax thinks its a leaf
     else:
         return x

--- a/Test/Optimizer/test_sr_onthefly.py
+++ b/Test/Optimizer/test_sr_onthefly.py
@@ -12,8 +12,6 @@ from jax.scipy.sparse.linalg import cg
 from netket.optimizer.jax._sr_onthefly import *
 from netket.optimizer.jax.stochastic_reconfiguration import _jax_cg_solve_onthefly
 
-# TODO more sophisitcated example?
-
 
 @partial(jax.vmap, in_axes=(None, 0))
 def f(params, x):
@@ -73,7 +71,6 @@ def tree_toreal_flat(x):
 def reassemble_complex(x, fun=tree_toreal_flat, target=params):
     # target: a tree with the expected shape and types of the result
     (res,) = jax.linear_transpose(fun, target)(x)
-    # TODO ...
     res = tree_conj(res)
     # fix the dtypes:
     return tree_cast(res, target)
@@ -116,20 +113,18 @@ def test_reassemble_complex():
 
 def test_vjp():
     actual = O_vjp(samples, params, v_tilde, f)
-    # TODO ...
     expected = tree_conj(reassemble_complex((v_tilde @ ok_real).real))
     assert tree_allclose(actual, expected)
 
 
 def test_mean():
     actual = O_mean(samples, params, f)
-    # TODO ...
     expected = tree_conj(reassemble_complex(okmean_real.real))
     assert tree_allclose(actual, expected)
 
 
-def test_Odagger_w():
-    actual = Odagger_w(samples, params, v_tilde, f)
+def test_OH_w():
+    actual = OH_w(samples, params, v_tilde, f)
     expected = reassemble_complex((ok_real.conjugate().transpose() @ v_tilde).real)
     assert tree_allclose(actual, expected)
 
@@ -170,7 +165,7 @@ def test_matvec_linear_transpose():
     # S^T = (O^H O)^T = O^T O* = (O^H O)* = S*
     # S^T w = S* w = (S w*)*
     expected = tree_conj(mat_vec(tree_conj(w), f, params, samples, 0.0))
-    # e, = jax.linear_transpose(lambda v_: reassemble_complex(S_real @ tree_toreal_flat(v_)), v)(v)
+    # (expected,) = jax.linear_transpose(lambda v_: reassemble_complex(S_real @ tree_toreal_flat(v_)), v)(v)
     assert tree_allclose(actual, expected)
 
 

--- a/Test/Optimizer/test_sr_onthefly.py
+++ b/Test/Optimizer/test_sr_onthefly.py
@@ -42,10 +42,64 @@ S = dok.conjugate().transpose() @ dok / n_samp
 
 real_ind = flatten(jax.tree_map(jax.numpy.isrealobj, params))
 def setzero_imag_part_of_real_params(x):
-    # workaround for imag not differentiable
+    # workaround for
+    # NotImplementedError: Transpose rule (for reverse-mode differentiation) for 'imag' not implemented
     return jax.ops.index_add(x, real_ind, -1j*(-1j*x[real_ind]).real)
 
 
+
+
+#flatten params to a vector of real params
+
+
+def toreal(x):
+    if jnp.iscomplexobj(x):
+        # workaround for
+        # NotImplementedError: Transpose rule (for reverse-mode differentiation) for 'imag' not implemented
+        return jnp.array([x.real, (-1j*x).real]) # need to use sth which jax thinks its a leaf
+    else:
+        return x
+
+def tree_toreal(x):
+    return jax.tree_map(toreal, x)
+
+def tree_toreal_flat(x):
+    return flatten(tree_toreal(x))
+
+params_real_flat = tree_toreal_flat(params)
+
+# invert the trafo using linear_transpose (AD)
+def reassemble_complex(x, fun=tree_toreal_flat, target=params):
+    # target: some tree with the shape and types we want
+    _lt = jax.linear_transpose(fun, target)
+    # jax gradient is actually the conjugated one, so we need to fix it:
+    return jax.tree_map(jax.lax.conj, _lt(x)[0])
+
+
+def f_real_flat(p, samples):
+    return f(reassemble_complex(p) , samples)
+
+grad_real_flat = tree_toreal_flat(grad)
+v_real_flat = tree_toreal_flat(v)
+
+def f_real_flat_scalar(params, x):
+    return f_real_flat(params, jnp.expand_dims(x, 0))[0]
+
+def _rea(x):
+    re, im = x
+    return re +1j*im
+
+
+@partial(jax.vmap, in_axes=(None,0))
+def grads_real(params, x):
+    r = jax.grad(lambda pars, v: f_real_flat_scalar(pars, v).real)(params_real_flat, x)
+    i = jax.grad(lambda pars, v: f_real_flat_scalar(pars, v).imag)(params_real_flat, x)
+    return _rea((r,i))
+
+ok_real = grads_real(params_real_flat, samples)
+okmean_real = ok_real.mean(axis=0)
+dok_real = ok_real - okmean_real
+S_real = dok_real.conjugate().transpose() @ dok_real / n_samp
 
 
 def test_f_flat():
@@ -108,5 +162,10 @@ def test_cg():
     def mv(v):
         return setzero_imag_part_of_real_params(S @ v + diag_shift * v)
     e = setzero_imag_part_of_real_params(cg(mv, grad_flat, x0=v_flat, tol=sparse_tol, maxiter=sparse_maxiter)[0])
+    def mv_real(v):
+        #_compose_result_real also takes real here
+        return (S_real @ v + diag_shift * v).real
+    e2 = flatten(reassemble_complex(cg(mv_real, grad_real_flat, x0=v_real_flat, tol=sparse_tol, maxiter=sparse_maxiter)[0]))
     assert jnp.allclose(a, e)
     assert jnp.allclose(b, e)
+    assert jnp.allclose(e, e2)

--- a/Test/Optimizer/test_sr_onthefly.py
+++ b/Test/Optimizer/test_sr_onthefly.py
@@ -136,7 +136,7 @@ def test_vjp():
 
 
 def test_obar():
-    a = Obar(samples, params, f, samples.shape[0])
+    a = Obar(samples, params, f)
     e = reassemble_complex(okmean_real.real)
     assert tree_allclose(tree_conj(a), e)
 
@@ -156,14 +156,14 @@ def test_odagov():
 
 
 def test_odagdeltaov():
-    a = odagdeltaov(samples, params, v, f, n_samp)
+    a = odagdeltaov(samples, params, v, f)
     e = reassemble_complex(S_real @ v_real_flat)
     assert tree_allclose(a, e)
 
 
 def test_matvec():
     diag_shift = 0.01
-    a = mat_vec(v, f, params, samples, diag_shift, n_samp)
+    a = mat_vec(v, f, params, samples, diag_shift)
     e = reassemble_complex(S_real @ v_real_flat + diag_shift * v_real_flat)
     assert tree_allclose(a, e)
 
@@ -174,7 +174,7 @@ def test_cg():
     sparse_tol = 1.0e-5
     sparse_maxiter = None
     a = _jax_cg_solve_onthefly(
-        v, f, params, samples, grad, diag_shift, n_samp, sparse_tol, sparse_maxiter
+        v, f, params, samples, grad, diag_shift, sparse_tol, sparse_maxiter
     )
 
     def mv_real(v):

--- a/Test/Optimizer/test_sr_onthefly.py
+++ b/Test/Optimizer/test_sr_onthefly.py
@@ -1,5 +1,6 @@
 import pytest
 from jax.config import config
+
 config.update("jax_enable_x64", True)
 import jax
 import jax.numpy as jnp
@@ -10,61 +11,83 @@ from netket.optimizer.jax.stochastic_reconfiguration import _jax_cg_solve_onthef
 
 # TODO more sophisitcated example?
 
-@partial(jax.vmap, in_axes=(None,0))
+
+@partial(jax.vmap, in_axes=(None, 0))
 def f(params, x):
-    return params['a'][0]*x[0]+params['b']*x[1]+params['c']*(x[0]*x[1])+jnp.sin(x[1]*params['a'][1])
+    return (
+        params["a"][0] * x[0]
+        + params["b"] * x[1]
+        + params["c"] * (x[0] * x[1])
+        + jnp.sin(x[1] * params["a"][1])
+    )
+
 
 samples = jnp.array(np.random.random((10, 2)))
 n_samp = samples.shape[0]
-params = jax.tree_map(jnp.array, {'a':[1., -4.], 'b':2., 'c':-0.55+4.33j})
-v = jax.tree_map(jnp.array, {'a':[0.7, -3.9], 'b':0.3, 'c':-0.74+3j})
-grad = jax.tree_map(jnp.array, {'a':[0.01, 1.99], 'b':-0.231, 'c':1.22-0.45j})
-vprime = jnp.array(np.random.random(samples.shape[0])+1j*np.random.random(samples.shape[0]))
+params = jax.tree_map(jnp.array, {"a": [1.0, -4.0], "b": 2.0, "c": -0.55 + 4.33j})
+v = jax.tree_map(jnp.array, {"a": [0.7, -3.9], "b": 0.3, "c": -0.74 + 3j})
+grad = jax.tree_map(jnp.array, {"a": [0.01, 1.99], "b": -0.231, "c": 1.22 - 0.45j})
+vprime = jnp.array(
+    np.random.random(samples.shape[0]) + 1j * np.random.random(samples.shape[0])
+)
 
-params_flat, conv = jax.flatten_util.ravel_pytree(params)  # promotes types automatically
+params_flat, conv = jax.flatten_util.ravel_pytree(
+    params
+)  # promotes types automatically
 v_flat, _ = jax.flatten_util.ravel_pytree(v)
 grad_flat, _ = jax.flatten_util.ravel_pytree(grad)
 
+
 def f_flat(params_flat, x):
     return f(conv(params_flat), x)
+
 
 def flatten(x):
     x_flat, _ = jax.flatten_util.ravel_pytree(x)
     return x_flat
 
+
 def f_flat_scalar(params, x):
     return f_flat(params, jnp.expand_dims(x, 0))[0]
 
-ok = jax.vmap(jax.grad(f_flat_scalar, argnums=0, holomorphic=True), in_axes=(None, 0))(params_flat, samples).conjugate() # natural gradient
+
+ok = jax.vmap(jax.grad(f_flat_scalar, argnums=0, holomorphic=True), in_axes=(None, 0))(
+    params_flat, samples
+).conjugate()  # natural gradient
 okmean = ok.mean(axis=0)
 dok = ok - okmean
 S = dok.conjugate().transpose() @ dok / n_samp
 
 real_ind = flatten(jax.tree_map(jax.numpy.isrealobj, params))
+
+
 def setzero_imag_part_of_real_params(x):
     # workaround for
     # NotImplementedError: Transpose rule (for reverse-mode differentiation) for 'imag' not implemented
-    return jax.ops.index_add(x, real_ind, -1j*(-1j*x[real_ind]).real)
+    return jax.ops.index_add(x, real_ind, -1j * (-1j * x[real_ind]).real)
 
 
-
-
-#flatten params to a vector of real params
+# flatten params to a vector of real params
 
 
 def toreal(x):
     if jnp.iscomplexobj(x):
         # workaround for
         # NotImplementedError: Transpose rule (for reverse-mode differentiation) for 'imag' not implemented
-        return jnp.array([x.real, (-1j*x).real]) # need to use sth which jax thinks its a leaf
+        return jnp.array(
+            [x.real, (-1j * x).real]
+        )  # need to use sth which jax thinks its a leaf
     else:
         return x
+
 
 def tree_toreal(x):
     return jax.tree_map(toreal, x)
 
+
 def tree_toreal_flat(x):
     return flatten(tree_toreal(x))
+
 
 params_real_flat = tree_toreal_flat(params)
 
@@ -77,24 +100,28 @@ def reassemble_complex(x, fun=tree_toreal_flat, target=params):
 
 
 def f_real_flat(p, samples):
-    return f(reassemble_complex(p) , samples)
+    return f(reassemble_complex(p), samples)
+
 
 grad_real_flat = tree_toreal_flat(grad)
 v_real_flat = tree_toreal_flat(v)
 
+
 def f_real_flat_scalar(params, x):
     return f_real_flat(params, jnp.expand_dims(x, 0))[0]
 
+
 def _rea(x):
     re, im = x
-    return re +1j*im
+    return re + 1j * im
 
 
-@partial(jax.vmap, in_axes=(None,0))
+@partial(jax.vmap, in_axes=(None, 0))
 def grads_real(params, x):
     r = jax.grad(lambda pars, v: f_real_flat_scalar(pars, v).real)(params_real_flat, x)
     i = jax.grad(lambda pars, v: f_real_flat_scalar(pars, v).imag)(params_real_flat, x)
-    return _rea((r,i))
+    return _rea((r, i))
+
 
 ok_real = grads_real(params_real_flat, samples)
 okmean_real = ok_real.mean(axis=0)
@@ -105,7 +132,8 @@ S_real = dok_real.conjugate().transpose() @ dok_real / n_samp
 def test_f_flat():
     a = f(params, samples)
     b = f_flat(params_flat, samples)
-    assert jnp.allclose(a,b)
+    assert jnp.allclose(a, b)
+
 
 def test_vjp():
     a = O_vjp(samples, params_flat, vprime, f_flat)
@@ -122,12 +150,14 @@ def test_obar():
     assert jnp.allclose(a, e)
     assert jnp.allclose(b, e)
 
+
 def test_jvp():
     a = O_jvp(samples, params, v, f)
     b = O_jvp(samples, params_flat, v_flat, f_flat)
-    e = ok  @ v_flat
+    e = ok @ v_flat
     assert jnp.allclose(a, e)
     assert jnp.allclose(b, e)
+
 
 def test_odagov():
     a = flatten(odagov(samples, params, v, f))
@@ -135,6 +165,7 @@ def test_odagov():
     e = setzero_imag_part_of_real_params(ok.transpose().conjugate() @ (ok @ v_flat))
     assert jnp.allclose(a, e)
     assert jnp.allclose(b, e)
+
 
 def test_odagdeltaov():
     a = flatten(odagdeltaov(samples, params, v, f))
@@ -144,28 +175,62 @@ def test_odagdeltaov():
     assert jnp.allclose(a, e)
     assert jnp.allclose(b, e)
 
+
 def test_matvec():
     diag_shift = 0.01
     a = flatten(mat_vec(v, f, params, samples, diag_shift, n_samp))
     b = mat_vec(v_flat, f_flat, params_flat, samples, diag_shift, n_samp)
-    e = setzero_imag_part_of_real_params(dok.transpose().conjugate() @ (dok @ v_flat/n_samp) + diag_shift * v_flat)
+    e = setzero_imag_part_of_real_params(
+        dok.transpose().conjugate() @ (dok @ v_flat / n_samp) + diag_shift * v_flat
+    )
     assert jnp.allclose(a, e)
     assert jnp.allclose(b, e)
+
 
 def test_cg():
     # also tests if matvec can be jitted and be differentiated with AD
     diag_shift = 0.001
     sparse_tol = 1.0e-5
     sparse_maxiter = None
-    a = flatten(_jax_cg_solve_onthefly(v, f, params, samples, grad, diag_shift, n_samp, sparse_tol, sparse_maxiter))
-    b = _jax_cg_solve_onthefly(v_flat, f_flat, params_flat, samples, grad_flat, diag_shift, n_samp, sparse_tol, sparse_maxiter)
+    a = flatten(
+        _jax_cg_solve_onthefly(
+            v, f, params, samples, grad, diag_shift, n_samp, sparse_tol, sparse_maxiter
+        )
+    )
+    b = _jax_cg_solve_onthefly(
+        v_flat,
+        f_flat,
+        params_flat,
+        samples,
+        grad_flat,
+        diag_shift,
+        n_samp,
+        sparse_tol,
+        sparse_maxiter,
+    )
+
     def mv(v):
         return setzero_imag_part_of_real_params(S @ v + diag_shift * v)
-    e = setzero_imag_part_of_real_params(cg(mv, grad_flat, x0=v_flat, tol=sparse_tol, maxiter=sparse_maxiter)[0])
+
+    e = setzero_imag_part_of_real_params(
+        cg(mv, grad_flat, x0=v_flat, tol=sparse_tol, maxiter=sparse_maxiter)[0]
+    )
+
     def mv_real(v):
-        #_compose_result_real also takes real here
+        # _compose_result_real also takes real here
         return (S_real @ v + diag_shift * v).real
-    e2 = flatten(reassemble_complex(cg(mv_real, grad_real_flat, x0=v_real_flat, tol=sparse_tol, maxiter=sparse_maxiter)[0]))
+
+    e2 = flatten(
+        reassemble_complex(
+            cg(
+                mv_real,
+                grad_real_flat,
+                x0=v_real_flat,
+                tol=sparse_tol,
+                maxiter=sparse_maxiter,
+            )[0]
+        )
+    )
     assert jnp.allclose(a, e)
     assert jnp.allclose(b, e)
     assert jnp.allclose(e, e2)

--- a/Test/Optimizer/test_sr_onthefly.py
+++ b/Test/Optimizer/test_sr_onthefly.py
@@ -1,8 +1,12 @@
 import pytest
+from jax.config import config
+config.update("jax_enable_x64", True)
 import jax
 import jax.numpy as jnp
 import numpy as np
+from jax.scipy.sparse.linalg import cg
 from netket.optimizer.jax._sr_onthefly import *
+from netket.optimizer.jax.stochastic_reconfiguration import _jax_cg_solve_onthefly
 
 # TODO more sophisitcated example?
 
@@ -11,12 +15,15 @@ def f(params, x):
     return params['a'][0]*x[0]+params['b']*x[1]+params['c']*(x[0]*x[1])+jnp.sin(x[1]*params['a'][1])
 
 samples = jnp.array(np.random.random((10, 2)))
+n_samp = samples.shape[0]
 params = jax.tree_map(jnp.array, {'a':[1., -4.], 'b':2., 'c':-0.55+4.33j})
 v = jax.tree_map(jnp.array, {'a':[0.7, -3.9], 'b':0.3, 'c':-0.74+3j})
+grad = jax.tree_map(jnp.array, {'a':[0.01, 1.99], 'b':-0.231, 'c':1.22-0.45j})
 vprime = jnp.array(np.random.random(samples.shape[0])+1j*np.random.random(samples.shape[0]))
 
 params_flat, conv = jax.flatten_util.ravel_pytree(params)  # promotes types automatically
 v_flat, _ = jax.flatten_util.ravel_pytree(v)
+grad_flat, _ = jax.flatten_util.ravel_pytree(grad)
 
 def f_flat(params_flat, x):
     return f(conv(params_flat), x)
@@ -31,10 +38,12 @@ def f_flat_scalar(params, x):
 ok = jax.vmap(jax.grad(f_flat_scalar, argnums=0, holomorphic=True), in_axes=(None, 0))(params_flat, samples).conjugate() # natural gradient
 okmean = ok.mean(axis=0)
 dok = ok - okmean
+S = dok.conjugate().transpose() @ dok / n_samp
 
-def setzero_real_params(x):
-    real_ind = flatten(jax.tree_map(jax.numpy.isrealobj, params))
-    return jax.ops.index_add(x, real_ind, -1j*x[real_ind].imag)
+real_ind = flatten(jax.tree_map(jax.numpy.isrealobj, params))
+def setzero_imag_part_of_real_params(x):
+    # workaround for imag not differentiable
+    return jax.ops.index_add(x, real_ind, -1j*(-1j*x[real_ind]).real)
 
 
 
@@ -47,7 +56,7 @@ def test_f_flat():
 def test_vjp():
     a = O_vjp(samples, params_flat, vprime, f_flat)
     b = flatten(O_vjp(samples, params, vprime, f))
-    e = setzero_real_params(vprime @ ok)
+    e = setzero_imag_part_of_real_params(vprime @ ok)
     assert jnp.allclose(a, e)
     assert jnp.allclose(b, e)
 
@@ -69,7 +78,7 @@ def test_jvp():
 def test_odagov():
     a = flatten(odagov(samples, params, v, f))
     b = odagov(samples, params_flat, v_flat, f_flat)
-    e = setzero_real_params(ok.transpose().conjugate() @ (ok @ v_flat))
+    e = setzero_imag_part_of_real_params(ok.transpose().conjugate() @ (ok @ v_flat))
     assert jnp.allclose(a, e)
     assert jnp.allclose(b, e)
 
@@ -77,15 +86,27 @@ def test_odagdeltaov():
     a = flatten(odagdeltaov(samples, params, v, f))
     b = odagdeltaov(samples, params_flat, v_flat, f_flat)
     # differnt calculation, but same result since additional terms are equal to zero
-    e = setzero_real_params(dok.transpose().conjugate() @ (dok @ v_flat))
+    e = setzero_imag_part_of_real_params(dok.transpose().conjugate() @ (dok @ v_flat))
     assert jnp.allclose(a, e)
     assert jnp.allclose(b, e)
 
 def test_matvec():
-    n_samp = samples.shape[0]
     diag_shift = 0.01
     a = flatten(mat_vec(v, f, params, samples, diag_shift, n_samp))
     b = mat_vec(v_flat, f_flat, params_flat, samples, diag_shift, n_samp)
-    e = setzero_real_params(dok.transpose().conjugate() @ (dok @ v_flat/n_samp) + diag_shift * v_flat)
+    e = setzero_imag_part_of_real_params(dok.transpose().conjugate() @ (dok @ v_flat/n_samp) + diag_shift * v_flat)
+    assert jnp.allclose(a, e)
+    assert jnp.allclose(b, e)
+
+def test_cg():
+    # also tests if matvec can be jitted and be differentiated with AD
+    diag_shift = 0.001
+    sparse_tol = 1.0e-5
+    sparse_maxiter = None
+    a = flatten(_jax_cg_solve_onthefly(v, f, params, samples, grad, diag_shift, n_samp, sparse_tol, sparse_maxiter))
+    b = _jax_cg_solve_onthefly(v_flat, f_flat, params_flat, samples, grad_flat, diag_shift, n_samp, sparse_tol, sparse_maxiter)
+    def mv(v):
+        return setzero_imag_part_of_real_params(S @ v + diag_shift * v)
+    e = setzero_imag_part_of_real_params(cg(mv, grad_flat, x0=v_flat, tol=sparse_tol, maxiter=sparse_maxiter)[0])
     assert jnp.allclose(a, e)
     assert jnp.allclose(b, e)

--- a/Test/Optimizer/test_sr_onthefly.py
+++ b/Test/Optimizer/test_sr_onthefly.py
@@ -138,7 +138,7 @@ def test_vjp():
 
 
 def test_obar():
-    a = Obar(samples, params, f)
+    a = Obar(samples, params, f, samples.shape[0])
     e = reassemble_complex(okmean_real.real)
     assert tree_allclose(tree_conj(a), e)
 
@@ -158,7 +158,7 @@ def test_odagov():
 
 
 def test_odagdeltaov():
-    a = odagdeltaov(samples, params, v, f, factor=1.0 / n_samp)
+    a = odagdeltaov(samples, params, v, f, n_samp)
     e = reassemble_complex(S_real @ v_real_flat)
     assert tree_allclose(a, e)
 

--- a/Test/Optimizer/test_sr_onthefly.py
+++ b/Test/Optimizer/test_sr_onthefly.py
@@ -4,6 +4,7 @@ from jax.config import config
 config.update("jax_enable_x64", True)
 import jax
 import jax.numpy as jnp
+import jax.flatten_util
 import numpy as np
 from jax.scipy.sparse.linalg import cg
 from netket.optimizer.jax._sr_onthefly import *

--- a/Test/Optimizer/test_sr_onthefly.py
+++ b/Test/Optimizer/test_sr_onthefly.py
@@ -1,0 +1,81 @@
+import pytest
+import jax
+import jax.numpy as jnp
+import numpy as np
+from netket.optimizer.jax._sr_onthefly import *
+
+# TODO more sophisitcated example?
+
+@partial(jax.vmap, in_axes=(None,0))
+def f(params, x):
+    return params['a'][0]*x[0]+params['b']*x[1]+params['c']*(x[0]*x[1])+jnp.sin(x[1]*params['a'][1])
+
+samples = jnp.array(np.random.random((10, 2)))
+params = jax.tree_map(jnp.array, {'a':[1., -4.], 'b':2., 'c':-0.55+4.33j})
+v = jax.tree_map(jnp.array, {'a':[0.7, -3.9], 'b':0.3, 'c':-0.74+3j})
+vprime = jnp.array(np.random.random(samples.shape[0])+1j*np.random.random(samples.shape[0]))
+
+params_flat, conv = jax.flatten_util.ravel_pytree(params)  # promotes types automatically
+v_flat, _ = jax.flatten_util.ravel_pytree(v)
+
+def f_flat(params_flat, x):
+    return f(conv(params_flat), x)
+
+def flatten(x):
+    x_flat, _ = jax.flatten_util.ravel_pytree(x)
+    return x_flat
+
+def f_flat_scalar(params, x):
+    return f_flat(params, jnp.expand_dims(x, 0))[0]
+
+ok = jax.vmap(jax.grad(f_flat_scalar, argnums=0, holomorphic=True), in_axes=(None, 0))(params_flat, samples).conjugate() # natural gradient
+
+def setzero_real_params(x):
+    real_ind = flatten(jax.tree_map(jax.numpy.isreal, params))
+    return jax.ops.index_add(x, real_ind, -1j*x[real_ind].imag)
+
+
+
+
+def test_f_flat():
+    a = f(params, samples)
+    b = f_flat(params_flat, samples)
+    assert jnp.allclose(a,b)
+
+def test_vjp():
+    a = O_vjp(samples, params_flat, vprime, f_flat)
+    b = flatten(O_vjp(samples, params, vprime, f))
+    e = setzero_real_params(vprime @ ok)
+    assert jnp.allclose(a, e)
+    assert jnp.allclose(b, e)
+
+
+def test_obar():
+    a = flatten(Obar(samples, params, f))
+    b = Obar(samples, params_flat, f_flat)
+    e = ok.mean(axis=0)
+    assert jnp.allclose(a, e)
+    assert jnp.allclose(b, e)
+
+def test_jvp():
+    a = O_jvp(samples, params, v, f)
+    b = O_jvp(samples, params_flat, v_flat, f_flat)
+    e = ok  @ v_flat
+    assert jnp.allclose(a, e)
+    assert jnp.allclose(b, e)
+
+def test_odagov():
+    a = flatten(odagov(samples, params, v, f))
+    b = odagov(samples, params_flat, v_flat, f_flat)
+    e = setzero_real_params(ok.transpose().conjugate() @ (ok @ v_flat))
+    assert jnp.allclose(a, e)
+    assert jnp.allclose(b, e)
+
+def test_odagdeltaov():
+    a = flatten(odagdeltaov(samples, params, v, f))
+    b = odagdeltaov(samples, params_flat, v_flat, f_flat)
+    # differnt calculation, but same result since additional terms are equal zero
+    dok = ok - ok.mean(axis=0)
+    e = setzero_real_params(dok.transpose().conjugate() @ (dok @ v_flat))
+    assert jnp.allclose(a, e)
+    assert jnp.allclose(b, e)

--- a/netket/_vmc.py
+++ b/netket/_vmc.py
@@ -19,7 +19,14 @@ class Vmc(AbstractVariationalDriver):
     """
 
     def __init__(
-        self, hamiltonian, sampler, optimizer, n_samples, n_discard=None, sr=None, sronthefly=False
+        self,
+        hamiltonian,
+        sampler,
+        optimizer,
+        n_samples,
+        n_discard=None,
+        sr=None,
+        sronthefly=False,
     ):
         """
         Initializes the driver class.
@@ -158,12 +165,17 @@ class Vmc(AbstractVariationalDriver):
 
                 self._grads = tree_map(_sum_inplace, self._grads)
 
-                self._dp = self._sr.compute_update_onthefly(samples_r, self._grads, self._dp)
+                self._dp = self._sr.compute_update_onthefly(
+                    samples_r, self._grads, self._dp
+                )
 
             else:
                 # When using the SR (Natural gradient) we need to have the full jacobian
                 self._grads, self._jac = self._machine.vector_jacobian_prod(
-                    samples_r, eloc_r / self._n_samples, self._grads, return_jacobian=True
+                    samples_r,
+                    eloc_r / self._n_samples,
+                    self._grads,
+                    return_jacobian=True,
                 )
 
                 self._grads = tree_map(_sum_inplace, self._grads)

--- a/netket/_vmc.py
+++ b/netket/_vmc.py
@@ -26,7 +26,6 @@ class Vmc(AbstractVariationalDriver):
         n_samples,
         n_discard=None,
         sr=None,
-        sronthefly=False,
     ):
         """
         Initializes the driver class.
@@ -67,7 +66,6 @@ class Vmc(AbstractVariationalDriver):
         self._ham = hamiltonian
         self._sampler = sampler
         self.sr = sr
-        self._sr_onthefly = sronthefly
 
         self._npar = self._machine.n_par
 
@@ -157,7 +155,7 @@ class Vmc(AbstractVariationalDriver):
 
         # Perform update
         if self._sr:
-            if self._sr_onthefly:
+            if self._sr.onthefly:
 
                 self._grads = self._machine.vector_jacobian_prod(
                     samples_r, eloc_r / self._n_samples, self._grads

--- a/netket/optimizer/jax/__init__.py
+++ b/netket/optimizer/jax/__init__.py
@@ -55,6 +55,7 @@ def _JaxSR(
     svd_threshold=None,
     sparse_tol=None,
     sparse_maxiter=None,
+    onthefly=True,
 ):
     return SR(
         machine,
@@ -64,4 +65,5 @@ def _JaxSR(
         svd_threshold,
         sparse_tol,
         sparse_maxiter,
+        onthefly,
     )

--- a/netket/optimizer/jax/_sr_onthefly.py
+++ b/netket/optimizer/jax/_sr_onthefly.py
@@ -28,7 +28,9 @@ def O_vjp(x, theta, v, forward_fn, return_vjp_fun=False, vjp_fun=None):
 def Obar(samples, theta, forward_fn, **kwargs):
     # TODO better way to get dtype
     dtype = forward_fn(theta, samples[:1])[0].dtype
-    v = jax.lax.broadcast( jnp.array(1./(samples.shape[0]*n_nodes), dtype=dtype) , (samples.shape[0],))
+    v = jax.lax.broadcast(
+        jnp.array(1.0 / (samples.shape[0] * n_nodes), dtype=dtype), (samples.shape[0],)
+    )
     return O_vjp(samples, theta, v, forward_fn, **kwargs)
 
 
@@ -65,7 +67,10 @@ def odagdeltaov(samples, theta, v, forward_fn, vjp_fun=None):
     # vprime /= n_samp (elementwise)
     vprime = jax.lax.mul(
         vprime,
-        jax.lax.broadcast(jnp.array(1.0 / (samples.shape[0]*n_nodes), dtype=vprime.dtype), vprime.shape),
+        jax.lax.broadcast(
+            jnp.array(1.0 / (samples.shape[0] * n_nodes), dtype=vprime.dtype),
+            vprime.shape,
+        ),
     )
 
     res = O_vjp(samples, theta, vprime.conjugate(), forward_fn, vjp_fun=vjp_fun)

--- a/netket/optimizer/jax/_sr_onthefly.py
+++ b/netket/optimizer/jax/_sr_onthefly.py
@@ -1,0 +1,52 @@
+import jax
+import jax.numpy as jnp
+from functools import partial
+
+
+# onthefly SR
+# since we cant store O if #samples x #params is too large
+
+def O_jvp(x, theta, v, vlogwf):
+    _, res = jax.jvp(lambda p: vlogwf(p,x), (theta,), (v,))
+    return res
+
+
+def O_vjp(x, theta, v, vlogwf, return_vjp_fun=False, vjp_fun=None):
+    if vjp_fun is None:
+        _, vjp_fun = jax.vjp(vlogwf, theta, x)
+    res, _ = vjp_fun(v)
+    if return_vjp_fun:
+        return res, vjp_fun
+    else:
+        return res
+
+
+# calculate \langle O \rangle
+def Obar(samples, theta, vlogwf, **kwargs):
+    # TODO better way to get dtype
+    dtype = vlogwf(theta, samples[:1])[0].dtype
+    v = jnp.ones(samples.shape[0], dtype=dtype)/samples.shape[0]
+    return O_vjp(samples, theta, v, vlogwf, **kwargs)
+
+
+# calculate O^\dagger O v
+# @partial(jax.jit, static_argnums=3)
+def odagov(samples, theta, v, vlogwf):
+    vprime = O_jvp(samples, theta, v, vlogwf)
+    res = O_vjp(samples, theta, vprime.conjugate(), vlogwf)
+    return res.conjugate()
+
+
+# calculate O^\dagger \Delta O v
+# where \Delta O = O-\langle O \rangle
+# optional: pass jvp_fun to be reused
+# TODO vjp_fun and jit??
+# @partial(jax.jit, static_argnums=3)
+def delta_odagov(samples, theta, v, vlogwf, vjp_fun=None, factor=1.):
+    # reuse vjp_fun from O_mean below for O_vjp
+    O_mean, vjp_fun = Obar(samples, theta, vlogwf, return_vjp_fun=True, vjp_fun=vjp_fun)
+    vprime = O_jvp(samples, theta, v, vlogwf)
+    vprime = vprime - jax.lax.broadcast(jax.lax.dot(O_mean,v),vprime.shape) 
+    vprime = vprime/factor
+    res = O_vjp(samples, theta, vprime.conjugate(), vlogwf, vjp_fun=vjp_fun)
+    return res.conjugate()

--- a/netket/optimizer/jax/_sr_onthefly.py
+++ b/netket/optimizer/jax/_sr_onthefly.py
@@ -5,101 +5,173 @@ from netket.stats import sum_inplace as _sum_inplace
 from netket.utils import n_nodes
 
 
-# onthefly SR
-# since we cant store O if #samples x #params is too large
+# TODO ...
+
+
+def tree_conj(t):
+    r"""
+    conjugate all complex leaves
+    The real leaves are left untouched.
+
+    t: pytree
+    """
+    return jax.tree_map(lambda x: jax.lax.conj(x) if jnp.iscomplexobj(x) else x, t)
+
+
+def tree_dot(a, b):
+    r"""
+    compute the dot product of a and b
+    TODO ...
+
+    a, b: pytrees with the same treedef
+    """
+    res = jax.tree_util.tree_reduce(
+        jax.numpy.add, jax.tree_map(jax.numpy.sum, jax.tree_multimap(jax.lax.mul, a, b))
+    )
+    # convert shape from () to (1,)
+    return jnp.expand_dims(res, 0)
+
+
+def tree_cast(x, target):
+    r"""
+    Cast each leaf of x to the dtype of the corresponding leaf in target.
+    The imaginary part of complex leaves which are cast to real is discarded
+
+    x: a pytree with arrays as leaves
+    target: a pytree with the same treedef as x where only the dtypes of the leaves are accessed
+    """
+    # astype alone would also work, however that raises ComplexWarning when casting complex to real
+    # therefore the real is taken first where needed
+    return jax.tree_multimap(
+        lambda x, target: (x if jnp.iscomplexobj(target) else x.real).astype(
+            target.dtype
+        ),
+        x,
+        target,
+    )
+
+
+def tree_axpy(a, x, y):
+    r"""
+    compute a * x + y
+
+    a: scalar
+    x, y: pytrees with the same treedef
+    """
+    return jax.tree_multimap(lambda x_, y_: a * x_ + y_, x, y)
 
 
 def O_jvp(x, theta, v, forward_fn):
+    # TODO apply the transpose of sum_inplace (allreduce) to v here
+    # in order to get correct transposition with MPI
     _, res = jax.jvp(lambda p: forward_fn(p, x), (theta,), (v,))
     return res
 
 
-def O_vjp(x, theta, v, forward_fn, return_vjp_fun=False, vjp_fun=None):
+def O_vjp(x, theta, v, forward_fn, return_vjp_fun=False, vjp_fun=None, allreduce=True):
     if vjp_fun is None:
         _, vjp_fun = jax.vjp(forward_fn, theta, x)
     res, _ = vjp_fun(v)
+
+    if allreduce:
+        res = jax.tree_map(_sum_inplace, res)
+
     if return_vjp_fun:
         return res, vjp_fun
     else:
         return res
 
 
-# calculate \langle O \rangle
-def Obar(samples, theta, forward_fn, **kwargs):
-    # TODO better way to get dtype
+def O_mean(samples, theta, forward_fn, **kwargs):
+    r"""
+    compute \langle O \rangle
+
+    TODO ...
+    """
     dtype = forward_fn(theta, samples[:1])[0].dtype
-    v = jax.lax.broadcast(
-        jnp.array(1.0 / (samples.shape[0] * n_nodes), dtype=dtype), (samples.shape[0],)
-    )
+    v = jnp.ones(samples.shape[0], dtype=dtype) * (1.0 / (samples.shape[0] * n_nodes))
     return O_vjp(samples, theta, v, forward_fn, **kwargs)
 
 
-# calculate O^\dagger O v
-def odagov(samples, theta, v, forward_fn):
-    vprime = O_jvp(samples, theta, v, forward_fn)
-    res = O_vjp(samples, theta, vprime.conjugate(), forward_fn)
-    return jax.tree_map(jax.lax.conj, res)  # return res.conjugate()
+def Odagger_w(samples, theta, w, forward_fn, **kwargs):
+    r"""
+    compute  O^\dagger w
+
+    TODO ...
+    """
+    # O^H w = (w^H O)^H
+    # The transposition of the 1D arrays is omitted in the implementation:
+    # (w^H O)^H -> (w* O)*
+
+    # TODO The allreduce in O_vjp could be deferred until after the tree_cast
+    # where the amount of data to be transferred would potentially be smaller
+    res = tree_conj(O_vjp(samples, theta, w.conjugate(), forward_fn, **kwargs))
+    # TODO ...
+    return tree_cast(res, theta)
 
 
-# calculate O^\dagger \Delta O v
-# where \Delta O = O-\langle O \rangle
-# optional: pass jvp_fun to be reused
-def odagdeltaov(samples, theta, v, forward_fn, vjp_fun=None):
-    # reuse vjp_fun from O_mean below for O_vjp
-    O_mean, vjp_fun = Obar(
-        samples, theta, forward_fn, return_vjp_fun=True, vjp_fun=vjp_fun
+def Odagger_O_v(samples, theta, v, forward_fn):
+    r"""
+    compute  \langle O^\dagger O \rangle v
+
+    TODO ...
+    """
+    v_tilde = O_jvp(samples, theta, v, forward_fn)
+    v_tilde = v_tilde * (1.0 / (samples.shape[0] * n_nodes))
+    return Odagger_w(samples, theta, v_tilde, forward_fn)
+
+
+def Odagger_DeltaO_v(samples, theta, v, forward_fn, vjp_fun=None):
+    r"""
+    compute \langle O^\dagger \DeltaO \rangle v
+    where \DeltaO = O - \langle O \rangle
+
+    optional: pass jvp_fun to be reused
+
+    TODO ...
+    """
+
+    # here the allreduce is deferred until after the dot product,
+    # where only scalars instead of vectors have to be summed
+    # the vjp_fun is returned so that it can be reused for O_vjp below
+    omean, vjp_fun = O_mean(
+        samples,
+        theta,
+        forward_fn,
+        return_vjp_fun=True,
+        vjp_fun=vjp_fun,
+        allreduce=False,
     )
-    vprime = O_jvp(
-        samples, theta, v, forward_fn
-    )  # is an array of size n_samples; each MPI rank has its own slice
-    # TODO tree_dot would be nice
-    # here we use jax.numpy.add to automatically promote nonhomogeneous parameters to the larger type
-
-    # omeanv = O_mean.dot(v); is a scalar
-    omeanv = jax.tree_util.tree_reduce(
-        jax.numpy.add,
-        jax.tree_map(jax.numpy.sum, jax.tree_multimap(jax.lax.mul, O_mean, v)),
-    )
+    omeanv = tree_dot(omean, v)  # omeanv = omean.dot(v); is a scalar
     omeanv = _sum_inplace(omeanv)  # MPI Allreduce w/ MPI_SUM
 
-    # vprime -= omeanv (elementwise)
-    vprime = vprime - jax.lax.broadcast(omeanv, vprime.shape)
-    # vprime /= n_samp (elementwise)
-    vprime = jax.lax.mul(
-        vprime,
-        jax.lax.broadcast(
-            jnp.array(1.0 / (samples.shape[0] * n_nodes), dtype=vprime.dtype),
-            vprime.shape,
-        ),
-    )
+    # v_tilde is an array of size n_samples; each MPI rank has its own slice
+    v_tilde = O_jvp(samples, theta, v, forward_fn)
+    # v_tilde -= omeanv (elementwise):
+    v_tilde = v_tilde - omeanv
+    # v_tilde /= n_samples (elementwise):
+    v_tilde = v_tilde * (1.0 / (samples.shape[0] * n_nodes))
 
-    res = O_vjp(samples, theta, vprime.conjugate(), forward_fn, vjp_fun=vjp_fun)
-    res = jax.tree_map(jax.lax.conj, res)  # res = res.conjugate()
-    # convert back the parameters which were promoted earlier:
-    # astype alone would also work, however this raises ComplexWarning when casting complex to real, so we take the real where needed first
-    res = jax.tree_multimap(
-        lambda x, target: (x if jnp.iscomplexobj(target) else x.real).astype(
-            target.dtype
-        ),
-        res,
-        v,
-    )
-    res = jax.tree_map(_sum_inplace, res)  # MPI Allreduce w/ MPI_SUM
-    return res
+    return Odagger_w(samples, theta, v_tilde, forward_fn, vjp_fun=vjp_fun)
 
 
+# TODO allow passing vjp_fun from e.g. a preceding gradient calculation with the same samples
+# TODO optionally return vjp_fun so that it can be reused in subsequent calls
 def mat_vec(v, forward_fn, params, samples, diag_shift):
-    # all the leaves of v need to be arrays
-    # when using MPI:
-    #      each rank has its own slice of samples
-    res = odagdeltaov(samples, params, v, forward_fn)
+    r"""
+    compute (S + diag_shift) v
+    where S = \langle O^\dagger \DeltaO \rangle
+    \DeltaO = O - \langle O \rangle
+    TODO ...
+
+    v: a pytree with the same structure as params
+    forward_fn(params, x): a vectorised function returning the logarithm of the wavefunction for each configuration in x
+    params: pytree of parameters with arrays as leaves
+    samples: an array of samples (when using MPI each rank has its own slice of samples)
+    diag_shift: a scalar diagonal shift
+    """
+
+    res = Odagger_DeltaO_v(samples, params, v, forward_fn)
     # add diagonal shift:
-    shiftv = jax.tree_map(
-        lambda x: jax.lax.mul(
-            x, jax.lax.broadcast(jnp.array(diag_shift, dtype=x.dtype), x.shape)
-        ),
-        v,
-    )
-    # res += diag_shift * v
-    res = jax.tree_multimap(jax.lax.add, res, shiftv)
+    res = tree_axpy(diag_shift, v, res)  # res += diag_shift * v
     return res

--- a/netket/optimizer/jax/_sr_onthefly.py
+++ b/netket/optimizer/jax/_sr_onthefly.py
@@ -4,8 +4,11 @@ from functools import partial
 from netket.stats import sum_inplace as _sum_inplace
 from netket.utils import n_nodes
 
+# Stochastic Reconfiguration with jvp and vjp
 
-# TODO ...
+# Here O (Oks) is the jacobian (derivatives w.r.t. params) of the vectorised (in x) log wavefunction (forward_fn) evaluated at all samples.
+# instead of computing (and storing) the full jacobian matrix jvp and vjp are used to implement the matrix vector multiplications with it.
+# Expectation values are then just the mean over the leading dimension.
 
 
 def tree_conj(t):
@@ -20,8 +23,7 @@ def tree_conj(t):
 
 def tree_dot(a, b):
     r"""
-    compute the dot product of a and b
-    TODO ...
+    compute the dot product of of the flattened arrays of a and b (without actually flattening)
 
     a, b: pytrees with the same treedef
     """
@@ -29,6 +31,7 @@ def tree_dot(a, b):
         jax.numpy.add, jax.tree_map(jax.numpy.sum, jax.tree_multimap(jax.lax.mul, a, b))
     )
     # convert shape from () to (1,)
+    # this is needed for automatic broadcasting to work also when transposed with linear_transpose
     return jnp.expand_dims(res, 0)
 
 
@@ -61,16 +64,16 @@ def tree_axpy(a, x, y):
     return jax.tree_multimap(lambda x_, y_: a * x_ + y_, x, y)
 
 
-def O_jvp(x, theta, v, forward_fn):
+def O_jvp(x, params, v, forward_fn):
     # TODO apply the transpose of sum_inplace (allreduce) to v here
     # in order to get correct transposition with MPI
-    _, res = jax.jvp(lambda p: forward_fn(p, x), (theta,), (v,))
+    _, res = jax.jvp(lambda p: forward_fn(p, x), (params,), (v,))
     return res
 
 
-def O_vjp(x, theta, v, forward_fn, return_vjp_fun=False, vjp_fun=None, allreduce=True):
+def O_vjp(x, params, v, forward_fn, return_vjp_fun=False, vjp_fun=None, allreduce=True):
     if vjp_fun is None:
-        _, vjp_fun = jax.vjp(forward_fn, theta, x)
+        _, vjp_fun = jax.vjp(forward_fn, params, x)
     res, _ = vjp_fun(v)
 
     if allreduce:
@@ -82,22 +85,20 @@ def O_vjp(x, theta, v, forward_fn, return_vjp_fun=False, vjp_fun=None, allreduce
         return res
 
 
-def O_mean(samples, theta, forward_fn, **kwargs):
+def O_mean(samples, params, forward_fn, **kwargs):
     r"""
     compute \langle O \rangle
-
-    TODO ...
+    i.e. the mean of the rows of the jacobian of forward_fn
     """
-    dtype = forward_fn(theta, samples[:1])[0].dtype
+    dtype = forward_fn(params, samples[:1])[0].dtype
     v = jnp.ones(samples.shape[0], dtype=dtype) * (1.0 / (samples.shape[0] * n_nodes))
-    return O_vjp(samples, theta, v, forward_fn, **kwargs)
+    return O_vjp(samples, params, v, forward_fn, **kwargs)
 
 
-def Odagger_w(samples, theta, w, forward_fn, **kwargs):
+def OH_w(samples, params, w, forward_fn, **kwargs):
     r"""
-    compute  O^\dagger w
-
-    TODO ...
+    compute  O^H w
+    (where ^H is the hermitian transpose)
     """
     # O^H w = (w^H O)^H
     # The transposition of the 1D arrays is omitted in the implementation:
@@ -105,38 +106,34 @@ def Odagger_w(samples, theta, w, forward_fn, **kwargs):
 
     # TODO The allreduce in O_vjp could be deferred until after the tree_cast
     # where the amount of data to be transferred would potentially be smaller
-    res = tree_conj(O_vjp(samples, theta, w.conjugate(), forward_fn, **kwargs))
-    # TODO ...
-    return tree_cast(res, theta)
+    res = tree_conj(O_vjp(samples, params, w.conjugate(), forward_fn, **kwargs))
+    #
+    return tree_cast(res, params)
 
 
-def Odagger_O_v(samples, theta, v, forward_fn):
+def Odagger_O_v(samples, params, v, forward_fn):
     r"""
     compute  \langle O^\dagger O \rangle v
-
-    TODO ...
     """
-    v_tilde = O_jvp(samples, theta, v, forward_fn)
+    v_tilde = O_jvp(samples, params, v, forward_fn)
     v_tilde = v_tilde * (1.0 / (samples.shape[0] * n_nodes))
-    return Odagger_w(samples, theta, v_tilde, forward_fn)
+    return OH_w(samples, params, v_tilde, forward_fn)
 
 
-def Odagger_DeltaO_v(samples, theta, v, forward_fn, vjp_fun=None):
+def Odagger_DeltaO_v(samples, params, v, forward_fn, vjp_fun=None):
     r"""
     compute \langle O^\dagger \DeltaO \rangle v
     where \DeltaO = O - \langle O \rangle
 
     optional: pass jvp_fun to be reused
-
-    TODO ...
     """
 
     # here the allreduce is deferred until after the dot product,
     # where only scalars instead of vectors have to be summed
-    # the vjp_fun is returned so that it can be reused for O_vjp below
+    # the vjp_fun is returned so that it can be reused in OH_w below
     omean, vjp_fun = O_mean(
         samples,
-        theta,
+        params,
         forward_fn,
         return_vjp_fun=True,
         vjp_fun=vjp_fun,
@@ -146,23 +143,27 @@ def Odagger_DeltaO_v(samples, theta, v, forward_fn, vjp_fun=None):
     omeanv = _sum_inplace(omeanv)  # MPI Allreduce w/ MPI_SUM
 
     # v_tilde is an array of size n_samples; each MPI rank has its own slice
-    v_tilde = O_jvp(samples, theta, v, forward_fn)
+    v_tilde = O_jvp(samples, params, v, forward_fn)
     # v_tilde -= omeanv (elementwise):
     v_tilde = v_tilde - omeanv
     # v_tilde /= n_samples (elementwise):
     v_tilde = v_tilde * (1.0 / (samples.shape[0] * n_nodes))
 
-    return Odagger_w(samples, theta, v_tilde, forward_fn, vjp_fun=vjp_fun)
+    return OH_w(samples, params, v_tilde, forward_fn, vjp_fun=vjp_fun)
 
 
 # TODO allow passing vjp_fun from e.g. a preceding gradient calculation with the same samples
-# TODO optionally return vjp_fun so that it can be reused in subsequent calls
+# and optionally return vjp_fun so that it can be reused in subsequent calls
+# TODO block the computations (in the same way as done with MPI) if memory consumtion becomes an issue
 def mat_vec(v, forward_fn, params, samples, diag_shift):
     r"""
     compute (S + diag_shift) v
-    where S = \langle O^\dagger \DeltaO \rangle
-    \DeltaO = O - \langle O \rangle
-    TODO ...
+
+    where the elements of S are given by
+    S_kl = \langle O_k^\dagger \DeltaO_ \rangle
+    \DeltaO_k = O_k - \langle O_k \rangle
+    and O_k (operator) is derivative of the log wavefunction w.r.t parameter k
+    The expectation values are calculated as mean over the samples
 
     v: a pytree with the same structure as params
     forward_fn(params, x): a vectorised function returning the logarithm of the wavefunction for each configuration in x

--- a/netket/optimizer/jax/_sr_onthefly.py
+++ b/netket/optimizer/jax/_sr_onthefly.py
@@ -6,8 +6,9 @@ from functools import partial
 # onthefly SR
 # since we cant store O if #samples x #params is too large
 
+
 def O_jvp(x, theta, v, vlogwf):
-    _, res = jax.jvp(lambda p: vlogwf(p,x), (theta,), (v,))
+    _, res = jax.jvp(lambda p: vlogwf(p, x), (theta,), (v,))
     return res
 
 
@@ -25,7 +26,7 @@ def O_vjp(x, theta, v, vlogwf, return_vjp_fun=False, vjp_fun=None):
 def Obar(samples, theta, vlogwf, **kwargs):
     # TODO better way to get dtype
     dtype = vlogwf(theta, samples[:1])[0].dtype
-    v = jnp.ones(samples.shape[0], dtype=dtype)/samples.shape[0]
+    v = jnp.ones(samples.shape[0], dtype=dtype) / samples.shape[0]
     return O_vjp(samples, theta, v, vlogwf, **kwargs)
 
 
@@ -42,27 +43,50 @@ def odagov(samples, theta, v, vlogwf):
 # optional: pass jvp_fun to be reused
 # TODO vjp_fun and jit??
 # @partial(jax.jit, static_argnums=3)
-def odagdeltaov(samples, theta, v, vlogwf, vjp_fun=None, factor=1.):
+def odagdeltaov(samples, theta, v, vlogwf, vjp_fun=None, factor=1.0):
     # reuse vjp_fun from O_mean below for O_vjp
     O_mean, vjp_fun = Obar(samples, theta, vlogwf, return_vjp_fun=True, vjp_fun=vjp_fun)
-    vprime = O_jvp(samples, theta, v, vlogwf) # is an array of size n_samples
+    vprime = O_jvp(samples, theta, v, vlogwf)  # is an array of size n_samples
     # TODO tree_dot would be nice
     # here we use jax.numpy.add to automatically promote nonhomogeneous parameters to the larger type
-    omeanv = jax.tree_util.tree_reduce(jax.numpy.add, jax.tree_map(jax.numpy.sum, jax.tree_multimap(jax.lax.mul, O_mean, v)))  # omeanv = O_mean.dot(v); is a scalar
-    vprime = vprime - jax.lax.broadcast(omeanv, vprime.shape)  # vprime -= omeanv (elementwise)
-    vprime = jax.lax.mul(vprime, jax.lax.broadcast(jnp.array(factor, dtype=vprime.dtype), vprime.shape))  # vprime *= factor (elementwise)
+
+    # omeanv = O_mean.dot(v); is a scalar
+    omeanv = jax.tree_util.tree_reduce(
+        jax.numpy.add,
+        jax.tree_map(jax.numpy.sum, jax.tree_multimap(jax.lax.mul, O_mean, v)),
+    )
+    # vprime -= omeanv (elementwise)
+    vprime = vprime - jax.lax.broadcast(omeanv, vprime.shape)
+    # vprime *= factor (elementwise)
+    vprime = jax.lax.mul(
+        vprime, jax.lax.broadcast(jnp.array(factor, dtype=vprime.dtype), vprime.shape)
+    )
+
     res = O_vjp(samples, theta, vprime.conjugate(), vlogwf, vjp_fun=vjp_fun)
     res = jax.tree_map(jax.lax.conj, res)  # res = res.conjugate()
     # convert back the parameters which were promoted earlier:
     # astype alone would also work, however this raises ComplexWarning when casting complex to real, so we take the real where needed first
-    res = jax.tree_multimap(lambda x, target: (x if jnp.iscomplexobj(target) else x.real).astype(target.dtype), res, v)
+    res = jax.tree_multimap(
+        lambda x, target: (x if jnp.iscomplexobj(target) else x.real).astype(
+            target.dtype
+        ),
+        res,
+        v,
+    )
     return res
+
 
 def mat_vec(v, forward_fn, params, samples, diag_shift, n_samp):
     # all the leaves of v need to be arrays, since we need to broadcast
     # TODO where to do the 1/n_samp ?
-    res = odagdeltaov(samples, params, v, forward_fn, factor=1./n_samp)
+    res = odagdeltaov(samples, params, v, forward_fn, factor=1.0 / n_samp)
     # add diagonal shift:
-    shiftv = jax.tree_map(lambda x: jax.lax.mul(x, jax.lax.broadcast(jnp.array(diag_shift, dtype=x.dtype), x.shape)), v)
-    res = jax.tree_multimap(jax.lax.add, res, shiftv)  # res += diag_shift * v
+    shiftv = jax.tree_map(
+        lambda x: jax.lax.mul(
+            x, jax.lax.broadcast(jnp.array(diag_shift, dtype=x.dtype), x.shape)
+        ),
+        v,
+    )
+    # res += diag_shift * v
+    res = jax.tree_multimap(jax.lax.add, res, shiftv)
     return res

--- a/netket/optimizer/jax/_sr_onthefly.py
+++ b/netket/optimizer/jax/_sr_onthefly.py
@@ -47,8 +47,22 @@ def odagdeltaov(samples, theta, v, vlogwf, vjp_fun=None, factor=1.):
     O_mean, vjp_fun = Obar(samples, theta, vlogwf, return_vjp_fun=True, vjp_fun=vjp_fun)
     vprime = O_jvp(samples, theta, v, vlogwf) # is an array of size n_samples
     # TODO tree_dot would be nice
-    omeanv = jax.tree_util.tree_reduce(jax.lax.add, jax.tree_map(jax.numpy.sum, jax.tree_multimap(jax.lax.mul, O_mean, v)))  # omeanv = O_mean.dot(v); is a scalar
+    # here we use jax.numpy.add to automatically promote nonhomogeneous parameters to the larger type
+    omeanv = jax.tree_util.tree_reduce(jax.numpy.add, jax.tree_map(jax.numpy.sum, jax.tree_multimap(jax.lax.mul, O_mean, v)))  # omeanv = O_mean.dot(v); is a scalar
     vprime = vprime - jax.lax.broadcast(omeanv, vprime.shape)  # vprime -= omeanv (elementwise)
     vprime = jax.lax.mul(vprime, jax.lax.broadcast(jnp.array(factor, dtype=vprime.dtype), vprime.shape))  # vprime *= factor (elementwise)
     res = O_vjp(samples, theta, vprime.conjugate(), vlogwf, vjp_fun=vjp_fun)
-    return jax.tree_map(jax.lax.conj, res)  # return res.conjugate()
+    res = jax.tree_map(jax.lax.conj, res)  # res = res.conjugate()
+    # convert back the parameters which were promoted earlier:
+    # astype alone would also work, however this raises ComplexWarning when casting complex to real, so we take the real where needed first
+    res = jax.tree_multimap(lambda x, target: (x if jnp.iscomplexobj(target) else x.real).astype(target.dtype), res, v)
+    return res
+
+def mat_vec(v, forward_fn, params, samples, diag_shift, n_samp):
+    # all the leaves of v need to be arrays, since we need to broadcast
+    # TODO where to do the 1/n_samp ?
+    res = odagdeltaov(samples, params, v, forward_fn, factor=1./n_samp)
+    # add diagonal shift:
+    shiftv = jax.tree_map(lambda x: jax.lax.mul(x, jax.lax.broadcast(jnp.array(diag_shift, dtype=x.dtype), x.shape)), v)
+    res = jax.tree_multimap(jax.lax.add, res, shiftv)  # res += diag_shift * v
+    return res

--- a/netket/optimizer/jax/stochastic_reconfiguration.py
+++ b/netket/optimizer/jax/stochastic_reconfiguration.py
@@ -60,10 +60,27 @@ def _jax_cg_solve(
 
 
 @partial(jit, static_argnums=1)
-def _jax_cg_solve_onthefly(x0, forward_fn, params, samples, grad, diag_shift, n_samp, sparse_tol, sparse_maxiter):
+def _jax_cg_solve_onthefly(
+    x0,
+    forward_fn,
+    params,
+    samples,
+    grad,
+    diag_shift,
+    n_samp,
+    sparse_tol,
+    sparse_maxiter,
+):
     # leaves in x0 and grad are required to be arrays and need to have the same structure
-    # TODO !!! MPI
-    _mat_vec = partial(_mat_vec_onthefly, forward_fn=forward_fn, params=params, samples=samples, diag_shift=diag_shift, n_samp=n_samp)
+    # TODO MPI
+    _mat_vec = partial(
+        _mat_vec_onthefly,
+        forward_fn=forward_fn,
+        params=params,
+        samples=samples,
+        diag_shift=diag_shift,
+        n_samp=n_samp,
+    )
     out, _ = cg(_mat_vec, grad, x0=x0, tol=sparse_tol, maxiter=sparse_maxiter)
     return out
 
@@ -236,7 +253,6 @@ class SR:
 
         return out
 
-
     def compute_update_onthefly(self, samples, grad, out=None):
         r"""
         Solves the SR flow equation for the parameter update ẋ.
@@ -256,7 +272,6 @@ class SR:
         # TODO pass vjp_fun from gradient calculation which can be reused for delta_odagov
         # TODO describe somewhere that vjp and jvp just automagically work with pytrees so we dont have to flatten
         # TODO MPI
-
 
         n_samp = samples.shape[0]
 
@@ -279,7 +294,6 @@ class SR:
             self._x0 = out
 
         return out
-
 
     def __repr__(self):
         rep = "SR(solver="

--- a/netket/optimizer/jax/stochastic_reconfiguration.py
+++ b/netket/optimizer/jax/stochastic_reconfiguration.py
@@ -11,7 +11,7 @@ from jax.tree_util import tree_flatten
 from netket.vmc_common import jax_shape_for_update
 from netket.utils import n_nodes, mpi4jax_available
 
-from ._sr_onthefly import odagdeltaov
+from ._sr_onthefly import mat_vec as _mat_vec_onthefly
 
 
 def _S_grad_mul(oks, v, n_samp):
@@ -60,20 +60,10 @@ def _jax_cg_solve(
 
 
 @partial(jit, static_argnums=(1, 9))
-def _jax_cg_solve_onthefly(x0, forward_fn, params, samples, grad, diag_shift, n_samp, sparse_tol, sparse_maxiter, has_complex_parameters):
+def _jax_cg_solve_onthefly(x0, forward_fn, params, samples, grad, diag_shift, n_samp, sparse_tol, sparse_maxiter):
     # leaves in x0 and grad are required to be arrays and need to have the same structure
     # TODO !!! MPI
-    def _mat_vec(v):
-        # all the leaves of v need to be arrays, since we need to broadcast
-        # TODO where to do the 1/n_samp ?
-        res = odagdeltaov(samples, params, v, forward_fn, factor=1./n_samp)
-        # add diagonal shift:
-        shiftv = jax.tree_map(lambda x: jax.lax.mul(x, jax.lax.broadcast(jnp.array(diag_shift, dtype=x.dtype), x.shape)), v)
-        res = jax.tree_multimap(jax.lax.add, res, shiftv)
-        if not has_complex_parameters:
-            res = jax.tree_map(jax.lax.real, res)
-        return res
-
+    _mat_vec = partial(_mat_vec_onthefly, forward_fn=forward_fn, params=params, samples=samples, diag_shift=diag_shift, n_samp=n_samp)
     out, _ = cg(_mat_vec, grad, x0=x0, tol=sparse_tol, maxiter=sparse_maxiter)
     return out
 
@@ -271,11 +261,7 @@ class SR:
         n_samp = samples.shape[0]
 
         if self._x0 is None:
-            # TODO zeros_like for pytree would be nice
-            self._x0 = jax.tree_map(partial(jax.numpy.multiply, 0), grad)  # x0 = jnp.zeros_like(grad)
-
-        if not self.has_complex_parameters:
-            grad = jax.tree_map(jax.lax.real, grad)  # grad = grad.real
+            self._x0 = jax.tree_map(jnp.zeros_like, grad)  # x0 = jnp.zeros_like(grad)
 
         if self._use_iterative:
             if self._lsq_solver == "cg":
@@ -289,7 +275,6 @@ class SR:
                     n_samp,
                     self.sparse_tol,
                     self.sparse_maxiter,
-                    self.has_complex_parameters
                 )
             self._x0 = out
 

--- a/netket/optimizer/jax/stochastic_reconfiguration.py
+++ b/netket/optimizer/jax/stochastic_reconfiguration.py
@@ -42,9 +42,7 @@ def _matvec_real(v, oks, diag_shift):
 
 
 @partial(jit, static_argnums=1)
-def _jax_cg_solve(
-    x0, mat_vec, oks, grad, diag_shift, sparse_tol, sparse_maxiter
-):
+def _jax_cg_solve(x0, mat_vec, oks, grad, diag_shift, sparse_tol, sparse_maxiter):
     r"""
     Solves the SR flow equation using the conjugate gradient method
     """
@@ -101,7 +99,7 @@ _flatten_grad_and_oks = jax.jit(_shape_for_sr)
 
 @jit
 def _subtract_mean_from_oks(oks):
-    return oks - _sum_inplace(jnp.sum(oks, axis=0) / (oks.shape[0]*n_nodes))
+    return oks - _sum_inplace(jnp.sum(oks, axis=0) / (oks.shape[0] * n_nodes))
 
 
 class SR:

--- a/netket/optimizer/jax/stochastic_reconfiguration.py
+++ b/netket/optimizer/jax/stochastic_reconfiguration.py
@@ -115,7 +115,7 @@ class SR:
         svd_threshold=None,
         sparse_tol=None,
         sparse_maxiter=None,
-        onthefly=True
+        onthefly=True,
     ):
 
         if n_nodes > 1 and not mpi4jax_available:

--- a/netket/optimizer/jax/stochastic_reconfiguration.py
+++ b/netket/optimizer/jax/stochastic_reconfiguration.py
@@ -1,4 +1,4 @@
-from functools import partial, singledispatch
+from functools import partial
 from netket.stats import sum_inplace as _sum_inplace
 from netket.utils import n_nodes
 
@@ -8,21 +8,12 @@ import jax.numpy as jnp
 from jax import jit
 from jax.scipy.sparse.linalg import cg
 from jax.tree_util import tree_flatten
-from jax.flatten_util import ravel_pytree
 from netket.vmc_common import jax_shape_for_update
 from netket.utils import n_nodes, mpi4jax_available
 
-from ._sr_onthefly import delta_odagov
+from ._sr_onthefly import odagdeltaov
 
 
-# TODO optionally pass vjp_fun
-def _S_grad_mul_onthefly(forward_fn, params, samples, v, n_samp):
-    # forward_fn is vectorised in samples
-    # TODO where to do the n_samp division
-    return delta_odagov(samples, params, v, forward_fn, factor=n_samp)
-
-
-@singledispatch
 def _S_grad_mul(oks, v, n_samp):
     r"""
     Computes y = 1/N * ( O^\dagger * O * v ) where v is a vector of
@@ -31,14 +22,6 @@ def _S_grad_mul(oks, v, n_samp):
     v_tilde = jnp.matmul(oks, v) / n_samp
     y = jnp.matmul(oks.conjugate().transpose(), v_tilde)
     return y
-
-# TODO avoid workaround
-# TODO where to jit
-# TODO optionally pass vjp_fun
-@_S_grad_mul.register
-def _S_grad_mul_onthefly_test(args: tuple, v, n_samp):
-    forward_fn, params, samples = args
-    return _S_grad_mul_onthefly(forward_fn, params, samples, v, n_samp)
 
 
 def _compose_result_cmplx(v, y, diag_shift):
@@ -74,16 +57,23 @@ def _jax_cg_solve(
     out, _ = cg(_mat_vec, grad, x0=x0, tol=sparse_tol, maxiter=sparse_maxiter)
 
     return out
-# cant use the other one cause wee need static_argnums for forward_fn
-@partial(jit, static_argnums=(1,2))
-def _jax_cg_solve_onthefly(
-    x0, mat_vec, forward_fn, params, samples, grad, diag_shift, n_samp, sparse_tol, sparse_maxiter
-):
-    r"""
-    Solves the SR flow equation using the conjugate gradient method
-    """
 
-    _mat_vec = partial(mat_vec, oks=(forward_fn, params, samples), diag_shift=diag_shift, n_samp=n_samp)
+
+@partial(jit, static_argnums=(1, 9))
+def _jax_cg_solve_onthefly(x0, forward_fn, params, samples, grad, diag_shift, n_samp, sparse_tol, sparse_maxiter, has_complex_parameters):
+    # leaves in x0 and grad are required to be arrays and need to have the same structure
+    # TODO !!! MPI
+    def _mat_vec(v):
+        # all the leaves of v need to be arrays, since we need to broadcast
+        # TODO where to do the 1/n_samp ?
+        res = odagdeltaov(samples, params, v, forward_fn, factor=1./n_samp)
+        # add diagonal shift:
+        shiftv = jax.tree_map(lambda x: jax.lax.mul(x, jax.lax.broadcast(jnp.array(diag_shift, dtype=x.dtype), x.shape)), v)
+        res = jax.tree_multimap(jax.lax.add, res, shiftv)
+        if not has_complex_parameters:
+            res = jax.tree_map(jax.lax.real, res)
+        return res
+
     out, _ = cg(_mat_vec, grad, x0=x0, tol=sparse_tol, maxiter=sparse_maxiter)
     return out
 
@@ -192,15 +182,6 @@ class SR:
         else:
             self._mat_vec = _matvec_real
 
-        # captured here
-        # TODO move it to jax machine??
-        _, unravel_pytree  = ravel_pytree(self._machine.parameters)
-        def forward_fn_flat(params_flat, inputs, **kwargs):
-            par = unravel_pytree(params_flat)
-            return self._machine._forward_fn_nj(par, inputs, **kwargs)
-        self._forward_fn_flat = forward_fn_flat
-
-
     def compute_update(self, oks, grad, out=None):
         r"""
         Solves the SR flow equation for the parameter update ẋ.
@@ -265,6 +246,7 @@ class SR:
 
         return out
 
+
     def compute_update_onthefly(self, samples, grad, out=None):
         r"""
         Solves the SR flow equation for the parameter update ẋ.
@@ -281,61 +263,37 @@ class SR:
             out: A pytree of the parameter updates that will be ignored
         """
 
-        # TODO pass vjp_fun from gradient calculation
-        # which can be reused for delta_odagov
+        # TODO pass vjp_fun from gradient calculation which can be reused for delta_odagov
+        # TODO describe somewhere that vjp and jvp just automagically work with pytrees so we dont have to flatten
+        # TODO MPI
 
-        if self.has_complex_parameters is None or self._machine is None:
-            raise ValueError("This SR object is not properly initialized.")
 
-        grad_flat, unravel_pytree  = ravel_pytree(grad)
-        params_flat, _  = ravel_pytree(self._machine.parameters)
         n_samp = samples.shape[0]
-        n_par = params_flat.shape[0]
 
         if self._x0 is None:
-            if self.has_complex_parameters:
-                self._x0 = jnp.zeros(n_par, dtype=jnp.complex128)
-            else:
-                self._x0 = jnp.zeros(n_par, dtype=jnp.float64)
+            # TODO zeros_like for pytree would be nice
+            self._x0 = jax.tree_map(partial(jax.numpy.multiply, 0), grad)  # x0 = jnp.zeros_like(grad)
 
+        if not self.has_complex_parameters:
+            grad = jax.tree_map(jax.lax.real, grad)  # grad = grad.real
 
-        if self.has_complex_parameters:
-            if self._use_iterative:
-                if self._lsq_solver == "cg":
-                    out = _jax_cg_solve_onthefly(
-                        self._x0,
-                        self._mat_vec,
-                        self._forward_fn_flat,
-                        params_flat,
-                        samples,
-                        grad_flat,
-                        self._diag_shift,
-                        n_samp,
-                        self.sparse_tol,
-                        self.sparse_maxiter,
-                    )
-                self._x0 = out
-        else:
-            if self._use_iterative:
-                if self._lsq_solver == "cg":
-                    out = _jax_cg_solve_onthefly(
-                        self._x0,
-                        self._mat_vec,
-                        self._forward_fn_flat,
-                        params_flat,
-                        samples,
-                        grad_flat.real,
-                        self._diag_shift,
-                        n_samp,
-                        self.sparse_tol,
-                        self.sparse_maxiter,
-                    )
-                self._x0 = out
-
-        out = unravel_pytree(out)
+        if self._use_iterative:
+            if self._lsq_solver == "cg":
+                out = _jax_cg_solve_onthefly(
+                    self._x0,
+                    self._machine._forward_fn_nj,
+                    self._machine.parameters,
+                    samples,
+                    grad,
+                    self._diag_shift,
+                    n_samp,
+                    self.sparse_tol,
+                    self.sparse_maxiter,
+                    self.has_complex_parameters
+                )
+            self._x0 = out
 
         return out
-
 
 
     def __repr__(self):

--- a/netket/optimizer/jax/stochastic_reconfiguration.py
+++ b/netket/optimizer/jax/stochastic_reconfiguration.py
@@ -115,6 +115,7 @@ class SR:
         svd_threshold=None,
         sparse_tol=None,
         sparse_maxiter=None,
+        onthefly=True
     ):
 
         if n_nodes > 1 and not mpi4jax_available:
@@ -125,6 +126,7 @@ class SR:
                 """
             )
 
+        self._onthefly = onthefly
         self._lsq_solver = lsq_solver
         self._diag_shift = diag_shift
         self._use_iterative = use_iterative
@@ -312,3 +314,7 @@ class SR:
     @property
     def has_complex_parameters(self):
         return self._has_complex_parameters
+
+    @property
+    def onthefly(self):
+        return self._onthefly

--- a/netket/optimizer/jax/stochastic_reconfiguration.py
+++ b/netket/optimizer/jax/stochastic_reconfiguration.py
@@ -59,7 +59,7 @@ def _jax_cg_solve(
     return out
 
 
-@partial(jit, static_argnums=(1, 9))
+@partial(jit, static_argnums=1)
 def _jax_cg_solve_onthefly(x0, forward_fn, params, samples, grad, diag_shift, n_samp, sparse_tol, sparse_maxiter):
     # leaves in x0 and grad are required to be arrays and need to have the same structure
     # TODO !!! MPI

--- a/netket/optimizer/jax/stochastic_reconfiguration.py
+++ b/netket/optimizer/jax/stochastic_reconfiguration.py
@@ -261,6 +261,14 @@ class SR:
             out: A pytree of the parameter updates that will be ignored
         """
 
+        grad = jax.tree_multimap(
+            lambda x, target: (x if jnp.iscomplexobj(target) else x.real).astype(
+                target.dtype
+            ),
+            grad,
+            self._machine.parameters,
+        )
+
         if self._x0 is None:
             self._x0 = jax.tree_map(jnp.zeros_like, grad)  # x0 = jnp.zeros_like(grad)
 

--- a/netket/optimizer/numpy/stochastic_reconfiguration.py
+++ b/netket/optimizer/numpy/stochastic_reconfiguration.py
@@ -323,3 +323,7 @@ class SR:
     @property
     def has_complex_parameters(self):
         return self._has_complex_parameters
+
+    @property
+    def onthefly(self):
+        return False

--- a/netket/stats/_sum_inplace.py
+++ b/netket/stats/_sum_inplace.py
@@ -78,7 +78,8 @@ if jax_available:
             if _n_nodes == 1:
                 return x
             else:
-                res, _ = mpi4jax.Allreduce(x, op=_MPI.SUM, comm=_MPI_comm)
+                token = jax.lax.create_token(0)
+                res, _ = mpi4jax.Allreduce(x, op=_MPI.SUM, comm=_MPI_comm, token=token)
                 return res
 
     else:

--- a/netket/stats/_sum_inplace.py
+++ b/netket/stats/_sum_inplace.py
@@ -78,6 +78,9 @@ if jax_available:
             if _n_nodes == 1:
                 return x
             else:
+                # Note: We must supply a token because we can't transpose `create_token`.
+                # The token can't depend on x for the same reason
+                # This token depends on a constant and will be eliminated by DCE
                 token = jax.lax.create_token(0)
                 res, _ = mpi4jax.Allreduce(x, op=_MPI.SUM, comm=_MPI_comm, token=token)
                 return res

--- a/netket/utils.py
+++ b/netket/utils.py
@@ -47,6 +47,11 @@ if jax_available:
 else:
     mpi4jax_available = False
 
+if mpi4jax_available and not mpi4jax.__version__ >= "0.2.7":
+    raise ImportError(
+        "Netket is only compatible with mpi4jax >= 0.2.7. Please update it (`pip install -U mpi4jax`)."
+    )
+
 try:
     import torch
 

--- a/netket/utils.py
+++ b/netket/utils.py
@@ -1,3 +1,5 @@
+from distutils.version import LooseVersion as _LooseVersion
+
 try:
     from mpi4py import MPI
 
@@ -47,10 +49,15 @@ if jax_available:
 else:
     mpi4jax_available = False
 
-if mpi4jax_available and not mpi4jax.__version__ >= "0.2.7":
-    raise ImportError(
-        "Netket is only compatible with mpi4jax >= 0.2.7. Please update it (`pip install -U mpi4jax`)."
-    )
+
+if mpi4jax_available:
+    _min_mpi4jax_version = "0.2.7"
+    if not _LooseVersion(mpi4jax.__version__) >= _LooseVersion(_min_mpi4jax_version):
+        raise ImportError(
+            "Netket is only compatible with mpi4jax >= {}. Please update it (`pip install -U mpi4jax`).".format(
+                _min_mpi4jax_version
+            )
+        )
 
 try:
     import torch

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ DEV_DEPENDENCIES = [
 MPI_DEPENDENCIES = ["mpi4py>=3.0.1"]
 JAX_DEPENDENCIES = ["jax"]
 
-MPIJAX_DEPENDENCIES = ["mpi4jax>=0.2.6"]
+MPIJAX_DEPENDENCIES = ["mpi4jax>=0.2.7"]
 
 setup(
     name="netket",


### PR DESCRIPTION
Adds the option to do stochastic reconfiguration where the gradients are never stored, but (re-)calculated using  jvp and vjp for every matrix-vector product in the iterative solver.

There are several advantages of this approach:
- works for large numbers of samples and parameters where its impossible to store the gradients
- non-homogeneous parameters can be treated more easily
- can be faster for certain kinds of machines

I guess the integration in the existing SR class still needs some tweaking...
Also see the test for a version of the existing code which can deal with non-homogeneous parameters