### PR TITLE
add (again) graph argument to hilbert constructors with depwarn

### DIFF
--- a/Test/Hilbert/test_hilbert.py
+++ b/Test/Hilbert/test_hilbert.py
@@ -159,3 +159,14 @@ def test_state_iteration():
 
     for state, ref in zip(hilbert.states(), reference):
         assert np.allclose(state, ref)
+
+
+def test_graph_deprecation():
+    g = nk.graph.Edgeless(3)
+
+    with pytest.warns(FutureWarning):
+        hilbert = Spin(s=0.5, graph=g)
+
+    with pytest.warns(FutureWarning):
+        with pytest.raises(ValueError):
+            hilbert = Spin(s=0.5, graph=g, N=3)

--- a/netket/hilbert/_deprecations.py
+++ b/netket/hilbert/_deprecations.py
@@ -1,0 +1,27 @@
+from netket._core import warn_deprecation
+
+# To be removed in v3.1
+def graph_to_N_depwarn(N, graph):
+
+    if graph is not None:
+        warn_deprecation(
+            r"""
+            The ``graph`` argument for hilbert spaces has been deprecated in v3.0.
+			It has been replaced by the argument ``N`` accepting an integer, with 
+			the number of nodese in the graph. 
+
+			You can update your code by passing `N=_your_graph.n_nodes`.
+			If you are also using Ising, Heisemberg, BoseHubbard or GraphOperator
+			hamiltonians you must now provide them with the extra argument
+			``graph=_your_graph``, as they no longer take it from the hilbert space.
+			"""
+        )
+
+        if N == 1:
+            return graph.n_nodes
+        else:
+            raise ValueError(
+                "Graph object can only take one argumnent among N and graph (deprecated)."
+            )
+
+    return N

--- a/netket/hilbert/boson.py
+++ b/netket/hilbert/boson.py
@@ -1,4 +1,7 @@
 from .custom_hilbert import CustomHilbert
+from ._deprecations import graph_to_N_depwarn
+
+from netket.graph import AbstractGraph
 
 import numpy as _np
 from netket import random as _random
@@ -15,6 +18,7 @@ class Boson(CustomHilbert):
         n_max: Optional[int] = None,
         N: int = 1,
         n_bosons: Optional[int] = None,
+        graph: Optional[AbstractGraph] = None,
     ):
         r"""
         Constructs a new ``Boson`` given a maximum occupation number, number of sites
@@ -26,6 +30,7 @@ class Boson(CustomHilbert):
           N: number of bosonic modes (default = 1)
           n_bosons: Constraint for the number of bosons. If None, no constraint
             is imposed.
+          graph: (Deprecated, pleaese use `N`) A graph, from which the number of nodes is extracted.
 
         Examples:
            Simple boson hilbert space.
@@ -35,6 +40,7 @@ class Boson(CustomHilbert):
            >>> print(hi.size)
            3
         """
+        N = graph_to_N_depwarn(N=N, graph=graph)
 
         self._n_max = n_max
 

--- a/netket/hilbert/custom_hilbert.py
+++ b/netket/hilbert/custom_hilbert.py
@@ -1,9 +1,11 @@
 from .abstract_hilbert import AbstractHilbert
 from .hilbert_index import HilbertIndex
+from ._deprecations import graph_to_N_depwarn
 
 from numba import jit
 import numpy as _np
 from netket import random as _random
+from netket.graph import AbstractGraph
 
 from typing import Optional, List
 
@@ -16,6 +18,7 @@ class CustomHilbert(AbstractHilbert):
         local_states: Optional[List[float]],
         N: int = 1,
         constraints: Optional = None,
+        graph: Optional[AbstractGraph] = None,
     ):
         r"""
         Constructs a new ``CustomHilbert`` given a list of eigenvalues of the states and
@@ -38,6 +41,7 @@ class CustomHilbert(AbstractHilbert):
            >>> print(hi.size)
            100
         """
+        N = graph_to_N_depwarn(N=N, graph=graph)
 
         assert isinstance(N, int)
 

