### PR TITLE
[RFC] Hilbert space new API

### DIFF
--- a/Examples/AKLT/AKLT_ed.py
+++ b/Examples/AKLT/AKLT_ed.py
@@ -46,7 +46,7 @@ g = nk.graph.Hypercube(length=L, n_dim=1, pbc=True)
 hi = nk.hilbert.Spin(s=1, N=L)
 
 # AKLT model Hamiltonian as graph
-ha = nk.operator.GraphOperator(hilbert=hi, graph=g.n_nodes, bond_ops=[P2_AKLT.tolist()])
+ha = nk.operator.GraphOperator(hilbert=hi, graph=g, bond_ops=[P2_AKLT.tolist()])
 
 # Perform Lanczos Exact Diagonalization to get lowest three eigenvalues
 w, v = nk.exact.lanczos_ed(ha, k=3, compute_eigenvectors=True)

--- a/Examples/AKLT/AKLT_ed.py
+++ b/Examples/AKLT/AKLT_ed.py
@@ -39,13 +39,14 @@ heisenberg = 0.5 * (np.kron(Sup, Sdn) + np.kron(Sdn, Sup)) + np.kron(Sz, Sz)
 P2_AKLT = 0.5 * heisenberg + np.dot(heisenberg, heisenberg) / 6.0 + np.identity(9) / 3.0
 
 # 1D Lattice
-g = nk.graph.Hypercube(length=10, n_dim=1, pbc=True)
+L = 10
+g = nk.graph.Hypercube(length=L, n_dim=1, pbc=True)
 
 # Hilbert space of spin-1s on the graph
-hi = nk.hilbert.Spin(s=1, graph=g)
+hi = nk.hilbert.Spin(s=1, N=L)
 
 # AKLT model Hamiltonian as graph
-ha = nk.operator.GraphOperator(hilbert=hi, bond_ops=[P2_AKLT.tolist()])
+ha = nk.operator.GraphOperator(hilbert=hi, graph=g.n_nodes, bond_ops=[P2_AKLT.tolist()])
 
 # Perform Lanczos Exact Diagonalization to get lowest three eigenvalues
 w, v = nk.exact.lanczos_ed(ha, k=3, compute_eigenvectors=True)

--- a/Examples/BoseHubbard1d/bosehubbard1d.py
+++ b/Examples/BoseHubbard1d/bosehubbard1d.py
@@ -18,13 +18,13 @@ import netket as nk
 g = nk.graph.Hypercube(length=8, n_dim=1, pbc=True)
 
 # Boson Hilbert Space
-hi = nk.hilbert.Boson(graph=g, n_max=3, n_bosons=8)
+hi = nk.hilbert.Boson(N=g.n_nodes, n_max=3, n_bosons=8)
 
 # Bose Hubbard Hamiltonian
-ha = nk.operator.BoseHubbard(U=4.0, hilbert=hi)
+ha = nk.operator.BoseHubbard(hilbert=hi, graph=g.n_nodes, U=4.0)
 
 # RBM Machine with one-hot encoding, real parameters, and symmetries
-ma = nk.machine.RbmMultiVal(hilbert=hi, alpha=1, dtype=float, symmetry=True)
+ma = nk.machine.RbmMultiVal(hilbert=hi, alpha=1, dtype=float, automorphisms=g)
 ma.init_random_parameters(seed=1234, sigma=0.01)
 
 # Sampler using Hamiltonian moves, thus preserving the total number of particles

--- a/Examples/BoseHubbard1d/bosehubbard1d.py
+++ b/Examples/BoseHubbard1d/bosehubbard1d.py
@@ -21,7 +21,7 @@ g = nk.graph.Hypercube(length=8, n_dim=1, pbc=True)
 hi = nk.hilbert.Boson(N=g.n_nodes, n_max=3, n_bosons=8)
 
 # Bose Hubbard Hamiltonian
-ha = nk.operator.BoseHubbard(hilbert=hi, graph=g.n_nodes, U=4.0)
+ha = nk.operator.BoseHubbard(hilbert=hi, graph=g, U=4.0)
 
 # RBM Machine with one-hot encoding, real parameters, and symmetries
 ma = nk.machine.RbmMultiVal(hilbert=hi, alpha=1, dtype=float, automorphisms=g)

--- a/Examples/BoseHubbard1d/bosehubbard1d_jastrow.py
+++ b/Examples/BoseHubbard1d/bosehubbard1d_jastrow.py
@@ -21,7 +21,7 @@ g = nk.graph.Hypercube(length=12, n_dim=1, pbc=True)
 hi = nk.hilbert.Boson(N=g.n_nodes, n_max=3, n_bosons=12)
 
 # Bose Hubbard Hamiltonian
-ha = nk.operator.BoseHubbard(U=4.0, hilbert=hi, graph=g.n_nodes)
+ha = nk.operator.BoseHubbard(U=4.0, hilbert=hi, graph=g)
 
 # Jastrow Machine with Symmetry
 ma = nk.machine.JastrowSymm(hilbert=hi, automorphisms=g)

--- a/Examples/BoseHubbard1d/bosehubbard1d_jastrow.py
+++ b/Examples/BoseHubbard1d/bosehubbard1d_jastrow.py
@@ -18,13 +18,13 @@ import netket as nk
 g = nk.graph.Hypercube(length=12, n_dim=1, pbc=True)
 
 # Boson Hilbert Space
-hi = nk.hilbert.Boson(graph=g, n_max=3, n_bosons=12)
+hi = nk.hilbert.Boson(N=g.n_nodes, n_max=3, n_bosons=12)
 
 # Bose Hubbard Hamiltonian
-ha = nk.operator.BoseHubbard(U=4.0, hilbert=hi)
+ha = nk.operator.BoseHubbard(U=4.0, hilbert=hi, graph=g.n_nodes)
 
 # Jastrow Machine with Symmetry
-ma = nk.machine.JastrowSymm(hilbert=hi)
+ma = nk.machine.JastrowSymm(hilbert=hi, automorphisms=g)
 ma.init_random_parameters(seed=1234, sigma=0.01)
 
 # Sampler

--- a/Examples/CustomGraph/custom_graph.py
+++ b/Examples/CustomGraph/custom_graph.py
@@ -22,10 +22,10 @@ gnx = nx.star_graph(10)
 g = nk.graph.CustomGraph(list(gnx.edges))
 
 # Hilbert space of spins on the graph
-hi = nk.hilbert.Spin(s=0.5, graph=g)
+hi = nk.hilbert.Spin(s=0.5, graph=g.n_nodes.n_nodes)
 
 # Ising spin hamiltonian
-ha = nk.operator.Ising(h=1.0, hilbert=hi)
+ha = nk.operator.Ising(hilbert=hi, graph=g.n_nodes, h=1.0)
 
 # RBM Spin Machine
 ma = nk.machine.RbmSpin(alpha=1, hilbert=hi)

--- a/Examples/CustomGraph/custom_graph.py
+++ b/Examples/CustomGraph/custom_graph.py
@@ -22,7 +22,7 @@ gnx = nx.star_graph(10)
 g = nk.graph.CustomGraph(list(gnx.edges))
 
 # Hilbert space of spins on the graph
-hi = nk.hilbert.Spin(s=0.5, graph=g.n_nodes.n_nodes)
+hi = nk.hilbert.Spin(s=0.5, graph=g.n_nodes)
 
 # Ising spin hamiltonian
 ha = nk.operator.Ising(hilbert=hi, graph=g, h=1.0)

--- a/Examples/CustomGraph/custom_graph.py
+++ b/Examples/CustomGraph/custom_graph.py
@@ -25,7 +25,7 @@ g = nk.graph.CustomGraph(list(gnx.edges))
 hi = nk.hilbert.Spin(s=0.5, graph=g.n_nodes.n_nodes)
 
 # Ising spin hamiltonian
-ha = nk.operator.Ising(hilbert=hi, graph=g.n_nodes, h=1.0)
+ha = nk.operator.Ising(hilbert=hi, graph=g, h=1.0)
 
 # RBM Spin Machine
 ma = nk.machine.RbmSpin(alpha=1, hilbert=hi)

--- a/Examples/CustomGraph/custom_graph.py
+++ b/Examples/CustomGraph/custom_graph.py
@@ -22,7 +22,7 @@ gnx = nx.star_graph(10)
 g = nk.graph.CustomGraph(list(gnx.edges))
 
 # Hilbert space of spins on the graph
-hi = nk.hilbert.Spin(s=0.5, graph=g.n_nodes)
+hi = nk.hilbert.Spin(s=1 / 2, N=g.n_nodes)
 
 # Ising spin hamiltonian
 ha = nk.operator.Ising(hilbert=hi, graph=g, h=1.0)

