### PR TITLE
Standardize use of AbstractGraph.n_nodes and add n_edges

### DIFF
--- a/Test/Graph/test_graph.py
+++ b/Test/Graph/test_graph.py
@@ -125,7 +125,7 @@ def tonx(graph):
         return nx.from_edgelist(edges)
 
     gx = nx.Graph()
-    for i in range(graph.n_sites):
+    for i in range(graph.n_nodes):
         gx.add_node(i)
     return gx
 
@@ -192,12 +192,12 @@ def test_adjacency_list():
         neigh = []
         g = nx.Graph()
 
-        for i in range(graph.n_sites):
+        for i in range(graph.n_nodes):
             g.add_node(i)
 
         for edge in graph.edges():
             g.add_edge(edge[0], edge[1])
-        for i in range(graph.n_sites):
+        for i in range(graph.n_nodes):
             neigh.append(set(g.neighbors(i)))
         dim = len(neigh)
         adl = graph.adjacency_list()

--- a/Test/Graph/test_graph.py
+++ b/Test/Graph/test_graph.py
@@ -133,6 +133,7 @@ def tonx(graph):
 def test_size_is_positive():
     for graph in graphs:
         assert graph.n_nodes > 0
+        assert graph.n_edges >= 0
 
 
 def test_is_connected():

--- a/Test/Graph/test_graph.py
+++ b/Test/Graph/test_graph.py
@@ -210,7 +210,7 @@ def test_grid_color_pbc():
     g = Grid([4, 4], pbc=True, color_edges=True)
     assert len(g.edges(color=0)) == 16
     assert len(g.edges(color=1)) == 16
-    assert len(g.edges()) == 32
+    assert g.n_edges == 32
 
     g = Grid([4, 2], pbc=True, color_edges=True)
     assert len(g.edges(color=0)) == 8
@@ -261,4 +261,4 @@ def test_union():
         ug = nk.graph.disjoint_union(graph, graph1)
 
         assert ug.n_nodes == graph1.n_nodes + graph.n_nodes
-        assert len(ug.edges()) == len(graph1.edges()) + len(graph.edges())
+        assert ug.n_edges == graph1.n_edges + graph.n_edges

--- a/Test/Graph/test_graph.py
+++ b/Test/Graph/test_graph.py
@@ -114,9 +114,10 @@ def test_edges_are_correct():
 
 
 def test_nodes():
+    count = lambda it: sum(1 for _ in it)
     for graph in graphs:
         nodes = graph.nodes()
-        assert len(nodes) == graph.n_nodes
+        assert count(nodes) == graph.n_nodes
 
 
 def tonx(graph):
@@ -214,18 +215,21 @@ def test_adjacency_list():
 
 
 def test_grid_color_pbc():
+    # compute length from iterator
+    count = lambda it: sum(1 for _ in it)
+
     g = Grid([4, 4], pbc=True, color_edges=True)
-    assert len(g.edges(color=0)) == 16
-    assert len(g.edges(color=1)) == 16
+    assert count(g.edges(color=0)) == 16
+    assert count(g.edges(color=1)) == 16
     assert g.n_edges == 32
 
     g = Grid([4, 2], pbc=True, color_edges=True)
-    assert len(g.edges(color=0)) == 8
-    assert len(g.edges(color=1)) == 4
+    assert count(g.edges(color=0)) == 8
+    assert count(g.edges(color=1)) == 4
 
     g = Grid([4, 2], pbc=False, color_edges=True)
-    assert len(g.edges(color=0)) == 6
-    assert len(g.edges(color=1)) == 4
+    assert count(g.edges(color=0)) == 6
+    assert count(g.edges(color=1)) == 4
 
     with pytest.raises(ValueError, match="Directions with length <= 2 cannot have PBC"):
         g = Grid([2, 4], pbc=[True, True])

--- a/Test/Graph/test_graph.py
+++ b/Test/Graph/test_graph.py
@@ -113,6 +113,12 @@ def test_edges_are_correct():
         check_edges(3, 7, pbc)
 
 
+def test_nodes():
+    for graph in graphs:
+        nodes = graph.nodes()
+        assert len(nodes) == graph.n_nodes
+
+
 def tonx(graph):
     adl = graph.adjacency_list()
     i = 0

