### PR TITLE
Use __matmul__ (@) for the operator product

### DIFF
--- a/Test/Operator/test_local_operator.py
+++ b/Test/Operator/test_local_operator.py
@@ -211,9 +211,15 @@ def test_mul_matmul():
 
     sx0sy1_hat = sx0_hat @ sy1_hat
     assert np.allclose(sx0sy1_hat.to_dense(), sx0_hat.to_dense() @ sy1_hat.to_dense())
+    sx0sy1_hat = sx0_hat * sy1_hat
+    assert np.allclose(sx0sy1_hat.to_dense(), sx0_hat.to_dense() @ sy1_hat.to_dense())
 
     op = nk.operator.LocalOperator(hi, sx, [0])
     op @= nk.operator.LocalOperator(hi, sy, [1])
+    assert np.allclose(op.to_dense(), sx0sy1_hat.to_dense())
+
+    op = nk.operator.LocalOperator(hi, sx, [0])
+    op *= nk.operator.LocalOperator(hi, sy, [1])
     assert np.allclose(op.to_dense(), sx0sy1_hat.to_dense())
 
     assert np.allclose((2.0 * sx0sy1_hat).to_dense(), 2.0 * sx0sy1_hat.to_dense())
@@ -222,15 +228,8 @@ def test_mul_matmul():
     op *= 2.0
     assert np.allclose(op.to_dense(), 2.0 * sx0sy1_hat.to_dense())
 
-    with pytest.raises(TypeError):
-        doesnotwork = sx0_hat * sy1_hat
-    with pytest.raises(TypeError):
-        op = nk.operator.LocalOperator(hi, sx, [0])
-        op *= nk.operator.LocalOperator(hi, sy, [1])
-
     with pytest.raises(NotImplementedError):
         doesnotwork = sx0_hat @ 2.0
-
     with pytest.raises(NotImplementedError):
         op = nk.operator.LocalOperator(hi, sx, [0])
         op @= 2.0

--- a/Test/Operator/test_local_operator.py
+++ b/Test/Operator/test_local_operator.py
@@ -212,11 +212,25 @@ def test_mul_matmul():
     sx0sy1_hat = sx0_hat @ sy1_hat
     assert np.allclose(sx0sy1_hat.to_dense(), sx0_hat.to_dense() @ sy1_hat.to_dense())
 
+    op = nk.operator.LocalOperator(hi, sx, [0])
+    op @= nk.operator.LocalOperator(hi, sy, [1])
+    assert np.allclose(op.to_dense(), sx0sy1_hat.to_dense())
+
     assert np.allclose((2.0 * sx0sy1_hat).to_dense(), 2.0 * sx0sy1_hat.to_dense())
     assert np.allclose((sx0sy1_hat * 2.0).to_dense(), 2.0 * sx0sy1_hat.to_dense())
 
+    op *= 2.0
+    assert np.allclose(op.to_dense(), 2.0 * sx0sy1_hat.to_dense())
+
     with pytest.raises(TypeError):
         doesnotwork = sx0_hat * sy1_hat
+    with pytest.raises(TypeError):
+        op = nk.operator.LocalOperator(hi, sx, [0])
+        op *= nk.operator.LocalOperator(hi, sy, [1])
 
     with pytest.raises(NotImplementedError):
         doesnotwork = sx0_hat @ 2.0
+
+    with pytest.raises(NotImplementedError):
+        op = nk.operator.LocalOperator(hi, sx, [0])
+        op @= 2.0

--- a/Test/Operator/test_operator.py
+++ b/Test/Operator/test_operator.py
@@ -48,20 +48,17 @@ sz = [[1, 0], [0, -1]]
 g = nk.graph.Graph(edges=[[i, i + 1] for i in range(20)])
 hi = nk.hilbert.CustomHilbert(local_states=[-1, 1], graph=g)
 