--- a/Examples/CustomHamiltonian/custom_hamiltonian.py
+++ b/Examples/CustomHamiltonian/custom_hamiltonian.py
@@ -20,7 +20,7 @@ L = 20
 g = nk.graph.Hypercube(length=L, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
-hi = nk.hilbert.Spin(s=0.5, graph=g)
+hi = nk.hilbert.Spin(s=0.5, graph=g.n_nodes)
 
 
 # Defining the Ising hamiltonian (with sign problem here)

--- a/Examples/CustomHamiltonian/custom_hamiltonian.py
+++ b/Examples/CustomHamiltonian/custom_hamiltonian.py
@@ -20,7 +20,7 @@ L = 20
 g = nk.graph.Hypercube(length=L, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
-hi = nk.hilbert.Spin(s=0.5, graph=g.n_nodes)
+hi = nk.hilbert.Spin(s=0.5, N=g.n_nodes)
 
 
 # Defining the Ising hamiltonian (with sign problem here)

--- a/Examples/CustomHamiltonian/custom_hamiltonian.py
+++ b/Examples/CustomHamiltonian/custom_hamiltonian.py
@@ -20,7 +20,7 @@ L = 20
 g = nk.graph.Hypercube(length=L, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
-hi = nk.hilbert.Spin(s=0.5, N=g.n_nodes)
+hi = nk.hilbert.Spin(s=1 / 2, N=g.n_nodes)
 
 
 # Defining the Ising hamiltonian (with sign problem here)

--- a/Examples/CustomMachine/ising1d.py
+++ b/Examples/CustomMachine/ising1d.py
@@ -19,7 +19,7 @@ from rbm import PyRbm
 g = nk.graph.Hypercube(length=20, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
-hi = nk.hilbert.Spin(s=0.5, N=g.n_nodes)
+hi = nk.hilbert.Spin(s=1 / 2, N=g.n_nodes)
 
 # Ising spin hamiltonian
 ha = nk.operator.Ising(hilbert=hi, graph=g, h=1.0)

--- a/Examples/CustomMachine/ising1d.py
+++ b/Examples/CustomMachine/ising1d.py
@@ -19,10 +19,10 @@ from rbm import PyRbm
 g = nk.graph.Hypercube(length=20, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
-hi = nk.hilbert.Spin(s=0.5, graph=g)
+hi = nk.hilbert.Spin(s=0.5, graph=g.n_nodes)
 
 # Ising spin hamiltonian
-ha = nk.operator.Ising(h=1.0, hilbert=hi)
+ha = nk.operator.Ising(hilbert=hi, graph=g, h=1.0)
 
 # RBM Spin Machine
 ma = PyRbm(alpha=1, hilbert=hi)

--- a/Examples/CustomMachine/ising1d.py
+++ b/Examples/CustomMachine/ising1d.py
@@ -19,7 +19,7 @@ from rbm import PyRbm
 g = nk.graph.Hypercube(length=20, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
-hi = nk.hilbert.Spin(s=0.5, graph=g.n_nodes)
+hi = nk.hilbert.Spin(s=0.5, N=g.n_nodes)
 
 # Ising spin hamiltonian
 ha = nk.operator.Ising(hilbert=hi, graph=g, h=1.0)

--- a/Examples/CustomSampler/customsampler_heisenberg1d.py
+++ b/Examples/CustomSampler/customsampler_heisenberg1d.py
@@ -21,13 +21,13 @@ g = nk.graph.Hypercube(length=l, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
 # with total Sz equal to 0
-hi = nk.hilbert.Spin(s=0.5, graph=g, total_sz=0)
+hi = nk.hilbert.Spin(s=0.5, graph=g.n_nodes, total_sz=0)
 
 # Heisenberg hamiltonian
 ha = nk.operator.Heisenberg(hilbert=hi)
 
 # Symmetric RBM Spin Machine
-ma = nk.machine.RbmSpinSymm(alpha=1, hilbert=hi)
+ma = nk.machine.RbmSpinSymm(alpha=1, hilbert=hi, automorphisms=g)
 ma.init_random_parameters(seed=1234, sigma=0.01)
 
 

--- a/Examples/CustomSampler/customsampler_heisenberg1d.py
+++ b/Examples/CustomSampler/customsampler_heisenberg1d.py
@@ -21,7 +21,7 @@ g = nk.graph.Hypercube(length=l, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
 # with total Sz equal to 0
-hi = nk.hilbert.Spin(s=0.5, graph=g.n_nodes, total_sz=0)
+hi = nk.hilbert.Spin(s=1/2, N=g.n_nodes, total_sz=0)
 
 # Heisenberg hamiltonian
 ha = nk.operator.Heisenberg(hilbert=hi)

--- a/Examples/CustomSampler/customsampler_heisenberg1d.py
+++ b/Examples/CustomSampler/customsampler_heisenberg1d.py
@@ -21,7 +21,7 @@ g = nk.graph.Hypercube(length=l, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
 # with total Sz equal to 0
-hi = nk.hilbert.Spin(s=1/2, N=g.n_nodes, total_sz=0)
+hi = nk.hilbert.Spin(s=1 / 2, N=g.n_nodes, total_sz=0)
 
 # Heisenberg hamiltonian
 ha = nk.operator.Heisenberg(hilbert=hi)

--- a/Examples/CustomSampler/exchange_kernel.py
+++ b/Examples/CustomSampler/exchange_kernel.py
@@ -6,7 +6,7 @@ g = nk.graph.Hypercube(length=20, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
 # with total Sz equal to 0
-hi = nk.hilbert.Spin(s=0.5, graph=g.n_nodes, total_sz=0)
+hi = nk.hilbert.Spin(s=1/2, N=g.n_nodes, total_sz=0)
 
 # Heisenberg hamiltonian
 ha = nk.operator.Heisenberg(hilbert=hi)

--- a/Examples/CustomSampler/exchange_kernel.py
+++ b/Examples/CustomSampler/exchange_kernel.py
@@ -6,7 +6,7 @@ g = nk.graph.Hypercube(length=20, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
 # with total Sz equal to 0
-hi = nk.hilbert.Spin(s=0.5, graph=g, total_sz=0)
+hi = nk.hilbert.Spin(s=0.5, graph=g.n_nodes, total_sz=0)
 
 # Heisenberg hamiltonian
 ha = nk.operator.Heisenberg(hilbert=hi)

--- a/Examples/CustomSampler/exchange_kernel.py
+++ b/Examples/CustomSampler/exchange_kernel.py
@@ -6,7 +6,7 @@ g = nk.graph.Hypercube(length=20, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
 # with total Sz equal to 0
-hi = nk.hilbert.Spin(s=1/2, N=g.n_nodes, total_sz=0)
+hi = nk.hilbert.Spin(s=1 / 2, N=g.n_nodes, total_sz=0)
 
 # Heisenberg hamiltonian
 ha = nk.operator.Heisenberg(hilbert=hi)

--- a/Examples/DissipativeIsing1d/ising1d.py
+++ b/Examples/DissipativeIsing1d/ising1d.py
@@ -25,7 +25,7 @@ Vp = 2.0
 g = nk.graph.Hypercube(length=L, n_dim=1, pbc=False)
 
 # Hilbert space of spins on the graph
-hi = nk.hilbert.Spin(s=0.5, graph=g.n_nodes)
+hi = nk.hilbert.Spin(s=1 / 2, N=g.n_nodes)
 
 
 # Defining the Ising hamiltonian (with sign problem here)

--- a/Examples/DissipativeIsing1d/ising1d.py
+++ b/Examples/DissipativeIsing1d/ising1d.py
@@ -25,7 +25,7 @@ Vp = 2.0
 g = nk.graph.Hypercube(length=L, n_dim=1, pbc=False)
 
 # Hilbert space of spins on the graph
-hi = nk.hilbert.Spin(s=0.5, graph=g)
+hi = nk.hilbert.Spin(s=0.5, graph=g.n_nodes)
 
 
 # Defining the Ising hamiltonian (with sign problem here)

--- a/Examples/EarlyStopping/heisenberg1d.py
+++ b/Examples/EarlyStopping/heisenberg1d.py
@@ -21,7 +21,7 @@ g = nk.graph.Hypercube(length=20, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
 # with total Sz equal to 0
-hi = nk.hilbert.Spin(s=0.5, graph=g.n_nodes, total_sz=0)
+hi = nk.hilbert.Spin(s=1/2, N=g.n_nodes, total_sz=0)
 
 # Heisenberg hamiltonian
 ha = nk.operator.Heisenberg(hilbert=hi)

--- a/Examples/EarlyStopping/heisenberg1d.py
+++ b/Examples/EarlyStopping/heisenberg1d.py
@@ -21,7 +21,7 @@ g = nk.graph.Hypercube(length=20, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
 # with total Sz equal to 0
-hi = nk.hilbert.Spin(s=1/2, N=g.n_nodes, total_sz=0)
+hi = nk.hilbert.Spin(s=1 / 2, N=g.n_nodes, total_sz=0)
 
 # Heisenberg hamiltonian
 ha = nk.operator.Heisenberg(hilbert=hi)

--- a/Examples/EarlyStopping/heisenberg1d.py
+++ b/Examples/EarlyStopping/heisenberg1d.py
@@ -21,13 +21,13 @@ g = nk.graph.Hypercube(length=20, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
 # with total Sz equal to 0
-hi = nk.hilbert.Spin(s=0.5, graph=g, total_sz=0)
+hi = nk.hilbert.Spin(s=0.5, graph=g.n_nodes, total_sz=0)
 
 # Heisenberg hamiltonian
 ha = nk.operator.Heisenberg(hilbert=hi)
 
 # Symmetric RBM Spin Machine
-ma = nk.machine.RbmSpin(alpha=1, hilbert=hi, symmetry=True)
+ma = nk.machine.RbmSpin(alpha=1, hilbert=hi, automorphisms=g)
 ma.init_random_parameters(seed=1234, sigma=0.01)
 
 # Metropolis Exchange Sampling

--- a/Examples/ExactDiag/dissipative_ising1.py
+++ b/Examples/ExactDiag/dissipative_ising1.py
@@ -23,7 +23,7 @@ L = 9
 g = nk.graph.Hypercube(length=L, n_dim=1, pbc=False)
 
 # Hilbert space of spins on the graph
-hi = nk.hilbert.Spin(s=1/2, N=g.n_nodes)
+hi = nk.hilbert.Spin(s=1 / 2, N=g.n_nodes)
 
 
 # Defining the Ising hamiltonian (with sign problem here)

--- a/Examples/ExactDiag/dissipative_ising1.py
+++ b/Examples/ExactDiag/dissipative_ising1.py
@@ -23,7 +23,7 @@ L = 9
 g = nk.graph.Hypercube(length=L, n_dim=1, pbc=False)
 
 # Hilbert space of spins on the graph
-hi = nk.hilbert.Spin(s=0.5, graph=g)
+hi = nk.hilbert.Spin(s=0.5, graph=g.n_nodes)
 
 
 # Defining the Ising hamiltonian (with sign problem here)

--- a/Examples/ExactDiag/dissipative_ising1.py
+++ b/Examples/ExactDiag/dissipative_ising1.py
@@ -23,7 +23,7 @@ L = 9
 g = nk.graph.Hypercube(length=L, n_dim=1, pbc=False)
 
 # Hilbert space of spins on the graph
-hi = nk.hilbert.Spin(s=0.5, graph=g.n_nodes)
+hi = nk.hilbert.Spin(s=1/2, N=g.n_nodes)
 
 
 # Defining the Ising hamiltonian (with sign problem here)

--- a/Examples/ExactDiag/heisenberg1.py
+++ b/Examples/ExactDiag/heisenberg1.py
@@ -19,7 +19,7 @@ from scipy.sparse.linalg import eigsh
 g = nk.graph.Hypercube(length=16, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
-hi = nk.hilbert.Spin(s=0.5, graph=g)
+hi = nk.hilbert.Spin(s=0.5, graph=g.n_nodes)
 
 # Heisenberg spin hamiltonian
 ha = nk.operator.Heisenberg(hilbert=hi)

--- a/Examples/ExactDiag/heisenberg1.py
+++ b/Examples/ExactDiag/heisenberg1.py
@@ -19,7 +19,7 @@ from scipy.sparse.linalg import eigsh
 g = nk.graph.Hypercube(length=16, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
-hi = nk.hilbert.Spin(s=1/2, N=g.n_nodes)
+hi = nk.hilbert.Spin(s=1 / 2, N=g.n_nodes)
 
 # Heisenberg spin hamiltonian
 ha = nk.operator.Heisenberg(hilbert=hi)

--- a/Examples/ExactDiag/heisenberg1.py
+++ b/Examples/ExactDiag/heisenberg1.py
@@ -19,7 +19,7 @@ from scipy.sparse.linalg import eigsh
 g = nk.graph.Hypercube(length=16, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
-hi = nk.hilbert.Spin(s=0.5, graph=g.n_nodes)
+hi = nk.hilbert.Spin(s=1/2, N=g.n_nodes)
 
 # Heisenberg spin hamiltonian
 ha = nk.operator.Heisenberg(hilbert=hi)

--- a/Examples/GraphOperator/Ising/ising.py
+++ b/Examples/GraphOperator/Ising/ising.py
@@ -29,7 +29,7 @@ bond_operator = [mszsz]
 g = nk.graph.Hypercube(length=L, n_dim=1, pbc=True)
 
 # Custom Hilbert Space
-hi = nk.hilbert.Spin(s=1/2, N=g.n_nodes)
+hi = nk.hilbert.Spin(s=1 / 2, N=g.n_nodes)
 
 # Graph Operator
 op = nk.operator.GraphOperator(hi, siteops=site_operator, bondops=bond_operator)

--- a/Examples/GraphOperator/Ising/ising.py
+++ b/Examples/GraphOperator/Ising/ising.py
@@ -29,7 +29,7 @@ bond_operator = [mszsz]
 g = nk.graph.Hypercube(length=L, n_dim=1, pbc=True)
 
 # Custom Hilbert Space
-hi = nk.hilbert.Spin(s=0.5, graph=g.n_nodes)
+hi = nk.hilbert.Spin(s=1/2, N=g.n_nodes)
 
 # Graph Operator
 op = nk.operator.GraphOperator(hi, siteops=site_operator, bondops=bond_operator)

--- a/Examples/GraphOperator/Ising/ising.py
+++ b/Examples/GraphOperator/Ising/ising.py
@@ -29,7 +29,7 @@ bond_operator = [mszsz]
 g = nk.graph.Hypercube(length=L, n_dim=1, pbc=True)
 
 # Custom Hilbert Space
-hi = nk.hilbert.Spin(s=0.5, graph=g)
+hi = nk.hilbert.Spin(s=0.5, graph=g.n_nodes)
 
 # Graph Operator
 op = nk.operator.GraphOperator(hi, siteops=site_operator, bondops=bond_operator)

--- a/Examples/GraphOperator/J1J2/j1j2.py
+++ b/Examples/GraphOperator/J1J2/j1j2.py
@@ -50,7 +50,7 @@ edge_colors = [[u, v, G[u][v]["color"]] for u, v in G.edges]
 g = nk.graph.CustomGraph(edge_colors)
 
 # Spin based Hilbert Space
-hi = nk.hilbert.Spin(s=0.5, total_sz=0.0, graph=g.n_nodes)
+hi = nk.hilbert.Spin(s=1/2, total_sz=0.0, N=g.n_nodes)
 
 # Custom Hamiltonian operator
 op = nk.operator.GraphOperator(hi, bondops=bond_operator, bondops_colors=bond_color)

--- a/Examples/GraphOperator/J1J2/j1j2.py
+++ b/Examples/GraphOperator/J1J2/j1j2.py
@@ -50,7 +50,7 @@ edge_colors = [[u, v, G[u][v]["color"]] for u, v in G.edges]
 g = nk.graph.CustomGraph(edge_colors)
 
 # Spin based Hilbert Space
-hi = nk.hilbert.Spin(s=1/2, total_sz=0.0, N=g.n_nodes)
+hi = nk.hilbert.Spin(s=1 / 2, total_sz=0.0, N=g.n_nodes)
 
 # Custom Hamiltonian operator
 op = nk.operator.GraphOperator(hi, bondops=bond_operator, bondops_colors=bond_color)

--- a/Examples/GraphOperator/J1J2/j1j2.py
+++ b/Examples/GraphOperator/J1J2/j1j2.py
@@ -50,7 +50,7 @@ edge_colors = [[u, v, G[u][v]["color"]] for u, v in G.edges]
 g = nk.graph.CustomGraph(edge_colors)
 
 # Spin based Hilbert Space
-hi = nk.hilbert.Spin(s=0.5, total_sz=0.0, graph=g)
+hi = nk.hilbert.Spin(s=0.5, total_sz=0.0, graph=g.n_nodes)
 
 # Custom Hamiltonian operator
 op = nk.operator.GraphOperator(hi, bondops=bond_operator, bondops_colors=bond_color)

--- a/Examples/Heisenberg1d/heisenberg1d.py
+++ b/Examples/Heisenberg1d/heisenberg1d.py
@@ -19,7 +19,7 @@ g = nk.graph.Hypercube(length=20, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
 # with total Sz equal to 0
-hi = nk.hilbert.Spin(s=0.5, graph=g.n_nodes, total_sz=0)
+hi = nk.hilbert.Spin(s=1/2, N=g.n_nodes, total_sz=0)
 
 # Heisenberg hamiltonian
 ha = nk.operator.Heisenberg(hilbert=hi)

--- a/Examples/Heisenberg1d/heisenberg1d.py
+++ b/Examples/Heisenberg1d/heisenberg1d.py
@@ -19,13 +19,13 @@ g = nk.graph.Hypercube(length=20, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
 # with total Sz equal to 0
-hi = nk.hilbert.Spin(s=0.5, graph=g, total_sz=0)
+hi = nk.hilbert.Spin(s=0.5, graph=g.n_nodes, total_sz=0)
 
 # Heisenberg hamiltonian
 ha = nk.operator.Heisenberg(hilbert=hi)
 
 # Symmetric RBM Spin Machine
-ma = nk.machine.RbmSpin(alpha=1, hilbert=hi, symmetry=True)
+ma = nk.machine.RbmSpin(alpha=1, hilbert=hi, automorphisms=g)
 ma.init_random_parameters(seed=1234, sigma=0.01)
 
 # Metropolis Exchange Sampling

--- a/Examples/Heisenberg1d/heisenberg1d.py
+++ b/Examples/Heisenberg1d/heisenberg1d.py
@@ -19,7 +19,7 @@ g = nk.graph.Hypercube(length=20, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
 # with total Sz equal to 0
-hi = nk.hilbert.Spin(s=1/2, N=g.n_nodes, total_sz=0)
+hi = nk.hilbert.Spin(s=1 / 2, N=g.n_nodes, total_sz=0)
 
 # Heisenberg hamiltonian
 ha = nk.operator.Heisenberg(hilbert=hi)

--- a/Examples/Heisenberg1d/heisenberg1d_conv.py
+++ b/Examples/Heisenberg1d/heisenberg1d_conv.py
@@ -20,7 +20,7 @@ g = nk.graph.Hypercube(length=L, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
 # with total Sz equal to 0
-hi = nk.hilbert.Spin(s=0.5, graph=g.n_nodes, total_sz=0)
+hi = nk.hilbert.Spin(s=1/2, N=g.n_nodes, total_sz=0)
 
 # Heisenberg hamiltonian
 ha = nk.operator.Heisenberg(hilbert=hi)

--- a/Examples/Heisenberg1d/heisenberg1d_conv.py
+++ b/Examples/Heisenberg1d/heisenberg1d_conv.py
@@ -20,7 +20,7 @@ g = nk.graph.Hypercube(length=L, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
 # with total Sz equal to 0
-hi = nk.hilbert.Spin(s=1/2, N=g.n_nodes, total_sz=0)
+hi = nk.hilbert.Spin(s=1 / 2, N=g.n_nodes, total_sz=0)
 
 # Heisenberg hamiltonian
 ha = nk.operator.Heisenberg(hilbert=hi)

--- a/Examples/Heisenberg1d/heisenberg1d_conv.py
+++ b/Examples/Heisenberg1d/heisenberg1d_conv.py
@@ -20,7 +20,7 @@ g = nk.graph.Hypercube(length=L, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
 # with total Sz equal to 0
-hi = nk.hilbert.Spin(s=0.5, graph=g, total_sz=0)
+hi = nk.hilbert.Spin(s=0.5, graph=g.n_nodes, total_sz=0)
 
 # Heisenberg hamiltonian
 ha = nk.operator.Heisenberg(hilbert=hi)

--- a/Examples/Heisenberg1d/heisenberg1d_ffnn.py
+++ b/Examples/Heisenberg1d/heisenberg1d_ffnn.py
@@ -20,7 +20,7 @@ g = nk.graph.Hypercube(length=L, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
 # with total Sz equal to 0
-hi = nk.hilbert.Spin(s=0.5, graph=g.n_nodes, total_sz=0)
+hi = nk.hilbert.Spin(s=1/2, N=g.n_nodes, total_sz=0)
 
 # Heisenberg hamiltonian
 ha = nk.operator.Heisenberg(hilbert=hi)

--- a/Examples/Heisenberg1d/heisenberg1d_ffnn.py
+++ b/Examples/Heisenberg1d/heisenberg1d_ffnn.py
@@ -20,7 +20,7 @@ g = nk.graph.Hypercube(length=L, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
 # with total Sz equal to 0
-hi = nk.hilbert.Spin(s=1/2, N=g.n_nodes, total_sz=0)
+hi = nk.hilbert.Spin(s=1 / 2, N=g.n_nodes, total_sz=0)
 
 # Heisenberg hamiltonian
 ha = nk.operator.Heisenberg(hilbert=hi)

--- a/Examples/Heisenberg1d/heisenberg1d_ffnn.py
+++ b/Examples/Heisenberg1d/heisenberg1d_ffnn.py
@@ -20,7 +20,7 @@ g = nk.graph.Hypercube(length=L, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
 # with total Sz equal to 0
-hi = nk.hilbert.Spin(s=0.5, graph=g, total_sz=0)
+hi = nk.hilbert.Spin(s=0.5, graph=g.n_nodes, total_sz=0)
 
 # Heisenberg hamiltonian
 ha = nk.operator.Heisenberg(hilbert=hi)

--- a/Examples/Heisenberg1d/heisenberg1d_jastrow.py
+++ b/Examples/Heisenberg1d/heisenberg1d_jastrow.py
@@ -19,7 +19,7 @@ g = nk.graph.Hypercube(length=20, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
 # with total Sz equal to 0
-hi = nk.hilbert.Spin(s=0.5, graph=g.n_nodes, total_sz=0)
+hi = nk.hilbert.Spin(s=1/2,N=g.n_nodes, total_sz=0)
 
 # Heisenberg hamiltonian
 ha = nk.operator.Heisenberg(hilbert=hi)

--- a/Examples/Heisenberg1d/heisenberg1d_jastrow.py
+++ b/Examples/Heisenberg1d/heisenberg1d_jastrow.py
@@ -19,13 +19,13 @@ g = nk.graph.Hypercube(length=20, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
 # with total Sz equal to 0
-hi = nk.hilbert.Spin(s=0.5, graph=g, total_sz=0)
+hi = nk.hilbert.Spin(s=0.5, graph=g.n_nodes, total_sz=0)
 
 # Heisenberg hamiltonian
 ha = nk.operator.Heisenberg(hilbert=hi)
 
 # Symmetric RBM Spin Machine
-ma = nk.machine.JastrowSymm(hilbert=hi, dtype=float)
+ma = nk.machine.JastrowSymm(hilbert=hi, automorphisms=g, dtype=float)
 ma.init_random_parameters(seed=1234, sigma=0.01)
 
 # Metropolis Exchange Sampling

--- a/Examples/Heisenberg1d/heisenberg1d_jastrow.py
+++ b/Examples/Heisenberg1d/heisenberg1d_jastrow.py
@@ -19,7 +19,7 @@ g = nk.graph.Hypercube(length=20, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
 # with total Sz equal to 0
-hi = nk.hilbert.Spin(s=1/2,N=g.n_nodes, total_sz=0)
+hi = nk.hilbert.Spin(s=1 / 2, N=g.n_nodes, total_sz=0)
 
 # Heisenberg hamiltonian
 ha = nk.operator.Heisenberg(hilbert=hi)

--- a/Examples/Ising1d/ising1d.py
+++ b/Examples/Ising1d/ising1d.py
@@ -18,7 +18,7 @@ import netket as nk
 g = nk.graph.Hypercube(length=20, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
-hi = nk.hilbert.Spin(s=1/2, N=g.n_nodes)
+hi = nk.hilbert.Spin(s=1 / 2, N=g.n_nodes)
 
 # Ising spin hamiltonian
 ha = nk.operator.Ising(h=1.0, hilbert=hi, graph=g)

--- a/Examples/Ising1d/ising1d.py
+++ b/Examples/Ising1d/ising1d.py
@@ -18,10 +18,10 @@ import netket as nk
 g = nk.graph.Hypercube(length=20, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
-hi = nk.hilbert.Spin(s=0.5, graph=g)
+hi = nk.hilbert.Spin(s=0.5, N=g.n_nodes)
 
 # Ising spin hamiltonian
-ha = nk.operator.Ising(h=1.0, hilbert=hi)
+ha = nk.operator.Ising(h=1.0, hilbert=hi, graph=g.n_nodes)
 
 # RBM Spin Machine
 ma = nk.machine.RbmSpin(alpha=1, hilbert=hi)

--- a/Examples/Ising1d/ising1d.py
+++ b/Examples/Ising1d/ising1d.py
@@ -18,10 +18,10 @@ import netket as nk
 g = nk.graph.Hypercube(length=20, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
-hi = nk.hilbert.Spin(s=0.5, N=g.n_nodes)
+hi = nk.hilbert.Spin(s=1/2, N=g.n_nodes)
 
 # Ising spin hamiltonian
-ha = nk.operator.Ising(h=1.0, hilbert=hi, graph=g.n_nodes)
+ha = nk.operator.Ising(h=1.0, hilbert=hi, graph=g)
 
 # RBM Spin Machine
 ma = nk.machine.RbmSpin(alpha=1, hilbert=hi)

--- a/Examples/Ising1d/ising1d_jastrow.py
+++ b/Examples/Ising1d/ising1d_jastrow.py
@@ -18,10 +18,10 @@ import netket as nk
 g = nk.graph.Hypercube(length=20, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
-hi = nk.hilbert.Spin(s=0.5, graph=g)
+hi = nk.hilbert.Spin(s=0.5, graph=g.n_nodes)
 
 # Ising spin hamiltonian
-ha = nk.operator.Ising(h=1.0, hilbert=hi)
+ha = nk.operator.Ising(hilbert=hi, graph=g, h=1.0)
 
 # Jastrow Machine
 ma = nk.machine.Jastrow(hilbert=hi)

--- a/Examples/Ising1d/ising1d_jastrow.py
+++ b/Examples/Ising1d/ising1d_jastrow.py
@@ -18,7 +18,7 @@ import netket as nk
 g = nk.graph.Hypercube(length=20, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
-hi = nk.hilbert.Spin(s=0.5, graph=g.n_nodes)
+hi = nk.hilbert.Spin(s=1/2, N=g.n_nodes)
 
 # Ising spin hamiltonian
 ha = nk.operator.Ising(hilbert=hi, graph=g, h=1.0)

--- a/Examples/Ising1d/ising1d_jastrow.py
+++ b/Examples/Ising1d/ising1d_jastrow.py
@@ -18,7 +18,7 @@ import netket as nk
 g = nk.graph.Hypercube(length=20, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
-hi = nk.hilbert.Spin(s=1/2, N=g.n_nodes)
+hi = nk.hilbert.Spin(s=1 / 2, N=g.n_nodes)
 
 # Ising spin hamiltonian
 ha = nk.operator.Ising(hilbert=hi, graph=g, h=1.0)

--- a/Examples/Ising1d/torch_rbm.py
+++ b/Examples/Ising1d/torch_rbm.py
@@ -22,10 +22,10 @@ class LogCoshSum(torch.nn.Module):
 g = nk.graph.Hypercube(length=20, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
-hi = nk.hilbert.Spin(s=0.5, graph=g)
+hi = nk.hilbert.Spin(s=0.5, graph=g.n_nodes)
 
 # Ising spin hamiltonian
-ha = nk.operator.Ising(h=1.0, hilbert=hi)
+ha = nk.operator.Ising(hilbert=hi, graph=g, h=1.0)
 
 input_size = hi.size
 alpha = 1

--- a/Examples/Ising1d/torch_rbm.py
+++ b/Examples/Ising1d/torch_rbm.py
@@ -22,7 +22,7 @@ class LogCoshSum(torch.nn.Module):
 g = nk.graph.Hypercube(length=20, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
-hi = nk.hilbert.Spin(s=0.5, graph=g.n_nodes)
+hi = nk.hilbert.Spin(s=1/2, N=g.n_nodes)
 
 # Ising spin hamiltonian
 ha = nk.operator.Ising(hilbert=hi, graph=g, h=1.0)

--- a/Examples/Ising1d/torch_rbm.py
+++ b/Examples/Ising1d/torch_rbm.py
@@ -22,7 +22,7 @@ class LogCoshSum(torch.nn.Module):
 g = nk.graph.Hypercube(length=20, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
-hi = nk.hilbert.Spin(s=1/2, N=g.n_nodes)
+hi = nk.hilbert.Spin(s=1 / 2, N=g.n_nodes)
 
 # Ising spin hamiltonian
 ha = nk.operator.Ising(hilbert=hi, graph=g, h=1.0)

--- a/Examples/Ising2d/ising2d.py
+++ b/Examples/Ising2d/ising2d.py
@@ -18,10 +18,10 @@ import netket as nk
 g = nk.graph.Hypercube(length=5, n_dim=2, pbc=True)
 
 # Hilbert space of spins on the graph
-hi = nk.hilbert.Spin(s=0.5, graph=g)
+hi = nk.hilbert.Spin(s=0.5, N=g.n_nodes)
 
 # Ising spin hamiltonian at the critical point
-ha = nk.operator.Ising(h=3.0, hilbert=hi)
+ha = nk.operator.Ising(hilbert=hi, graph=g.n_nodes, h=3.0)
 
 # RBM Spin Machine
 ma = nk.machine.RbmSpin(alpha=1, hilbert=hi)

--- a/Examples/Ising2d/ising2d.py
+++ b/Examples/Ising2d/ising2d.py
@@ -18,7 +18,7 @@ import netket as nk
 g = nk.graph.Hypercube(length=5, n_dim=2, pbc=True)
 
 # Hilbert space of spins on the graph
-hi = nk.hilbert.Spin(s=0.5, N=g.n_nodes)
+hi = nk.hilbert.Spin(s=1 / 2, N=g.n_nodes)
 
 # Ising spin hamiltonian at the critical point
 ha = nk.operator.Ising(hilbert=hi, graph=g, h=3.0)

--- a/Examples/Ising2d/ising2d.py
+++ b/Examples/Ising2d/ising2d.py
@@ -21,7 +21,7 @@ g = nk.graph.Hypercube(length=5, n_dim=2, pbc=True)
 hi = nk.hilbert.Spin(s=0.5, N=g.n_nodes)
 
 # Ising spin hamiltonian at the critical point
-ha = nk.operator.Ising(hilbert=hi, graph=g.n_nodes, h=3.0)
+ha = nk.operator.Ising(hilbert=hi, graph=g, h=3.0)
 
 # RBM Spin Machine
 ma = nk.machine.RbmSpin(alpha=1, hilbert=hi)

--- a/Examples/J1J2/j1j2.py
+++ b/Examples/J1J2/j1j2.py
@@ -44,7 +44,7 @@ for i in range(L):
 g = nk.graph.Hypercube(length=L, n_dim=1, pbc=True)
 
 # Spin based Hilbert Space
-hi = nk.hilbert.Spin(s=0.5, total_sz=0.0, N=g.n_nodse)
+hi = nk.hilbert.Spin(s=0.5, total_sz=0.0, N=g.n_nodes)
 
 # Custom Hamiltonian operator
 ha = nk.operator.LocalOperator(hi)

--- a/Examples/J1J2/j1j2.py
+++ b/Examples/J1J2/j1j2.py
@@ -44,7 +44,7 @@ for i in range(L):
 g = nk.graph.Hypercube(length=L, n_dim=1, pbc=True)
 
 # Spin based Hilbert Space
-hi = nk.hilbert.Spin(s=0.5, total_sz=0.0, graph=g)
+hi = nk.hilbert.Spin(s=0.5, total_sz=0.0, N=g.n_nodse)
 
 # Custom Hamiltonian operator
 ha = nk.operator.LocalOperator(hi)
@@ -52,7 +52,7 @@ for mat, site in zip(mats, sites):
     ha += nk.operator.LocalOperator(hi, mat, site)
 
 # Restricted Boltzmann Machine
-ma = nk.machine.RbmSpin(hi, alpha=1, symmetry=True)
+ma = nk.machine.RbmSpin(hi, alpha=1, automorphisms=g)
 ma.init_random_parameters(seed=1234, sigma=0.01)
 
 # Exchange Sampler randomly exchange up to next-to-nearest neighbours

--- a/Examples/Jax/jax_example.py
+++ b/Examples/Jax/jax_example.py
@@ -7,9 +7,9 @@ L = 20
 g = nk.graph.Hypercube(length=L, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
-hi = nk.hilbert.Spin(s=0.5, graph=g)
+hi = nk.hilbert.Spin(s=0.5) ** L
 
-ha = nk.operator.Ising(h=1.0, hilbert=hi)
+ha = nk.operator.Ising(hilbert=hi, graph=g.n_nodes, h=1.0)
 
 alpha = 1
 ma = nk.machine.JaxRbm(hi, alpha, dtype=float)

--- a/Examples/Jax/jax_example.py
+++ b/Examples/Jax/jax_example.py
@@ -9,7 +9,7 @@ g = nk.graph.Hypercube(length=L, n_dim=1, pbc=True)
 # Hilbert space of spins on the graph
 hi = nk.hilbert.Spin(s=0.5) ** L
 
-ha = nk.operator.Ising(hilbert=hi, graph=g.n_nodes, h=1.0)
+ha = nk.operator.Ising(hilbert=hi, graph=g, h=1.0)
 
 alpha = 1
 ma = nk.machine.JaxRbm(hi, alpha, dtype=float)

--- a/Examples/Jax/jax_example.py
+++ b/Examples/Jax/jax_example.py
@@ -7,7 +7,7 @@ L = 20
 g = nk.graph.Hypercube(length=L, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
-hi = nk.hilbert.Spin(s=0.5) ** L
+hi = nk.hilbert.Spin(s=1 / 2) ** L
 
 ha = nk.operator.Ising(hilbert=hi, graph=g, h=1.0)
 

--- a/Examples/Jax/jax_sr_example.py
+++ b/Examples/Jax/jax_sr_example.py
@@ -11,7 +11,7 @@ g = nk.graph.Hypercube(length=L, n_dim=1, pbc=True)
 # Hilbert space of spins on the graph
 hi = nk.hilbert.Spin(s=0.5) ** L
 
-ha = nk.operator.Ising(hilbert=hi, graph=g.n_nodes, h=1.0)
+ha = nk.operator.Ising(hilbert=hi, graph=g, h=1.0)
 
 alpha = 1
 ma = nk.machine.JaxRbm(hi, alpha, dtype=complex)

--- a/Examples/Jax/jax_sr_example.py
+++ b/Examples/Jax/jax_sr_example.py
@@ -9,9 +9,9 @@ L = 20
 g = nk.graph.Hypercube(length=L, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
-hi = nk.hilbert.Spin(s=0.5, graph=g)
+hi = nk.hilbert.Spin(s=0.5) ** L
 
-ha = nk.operator.Ising(h=1.0, hilbert=hi)
+ha = nk.operator.Ising(hilbert=hi, graph=g.n_nodes, h=1.0)
 
 alpha = 1
 ma = nk.machine.JaxRbm(hi, alpha, dtype=complex)

--- a/Examples/Jax/jax_sr_example.py
+++ b/Examples/Jax/jax_sr_example.py
@@ -9,7 +9,7 @@ L = 20
 g = nk.graph.Hypercube(length=L, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
-hi = nk.hilbert.Spin(s=0.5) ** L
+hi = nk.hilbert.Spin(s=1 / 2) ** L
 
 ha = nk.operator.Ising(hilbert=hi, graph=g, h=1.0)
 

--- a/Examples/MPS/mps.py
+++ b/Examples/MPS/mps.py
@@ -10,7 +10,7 @@ g = nk.graph.Hypercube(length=L, n_dim=1, pbc=True)
 # Hilbert space of spins on the graph
 hi = nk.hilbert.Spin(s=0.5) ** L
 
-ha = nk.operator.Ising(hilbert=hi, graph=g.n_nodes, h=1.0)
+ha = nk.operator.Ising(hilbert=hi, graph=g, h=1.0)
 
 ma = nk.machine.MPSPeriodic(
     hi, g, bond_dim=4, diag=False, symperiod=None, dtype=complex

--- a/Examples/MPS/mps.py
+++ b/Examples/MPS/mps.py
@@ -8,11 +8,13 @@ L = 20
 g = nk.graph.Hypercube(length=L, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
-hi = nk.hilbert.Spin(graph=g, s=0.5)
+hi = nk.hilbert.Spin(s=0.5) ** L
 
-ha = nk.operator.Ising(h=1.0, hilbert=hi)
+ha = nk.operator.Ising(hilbert=hi, graph=g.n_nodes, h=1.0)
 
-ma = nk.machine.MPSPeriodic(hi, bond_dim=4, diag=False, symperiod=None, dtype=complex)
+ma = nk.machine.MPSPeriodic(
+    hi, g, bond_dim=4, diag=False, symperiod=None, dtype=complex
+)
 ma.jax_init_parameters(seed=1232)
 
 # Jax Sampler

--- a/Examples/MPS/mps.py
+++ b/Examples/MPS/mps.py
@@ -8,7 +8,7 @@ L = 20
 g = nk.graph.Hypercube(length=L, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
-hi = nk.hilbert.Spin(s=0.5) ** L
+hi = nk.hilbert.Spin(s=1 / 2) ** L
 
 ha = nk.operator.Ising(hilbert=hi, graph=g, h=1.0)
 

--- a/Examples/Observables/sigmax.py
+++ b/Examples/Observables/sigmax.py
@@ -19,7 +19,7 @@ L = 20
 g = nk.graph.Hypercube(length=L, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
-hi = nk.hilbert.Spin(s=0.5) ** L
+hi = nk.hilbert.Spin(s=1 / 2) ** L
 
 # Ising spin hamiltonian
 ha = nk.operator.Ising(hilbert=hi, graph=g, h=1.0)

--- a/Examples/Observables/sigmax.py
+++ b/Examples/Observables/sigmax.py
@@ -19,10 +19,10 @@ L = 20
 g = nk.graph.Hypercube(length=L, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
-hi = nk.hilbert.Spin(s=0.5, graph=g)
+hi = nk.hilbert.Spin(s=0.5) ** L
 
 # Ising spin hamiltonian
-ha = nk.operator.Ising(h=1.0, hilbert=hi)
+ha = nk.operator.Ising(hilbert=hi, graph=g.n_nodes, h=1.0)
 
 # RBM Spin Machine
 ma = nk.machine.RbmSpinReal(alpha=1, hilbert=hi)

--- a/Examples/Observables/sigmax.py
+++ b/Examples/Observables/sigmax.py
@@ -22,7 +22,7 @@ g = nk.graph.Hypercube(length=L, n_dim=1, pbc=True)
 hi = nk.hilbert.Spin(s=0.5) ** L
 
 # Ising spin hamiltonian
-ha = nk.operator.Ising(hilbert=hi, graph=g.n_nodes, h=1.0)
+ha = nk.operator.Ising(hilbert=hi, graph=g, h=1.0)
 
 # RBM Spin Machine
 ma = nk.machine.RbmSpinReal(alpha=1, hilbert=hi)

--- a/Examples/QuantumStateReconstruction/generate_data.py
+++ b/Examples/QuantumStateReconstruction/generate_data.py
@@ -24,7 +24,7 @@ def build_rotation(hi, basis):
 
 def generate(N, n_basis=20, n_shots=1000, seed=1234):
     g = gr.Hypercube(length=N, n_dim=1, pbc=False)
-    hi = hs.Spin(g, s=0.5)
+    hi = hs.Spin(g, s=1 / 2)
     ha = op.Ising(hilbert=hi, h=1)
     res = exact.lanczos_ed(ha, first_n=1, compute_eigenvectors=True)
 

--- a/Examples/RealMachines/j1j2.py
+++ b/Examples/RealMachines/j1j2.py
@@ -44,7 +44,7 @@ for i in range(L):
 g = nk.graph.Hypercube(length=L, n_dim=1, pbc=True)
 
 # Spin based Hilbert Space
-hi = nk.hilbert.Spin(s=0.5, total_sz=0.0, graph=g.n_nodes)
+hi = nk.hilbert.Spin(s=1/2, total_sz=0.0, N=g.n_nodes)
 
 # Custom Hamiltonian operator
 op = nk.operator.LocalOperator(hi)

--- a/Examples/RealMachines/j1j2.py
+++ b/Examples/RealMachines/j1j2.py
@@ -44,7 +44,7 @@ for i in range(L):
 g = nk.graph.Hypercube(length=L, n_dim=1, pbc=True)
 
 # Spin based Hilbert Space
-hi = nk.hilbert.Spin(s=0.5, total_sz=0.0, graph=g)
+hi = nk.hilbert.Spin(s=0.5, total_sz=0.0, graph=g.n_nodes)
 
 # Custom Hamiltonian operator
 op = nk.operator.LocalOperator(hi)
@@ -56,7 +56,7 @@ ma = nk.machine.RbmSpinPhase(hi, alpha=1)
 ma.init_random_parameters(seed=1234, sigma=0.1)
 
 # Sampler
-sa = nk.sampler.MetropolisExchange(machine=ma, graph=g)
+sa = nk.sampler.MetropolisExchange(machine=ma, graph=g.n_nodes)
 
 # Optimizer
 opt = nk.optimizer.Sgd(learning_rate=0.01)

--- a/Examples/RealMachines/j1j2.py
+++ b/Examples/RealMachines/j1j2.py
@@ -44,7 +44,7 @@ for i in range(L):
 g = nk.graph.Hypercube(length=L, n_dim=1, pbc=True)
 
 # Spin based Hilbert Space
-hi = nk.hilbert.Spin(s=1/2, total_sz=0.0, N=g.n_nodes)
+hi = nk.hilbert.Spin(s=1 / 2, total_sz=0.0, N=g.n_nodes)
 
 # Custom Hamiltonian operator
 op = nk.operator.LocalOperator(hi)
@@ -56,7 +56,7 @@ ma = nk.machine.RbmSpinPhase(hi, alpha=1)
 ma.init_random_parameters(seed=1234, sigma=0.1)
 
 # Sampler
-sa = nk.sampler.MetropolisExchange(machine=ma, N=g.n_nodes)
+sa = nk.sampler.MetropolisExchange(machine=ma, graph=g.n_nodes)
 
 # Optimizer
 opt = nk.optimizer.Sgd(learning_rate=0.01)

--- a/Examples/RealMachines/j1j2.py
+++ b/Examples/RealMachines/j1j2.py
@@ -56,7 +56,7 @@ ma = nk.machine.RbmSpinPhase(hi, alpha=1)
 ma.init_random_parameters(seed=1234, sigma=0.1)
 
 # Sampler
-sa = nk.sampler.MetropolisExchange(machine=ma, graph=g.n_nodes)
+sa = nk.sampler.MetropolisExchange(machine=ma, N=g.n_nodes)
 
 # Optimizer
 opt = nk.optimizer.Sgd(learning_rate=0.01)

--- a/Examples/RealMachines/rbm_phase.py
+++ b/Examples/RealMachines/rbm_phase.py
@@ -18,7 +18,7 @@ import netket as nk
 g = nk.graph.Hypercube(length=20, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
-hi = nk.hilbert.Spin(s=0.5, graph=g.n_nodes)
+hi = nk.hilbert.Spin(s=1/2, N=g.n_nodes)
 
 # Ising spin hamiltonian
 ha = nk.operator.Ising(hilbert=hi, graph=g, h=1.0)

--- a/Examples/RealMachines/rbm_phase.py
+++ b/Examples/RealMachines/rbm_phase.py
@@ -18,10 +18,10 @@ import netket as nk
 g = nk.graph.Hypercube(length=20, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
-hi = nk.hilbert.Spin(s=0.5, graph=g)
+hi = nk.hilbert.Spin(s=0.5, graph=g.n_nodes)
 
 # Ising spin hamiltonian
-ha = nk.operator.Ising(h=1.0, hilbert=hi)
+ha = nk.operator.Ising(hilbert=hi, graph=g, h=1.0)
 
 # RBM Spin Machine
 # Paremeterizing phase and amplitude separately

--- a/Examples/RealMachines/rbm_phase.py
+++ b/Examples/RealMachines/rbm_phase.py
@@ -18,7 +18,7 @@ import netket as nk
 g = nk.graph.Hypercube(length=20, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
-hi = nk.hilbert.Spin(s=1/2, N=g.n_nodes)
+hi = nk.hilbert.Spin(s=1 / 2, N=g.n_nodes)
 
 # Ising spin hamiltonian
 ha = nk.operator.Ising(hilbert=hi, graph=g, h=1.0)

--- a/Examples/RealMachines/rbm_real.py
+++ b/Examples/RealMachines/rbm_real.py
@@ -18,7 +18,7 @@ import netket as nk
 g = nk.graph.Hypercube(length=20, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
-hi = nk.hilbert.Spin(s=0.5, graph=g.n_nodes)
+hi = nk.hilbert.Spin(s=1/2, N=g.n_nodes)
 
 # Ising spin hamiltonian
 ha = nk.operator.Ising(hilbert=hi, graph=g, h=1.0)

--- a/Examples/RealMachines/rbm_real.py
+++ b/Examples/RealMachines/rbm_real.py
@@ -18,7 +18,7 @@ import netket as nk
 g = nk.graph.Hypercube(length=20, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
-hi = nk.hilbert.Spin(s=1/2, N=g.n_nodes)
+hi = nk.hilbert.Spin(s=1 / 2, N=g.n_nodes)
 
 # Ising spin hamiltonian
 ha = nk.operator.Ising(hilbert=hi, graph=g, h=1.0)

--- a/Examples/RealMachines/rbm_real.py
+++ b/Examples/RealMachines/rbm_real.py
@@ -18,10 +18,10 @@ import netket as nk
 g = nk.graph.Hypercube(length=20, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
-hi = nk.hilbert.Spin(s=0.5, graph=g)
+hi = nk.hilbert.Spin(s=0.5, graph=g.n_nodes)
 
 # Ising spin hamiltonian
-ha = nk.operator.Ising(h=1.0, hilbert=hi)
+ha = nk.operator.Ising(hilbert=hi, graph=g, h=1.0)
 
 # RBM Spin Machine
 ma = nk.machine.RbmSpinReal(alpha=1, hilbert=hi)

--- a/Examples/Supervised/Ising/ed.py
+++ b/Examples/Supervised/Ising/ed.py
@@ -21,7 +21,7 @@ def load_ed_data(L):
     g = nk.graph.Hypercube(length=L, n_dim=1, pbc=True)
 
     # Hilbert space of spins on the graph
-    hi = nk.hilbert.Spin(s=0.5, graph=g.n_nodes)
+    hi = nk.hilbert.Spin(s=0.5, N=g.n_nodes)
 
     # Ising spin hamiltonian
     ha = nk.operator.Ising(hilbert=hi, graph=g, h=1.0)

--- a/Examples/Supervised/Ising/ed.py
+++ b/Examples/Supervised/Ising/ed.py
@@ -21,7 +21,7 @@ def load_ed_data(L):
     g = nk.graph.Hypercube(length=L, n_dim=1, pbc=True)
 
     # Hilbert space of spins on the graph
-    hi = nk.hilbert.Spin(s=0.5, N=g.n_nodes)
+    hi = nk.hilbert.Spin(s=1 / 2, N=g.n_nodes)
 
     # Ising spin hamiltonian
     ha = nk.operator.Ising(hilbert=hi, graph=g, h=1.0)

--- a/Examples/Supervised/Ising/ed.py
+++ b/Examples/Supervised/Ising/ed.py
@@ -21,10 +21,10 @@ def load_ed_data(L):
     g = nk.graph.Hypercube(length=L, n_dim=1, pbc=True)
 
     # Hilbert space of spins on the graph
-    hi = nk.hilbert.Spin(s=0.5, graph=g)
+    hi = nk.hilbert.Spin(s=0.5, graph=g.n_nodes)
 
     # Ising spin hamiltonian
-    ha = nk.operator.Ising(h=1.0, hilbert=hi)
+    ha = nk.operator.Ising(hilbert=hi, graph=g, h=1.0)
 
     # Perform Lanczos Exact Diagonalization to get lowest three eigenvalues
     res = nk.exact.lanczos_ed(ha, first_n=3, compute_eigenvectors=True)

--- a/Examples/Supervised/J1J2/ed.py
+++ b/Examples/Supervised/J1J2/ed.py
@@ -44,7 +44,7 @@ def load_ed_data(L, J2=0.4):
     g = nk.graph.Hypercube(length=L, n_dim=1, pbc=True)
 
     # Spin based Hilbert Space
-    hi = nk.hilbert.Spin(s=0.5, N=g.n_nodes)
+    hi = nk.hilbert.Spin(s=1 / 2, N=g.n_nodes)
 
     # Custom Hamiltonian operator
     ha = nk.operator.LocalOperator(hi)

--- a/Examples/Supervised/J1J2/ed.py
+++ b/Examples/Supervised/J1J2/ed.py
@@ -44,7 +44,7 @@ def load_ed_data(L, J2=0.4):
     g = nk.graph.Hypercube(length=L, n_dim=1, pbc=True)
 
     # Spin based Hilbert Space
-    hi = nk.hilbert.Spin(s=0.5, graph=g.n_nodes)
+    hi = nk.hilbert.Spin(s=0.5, N=g.n_nodes)
 
     # Custom Hamiltonian operator
     ha = nk.operator.LocalOperator(hi)

--- a/Examples/Supervised/J1J2/ed.py
+++ b/Examples/Supervised/J1J2/ed.py
@@ -44,7 +44,7 @@ def load_ed_data(L, J2=0.4):
     g = nk.graph.Hypercube(length=L, n_dim=1, pbc=True)
 
     # Spin based Hilbert Space
-    hi = nk.hilbert.Spin(s=0.5, graph=g)
+    hi = nk.hilbert.Spin(s=0.5, graph=g.n_nodes)
 
     # Custom Hamiltonian operator
     ha = nk.operator.LocalOperator(hi)

--- a/Examples/Supervised/J1J2/load_data.py
+++ b/Examples/Supervised/J1J2/load_data.py
@@ -24,7 +24,7 @@ def load(path_to_samples, path_to_targets):
     # Create the hilbert space
     # TODO remove Hypercube here and put customgraph
     g = gr.Hypercube(length=len(tsamples[0]), n_dim=1)
-    hi = hs.Qubit(graph=g)
+    hi = hs.Qubit(graph=g.n_nodes)
 
     training_samples = []
     training_targets = []

--- a/Examples/Supervised/J1J2/load_data.py
+++ b/Examples/Supervised/J1J2/load_data.py
@@ -24,7 +24,7 @@ def load(path_to_samples, path_to_targets):
     # Create the hilbert space
     # TODO remove Hypercube here and put customgraph
     g = gr.Hypercube(length=len(tsamples[0]), n_dim=1)
-    hi = hs.Qubit(graph=g.n_nodes)
+    hi = hs.Qubit(N=g.n_nodes)
 
     training_samples = []
     training_targets = []

--- a/Examples/Tensorboard/ising1d.py
+++ b/Examples/Tensorboard/ising1d.py
@@ -22,7 +22,7 @@ import netket as nk
 g = nk.graph.Hypercube(length=20, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
-hi = nk.hilbert.Spin(s=1/2, N=g.n_nodes)
+hi = nk.hilbert.Spin(s=1 / 2, N=g.n_nodes)
 
 # Ising spin hamiltonian
 ha = nk.operator.Ising(hilbert=hi, graph=g, h=1.0)

--- a/Examples/Tensorboard/ising1d.py
+++ b/Examples/Tensorboard/ising1d.py
@@ -22,10 +22,10 @@ import netket as nk
 g = nk.graph.Hypercube(length=20, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
-hi = nk.hilbert.Spin(s=0.5, graph=g)
+hi = nk.hilbert.Spin(s=0.5, graph=g.n_nodes)
 
 # Ising spin hamiltonian
-ha = nk.operator.Ising(h=1.0, hilbert=hi)
+ha = nk.operator.Ising(hilbert=hi, graph=g, h=1.0)
 
 # RBM Spin Machine
 ma = nk.machine.RbmSpin(alpha=1, hilbert=hi)

--- a/Examples/Tensorboard/ising1d.py
+++ b/Examples/Tensorboard/ising1d.py
@@ -22,7 +22,7 @@ import netket as nk
 g = nk.graph.Hypercube(length=20, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
-hi = nk.hilbert.Spin(s=0.5, graph=g.n_nodes)
+hi = nk.hilbert.Spin(s=1/2, N=g.n_nodes)
 
 # Ising spin hamiltonian
 ha = nk.operator.Ising(hilbert=hi, graph=g, h=1.0)

--- a/Examples/Torch/torch_machine.py
+++ b/Examples/Torch/torch_machine.py
@@ -20,7 +20,7 @@ import numpy as np
 g = nk.graph.Hypercube(length=20, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
-hi = nk.hilbert.Spin(s=0.5, graph=g.n_nodes)
+hi = nk.hilbert.Spin(s=1/2, N=g.n_nodes)
 
 # Ising spin hamiltonian
 ha = nk.operator.Ising(hilbert=hi, graph=g, h=1.0)

--- a/Examples/Torch/torch_machine.py
+++ b/Examples/Torch/torch_machine.py
@@ -20,7 +20,7 @@ import numpy as np
 g = nk.graph.Hypercube(length=20, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
-hi = nk.hilbert.Spin(s=1/2, N=g.n_nodes)
+hi = nk.hilbert.Spin(s=1 / 2, N=g.n_nodes)
 
 # Ising spin hamiltonian
 ha = nk.operator.Ising(hilbert=hi, graph=g, h=1.0)

--- a/Examples/Torch/torch_machine.py
+++ b/Examples/Torch/torch_machine.py
@@ -20,10 +20,10 @@ import numpy as np
 g = nk.graph.Hypercube(length=20, n_dim=1, pbc=True)
 
 # Hilbert space of spins on the graph
-hi = nk.hilbert.Spin(s=0.5, graph=g)
+hi = nk.hilbert.Spin(s=0.5, graph=g.n_nodes)
 
 # Ising spin hamiltonian
-ha = nk.operator.Ising(h=1.0, hilbert=hi)
+ha = nk.operator.Ising(hilbert=hi, graph=g, h=1.0)
 
 
 input_size = hi.size

--- a/Test/Callbacks/test_callbacks.py
+++ b/Test/Callbacks/test_callbacks.py
@@ -2,17 +2,17 @@ import netket as nk
 import time
 
 SEED = 3141592
+L = 8
 
 
 def _vmc(n_iter=20):
     nk.random.seed(SEED)
-    g = nk.graph.Hypercube(length=8, n_dim=1)
-    hi = nk.hilbert.Spin(s=0.5, graph=g)
+    hi = nk.hilbert.Spin(s=0.5) ** L
 
     ma = nk.machine.RbmSpin(hilbert=hi, alpha=1)
     ma.init_random_parameters(sigma=0.01, seed=SEED)
 
-    ha = nk.operator.Ising(hi, h=1.0)
+    ha = nk.operator.Ising(hi, nk.graph.Hypercube(length=L, n_dim=1), h=1.0)
     sa = nk.sampler.MetropolisLocal(machine=ma)
 
     op = nk.optimizer.Sgd(ma, learning_rate=0.1)

--- a/Test/Dynamics/test_dynamics.py
+++ b/Test/Dynamics/test_dynamics.py
@@ -13,9 +13,9 @@ TIME = 20.0
 
 
 def _setup_model():
-    g = nk.graph.Hypercube(8, 1)
-    hi = nk.hilbert.Spin(g, 0.5)
-    ham = nk.operator.Heisenberg(hi)
+    L = 8
+    hi = nk.hilbert.Spin(0.5) ** L
+    ham = nk.operator.Heisenberg(hi, nk.graph.Hypercube(L, 1))
 
     psi0 = np.random.rand(hi.n_states) + 1j * np.random.rand(hi.n_states)
     psi0 /= norm(psi0)

--- a/Test/GroundState/test_vmc.py
+++ b/Test/GroundState/test_vmc.py
@@ -16,12 +16,12 @@ nk.random.seed(SEED)
 def _setup_vmc(lsq_solver=None):
     L = 4
     g = nk.graph.Hypercube(length=L, n_dim=1)
-    hi = nk.hilbert.Spin(s=0.5, graph=g)
+    hi = nk.hilbert.Spin(s=0.5, N=g.n_nodes)
 
     ma = nk.machine.RbmSpin(hilbert=hi, alpha=1)
     ma.init_random_parameters(sigma=0.01)
 
-    ha = nk.operator.Ising(hi, h=1.0)
+    ha = nk.operator.Ising(hi, graph=g, h=1.0)
     sa = nk.sampler.ExactSampler(machine=ma, sample_size=16)
     op = nk.optimizer.Sgd(ma, learning_rate=0.05)
 

--- a/Test/Hilbert/test_hilbert.py
+++ b/Test/Hilbert/test_hilbert.py
@@ -22,70 +22,54 @@ from netket.hilbert import *
 hilberts = {}
 
 # Spin 1/2
-hilberts["Spin 1/2"] = Spin(s=0.5, graph=nk.graph.Hypercube(length=20, n_dim=1))
+hilberts["Spin 1/2"] = Spin(s=0.5, N=20)
 
 # Spin 1/2 with total Sz
-hilberts["Spin 1/2 with total Sz"] = Spin(
-    s=0.5, total_sz=1.0, graph=nk.graph.Hypercube(length=20, n_dim=1)
-)
+hilberts["Spin 1/2 with total Sz"] = Spin(s=0.5, total_sz=1.0, N=20)
 
 # Spin 3
-hilberts["Spin 3"] = Spin(s=3, graph=nk.graph.Hypercube(length=25, n_dim=1))
+hilberts["Spin 3"] = Spin(s=3, N=25)
 
 # Boson
-hilberts["Boson"] = Boson(n_max=5, graph=nk.graph.Hypercube(length=41, n_dim=1))
+hilberts["Boson"] = Boson(n_max=5, N=41)
 
 # Boson with total number
-hilberts["Bosons with total number"] = Boson(
-    n_max=3, n_bosons=110, graph=nk.graph.Hypercube(length=120, n_dim=1)
-)
+hilberts["Bosons with total number"] = Boson(n_max=3, n_bosons=110, N=120)
 
 # Qubit
-hilberts["Qubit"] = nk.hilbert.Qubit(graph=nk.graph.Hypercube(length=100, n_dim=1))
+hilberts["Qubit"] = nk.hilbert.Qubit(100)
 
 # Custom Hilbert
-hilberts["Custom Hilbert"] = CustomHilbert(
-    local_states=[-1232, 132, 0], graph=nk.graph.Hypercube(length=70, n_dim=1)
-)
+hilberts["Custom Hilbert"] = CustomHilbert(local_states=[-1232, 132, 0], N=70)
 
 # Heisenberg 1d
-g1 = nk.graph.Hypercube(length=20, n_dim=1, pbc=True)
-hilberts["Heisenberg 1d"] = Spin(s=0.5, total_sz=0.0, graph=g1)
+hilberts["Heisenberg 1d"] = Spin(s=0.5, total_sz=0.0, N=20)
 
 # Bose Hubbard
-g3 = nk.graph.Hypercube(length=20, n_dim=1, pbc=True)
-hilberts["Bose Hubbard"] = Boson(n_max=4, n_bosons=20, graph=g3)
+hilberts["Bose Hubbard"] = Boson(n_max=4, n_bosons=20, N=20)
 
 #
 # Small hilbert space tests
 #
 
 # Spin 1/2
-hilberts["Spin 1/2 Small"] = Spin(s=0.5, graph=nk.graph.Hypercube(length=10, n_dim=1))
+hilberts["Spin 1/2 Small"] = Spin(s=0.5, N=10)
 
 # Spin 3
-hilberts["Spin 1/2 with total Sz Small"] = Spin(
-    s=3, total_sz=1.0, graph=nk.graph.Hypercube(length=4, n_dim=1)
-)
+hilberts["Spin 1/2 with total Sz Small"] = Spin(s=3, total_sz=1.0, N=4)
 
 # Boson
-hilberts["Boson Small"] = Boson(n_max=3, graph=nk.graph.Hypercube(length=5, n_dim=1))
+hilberts["Boson Small"] = Boson(n_max=3, N=5)
 
 # Qubit
-hilberts["Qubit Small"] = nk.hilbert.Qubit(
-    graph=nk.graph.Hypercube(length=1, n_dim=1, pbc=False)
-)
+hilberts["Qubit Small"] = nk.hilbert.Qubit(N=1)
 
 # Custom Hilbert
-hilberts["Custom Hilbert Small"] = CustomHilbert(
-    local_states=[-1232, 132, 0], graph=nk.graph.Hypercube(length=5, n_dim=1)
-)
+hilberts["Custom Hilbert Small"] = CustomHilbert(local_states=[-1232, 132, 0], N=5)
 
 # Custom Hilbert
 hilberts["Doubled Hilbert"] = nk.hilbert.DoubledHilbert(
-    CustomHilbert(
-        local_states=[-1232, 132, 0], graph=nk.graph.Hypercube(length=5, n_dim=1)
-    )
+    CustomHilbert(local_states=[-1232, 132, 0], N=5)
 )
 
 
@@ -159,9 +143,8 @@ def test_hilbert_index():
                 hi.n_states
 
         # Check that a large hilbert space raises error when constructing matrices
-        op = nk.operator.Heisenberg(
-            hilbert=Spin(s=0.5, graph=nk.graph.Hypercube(length=100, n_dim=1))
-        )
+        g = nk.graph.Hypercube(length=100, n_dim=1)
+        op = nk.operator.Heisenberg(hilbert=Spin(s=0.5, N=g.n_nodes), graph=g)
 
         with pytest.raises(RuntimeError):
             m1 = op.to_dense()
@@ -170,8 +153,7 @@ def test_hilbert_index():
 
 
 def test_state_iteration():
-    g = nk.graph.Hypercube(10, 1)
-    hilbert = Spin(g, s=0.5)
+    hilbert = Spin(s=0.5, N=10)
 
     reference = [np.array(el) for el in itertools.product([-1.0, 1.0], repeat=10)]
 

--- a/Test/Machine/test_machine.py
+++ b/Test/Machine/test_machine.py
@@ -29,7 +29,7 @@ dm_machines = {}
 g = nk.graph.Hypercube(length=4, n_dim=1)
 
 # Hilbert space of spins from given graph
-hi = Spin(s=0.5, graph=g)
+hi = Spin(s=0.5, N=g.n_nodes)
 
 
 if test_jax:
@@ -64,7 +64,7 @@ if test_jax:
         dtype=complex,
     )
 
-    machines["Jax mps"] = nk.machine.MPSPeriodic(hi, bond_dim=4, dtype=complex)
+    machines["Jax mps"] = nk.machine.MPSPeriodic(hi, graph=g, bond_dim=4, dtype=complex)
 
     machines["Jax RbmSpinPhase (R->C)"] = nk.machine.JaxRbmSpinPhase(hi, alpha=1)
 
@@ -88,7 +88,9 @@ if test_torch:
 
 machines["RbmSpin 1d Hypercube spin"] = nk.machine.RbmSpin(hilbert=hi, alpha=2)
 
-machines["RbmSpinSymm 1d Hypercube spin"] = nk.machine.RbmSpinSymm(hilbert=hi, alpha=2)
+machines["RbmSpinSymm 1d Hypercube spin"] = nk.machine.RbmSpinSymm(
+    hilbert=hi, alpha=2, automorphisms=g
+)
 
 machines["Real RBM"] = nk.machine.RbmSpinReal(hilbert=hi, alpha=2)
 
@@ -96,9 +98,9 @@ machines["Phase RBM"] = nk.machine.RbmSpinPhase(hilbert=hi, alpha=2)
 
 machines["Jastrow 1d Hypercube spin"] = nk.machine.Jastrow(hilbert=hi)
 
-hi = Spin(s=0.5, graph=g, total_sz=0)
+hi = Spin(s=0.5, N=g.n_nodes, total_sz=0)
 machines["Jastrow 1d Hypercube spin symm bias"] = nk.machine.Jastrow(
-    hilbert=hi, use_visible_bias=True, symmetry=True
+    hilbert=hi, use_visible_bias=True, automorphisms=g
 )
 
 dm_machines["Phase NDM"] = nk.machine.density_matrix.RbmSpin(
@@ -113,17 +115,19 @@ dm_machines["Phase NDM"] = nk.machine.density_matrix.RbmSpin(
 # machines["MPS 1d spin"] = nk.machine.MPSPeriodic(hi, bond_dim=3)
 
 # BOSONS
-hi = nk.hilbert.Boson(graph=g, n_max=3)
+hi = nk.hilbert.Boson(N=g.n_nodes, n_max=3)
 machines["RbmSpin 1d Hypercube boson"] = nk.machine.RbmSpin(hilbert=hi, alpha=1)
 
-machines["RbmSpinSymm 1d Hypercube boson"] = nk.machine.RbmSpinSymm(hilbert=hi, alpha=2)
+machines["RbmSpinSymm 1d Hypercube boson"] = nk.machine.RbmSpinSymm(
+    hilbert=hi, alpha=2, automorphisms=g
+)
 machines["RbmMultiVal 1d Hypercube boson"] = nk.machine.RbmMultiVal(
     hilbert=hi, n_hidden=2
 )
 machines["Jastrow 1d Hypercube boson"] = nk.machine.Jastrow(hilbert=hi)
 
 machines["JastrowSymm 1d Hypercube boson real"] = nk.machine.JastrowSymm(
-    hilbert=hi, dtype=float
+    hilbert=hi, dtype=float, automorphisms=g
 )
 # machines["MPS 1d boson"] = nk.machine.MPSPeriodic(hi, bond_dim=4)
 

--- a/Test/Operator/test_der_local_operator.py
+++ b/Test/Operator/test_der_local_operator.py
@@ -29,11 +29,11 @@ np.set_printoptions(linewidth=180)
 
 # 1D Lattice
 L = 3
-g = nk.graph.Hypercube(length=L, n_dim=1, pbc=False)
+# g = nk.graph.Hypercube(length=L, n_dim=1, pbc=False)
 
 # Hilbert space of spins on the graph
-hi = nk.hilbert.Spin(s=0.5, graph=g)
-hi_c = nk.hilbert.Spin(s=0.5, graph=g)
+hi = nk.hilbert.Spin(s=0.5) ** L
+hi_c = nk.hilbert.Spin(s=0.5) ** L
 
 # Defining the Ising hamiltonian (with sign problem here)
 # Using local operators

--- a/Test/Operator/test_liouvillian.py
+++ b/Test/Operator/test_liouvillian.py
@@ -25,12 +25,10 @@ import os
 np.set_printoptions(linewidth=180)
 
 # 1D Lattice
-L = 5
-g = nk.graph.Hypercube(length=L, n_dim=1, pbc=False)
+L = 4
 
 # Hilbert space of spins on the graph
-hi = nk.hilbert.Spin(s=0.5, graph=g)
-hi_c = nk.hilbert.Spin(s=0.5, graph=g)
+hi = nk.hilbert.Spin(s=0.5) ** L
 
 # Defining the Ising hamiltonian (with sign problem here)
 # Using local operators

--- a/Test/Operator/test_local_operator.py
+++ b/Test/Operator/test_local_operator.py
@@ -201,7 +201,7 @@ def test_simple_operators():
 
 
 def test_mul_matmul():
-    hi = nk.hilbert.Spin(nk.graph.Edgeless(2), s=1 / 2)
+    hi = nk.hilbert.Spin(s=1 / 2, N=2)
     sx0_hat = nk.operator.LocalOperator(hi, sx, [0])
     sy1_hat = nk.operator.LocalOperator(hi, sy, [1])
 

--- a/Test/Operator/test_local_operator.py
+++ b/Test/Operator/test_local_operator.py
@@ -232,7 +232,7 @@ def test_mul_matmul():
 
 
 def test_truediv():
-    hi = nk.hilbert.Spin(nk.graph.Edgeless(2), s=1 / 2)
+    hi = nk.hilbert.Spin(s=1 / 2, N=2)
 
     sx0_hat = nk.operator.LocalOperator(hi, sx, [0])
     sy1_hat = nk.operator.LocalOperator(hi, sy, [1])

--- a/Test/Operator/test_local_operator.py
+++ b/Test/Operator/test_local_operator.py
@@ -22,7 +22,7 @@ sz = [[1, 0], [0, -1]]
 sm = [[0, 0], [1, 0]]
 sp = [[0, 1], [0, 0]]
 g = nk.graph.Graph(edges=[[i, i + 1] for i in range(8)])
-hi = nk.hilbert.CustomHilbert(local_states=[-1, 1], graph=g)
+hi = nk.hilbert.CustomHilbert(local_states=[-1, 1], N=g.n_nodes)
 
 
 def _loc(*args):
@@ -153,8 +153,7 @@ def test_local_operator_add():
 
 def test_simple_operators():
     L = 4
-    g = nk.graph.Hypercube(L, 1)
-    hi = nk.hilbert.Spin(g, 0.5)
+    hi = nk.hilbert.Spin(0.5) ** L
 
     sx = [[0, 1], [1, 0]]
     sy = [[0, -1.0j], [1.0j, 0]]
@@ -167,7 +166,6 @@ def test_simple_operators():
         sx_hat = nk.operator.LocalOperator(hi, sx, [i])
         sy_hat = nk.operator.LocalOperator(hi, sy, [i])
         sz_hat = nk.operator.LocalOperator(hi, sz, [i])
-
         assert (sigmax(hi, i).to_dense() == sx_hat.to_dense()).all()
         assert (sigmay(hi, i).to_dense() == sy_hat.to_dense()).all()
         assert (sigmaz(hi, i).to_dense() == sz_hat.to_dense()).all()
@@ -176,26 +174,24 @@ def test_simple_operators():
     for i in range(L):
         sm_hat = nk.operator.LocalOperator(hi, sm, [i])
         sp_hat = nk.operator.LocalOperator(hi, sp, [i])
-
         assert (sigmam(hi, i).to_dense() == sm_hat.to_dense()).all()
         assert (sigmap(hi, i).to_dense() == sp_hat.to_dense()).all()
 
     print("Testing Sigma_+/- composition...")
 
-    hi = nk.hilbert.Spin(g, 0.5)
+    hi = nk.hilbert.Spin(0.5, N=L)
     for i in range(L):
         sx = sigmax(hi, i)
         sy = sigmay(hi, i)
-
         sigmam_hat = 0.5 * (sx + (-1j) * sy)
         sigmap_hat = 0.5 * (sx + (1j) * sy)
-
         assert (sigmam(hi, i).to_dense() == sigmam_hat.to_dense()).all()
         assert (sigmap(hi, i).to_dense() == sigmap_hat.to_dense()).all()
 
     print("Testing create/destroy composition...")
-    hi = nk.hilbert.Boson(g, 3)
+    hi = nk.hilbert.Boson(3, N=L)
     for i in range(L):
+        print("i=", i)
         a = bdestroy(hi, i)
         ad = bcreate(hi, i)
         n = bnumber(hi, i)

--- a/Test/Optimizer/test_sr.py
+++ b/Test/Optimizer/test_sr.py
@@ -10,11 +10,8 @@ def test_sr_no_segfault():
     """
     Tests the resolution of bug #317.
     """
-    # 1D Lattice
-    g = nk.graph.Hypercube(length=20, n_dim=1, pbc=True)
-
     # Hilbert space of spins on the graph
-    hi = nk.hilbert.Spin(s=0.5, graph=g)
+    hi = nk.hilbert.Spin(s=0.5) ** 20
     machine = nk.machine.RbmSpin(alpha=1, hilbert=hi)
     sr = SR(machine)
     assert sr.last_covariance_matrix is None
@@ -28,10 +25,7 @@ def test_svd_threshold():
         ValueError,
         match="The svd_threshold option is available only for non-sparse solvers.",
     ):
-        # 1D Lattice
-        g = nk.graph.Hypercube(length=20, n_dim=1, pbc=True)
-
         # Hilbert space of spins on the graph
-        hi = nk.hilbert.Spin(s=0.5, graph=g)
+        hi = nk.hilbert.Spin(s=0.5) ** 20
         machine = nk.machine.RbmSpin(alpha=1, hilbert=hi)
         SR(machine, use_iterative=True, svd_threshold=1e-3)

--- a/Test/Sampler/test_sampler.py
+++ b/Test/Sampler/test_sampler.py
@@ -19,7 +19,7 @@ from netket.utils import jax_available as test_jax
 g = nk.graph.Hypercube(length=4, n_dim=1)
 
 # Hilbert space of spins from given graph
-hi = nk.hilbert.Spin(s=0.5, graph=g)
+hi = nk.hilbert.Spin(s=0.5, N=g.n_nodes)
 ma = nk.machine.RbmSpin(hilbert=hi, alpha=1)
 ma.init_random_parameters(sigma=0.2)
 
@@ -32,7 +32,7 @@ samplers["Exact RbmSpin"] = sa
 sa = nk.sampler.MetropolisLocalPt(machine=ma, n_replicas=4)
 samplers["MetropolisLocalPt RbmSpin"] = sa
 
-ha = nk.operator.Ising(hilbert=hi, h=1.0)
+ha = nk.operator.Ising(hilbert=hi, graph=g, h=1.0)
 sa = nk.sampler.MetropolisHamiltonian(machine=ma, hamiltonian=ha)
 samplers["MetropolisHamiltonian RbmSpin"] = sa
 
@@ -42,12 +42,12 @@ maz.init_random_parameters(sigma=0)
 sa = nk.sampler.MetropolisLocal(machine=maz, sweep_size=hi.size + 1, n_chains=2)
 samplers["MetropolisLocal RbmSpin ZeroPars"] = sa
 
-mas = nk.machine.RbmSpinSymm(hilbert=hi, alpha=1)
+mas = nk.machine.RbmSpinSymm(hilbert=hi, alpha=1, automorphisms=g)
 mas.init_random_parameters(sigma=0.2)
 sa = nk.sampler.MetropolisHamiltonianPt(machine=mas, hamiltonian=ha, n_replicas=4)
 samplers["MetropolisHamiltonianPt RbmSpinSymm"] = sa
 
-hi = nk.hilbert.Boson(graph=g, n_max=3)
+hi = nk.hilbert.Boson(N=g.n_nodes, n_max=3)
 ma = nk.machine.RbmSpin(hilbert=hi, alpha=1)
 ma.init_random_parameters(sigma=0.1)
 sa = nk.sampler.MetropolisLocal(machine=ma)
@@ -56,15 +56,15 @@ samplers["MetropolisLocal Boson"] = sa
 sa = nk.sampler.MetropolisLocalPt(machine=ma, n_replicas=2)
 samplers["MetropolisLocalPt Boson"] = sa
 
-hi = nk.hilbert.Boson(graph=g, n_max=3)
+hi = nk.hilbert.Boson(N=g.n_nodes, n_max=3)
 ma = nk.machine.RbmSpin(hilbert=hi, alpha=1)
 ma.init_random_parameters(sigma=0.1)
 sa = nk.sampler.ExactSampler(machine=ma)
 samplers["Exact Boson"] = sa
 
-hi = nk.hilbert.Spin(s=0.5, graph=g)
+hi = nk.hilbert.Spin(s=0.5, N=g.n_nodes)
 g = nk.graph.Hypercube(length=3, n_dim=1)
-ma = nk.machine.RbmSpinSymm(hilbert=hi, alpha=1)
+ma = nk.machine.RbmSpinSymm(hilbert=hi, alpha=1, automorphisms=g)
 ma.init_random_parameters(sigma=0.2)
 l = hi.size
 X = [[0, 1], [1, 0]]
@@ -112,7 +112,7 @@ sa = nk.sampler.ExactSampler(machine=dm)
 samplers["Exact Diagonal Density Matrix"] = sa
 
 g = nk.graph.Hypercube(length=3, n_dim=1)
-hi = nk.hilbert.Spin(s=0.5, graph=g)
+hi = nk.hilbert.Spin(s=0.5, N=g.n_nodes)
 ma = nk.machine.density_matrix.RbmSpin(
     hilbert=hi,
     alpha=1,

--- a/Test/Sampler/test_sampler.py
+++ b/Test/Sampler/test_sampler.py
@@ -26,6 +26,12 @@ ma.init_random_parameters(sigma=0.2)
 sa = nk.sampler.MetropolisLocal(machine=ma, n_chains=16)
 samplers["MetropolisLocal RbmSpin"] = sa
 
+hib = nk.hilbert.Boson(n_max=1, N=g.n_nodes, n_bosons=1)
+mab = nk.machine.RbmSpin(hilbert=hib, alpha=1)
+mab.init_random_parameters(sigma=0.2)
+sa = nk.sampler.MetropolisExchange(machine=mab, n_chains=16, graph=g)
+samplers["MetropolisExchange RbmSpin(boson)"] = sa
+
 sa = nk.sampler.ExactSampler(machine=ma, sample_size=8)
 samplers["Exact RbmSpin"] = sa
 
@@ -136,6 +142,12 @@ if test_jax:
     ma = nk.machine.JaxRbm(hilbert=hi, alpha=1)
     ma.init_random_parameters(sigma=0.2)
     samplers["Metropolis Rbm Jax"] = nk.sampler.MetropolisLocal(ma, n_chains=16)
+
+    hib = nk.hilbert.Boson(n_max=1, N=g.n_nodes, n_bosons=1)
+    mab = nk.machine.JaxRbm(hilbert=hib, alpha=1)
+    mab.init_random_parameters(sigma=0.2)
+    sa = nk.sampler.MetropolisExchange(machine=mab, n_chains=16, graph=g)
+    samplers["MetropolisExchange RbmSpin(boson) Jax"] = sa
 
     # Test a machine which only works with 2D output and not 1D
     import jax

--- a/Test/Stats/test_stats.py
+++ b/Test/Stats/test_stats.py
@@ -11,9 +11,9 @@ from numba import jit
 
 def _setup():
     g = nk.graph.Hypercube(3, 2)
-    hi = nk.hilbert.Spin(g, 0.5)
+    hi = nk.hilbert.Spin(0.5, N=g.n_nodes)
 
-    ham = nk.operator.Heisenberg(hi)
+    ham = nk.operator.Heisenberg(hi, graph=g)
 
     ma = nk.machine.RbmSpin(hi, alpha=2)
     ma.init_random_parameters()

--- a/Test/SteadyState/test_steadystate.py
+++ b/Test/SteadyState/test_steadystate.py
@@ -16,8 +16,7 @@ sigmam = [[0, 0], [1, 0]]
 
 
 def _setup_system():
-    g = nk.graph.Hypercube(length=L, n_dim=1)
-    hi = nk.hilbert.Spin(s=0.5, graph=g)
+    hi = nk.hilbert.Spin(s=0.5) ** L
 
     ha = nk.operator.LocalOperator(hi)
     j_ops = []
@@ -59,8 +58,7 @@ def _setup_ss(**kwargs):
 
 
 def _setup_obs():
-    g = nk.graph.Hypercube(length=L, n_dim=1)
-    hi = nk.hilbert.Spin(s=0.5, graph=g)
+    hi = nk.hilbert.Spin(s=0.5) ** L
 
     obs_sx = nk.operator.LocalOperator(hi)
     for i in range(L):

--- a/netket/graph/graph.py
+++ b/netket/graph/graph.py
@@ -100,7 +100,7 @@ class NetworkX(AbstractGraph):
     def __pow__(self, exponent):
         if not isinstance(exponent, int):
             raise ValueError(
-                "Exponeent {} not valid: only integers are supported".format(exponent)
+                "Exponent {} not valid: only integers are supported".format(exponent)
             )
 
         base = self

--- a/netket/graph/graph.py
+++ b/netket/graph/graph.py
@@ -97,6 +97,19 @@ class NetworkX(AbstractGraph):
             str(type(self)).split(".")[-1][:-2], self.n_nodes
         )
 
+    def __pow__(self, exponent):
+        if not isinstance(exponent, int):
+            raise ValueError(
+                "Exponeent {} not valid: only integers are supported".format(exponent)
+            )
+
+        base = self
+        g = self
+        for i in range(1, exponent):
+            g = disjoint_union(g, base)
+
+        return g
+
 
 def Graph(nodes=[], edges=[]):
     r"""
@@ -197,9 +210,11 @@ def DoubledGraph(graph):
     dedges = list(graph.edges())
     n_v = graph.n_nodes
 
+    dnodes = [i for i in range(n_v)] + [i + n_v for i in range(n_v)]
+
     dedges += [(edge[0] + n_v, edge[1] + n_v) for edge in graph.edges()]
 
-    return Graph(edges=dedges)
+    return Graph(nodes=dnodes, edges=dedges)
 
 
 def disjoint_union(graph_1, graph_2):

--- a/netket/graph/graph.py
+++ b/netket/graph/graph.py
@@ -97,19 +97,6 @@ class NetworkX(AbstractGraph):
             str(type(self)).split(".")[-1][:-2], self.n_nodes
         )
 
-    def __pow__(self, exponent):
-        if not isinstance(exponent, int):
-            raise ValueError(
-                "Exponent {} not valid: only integers are supported".format(exponent)
-            )
-
-        base = self
-        g = self
-        for i in range(1, exponent):
-            g = disjoint_union(g, base)
-
-        return g
-
 
 def Graph(nodes=[], edges=[]):
     r"""

--- a/netket/hilbert/abstract_hilbert.py
+++ b/netket/hilbert/abstract_hilbert.py
@@ -1,6 +1,8 @@
 import abc
 import numpy as _np
 
+from typing import List, Tuple, Optional, Generator
+
 
 """int: Maximum number of states that can be indexed"""
 max_states = _np.iinfo(_np.int32).max

--- a/netket/hilbert/boson.py
+++ b/netket/hilbert/boson.py
@@ -4,21 +4,28 @@ import numpy as _np
 from netket import random as _random
 from numba import jit
 
+from typing import List, Tuple, Optional
+
 
 class Boson(CustomHilbert):
     r"""Hilbert space obtained as tensor product of local bosonic states."""
 
-    def __init__(self, n_max=None, N=1, n_bosons=None):
+    def __init__(
+        self,
+        n_max: Optional[int] = None,
+        N: int = 1,
+        n_bosons: Optional[int] = None,
+    ):
         r"""
         Constructs a new ``Boson`` given a maximum occupation number, number of sites
         and total number of bosons.
 
         Args:
-           n_max: Maximum occupation for a site (inclusive). If None, the local occupation
-                  number is unbounded.
-           N: Number of bosonic sites.
-           n_bosons: (optional) Constraint for the number of bosons. If None, no constraint
-                  is imposed.
+          n_max: Maximum occupation for a site (inclusive). If None, the local occupation
+            number is unbounded.
+          N: number of bosonic modes (default = 1)
+          n_bosons: Constraint for the number of bosons. If None, no constraint
+            is imposed.
 
         Examples:
            Simple boson hilbert space.

--- a/netket/hilbert/boson.py
+++ b/netket/hilbert/boson.py
@@ -8,27 +8,25 @@ from numba import jit
 class Boson(CustomHilbert):
     r"""Hilbert space obtained as tensor product of local bosonic states."""
 
-    def __init__(self, graph, n_max=None, n_bosons=None):
+    def __init__(self, n_max=None, N=1, n_bosons=None):
         r"""
-        Constructs a new ``Boson`` given a graph,  maximum occupation number,
+        Constructs a new ``Boson`` given a maximum occupation number, number of sites
         and total number of bosons.
 
         Args:
-           graph: Graph representation of sites.
            n_max: Maximum occupation for a site (inclusive). If None, the local occupation
                   number is unbounded.
-           n_bosons: Constraint for the number of bosons. If None, no constraint
+           N: Number of bosonic sites.
+           n_bosons: (optional) Constraint for the number of bosons. If None, no constraint
                   is imposed.
 
         Examples:
            Simple boson hilbert space.
 
-           >>> from netket.graph import Hypercube
            >>> from netket.hilbert import Boson
-           >>> g = Hypercube(length=10,n_dim=2,pbc=True)
-           >>> hi = Boson(graph=g, n_max=5, n_bosons=11)
+           >>> hi = Boson(n_max=5, n_bosons=11, N=3)
            >>> print(hi.size)
-           100
+           3
         """
 
         self._n_max = n_max
@@ -41,7 +39,7 @@ class Boson(CustomHilbert):
             if self._n_max is None:
                 self._n_max = n_bosons
             else:
-                if self._n_max * graph.n_nodes < n_bosons:
+                if self._n_max * N < n_bosons:
                     raise Exception(
                         """The required total number of bosons is not compatible
                         with the given n_max."""
@@ -64,7 +62,7 @@ class Boson(CustomHilbert):
 
         self._hilbert_index = None
 
-        super().__init__(graph, local_states, constraints)
+        super().__init__(local_states, N, constraints)
 
     @property
     def n_max(self):
@@ -93,7 +91,7 @@ class Boson(CustomHilbert):
 
            >>> import netket as nk
            >>> import numpy as np
-           >>> hi = nk.hilbert.Boson(n_max=3, graph=nk.graph.Hypercube(length=5, n_dim=1))
+           >>> hi = nk.hilbert.Boson(n_max=3, N=5)
            >>> rstate = np.zeros(hi.size)
            >>> rg = nk.utils.RandomEngine(seed=1234)
            >>> hi.random_vals(rstate, rg)

--- a/netket/hilbert/custom_hilbert.py
+++ b/netket/hilbert/custom_hilbert.py
@@ -215,8 +215,8 @@ class CustomHilbert(AbstractHilbert):
 
     def __pow__(self, n):
         if self._constraints is not None:
-            raise ValueError(
-                """Cannot exponentiate a CustomHilbret with a constraint. 
+            raise NotImplementedError(
+                """Cannot exponentiate a CustomHilbert with constraints. 
                 Construct it from scratch instead."""
             )
 

--- a/netket/hilbert/custom_hilbert.py
+++ b/netket/hilbert/custom_hilbert.py
@@ -5,11 +5,18 @@ from numba import jit
 import numpy as _np
 from netket import random as _random
 
+from typing import Optional, List
+
 
 class CustomHilbert(AbstractHilbert):
     r"""A custom hilbert space with discrete local quantum numbers."""
 
-    def __init__(self, local_states, N=1, constraints=None):
+    def __init__(
+        self,
+        local_states: Optional[List[float]],
+        N: int = 1,
+        constraints: Optional = None,
+    ):
         r"""
         Constructs a new ``CustomHilbert`` given a list of eigenvalues of the states and
         a number of sites, or modes, within this hilbert space.

--- a/netket/hilbert/custom_hilbert.py
+++ b/netket/hilbert/custom_hilbert.py
@@ -9,32 +9,32 @@ from netket import random as _random
 class CustomHilbert(AbstractHilbert):
     r"""A custom hilbert space with discrete local quantum numbers."""
 
-    def __init__(self, graph, local_states, constraints=None):
+    def __init__(self, local_states, N=1, constraints=None):
         r"""
-        Constructs a new ``CustomHilbert`` given a graph and a list of
-        eigenvalues of the states.
+        Constructs a new ``CustomHilbert`` given a list of eigenvalues of the states and
+        a number of sites, or modes, within this hilbert space.
 
         Args:
-           graph: Graph representation of sites.
-           local_states (list or None): Eigenvalues of the states. If the allowed states are an
+            local_states (list or None): Eigenvalues of the states. If the allowed states are an
                          infinite number, None should be passed as an argument.
-           constraints: A function specifying constraints on the quantum numbers.
+            N: Number of modes in this hilbert space (default 1).
+            constraints: A function specifying constraints on the quantum numbers.
                         Given a batch of quantum numbers it should return a vector
                         of bools specifying whether those states are valid or not.
 
         Examples:
            Simple custom hilbert space.
 
-           >>> from netket.graph import Hypercube
            >>> from netket.hilbert import CustomHilbert
            >>> g = Hypercube(length=10,n_dim=2,pbc=True)
-           >>> hi = CustomHilbert(graph=g, local_states=[-1232, 132, 0])
+           >>> hi = CustomHilbert(local_states=[-1232, 132, 0], N=100)
            >>> print(hi.size)
            100
         """
 
-        self.graph = graph
-        self._size = graph.n_nodes
+        assert isinstance(N, int)
+
+        self._size = N
 
         self._is_finite = local_states is not None
 
@@ -139,7 +139,7 @@ class CustomHilbert(AbstractHilbert):
 
            >>> import netket as nk
            >>> import numpy as np
-           >>> hi = nk.hilbert.Boson(n_max=3, graph=nk.graph.Hypercube(length=5, n_dim=1))
+           >>> hi = nk.hilbert.Boson(n_max=3, N=4)
            >>> rstate = np.zeros(hi.size)
            >>> hi.random_vals(rstate)
            >>> local_states = hi.local_states
@@ -205,6 +205,15 @@ class CustomHilbert(AbstractHilbert):
                     "The required state does not satisfy the given constraints."
                 )
             return found
+
+    def __pow__(self, n):
+        if self._constraints is not None:
+            raise ValueError(
+                """Cannot exponentiate a CustomHilbret with a constraint. 
+                Construct it from scratch instead."""
+            )
+
+        return CustomHilbert(self._local_states, self.size * n)
 
     def __repr__(self):
         constr = (

--- a/netket/hilbert/doubled_hilbert.py
+++ b/netket/hilbert/doubled_hilbert.py
@@ -1,5 +1,4 @@
 from .abstract_hilbert import AbstractHilbert
-from ..graph import DoubledGraph as _DoubledGraph
 
 import numpy as _np
 from netket import random as _random
@@ -19,20 +18,13 @@ class DoubledHilbert(AbstractHilbert):
         Examples:
             Simple superoperatorial hilbert space for few spins.
 
-           >>> from netket.graph import Hypercube
            >>> from netket.hilbert import Spin, DoubledHilbert
            >>> g = Hypercube(length=5,n_dim=2,pbc=True)
-           >>> hi = Spin(graph=g, s=0.5)
+           >>> hi = Spin(N=3, s=0.5)
            >>> hi2 = DoubledHilbert(hi)
            >>> print(hi2.size)
            50
         """
-        if hasattr(hilb, "graph"):
-            doubled_graph = _DoubledGraph(hilb.graph)
-        else:
-            doubled_graph = None
-
-        self.graph = doubled_graph
         self.physical = hilb
         self._size = 2 * hilb.size
 

--- a/netket/hilbert/qubit.py
+++ b/netket/hilbert/qubit.py
@@ -1,11 +1,10 @@
 from .custom_hilbert import CustomHilbert
-from netket.graph import Edgeless
 
 
 class Qubit(CustomHilbert):
     r"""Hilbert space obtained as tensor product of local qubit states."""
 
-    def __init__(self, graph=None, size=None):
+    def __init__(self, N=1):
         r"""Initializes a qubit hilbert space.
 
         Args:
@@ -24,10 +23,7 @@ class Qubit(CustomHilbert):
             >>> print(hi.size)
             100
         """
-
-        if graph is None:
-            graph = Edgeless(size)
-        super().__init__(graph, [0, 1])
+        super().__init__([0, 1], N)
 
     def __repr__(self):
         return "Qubit(N={})".format(self._size)

--- a/netket/hilbert/qubit.py
+++ b/netket/hilbert/qubit.py
@@ -4,7 +4,7 @@ from .custom_hilbert import CustomHilbert
 class Qubit(CustomHilbert):
     r"""Hilbert space obtained as tensor product of local qubit states."""
 
-    def __init__(self, N=1):
+    def __init__(self, N: int = 1):
         r"""Initializes a qubit hilbert space.
 
         Args:
@@ -24,6 +24,9 @@ class Qubit(CustomHilbert):
             100
         """
         super().__init__([0, 1], N)
+
+    def __pow__(self, n):
+        return Qubit(self.size * n)
 
     def __repr__(self):
         return "Qubit(N={})".format(self._size)

--- a/netket/hilbert/spin.py
+++ b/netket/hilbert/spin.py
@@ -68,7 +68,7 @@ class Spin(CustomHilbert):
 
            >>> import netket as nk
            >>> import numpy as np
-           >>> hi = nk.hilbert.Boson(n_max=3, N=4)
+           >>> hi = nk.hilbert.Spin(N=4)
            >>> rstate = np.zeros(hi.size)
            >>> hi.random_state(rstate)
            >>> local_states = hi.local_states

--- a/netket/hilbert/spin.py
+++ b/netket/hilbert/spin.py
@@ -6,11 +6,13 @@ import numpy as _np
 from netket import random as _random
 from numba import jit
 
+from typing import Optional, List
+
 
 class Spin(CustomHilbert):
     r"""Hilbert space obtained as tensor product of local spin states."""
 
-    def __init__(self, s, N=1, total_sz=None):
+    def __init__(self, s: float, N: int = 1, total_sz: Optional[float] = None):
         r"""Hilbert space obtained as tensor product of local spin states.
 
         Args:
@@ -125,7 +127,7 @@ class Spin(CustomHilbert):
         if self._total_sz is None:
             total_sz = None
         else:
-            total_sz * n
+            total_sz = total_sz * n
 
         return Spin(self._s, self.size * n, total_sz=total_sz)
 

--- a/netket/machine/density_matrix/rbm.py
+++ b/netket/machine/density_matrix/rbm.py
@@ -11,16 +11,19 @@ class RbmSpin(AbstractDensityMatrix):
         alpha=None,
         use_visible_bias=True,
         use_hidden_bias=True,
-        symmetry=None,
+        automorphisms=None,
         dtype=complex,
     ):
         super().__init__(hilbert, dtype=dtype, outdtype=complex)
 
-        if symmetry is True:
-            autom = hilbert.graph.automorphisms
+        if automorphisms is not None:
+            if isinstance(automorphisms, netket.graph.AbstractGraph):
+                automorphisms = automorphisms.automorphisms()
             import itertools
 
-            symmetry = [prod[0] + prod[1] for prod in itertools.product(autom, autom)]
+            automorphisms = [
+                prod[0] + prod[1] for prod in itertools.product(autom, autom)
+            ]
 
         input_like = _np.zeros(hilbert.size * 2)
         self._prbm = PureRbmSpin(
@@ -29,7 +32,7 @@ class RbmSpin(AbstractDensityMatrix):
             alpha,
             use_visible_bias,
             use_hidden_bias,
-            symmetry,
+            automorphisms,
             dtype,
         )
         self._plog_val = self._prbm.log_val

--- a/netket/machine/jastrow.py
+++ b/netket/machine/jastrow.py
@@ -46,8 +46,7 @@ class Jastrow(AbstractMachine):
         Args:
             hilbert: Hilbert space object for the system.
             use_visible_bias (bool): Whether to use the visible bias a_i.
-            symmetry (optional): Can be a graph or a custom matrix of automorphisms can
-                                 also be passed instead.
+            automorphisms (optional): Can be a graph or a custom matrix of automorphisms.
             dtype: either complex or float, it is the type used for the weights and biases.
 
         Examples:

--- a/netket/machine/jastrow.py
+++ b/netket/machine/jastrow.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from .abstract_machine import AbstractMachine
+from netket.graph import AbstractGraph
 import numpy as _np
 from numba import jit
 
@@ -36,7 +37,7 @@ class Jastrow(AbstractMachine):
         self,
         hilbert,
         use_visible_bias=False,
-        symmetry=None,
+        automorphisms=None,
         dtype=complex,
     ):
         r"""
@@ -45,8 +46,8 @@ class Jastrow(AbstractMachine):
         Args:
             hilbert: Hilbert space object for the system.
             use_visible_bias (bool): Whether to use the visible bias a_i.
-            symmetry (optional): if True, the automorphisms in hilbert.graph.automorphisms are used.
-                                 A custom matrix of automorphisms can also be passed instead.
+            symmetry (optional): Can be a graph or a custom matrix of automorphisms can
+                                 also be passed instead.
             dtype: either complex or float, it is the type used for the weights and biases.
 
         Examples:
@@ -55,9 +56,7 @@ class Jastrow(AbstractMachine):
 
             >>> from netket.machine import Jastrow
             >>> from netket.hilbert import Spin
-            >>> from netket.graph import Hypercube
-            >>> g = Hypercube(length=20, n_dim=1)
-            >>> hi = Spin(s=0.5, total_sz=0, graph=g)
+            >>> hi = Spin(s=0.5, total_sz=0, N=20)
             >>> ma = Jastrow(hilbert=hi)
             >>> print(ma.n_par)
             190
@@ -76,7 +75,7 @@ class Jastrow(AbstractMachine):
                 "Cannot construct a Jastrow factor with less than two visible units."
             )
 
-        if symmetry is None:
+        if automorphisms is None:
             n_sym = int((n * (n - 1)) // 2)
             self._Smap = _np.zeros((n, n), dtype=_np.intp)
 
@@ -88,11 +87,11 @@ class Jastrow(AbstractMachine):
                     k += 1
 
         else:
-            if symmetry is True:
-                autom = _np.asarray(hilbert.graph.automorphisms())
+            if isinstance(automorphisms, AbstractGraph):
+                autom = _np.asarray(automorphisms.automorphisms())
             else:
                 try:
-                    autom = _np.asarray(symmetry)
+                    autom = _np.asarray(automorphisms)
                     assert n == autom.shape[1]
                 except:
                     raise RuntimeError("Cannot find a valid automorphism array.")
@@ -269,10 +268,10 @@ class JastrowSymm(Jastrow):
     symmetry=True.
     """
 
-    def __init__(self, hilbert, use_visible_bias=False, dtype=complex):
+    def __init__(self, hilbert, automorphisms, use_visible_bias=False, dtype=complex):
         return super().__init__(
             hilbert=hilbert,
             use_visible_bias=use_visible_bias,
-            symmetry=True,
+            automorphisms=automorphisms,
             dtype=dtype,
         )

--- a/netket/machine/jax.py
+++ b/netket/machine/jax.py
@@ -412,7 +412,7 @@ def JaxRbm(hilbert, alpha, dtype=complex):
     )
 
 
-def MPSPeriodic(hilbert, bond_dim, diag=False, symperiod=None, dtype=complex):
+def MPSPeriodic(hilbert, graph, bond_dim, diag=False, symperiod=None, dtype=complex):
     r"""
     Constructs a periodic Matrix Product State (MPS) for a quantum state of discrete
     degrees of freedom, wrapped as Jax machine.  The MPS is defined as
@@ -441,12 +441,14 @@ def MPSPeriodic(hilbert, bond_dim, diag=False, symperiod=None, dtype=complex):
     """
     return Jax(
         hilbert,
-        MpsPeriodicLayer(hilbert, bond_dim, diag, symperiod, dtype),
+        MpsPeriodicLayer(hilbert, graph, bond_dim, diag, symperiod, dtype),
         dtype=dtype,
     )
 
 
-def MpsPeriodicLayer(hilbert, bond_dim, diag=False, symperiod=None, dtype=complex):
+def MpsPeriodicLayer(
+    hilbert, graph, bond_dim, diag=False, symperiod=None, dtype=complex
+):
     # default standard deviation equals 1e-2
     normal_init = jax.nn.initializers.normal()
 
@@ -469,7 +471,7 @@ def MpsPeriodicLayer(hilbert, bond_dim, diag=False, symperiod=None, dtype=comple
     # check whether graph is periodic chain
     import networkx as _nx
 
-    edges = hilbert.graph.edges()
+    edges = graph.edges()
     G = _nx.Graph()
     G.add_edges_from(edges)
 

--- a/netket/operator/_bose_hubbard.py
+++ b/netket/operator/_bose_hubbard.py
@@ -12,7 +12,7 @@ class BoseHubbard(AbstractOperator):
     on-site interactions and nearest-neighboring density-density interactions.
     """
 
-    def __init__(self, hilbert, U, V=0, J=1, mu=0):
+    def __init__(self, hilbert, graph, U, V=0, J=1, mu=0):
         r"""
         Constructs a new ``BoseHubbard`` given a hilbert space and a Hubbard
         interaction strength. The chemical potential and the density-density interaction strenght
@@ -35,6 +35,11 @@ class BoseHubbard(AbstractOperator):
            >>> print(op.hilbert.size)
            9
         """
+
+        assert (
+            graph.n_nodes == hilbert.size
+        ), "The size of the graph must match the hilbert space."
+
         self._U = U
         self._V = V
         self._J = J
@@ -44,7 +49,7 @@ class BoseHubbard(AbstractOperator):
 
         self._n_max = hilbert.n_max
         self._n_sites = hilbert.size
-        self._edges = _np.asarray(list(hilbert.graph.edges()))
+        self._edges = _np.asarray(list(graph.edges()))
         self._max_conn = 1 + self._edges.shape[0] * 2
         self._max_mels = _np.empty(self._max_conn, dtype=_np.complex128)
         self._max_xprime = _np.empty((self._max_conn, self._n_sites))

--- a/netket/operator/_graph_operator.py
+++ b/netket/operator/_graph_operator.py
@@ -5,7 +5,7 @@ import numpy as _np
 from numba import jit
 
 
-def GraphOperator(hilbert, site_ops=[], bond_ops=[], bond_ops_colors=[], graph=None):
+def GraphOperator(hilbert, graph, site_ops=[], bond_ops=[], bond_ops_colors=[]):
     r"""
     A graph-based quantum operator. In its simplest terms, this is the sum of
     local operators living on the edge of an arbitrary graph.
@@ -17,6 +17,7 @@ def GraphOperator(hilbert, site_ops=[], bond_ops=[], bond_ops_colors=[], graph=N
 
     Args:
      hilbert: Hilbert space the operator acts on.
+     graph: The graph upon which the hamiltonian is defined
      graph: The graph whose vertices and edges are considered to construct the
             operator. If None, the graph is deduced from the hilbert object.
      site_ops: A list of operators in matrix form that act
@@ -46,8 +47,9 @@ def GraphOperator(hilbert, site_ops=[], bond_ops=[], bond_ops_colors=[], graph=N
      20
     """
 
-    if graph is None:
-        graph = hilbert.graph
+    assert (
+        graph.n_nodes == hilbert.size
+    ), "The size of the graph must match the hilbert space"
 
     size = graph.n_nodes
 

--- a/netket/operator/_local_operator.py
+++ b/netket/operator/_local_operator.py
@@ -42,11 +42,9 @@ class LocalOperator(AbstractOperator):
         Examples:
            Constructs a ``LocalOperator`` without any operators.
 
-           >>> from netket.graph import CustomGraph
            >>> from netket.hilbert import CustomHilbert
            >>> from netket.operator import LocalOperator
-           >>> g = CustomGraph(edges=[[i, i + 1] for i in range(20)])
-           >>> hi = CustomHilbert(local_states=[1, -1], graph=g)
+           >>> hi = CustomHilbert(local_states=[1, -1])**20
            >>> empty_hat = LocalOperator(hi)
            >>> print(len(empty_hat.acting_on))
            0

--- a/netket/operator/_pauli_strings.py
+++ b/netket/operator/_pauli_strings.py
@@ -1,6 +1,5 @@
 from ._abstract_operator import AbstractOperator
 from ..hilbert import Qubit
-from ..graph import Edgeless
 
 import numpy as _np
 from numba import jit
@@ -51,9 +50,8 @@ class PauliStrings(AbstractOperator):
                 the Pauli operators X,Y,Z, or the identity I"""
             )
 
-        graph = Edgeless(_n_qubits)
         self._n_qubits = _n_qubits
-        self._hilbert = Qubit(graph)
+        self._hilbert = Qubit(_n_qubits)
 
         n_operators = len(operators)
 

--- a/netket/sampler/_kernels.py
+++ b/netket/sampler/_kernels.py
@@ -11,8 +11,8 @@ def _LocalKernel(machine):
 
 
 @singledispatch
-def _ExchangeKernel(machine, d_max):
-    return numpy._ExchangeKernel(machine.hilbert, d_max)
+def _ExchangeKernel(machine, clusters):
+    return numpy._ExchangeKernel(machine.hilbert, clusters)
 
 
 @singledispatch

--- a/netket/sampler/jax/__init__.py
+++ b/netket/sampler/jax/__init__.py
@@ -27,8 +27,8 @@ def _Jax_LocalKernel(machine):
 
 
 @_ExchangeKernel.register(JaxMachine)
-def _Jax_ExchangeKernel(machine, d_max):
-    return _JaxExchangeKernel(machine.hilbert, d_max)
+def _Jax_ExchangeKernel(machine, clusters):
+    return _JaxExchangeKernel(machine.hilbert, clusters)
 
 
 @_HamiltonianKernel.register(JaxMachine)

--- a/netket/sampler/jax/exchange_kernel.py
+++ b/netket/sampler/jax/exchange_kernel.py
@@ -3,20 +3,8 @@ import numpy
 
 
 class _JaxExchangeKernel:
-    def __init__(self, hilbert, d_max):
-        clusters = []
-        distances = jax.numpy.asarray(hilbert.graph.distances())
-        size = distances.shape[0]
-        for i in range(size):
-            for j in range(i + 1, size):
-                if distances[i][j] <= d_max:
-                    clusters.append((i, j))
-
-        self.clusters = numpy.empty((len(clusters), 2), dtype=numpy.int64)
-
-        for i, cluster in enumerate(clusters):
-            self.clusters[i] = numpy.asarray(cluster)
-        self.clusters = jax.numpy.asarray(self.clusters)
+    def __init__(self, hilbert, clusters):
+        self.clusters = jax.numpy.asarray(clusters)
 
         self.clusters_size = self.clusters.shape[0]
 

--- a/netket/sampler/metropolis_exchange.py
+++ b/netket/sampler/metropolis_exchange.py
@@ -1,5 +1,6 @@
 from .metropolis_hastings import *
 from ._kernels import _ExchangeKernel
+import numpy as _np
 
 
 def _compute_clusters(graph, d_max):
@@ -16,7 +17,7 @@ def _compute_clusters(graph, d_max):
     for i, cluster in enumerate(clusters):
         res_clusters[i] = _np.asarray(cluster)
 
-    return rese_clusters
+    return res_clusters
 
 
 def MetropolisExchange(

--- a/netket/sampler/metropolis_exchange.py
+++ b/netket/sampler/metropolis_exchange.py
@@ -2,7 +2,26 @@ from .metropolis_hastings import *
 from ._kernels import _ExchangeKernel
 
 
-def MetropolisExchange(machine, d_max=1, n_chains=16, sweep_size=None, **kwargs):
+def _compute_clusters(graph, d_max):
+    clusters = []
+    distances = _np.asarray(graph.distances())
+    size = distances.shape[0]
+    for i in range(size):
+        for j in range(i + 1, size):
+            if distances[i][j] <= d_max:
+                clusters.append((i, j))
+
+    res_clusters = _np.empty((len(clusters), 2), dtype=_np.int64)
+
+    for i, cluster in enumerate(clusters):
+        res_clusters[i] = _np.asarray(cluster)
+
+    return rese_clusters
+
+
+def MetropolisExchange(
+    machine, clusters=None, graph=None, d_max=1, n_chains=16, sweep_size=None, **kwargs
+):
     r"""
     This sampler acts locally only on two local degree of freedom :math:`s_i` and :math:`s_j`,
     and proposes a new state: :math:`s_1 \dots s^\prime_i \dots s^\prime_j \dots s_N`,
@@ -54,14 +73,33 @@ def MetropolisExchange(machine, d_max=1, n_chains=16, sweep_size=None, **kwargs)
           >>> print(sa.machine.hilbert.size)
           100
     """
-    transition_kernel = _ExchangeKernel(machine, d_max)
+    if clusters is None and graph is not None:
+        assert (
+            graph.n_nodes == machine.hilbert.size
+        ), "The size of the graph must match the hilbert space of the machine."
+        clusters = _compute_clusters(graph, d_max)
+    elif not (clusters is not None and graph is None):
+        raise ValueError(
+            """You must either provide the list of exchange-clusters or a netket graph, from
+                          which clusters will be computed using the maximum distance d_max. """
+        )
+
+    transition_kernel = _ExchangeKernel(machine, clusters)
 
     return MetropolisHastings(
         machine, transition_kernel, n_chains, sweep_size, **kwargs
     )
 
 
-def MetropolisExchangePt(machine, d_max=1, n_replicas=16, sweep_size=None, **kwargs):
+def MetropolisExchangePt(
+    machine,
+    clusters=None,
+    graph=None,
+    d_max=1,
+    n_replicas=16,
+    sweep_size=None,
+    **kwargs,
+):
     r"""
     This sampler performs parallel-tempering
     moves in addition to the local moves implemented in `MetropolisExchange`.
@@ -94,7 +132,19 @@ def MetropolisExchangePt(machine, d_max=1, n_replicas=16, sweep_size=None, **kwa
         >>> print(sa.machine.hilbert.size)
         100
     """
-    transition_kernel = _ExchangeKernel(machine, d_max)
+    if clusters is None and graph is not None:
+        assert (
+            graph.n_nodes == machine.hilbert.size
+        ), "The size of the graph must match the hilbert space of the machine."
+
+        clusters = _compute_clusters(graph, d_max)
+    elif not (clusters is not None and graph is None):
+        raise ValueError(
+            """You must either provide the list of exchange-clusters or a netket graph, from
+                          which clusters will be computed using the maximum distance d_max. """
+        )
+
+    transition_kernel = _ExchangeKernel(machine, clusters)
 
     return MetropolisHastingsPt(
         machine, transition_kernel, n_replicas, sweep_size, **kwargs

--- a/netket/sampler/numpy/exchange_kernel.py
+++ b/netket/sampler/numpy/exchange_kernel.py
@@ -4,20 +4,8 @@ from numba import jit, int64, float64
 
 
 class _ExchangeKernel:
-    def __init__(self, hilbert, d_max):
-        clusters = []
-        distances = _np.asarray(hilbert.graph.distances())
-        size = distances.shape[0]
-        for i in range(size):
-            for j in range(i + 1, size):
-                if distances[i][j] <= d_max:
-                    clusters.append((i, j))
-
-        self.clusters = _np.empty((len(clusters), 2), dtype=_np.int64)
-
-        for i, cluster in enumerate(clusters):
-            self.clusters[i] = _np.asarray(cluster)
-
+    def __init__(self, hilbert, clusters):
+        self.clusters = clusters
         self._hilbert = hilbert
 
     @staticmethod


### PR DESCRIPTION
In general, in `netket` we do not _need_ to work with graphs, unless we are working with symmetries.
Especially to newcomers, but also to make the API more succinct, I think it would bee nice to support an usage like
```python
import netket
# 
>>> netket.hilbert.Spin(1/2)**4
Spin(s=1/2, graph=4)
>>> netket.operator.spin.sigmax(hi, 1)
<netket.operator._local_operator.LocalOperator object at 0x10f84fcd0>
```

Where basically we can define the local Hilbert space (which implicitly it will be defined on an Edgeless graph with 1 node) and then tensor-exponentiate it to define it on N sites.

Under the hood, `pow` on an Hilbert space is doing `pow` on the graph, which corresponds to a disjoint union (or direct sum) of the two graphs, which I believe to be the only sensible operation possible in this case.

Of course, this mainly makes sense when working with Edgeless graphs.

--

To make this kind of api work, we need to switch two arguments: the Spin rational. (1//2, 1, 3//2...) should become the first argument, so that if the graph (now second argument) is unspecified, we can assume it to be an `edgeless(1)` graph.

I'd propose to change all hilbert spaces to such api.

--

In the future, this should allow us to also define multiplication among hilbert spaces (technically \otimes, but python let's us only use `*`) and compose non-homogeneeous hilbert spaces together. But that's for a future PR, as it would require some work on the samplers.

If you agree with this new api, then I will also convert the other hilbert spaces (bosons, qubits, and local_operator).