--- a/netket/graph/abstract_graph.py
+++ b/netket/graph/abstract_graph.py
@@ -20,6 +20,11 @@ class AbstractGraph(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
+    def nodes(self):
+        r"""list: List containing the nodes of the graph"""
+        raise NotImplementedError
+
+    @abc.abstractmethod
     def distances(self):
         r"""list[list]: List containing the distances between the nodes.
         The fact that some node may not be reachable from another is represented by -1"""

--- a/netket/graph/abstract_graph.py
+++ b/netket/graph/abstract_graph.py
@@ -36,18 +36,8 @@ class AbstractGraph(abc.ABC):
         r"""int: The number of vertices in the graph"""
         raise NotImplementedError
 
-    @property
-    def n_sites(self):
-        r"""int: The number of vertices in the graph"""
-        return self.n_nodes
-
-    @property
-    def n_vertices(self):
-        r"""int: The number of vertices in the graph"""
-        return self.n_nodes
-
     @abc.abstractmethod
     def adjacency_list(self):
         r"""list[list]: List containing the adjacency list of the graph where each node
-        is represented by an integer in [0, n_sites)"""
+        is represented by an integer in [0, n_nodes)"""
         raise NotImplementedError

--- a/netket/graph/abstract_graph.py
+++ b/netket/graph/abstract_graph.py
@@ -16,12 +16,12 @@ class AbstractGraph(abc.ABC):
 
     @abc.abstractmethod
     def edges(self):
-        r"""list: List containing the edges of the graph"""
+        r"""Iterator over the edges of the graph"""
         raise NotImplementedError
 
     @abc.abstractmethod
     def nodes(self):
-        r"""list: List containing the nodes of the graph"""
+        r"""Iterator over the nodes of the graph"""
         raise NotImplementedError
 
     @abc.abstractmethod

--- a/netket/graph/abstract_graph.py
+++ b/netket/graph/abstract_graph.py
@@ -33,8 +33,13 @@ class AbstractGraph(abc.ABC):
     @property
     @abc.abstractmethod
     def n_nodes(self):
-        r"""int: The number of vertices in the graph"""
+        r"""int: The number of nodes (or vertices) in the graph"""
         raise NotImplementedError
+
+    @property
+    def n_edges(self):
+        r"""int: The number of edges in the graph."""
+        return len(self.edges())
 
     @abc.abstractmethod
     def adjacency_list(self):

--- a/netket/graph/graph.py
+++ b/netket/graph/graph.py
@@ -43,15 +43,15 @@ class NetworkX(AbstractGraph):
         return _nx.is_connected(self.graph)
 
     def nodes(self):
-        return list(self.graph.nodes())
+        return self.graph.nodes()
 
     def edges(self, color=False):
         if color is True:
-            return list(self.graph.edges(data="color"))
+            return self.graph.edges(data="color")
         elif color is not False:
-            return [(u, v) for u, v, k in self.graph.edges(data="color") if k == color]
+            return ((u, v) for u, v, k in self.graph.edges(data="color") if k == color)
         else:  # color is False
-            return list(self.graph.edges())
+            return self.graph.edges()
 
     def distances(self):
         return _nx.floyd_warshall_numpy(self.graph).tolist()
@@ -195,7 +195,7 @@ def DoubledGraph(graph):
     The resulting graph is composed of two disjoint sub-graphs identical to the input.
     """
 
-    dedges = graph.edges()
+    dedges = list(graph.edges())
     n_v = graph.n_nodes
 
     dedges += [(edge[0] + n_v, edge[1] + n_v) for edge in graph.edges()]

--- a/netket/graph/graph.py
+++ b/netket/graph/graph.py
@@ -42,6 +42,9 @@ class NetworkX(AbstractGraph):
     def is_connected(self):
         return _nx.is_connected(self.graph)
 
+    def nodes(self):
+        return list(self.graph.nodes())
+
     def edges(self, color=False):
         if color is True:
             return list(self.graph.edges(data="color"))

--- a/netket/graph/graph.py
+++ b/netket/graph/graph.py
@@ -60,6 +60,10 @@ class NetworkX(AbstractGraph):
     def n_nodes(self):
         return self.graph.number_of_nodes()
 
+    @property
+    def n_edges(self):
+        return self.graph.size()
+
     def automorphisms(self):
         # TODO: check how to compute these when we have a coloured graph where there could
         #       be a duplicated edge with two different colors.

--- a/netket/graph/graph.py
+++ b/netket/graph/graph.py
@@ -168,13 +168,12 @@ def Edgeless(nodes):
     Args:
         nodes: An integer number of nodes or a list of ints that index nodes of a graph
     Example:
-        A 10-site one-dimensional lattice with periodic boundary conditions can be
-        constructed specifying the edges as follows:
-
         >>> import netket
         >>> g=netket.graph.Edgeless([0,1,2,3])
         >>> print(g.n_nodes)
         4
+        >>> print(g.n_edges)
+        0
     """
     if not isinstance(nodes, list):
         if not isinstance(nodes, int):

--- a/netket/graph/graph.py
+++ b/netket/graph/graph.py
@@ -189,7 +189,7 @@ def DoubledGraph(graph):
     """
 
     dedges = graph.edges()
-    n_v = graph.n_vertices
+    n_v = graph.n_nodes
 
     dedges += [(edge[0] + n_v, edge[1] + n_v) for edge in graph.edges()]
 

--- a/netket/graph/grid.py
+++ b/netket/graph/grid.py
@@ -8,7 +8,7 @@ class Grid(NetworkX):
     r"""A Grid lattice of d dimensions, and possibly different sizes of each dimension.
     Periodic boundary conditions can also be imposed"""
 
-    def __init__(self, length, pbc=True, color_edges=False):
+    def __init__(self, length, *, pbc=True, color_edges=False):
         """
         Constructs a new `Grid` given its length vector.
 
@@ -95,42 +95,40 @@ class Grid(NetworkX):
         return "Grid(length={}, pbc={})".format(self.length, self.pbc)
 
 
-def Hypercube(length, n_dim=1, pbc=True):
+def Hypercube(length, n_dim=1, *, pbc=True):
     r"""A hypercube lattice of side L in d dimensions.
     Periodic boundary conditions can also be imposed.
 
     Constructs a new ``Hypercube`` given its side length and dimension.
 
     Args:
-        length: Side length of the hypercube.
-             It must always be >=1
-         n_dim: Dimension of the hypercube. It must be at least 1.
+        length: Side length of the hypercube; must always be >=1
+         n_dim: Dimension of the hypercube; must be at least 1.
          pbc: If ``True`` then the constructed hypercube
              will have periodic boundary conditions, otherwise
              open boundary conditions are imposed.
 
     Examples:
-         A 10x10x10 hypercubic lattice with periodic boundary conditions can be
+         A 10x10x10 cubic lattice with periodic boundary conditions can be
          constructed as follows:
 
          >>> import netket
-         >>> g=netket.graph.Hypercube(length=10,n_dim=3,pbc=True)
+         >>> g = netket.graph.Hypercube(10, n_dim=3, pbc=True)
          >>> print(g.n_nodes)
          1000
     """
     length_vector = [length] * n_dim
-    return Grid(length_vector, pbc)
+    return Grid(length_vector, pbc=pbc)
 
 
-def Square(length, pbc=True):
+def Square(length, *, pbc=True):
     r"""A square lattice of side L.
     Periodic boundary conditions can also be imposed
 
     Constructs a new ``Square`` given its side length.
 
     Args:
-        length: Side length of the square.
-            It must always be >=1
+        length: Side length of the square; must always be >=1
         pbc: If ``True`` then the constructed hypercube
             will have periodic boundary conditions, otherwise
             open boundary conditions are imposed.
@@ -140,32 +138,31 @@ def Square(length, pbc=True):
         constructed as follows:
 
         >>> import netket
-        >>> g=netket.graph.Square(length=10,pbc=True)
+        >>> g=netket.graph.Square(10, pbc=True)
         >>> print(g.n_nodes)
         100
     """
     return Hypercube(length, n_dim=2, pbc=pbc)
 
 
-def Chain(length, pbc=True):
+def Chain(length, *, pbc=True):
     r"""A chain of L sites.
     Periodic boundary conditions can also be imposed
 
     Constructs a new ``Chain`` given its length.
 
     Args:
-      length: Length of the chain.
-             It must always be >=1
-         pbc: If ``True`` then the constructed hypercube
+      length: Length of the chain. It must always be >=1
+         pbc: If ``True`` then the constructed chain
              will have periodic boundary conditions, otherwise
              open boundary conditions are imposed.
 
     Examples:
-         A 10 site lattice with periodic boundary conditions can be
+         A 10 site chain with periodic boundary conditions can be
          constructed as follows:
 
          >>> import netket
-         >>> g=netket.graph.Square(length=10,pbc=True)
+         >>> g = netket.graph.Chain(10, pbc=True)
          >>> print(g.n_nodes)
          10
     """

--- a/netket/graph/lattice.py
+++ b/netket/graph/lattice.py
@@ -97,7 +97,7 @@ class Lattice(NetworkX):
     There are three different ways to refer to the lattice sites. A site can be labelled
     by a simple integer number (the site index) or by its coordinates (actual position in space)."""
 
-    def __init__(self, basis_vectors, extent, pbc=True, atoms_coord=[]):
+    def __init__(self, basis_vectors, extent, *, pbc=True, atoms_coord=[]):
         """
         Constructs a new ``Lattice`` given its side length and the features of the unit cell.
 

--- a/netket/operator/_bose_hubbard.py
+++ b/netket/operator/_bose_hubbard.py
@@ -44,7 +44,7 @@ class BoseHubbard(AbstractOperator):
 
         self._n_max = hilbert.n_max
         self._n_sites = hilbert.size
-        self._edges = _np.asarray(hilbert.graph.edges())
+        self._edges = _np.asarray(list(hilbert.graph.edges()))
         self._max_conn = 1 + self._edges.shape[0] * 2
         self._max_mels = _np.empty(self._max_conn, dtype=_np.complex128)
         self._max_xprime = _np.empty((self._max_conn, self._n_sites))

--- a/netket/operator/_hamiltonian.py
+++ b/netket/operator/_hamiltonian.py
@@ -31,7 +31,7 @@ class Ising(AbstractOperator):
         self._hilbert = hilbert
         self._n_sites = hilbert.size
         self._section = hilbert.size + 1
-        self._edges = _np.asarray(hilbert.graph.edges())
+        self._edges = _np.asarray(list(hilbert.graph.edges()))
         super().__init__()
 
     @property
@@ -101,7 +101,6 @@ class Ising(AbstractOperator):
         diag_ind = 0
 
         for i in range(x.shape[0]):
-
             mels[diag_ind] = 0.0
             for k in range(edges.shape[0]):
                 mels[diag_ind] += J * x[i, edges[k, 0]] * x[i, edges[k, 1]]

--- a/netket/sampler/custom_sampler.py
+++ b/netket/sampler/custom_sampler.py
@@ -58,7 +58,7 @@ def CustomSampler(
         >>> # Construct a Custom Sampler
         >>> # Using random local spin flips (Pauli X operator)
         >>> X = [[0, 1],[1, 0]]
-        >>> move_op = nk.operator.LocalOperator(hilbert=hi,operators=[X] * g.n_sites,acting_on=[[i] for i in range(g.n_sites)])
+        >>> move_op = nk.operator.LocalOperator(hilbert=hi,operators=[X] * g.n_nodes, acting_on=[[i] for i in range(g.n_nodes)])
         >>> sa = nk.sampler.CustomSampler(machine=ma, move_operators=move_op)
     """
     return MetropolisHastings(


### PR DESCRIPTION
Addressing one of the issues raised by @PhilipVinc in #514 with my suggestion of standardizing on `n_nodes` (also adding `n_edges` in the process).

Slight benefits compared to `n_vertices`:
1. `n_nodes` and `n_edges` have the same length.
2. networkx also uses the term nodes.

Slight downsides:
1. `n_nodes` is used a lot in the code to refer to MPI processes. This is unlikely to cause much confusion, though.