--- a/netket/hilbert/qubit.py
+++ b/netket/hilbert/qubit.py
@@ -1,17 +1,19 @@
 from .custom_hilbert import CustomHilbert
+from ._deprecations import graph_to_N_depwarn
+
+from netket.graph import AbstractGraph
+from typing import Optional
 
 
 class Qubit(CustomHilbert):
     r"""Hilbert space obtained as tensor product of local qubit states."""
 
-    def __init__(self, N: int = 1):
+    def __init__(self, N: int = 1, graph: Optional[AbstractGraph] = None):
         r"""Initializes a qubit hilbert space.
 
         Args:
-        graph: Graph representation of qubits. If None, size
-              is used to fix the total number of qubits.
-        size: Number of qubits. If None, a graph must be speficied.
-
+        N: Number of qubits.
+        graph: (deprecated) a graph from which to extract the number of sites.
 
         Examples:
             Simple spin hilbert space.
@@ -23,6 +25,8 @@ class Qubit(CustomHilbert):
             >>> print(hi.size)
             100
         """
+        N = graph_to_N_depwarn(N=N, graph=graph)
+
         super().__init__([0, 1], N)
 
     def __pow__(self, n):

--- a/netket/hilbert/spin.py
+++ b/netket/hilbert/spin.py
@@ -1,9 +1,11 @@
 from .custom_hilbert import CustomHilbert
+from ._deprecations import graph_to_N_depwarn
 
 from fractions import Fraction
 
 import numpy as _np
 from netket import random as _random
+from netket.graph import AbstractGraph
 from numba import jit
 
 from typing import Optional, List
@@ -12,7 +14,13 @@ from typing import Optional, List
 class Spin(CustomHilbert):
     r"""Hilbert space obtained as tensor product of local spin states."""
 
-    def __init__(self, s: float, N: int = 1, total_sz: Optional[float] = None):
+    def __init__(
+        self,
+        s: float,
+        N: int = 1,
+        total_sz: Optional[float] = None,
+        graph: Optional[AbstractGraph] = None,
+    ):
         r"""Hilbert space obtained as tensor product of local spin states.
 
         Args:
@@ -29,6 +37,8 @@ class Spin(CustomHilbert):
            >>> print(hi.size)
            4
         """
+        N = graph_to_N_depwarn(N=N, graph=graph)
+
         local_size = round(2 * s + 1)
         local_states = _np.empty(local_size)
 


### PR DESCRIPTION
With this PR:
```python
Python 3.8.5 (default, Jul 21 2020, 10:48:26)
[Clang 11.0.3 (clang-1103.0.32.62)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import netket as nk
>>> g=nk.graph.Edgeless(3)
>>> hi=nk.hilbert.Spin(1/2, graph=g)
/Users/filippovicentini/Dropbox/Ricerca/Codes/Python/netket/netket/hilbert/_deprecations.py:7: FutureWarning:
            The ``graph`` argument for hilbert spaces has been deprecated in v3.0.
			It has been replaced by the argument ``N`` accepting an integer, with
			the number of nodese in the graph.

			You can update your code by passing `N=_your_graph.n_nodes`.
			If you are also using Ising, Heisemberg, BoseHubbard or GraphOperator
			hamiltonians you must now provide them with the extra argument
			``graph=_your_graph``, as they no longer take it from the hilbert space.

  warn_deprecation(
>>> hi
Spin(s=1/2, N=3)
>>> hi2=nk.hilbert.Spin(1/2, graph=g, N=3)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/filippovicentini/Dropbox/Ricerca/Codes/Python/netket/netket/hilbert/spin.py", line 40, in __init__
    N = graph_to_N_depwarn(N=N, graph=graph)
  File "/Users/filippovicentini/Dropbox/Ricerca/Codes/Python/netket/netket/hilbert/_deprecations.py", line 23, in graph_to_N_depwarn
    raise ValueError(
ValueError: Graph object can only take one argumnent among N and graph (deprecated).
```