-sx_hat = nk.operator.LocalOperator(hi, [sx] * 3, [[0], [1], [5]])
-sy_hat = nk.operator.LocalOperator(hi, [sy] * 4, [[2], [3], [4], [9]])
-szsz_hat = nk.operator.LocalOperator(hi, sz, [0]) * nk.operator.LocalOperator(
-    hi, sz, [1]
-)
-szsz_hat += nk.operator.LocalOperator(hi, sz, [4]) * nk.operator.LocalOperator(
-    hi, sz, [5]
-)
-szsz_hat += nk.operator.LocalOperator(hi, sz, [6]) * nk.operator.LocalOperator(
-    hi, sz, [8]
-)
-szsz_hat += nk.operator.LocalOperator(hi, sz, [7]) * nk.operator.LocalOperator(
-    hi, sz, [0]
-)
+
+def _loc(*args):
+    return nk.operator.LocalOperator(hi, *args)
+
+
+sx_hat = _loc([sx] * 3, [[0], [1], [5]])
+sy_hat = _loc([sy] * 4, [[2], [3], [4], [9]])
+szsz_hat = _loc(sz, [0]) @ _loc(sz, [1])
+szsz_hat += _loc(sz, [4]) @ _loc(sz, [5])
+szsz_hat += _loc(sz, [6]) @ _loc(sz, [8])
+szsz_hat += _loc(sz, [7]) @ _loc(sz, [0])
 
 operators["Custom Hamiltonian"] = sx_hat + sy_hat + szsz_hat
 operators["Custom Hamiltonian Prod"] = sx_hat * 1.5 + (2.0 * sy_hat)
@@ -126,7 +123,7 @@ def test_no_segfault():
 
     hi = None
 
-    lo = lo * lo
+    lo = lo @ lo
 
     assert True
 

--- a/netket/operator/_abstract_operator.py
+++ b/netket/operator/_abstract_operator.py
@@ -143,7 +143,7 @@ class AbstractOperator(abc.ABC):
         return self.to_sparse().todense().A
 
     def apply(self, v):
-        return self.to_sparse().dot(v)
+        return self.to_linear_operator().dot(v)
 
     def __call__(self, v):
         return self.apply(v)

--- a/netket/operator/_abstract_operator.py
+++ b/netket/operator/_abstract_operator.py
@@ -15,7 +15,7 @@ class AbstractOperator(abc.ABC):
     @abc.abstractmethod
     def size(self):
         r"""int: The total number number of local degrees of freedom."""
-        return NotImplementedError
+        raise NotImplementedError()
 
     def get_conn_padded(self, x):
         r"""Finds the connected elements of the Operator.
@@ -65,7 +65,7 @@ class AbstractOperator(abc.ABC):
             array: An array containing the matrix elements :math:`O(x,x')` associated to each x'.
 
         """
-        return NotImplementedError
+        raise NotImplementedError()
 
     def n_conn(self, x, out=None):
         r"""Return the number of states connected to x.
@@ -101,7 +101,7 @@ class AbstractOperator(abc.ABC):
     @abc.abstractmethod
     def hilbert(self):
         r"""AbstractHilbert: The hilbert space associated to this operator."""
-        return NotImplementedError
+        raise NotImplementedError()
 
     def to_sparse(self):
         r"""Returns the sparse matrix representation of the operator. Note that,

--- a/netket/operator/_local_liouvillian.py
+++ b/netket/operator/_local_liouvillian.py
@@ -48,7 +48,7 @@ class LocalLiouvillian(AbstractOperator):
         Hnh = 1.0 * self._H
         max_conn_size = 0
         for L in self._jump_ops:
-            Hnh += -0.5j * L.conjugate().transpose() * L
+            Hnh += -0.5j * L.conjugate().transpose() @ L
             max_conn_size += (L.n_operators * L._max_op_size) ** 2
 
         self._max_dissipator_conn_size = max_conn_size

--- a/netket/operator/_local_operator.py
+++ b/netket/operator/_local_operator.py
@@ -259,9 +259,6 @@ class LocalOperator(AbstractOperator):
     def __rmul__(self, other):
         return self.__mul__(other)
 
-    def __rmatmul__(self, other):
-        return self.__mul__(other)
-
     def __radd__(self, other):
         return self.__radd__(other)
 

--- a/netket/operator/_local_operator.py
+++ b/netket/operator/_local_operator.py
@@ -170,10 +170,7 @@ class LocalOperator(AbstractOperator):
         if isinstance(other, AbstractOperator):
             return self.__imatmul__(other)
         elif not isinstance(other, numbers.Number):
-            raise TypeError(
-                f"LocalOperator can only be multiplied with numbers. "
-                "(For the operator product, please use the `@` operator, see PEP 465.)"
-            )
+            raise TypeError("`other` must be another NetKet operator or a scalar.")
         self._constant *= other
         self._diag_mels *= other
         self._mels *= other
@@ -215,10 +212,7 @@ class LocalOperator(AbstractOperator):
         if isinstance(other, AbstractOperator):
             return self.__matmul__(other)
         elif not isinstance(other, numbers.Number):
-            raise TypeError(
-                f"LocalOperator can only be multiplied with numbers. "
-                "(For the operator product, please use the `@` operator, see PEP 465.)"
-            )
+            raise TypeError("`other` must be another NetKet operator or a scalar.")
 
         new_ops = [_np.copy(op * other) for op in self._operators]
 

--- a/netket/operator/_local_operator.py
+++ b/netket/operator/_local_operator.py
@@ -136,7 +136,7 @@ class LocalOperator(AbstractOperator):
         if isinstance(other, numbers.Number):
             self._constant += other
 
-        return NotImplementedError
+        raise NotImplementedError()
 
     def __isub__(self, other):
         return self.__iadd__(-1 * other)
@@ -161,7 +161,7 @@ class LocalOperator(AbstractOperator):
                 constant=self._constant + other,
             )
 
-        return NotImplementedError
+        raise NotImplementedError()
 
     def __sub__(self, other):
         return self.__add__(-1 * other)

--- a/netket/operator/_local_operator.py
+++ b/netket/operator/_local_operator.py
@@ -167,10 +167,9 @@ class LocalOperator(AbstractOperator):
         return self.__add__(-1 * other)
 
     def __imul__(self, other):
-        """
-        Multply the operator by a number.
-        """
-        if not isinstance(other, numbers.Number):
+        if isinstance(other, AbstractOperator):
+            return self.__imatmul__(other)
+        elif not isinstance(other, numbers.Number):
             raise TypeError(
                 f"LocalOperator can only be multiplied with numbers. "
                 "(For the operator product, please use the `@` operator, see PEP 465.)"
@@ -213,7 +212,9 @@ class LocalOperator(AbstractOperator):
         return self
 
     def __mul__(self, other):
-        if not isinstance(other, numbers.Number):
+        if isinstance(other, AbstractOperator):
+            return self.__matmul__(other)
+        elif not isinstance(other, numbers.Number):
             raise TypeError(
                 f"LocalOperator can only be multiplied with numbers. "
                 "(For the operator product, please use the `@` operator, see PEP 465.)"


### PR DESCRIPTION
Python has (since [PEP 465](https://www.python.org/dev/peps/pep-0465/)) a matrix product operator `__matmul__` (`@`) distinct from `__mul__` (`*`) which is commonly used for element-wise multiplication.

Since this is a widely adopted convention in Python (in particular numpy), it makes sense for us to follow it as well, which is proposed in this PR. Then, expressions such as
```python
id = -1j * sx @ sy @ sz
```
have the same semantics for NetKet operators as for numpy arrays.

Note that `numpy.ndarray` uses `@` in this way, while the `numpy.matrix` uses `*` but is deprecated.

This PR also replaces the occasional `return NotImplementedError` with actually raising the exception.