### PR TITLE
Improve Hilbert space random_state interface

### DIFF
--- a/Test/Hilbert/test_hilbert.py
+++ b/Test/Hilbert/test_hilbert.py
@@ -108,8 +108,11 @@ def test_random_states():
                 for state in rstate:
                     assert state in local_states
 
-            with pytest.raises(TypeError):
-                hi.random_state(rstate)  # out is keyword-only
+            assert hi.random_state().shape == (hi.size,)
+            assert hi.random_state(10).shape == (10, hi.size)
+            assert hi.random_state(size=10).shape == (10, hi.size)
+            assert hi.random_state(size=(10,)).shape == (10, hi.size)
+            assert hi.random_state(size=(10, 2)).shape == (10, 2, hi.size)
 
 
 def test_hilbert_index():

--- a/Test/Hilbert/test_hilbert.py
+++ b/Test/Hilbert/test_hilbert.py
@@ -109,7 +109,7 @@ def test_random_states():
                     assert state in local_states
 
             with pytest.raises(TypeError):
-                hi.random_state(rstate) # out is keyword-only
+                hi.random_state(rstate)  # out is keyword-only
 
 
 def test_hilbert_index():

--- a/Test/Hilbert/test_hilbert.py
+++ b/Test/Hilbert/test_hilbert.py
@@ -161,7 +161,7 @@ def test_state_iteration():
         assert np.allclose(state, ref)
 
 
-def test_graph_deprecation():
+def test_deprecations():
     g = nk.graph.Edgeless(3)
 
     with pytest.warns(FutureWarning):
@@ -170,3 +170,7 @@ def test_graph_deprecation():
     with pytest.warns(FutureWarning):
         with pytest.raises(ValueError):
             hilbert = Spin(s=0.5, graph=g, N=3)
+
+    hi = Spin(0.5, N=2)
+    with pytest.warns(FutureWarning):
+        hi.random_vals()

--- a/Test/Hilbert/test_hilbert.py
+++ b/Test/Hilbert/test_hilbert.py
@@ -102,18 +102,18 @@ def test_random_states():
         print("name", name)
         if hi.is_discrete:
             rstate = np.zeros(hi.size)
-
             local_states = hi.local_states
-
             for i in range(100):
-                hi.random_state(rstate)
+                hi.random_state(out=rstate)
                 for state in rstate:
                     assert state in local_states
+
+            with pytest.raises(TypeError):
+                hi.random_state(rstate) # out is keyword-only
 
 
 def test_hilbert_index():
     """"""
-
     for name, hi in hilberts.items():
         assert hi.size > 0
         assert hi.local_size > 0

--- a/Test/Machine/test_machine.py
+++ b/Test/Machine/test_machine.py
@@ -249,9 +249,11 @@ def test_log_derivative():
         flatten = machine.numpy_flatten
 
         for i in range(100):
-            hi.random_state(out=v)
             if name in dm_machines:
-                hi.random_state(out=v[hi.size : 2 * hi.size])
+                hi.random_state(out=v[: hi.size])
+                hi.random_state(out=v[hi.size :])
+            else:
+                hi.random_state(out=v)
 
             machine.init_random_parameters(seed=i)
             randpars = flatten(machine.parameters)

--- a/Test/Machine/test_machine.py
+++ b/Test/Machine/test_machine.py
@@ -249,9 +249,9 @@ def test_log_derivative():
         flatten = machine.numpy_flatten
 
         for i in range(100):
-            hi.random_vals(v)
+            hi.random_state(out=v)
             if name in dm_machines:
-                hi.random_vals(v[hi.size : 2 * hi.size])
+                hi.random_state(out=v[hi.size : 2 * hi.size])
 
             machine.init_random_parameters(seed=i)
             randpars = flatten(machine.parameters)
@@ -289,7 +289,7 @@ def test_vector_jacobian():
         flatten = machine.numpy_flatten
 
         for i in range(batch_size):
-            hi.random_vals(v[i])
+            hi.random_state(out=v[i])
 
         machine.init_random_parameters(seed=1234, sigma=0.1)
         randpars = flatten(machine.parameters)
@@ -355,7 +355,7 @@ def test_to_array():
         for i in range(100):
             rstate = np.zeros(hi.size)
             local_states = hi.local_states
-            hi.random_vals(rstate)
+            hi.random_state(out=rstate)
 
             number = hi.state_to_number(rstate)
 
@@ -371,7 +371,7 @@ def test_to_array():
         for i in range(100):
             rstate = np.zeros(hi.size)
             local_states = hi.local_states
-            hi.random_vals(rstate)
+            hi.random_state(out=rstate)
 
             number = hi.state_to_number(rstate)
 

--- a/Test/Operator/test_operator.py
+++ b/Test/Operator/test_operator.py
@@ -83,7 +83,7 @@ def test_produce_elements_in_hilbert():
         local_states = hi.local_states
 
         for i in range(1000):
-            hi.random_state(rstate)
+            hi.random_state(out=rstate)
 
             rstatet, _ = ha.get_conn(rstate)
 
@@ -101,7 +101,7 @@ def test_operator_is_hermitean():
         local_states = hi.local_states
 
         for i in range(100):
-            hi.random_state(rstate)
+            hi.random_state(out=rstate)
             rstatet, mels = ha.get_conn(rstate)
 
             for k, state in enumerate(rstatet):

--- a/Test/Operator/test_operator.py
+++ b/Test/Operator/test_operator.py
@@ -83,7 +83,7 @@ def test_produce_elements_in_hilbert():
         local_states = hi.local_states
 
         for i in range(1000):
-            hi.random_vals(rstate)
+            hi.random_state(rstate)
 
             rstatet, _ = ha.get_conn(rstate)
 
@@ -101,7 +101,7 @@ def test_operator_is_hermitean():
         local_states = hi.local_states
 
         for i in range(100):
-            hi.random_vals(rstate)
+            hi.random_state(rstate)
             rstatet, mels = ha.get_conn(rstate)
 
             for k, state in enumerate(rstatet):

--- a/Test/Sampler/test_sampler.py
+++ b/Test/Sampler/test_sampler.py
@@ -204,7 +204,7 @@ def test_correct_sampling():
 
         n_samples = max(40 * n_states, 10000)
 
-        ord = randint(1, 3)
+        ord = randint(1, 3, size=()).item()
         assert ord == 1 or ord == 2
 
         sa.machine_pow = ord

--- a/netket/_qsr.py
+++ b/netket/_qsr.py
@@ -258,11 +258,7 @@ class Qsr(AbstractVariationalDriver):
     @staticmethod
     @jit
     def _get_rand_ind(n, n_max):
-        rand_ind = _np.empty(n, dtype=_np.intc)
-
-        for i in range(n):
-            rand_ind[i] = randint(0, n_max)
-        return rand_ind
+        return _np.asarray(randint(0, n_max, size=(n,)), dtype=_np.intc)
 
     def _estimate_stats(self, obs):
         return self._get_mc_stats(obs)[1]

--- a/netket/hilbert/abstract_hilbert.py
+++ b/netket/hilbert/abstract_hilbert.py
@@ -121,14 +121,17 @@ class AbstractHilbert(abc.ABC):
             yield self.number_to_state(i).reshape(-1)
 
     @abc.abstractmethod
-    def random_state(self, *, out=None, rgen=None):
-        r"""Member function generating uniformely distributed local random states.
+    def random_state(self, *, batch=None, out=None, rgen=None):
+        r"""Generates either a single or a batch of uniformly distributed random states.
 
         Args:
-            out: If provided, the random quantum numbers will be inserted into this array.
-                 It should be of the appropriate shape and dtype.
-            rgen: The random number generator. If None, the global
-                  NetKet random number generator is used.
+            batch: If provided, this method generates a batch of `batch` random states.
+                Otherwise, a single state is generated and a ndim=1 array is returned.
+            out: If provided, the random quantum numbers will be inserted into this array,
+                 which should be of the appropriate shape [either `(self.size(),)` or
+                 `(batch, self.size())`] and dtype.
+            rgen: The random number generator. If None, the global NetKet random
+                number generator is used.
         """
         raise NotImplementedError
 

--- a/netket/hilbert/abstract_hilbert.py
+++ b/netket/hilbert/abstract_hilbert.py
@@ -120,18 +120,6 @@ class AbstractHilbert(abc.ABC):
         for i in range(self.n_states):
             yield self.number_to_state(i).reshape(-1)
 
-    def random_vals(self, out=None, rgen=None):
-        r"""Member function generating uniformely distributed local random states.
-            Prefer random_state instad.
-
-        Args:
-            out: If provided, the random quantum numbers will be inserted into this array.
-                 It should be of the appropriate shape and dtype.
-            rgen: The random number generator. If None, the global
-                  NetKet random number generator is used.
-        """
-        return self.random_state(out, rgen)
-
     @abc.abstractmethod
     def random_state(self, out=None, rgen=None):
         r"""Member function generating uniformely distributed local random states.

--- a/netket/hilbert/abstract_hilbert.py
+++ b/netket/hilbert/abstract_hilbert.py
@@ -121,7 +121,7 @@ class AbstractHilbert(abc.ABC):
             yield self.number_to_state(i).reshape(-1)
 
     @abc.abstractmethod
-    def random_state(self, out=None, rgen=None):
+    def random_state(self, *, out=None, rgen=None):
         r"""Member function generating uniformely distributed local random states.
 
         Args:

--- a/netket/hilbert/abstract_hilbert.py
+++ b/netket/hilbert/abstract_hilbert.py
@@ -3,6 +3,8 @@ import numpy as _np
 
 from typing import List, Tuple, Optional, Generator
 
+from .._core import deprecated
+
 
 """int: Maximum number of states that can be indexed"""
 max_states = _np.iinfo(_np.int32).max
@@ -119,6 +121,13 @@ class AbstractHilbert(abc.ABC):
         """
         for i in range(self.n_states):
             yield self.number_to_state(i).reshape(-1)
+
+    @deprecated("use random_state instead")
+    def random_vals(self, *args, **kwargs):
+        """
+        Deprecated alias for random_state. Prefer using random_state directly.
+        """
+        return self.random_state(*args, **kwargs)
 
     @abc.abstractmethod
     def random_state(self, *, batch=None, out=None, rgen=None):

--- a/netket/hilbert/abstract_hilbert.py
+++ b/netket/hilbert/abstract_hilbert.py
@@ -130,19 +130,26 @@ class AbstractHilbert(abc.ABC):
         return self.random_state(*args, **kwargs)
 
     @abc.abstractmethod
-    def random_state(self, *, batch=None, out=None, rgen=None):
+    def random_state(self, size=None, *, out=None, rgen=None):
         r"""Generates either a single or a batch of uniformly distributed random states.
 
         Args:
-            batch: If provided, this method generates a batch of `batch` random states.
-                Otherwise, a single state is generated and a ndim=1 array is returned.
+            size: If provided, returns a batch of configurations of the form (size, #) if size
+                is an integer or (*size, #) if it is a tuple and where # is the Hilbert space size.
+                By default, a single random configuration with shape (#,) is returned.
             out: If provided, the random quantum numbers will be inserted into this array,
-                 which should be of the appropriate shape [either `(self.size(),)` or
-                 `(batch, self.size())`] and dtype.
+                 which should be of the appropriate shape (see `size`) and data type.
             rgen: The random number generator. If None, the global NetKet random
                 number generator is used.
+
+        Example:
+            >>> hi = netket.hilbert.Qubit(N=2)
+            >>> hi.random_state()
+            array([0., 1.])
+            >>> hi.random_state(size=2)
+            array([[0., 0.], [1., 0.]])
         """
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def all_states(self, out=None):
         r"""Returns all valid states of the Hilbert space.

--- a/netket/hilbert/abstract_hilbert.py
+++ b/netket/hilbert/abstract_hilbert.py
@@ -15,31 +15,31 @@ class AbstractHilbert(abc.ABC):
     @abc.abstractmethod
     def size(self):
         r"""int: The total number number of spins."""
-        return NotImplementedError
+        raise NotImplementedError()
 
     @property
     @abc.abstractmethod
     def is_discrete(self):
         r"""bool: Whether the hilbert space is discrete."""
-        return NotImplementedError
+        raise NotImplementedError()
 
     @property
     @abc.abstractmethod
     def is_finite(self):
         r"""bool: Whether the local hilbert space is finite."""
-        return NotImplementedError
+        raise NotImplementedError()
 
     @property
     @abc.abstractmethod
     def local_size(self):
         r"""int: Size of the local degrees of freedom that make the total hilbert space."""
-        return NotImplementedError
+        raise NotImplementedError()
 
     @property
     @abc.abstractmethod
     def local_states(self):
         r"""list[float]: A list of discreet local quantum numbers."""
-        return NotImplementedError
+        raise NotImplementedError()
 
     def numbers_to_states(self, numbers, out=None):
         r"""Returns the quantum numbers corresponding to the n-th basis state
@@ -50,7 +50,7 @@ class AbstractHilbert(abc.ABC):
             out: Array of quantum numbers corresponding to numbers.
                  If None, memory is allocated.
         """
-        return NotImplementedError
+        raise NotImplementedError()
 
     def number_to_state(self, number):
         r"""Returns the quantum number corresponding to the n-th basis state
@@ -84,7 +84,7 @@ class AbstractHilbert(abc.ABC):
         Returns:
             numpy.darray: Array of integers corresponding to out.
         """
-        return NotImplementedError
+        raise NotImplementedError()
 
     def state_to_number(self, state):
         r"""Returns the basis state number corresponding to given quantum states.
@@ -108,7 +108,7 @@ class AbstractHilbert(abc.ABC):
     def n_states(self):
         r"""int: The total dimension of the many-body Hilbert space.
         Throws an exception iff the space is not indexable."""
-        return NotImplementedError
+        raise NotImplementedError()
 
     def states(self):
         r"""Returns an iterator over all valid configurations of the Hilbert space.

--- a/netket/hilbert/boson.py
+++ b/netket/hilbert/boson.py
@@ -99,9 +99,8 @@ class Boson(CustomHilbert):
            >>> import netket as nk
            >>> import numpy as np
            >>> hi = nk.hilbert.Boson(n_max=3, N=5)
-           >>> rstate = np.zeros(hi.size)
            >>> rg = nk.utils.RandomEngine(seed=1234)
-           >>> hi.random_vals(rstate, rg)
+           >>> rstate = hi.random_state(rgen=rg)
            >>> local_states = hi.local_states
            >>> print(rstate[0] in local_states)
            True

--- a/netket/hilbert/boson.py
+++ b/netket/hilbert/boson.py
@@ -83,7 +83,7 @@ class Boson(CustomHilbert):
         if the number is unconstrained."""
         return self._n_bosons
 
-    def random_state(self, out=None, rgen=None):
+    def random_state(self, *, out=None, rgen=None):
         r"""Member function generating uniformely distributed local random states.
 
         Args:

--- a/netket/hilbert/boson.py
+++ b/netket/hilbert/boson.py
@@ -96,7 +96,7 @@ class Boson(CustomHilbert):
         ss = self.size
 
         for i in range(self.n_bosons):
-            s = rgen.randint(0, ss)
+            s = rgen.randint(0, ss, size=())
 
             out[sites[s]] += 1
 

--- a/netket/hilbert/boson.py
+++ b/netket/hilbert/boson.py
@@ -153,4 +153,4 @@ class Boson(CustomHilbert):
             ", n_bosons={}".format(self._n_bosons) if self._n_bosons is not None else ""
         )
         nmax = self._n_max if self._n_max < _np.iinfo(_np.intp).max else "INT_MAX"
-        return "Boson(n_max={}{}; N={})".format(nmax, nbosons, self._size)
+        return "Boson(n_max={}{}, N={})".format(nmax, nbosons, self._size)

--- a/netket/hilbert/custom_hilbert.py
+++ b/netket/hilbert/custom_hilbert.py
@@ -147,8 +147,7 @@ class CustomHilbert(AbstractHilbert):
            >>> import netket as nk
            >>> import numpy as np
            >>> hi = nk.hilbert.Boson(n_max=3, N=4)
-           >>> rstate = np.zeros(hi.size)
-           >>> hi.random_vals(rstate)
+           >>> rstate = hi.random_state()
            >>> local_states = hi.local_states
            >>> print(rstate[0] in local_states)
            True
@@ -168,7 +167,7 @@ class CustomHilbert(AbstractHilbert):
                 out[i] = self.local_states[rs]
 
             return out
-
+        
         return NotImplementedError
 
     def _get_hilbert_index(self):

--- a/netket/hilbert/custom_hilbert.py
+++ b/netket/hilbert/custom_hilbert.py
@@ -131,7 +131,7 @@ class CustomHilbert(AbstractHilbert):
 
         return out
 
-    def random_state(self, *, out=None, rgen=None):
+    def random_state(self, *, batch=None, out=None, rgen=None):
         r"""Member function generating uniformely distributed local random states.
 
         Args:
@@ -155,19 +155,18 @@ class CustomHilbert(AbstractHilbert):
 
         # Default version for discrete hilbert spaces without constraints
         # More specialized initializations can be defined in the derived classes
+        shape = (batch, self._size) if batch is not None else (self._size,)
         if self.is_discrete and self.is_finite and not self._do_constraints:
             if out is None:
-                out = _np.empty(self._size)
+                out = _np.empty(shape=shape)
 
             if rgen is None:
                 rgen = _random
 
-            for i in range(self._size):
-                rs = rgen.randint(0, self._local_size)
-                out[i] = self.local_states[rs]
+            out[:] = rgen.choice(self.local_states, size=shape)
 
             return out
-        
+
         return NotImplementedError
 
     def _get_hilbert_index(self):

--- a/netket/hilbert/custom_hilbert.py
+++ b/netket/hilbert/custom_hilbert.py
@@ -136,33 +136,15 @@ class CustomHilbert(AbstractHilbert):
 
         return out
 
-    def random_state(self, *, batch=None, out=None, rgen=None):
-        r"""Member function generating uniformely distributed local random states.
-
-        Args:
-            out: If provided, the random quantum numbers will be inserted into this array.
-                 It should be of the appropriate shape and dtype.
-            rgen: The random number generator. If None, the global
-                  NetKet random number generator is used.
-
-        Examples:
-           Test that a new random state is a possible state for the hilbert
-           space.
-
-           >>> import netket as nk
-           >>> import numpy as np
-           >>> hi = nk.hilbert.Boson(n_max=3, N=4)
-           >>> rstate = hi.random_state()
-           >>> local_states = hi.local_states
-           >>> print(rstate[0] in local_states)
-           True
-        """
+    def random_state(self, size=None, *, out=None, rgen=None):
         if not self.is_discrete or not self.is_finite or self._has_constraint:
             raise NotImplementedError()
 
         # Default version for discrete hilbert spaces without constraints.
         # More specialized initializations can be defined in the derived classes.
-        shape = (batch, self._size) if batch is not None else (self._size,)
+        if isinstance(size, int):
+            size = (size,)
+        shape = (*size, self._size) if size is not None else (self._size,)
 
         if out is None:
             out = _np.empty(shape=shape)

--- a/netket/hilbert/custom_hilbert.py
+++ b/netket/hilbert/custom_hilbert.py
@@ -226,6 +226,6 @@ class CustomHilbert(AbstractHilbert):
             if self._has_constraint
             else ""
         )
-        return "CustomHilbert(local_size={}{}; N={})".format(
+        return "CustomHilbert(N={}; local_size={}{})".format(
             len(self.local_states), constr, self.size
         )

--- a/netket/hilbert/custom_hilbert.py
+++ b/netket/hilbert/custom_hilbert.py
@@ -131,7 +131,7 @@ class CustomHilbert(AbstractHilbert):
 
         return out
 
-    def random_state(self, out=None, rgen=None):
+    def random_state(self, *, out=None, rgen=None):
         r"""Member function generating uniformely distributed local random states.
 
         Args:

--- a/netket/hilbert/doubled_hilbert.py
+++ b/netket/hilbert/doubled_hilbert.py
@@ -100,7 +100,7 @@ class DoubledHilbert(AbstractHilbert):
 
         return out
 
-    def random_state(self, out=None, rgen=None):
+    def random_state(self, *, out=None, rgen=None):
         if out is None:
             out = _np.empty(self._size)
 

--- a/netket/hilbert/doubled_hilbert.py
+++ b/netket/hilbert/doubled_hilbert.py
@@ -100,14 +100,18 @@ class DoubledHilbert(AbstractHilbert):
 
         return out
 
-    def random_state(self, *, out=None, rgen=None):
+    def random_state(self, size=None, *, out=None, rgen=None):
+        if isinstance(size, int):
+            size = (size,)
+        shape = (*size, self.size) if size is not None else (self.size,)
+
         if out is None:
-            out = _np.empty(self._size)
+            out = _np.empty(shape=shape)
 
         n = self.size_physical
 
-        self.physical.random_state(out=out[0:n], rgen=rgen)
-        self.physical.random_state(out=out[n : 2 * n], rgen=rgen)
+        self.physical.random_state(out=out[..., :n], size=size, rgen=rgen)
+        self.physical.random_state(out=out[..., n:], size=size, rgen=rgen)
 
         return out
 

--- a/netket/hilbert/spin.py
+++ b/netket/hilbert/spin.py
@@ -53,7 +53,21 @@ class Spin(CustomHilbert):
 
         super().__init__(local_states, N, constraints)
 
-    def random_state(self, *, out=None, rgen=None):
+    def _random_state_with_constraint(self, out, rgen):
+        sites = list(range(self.size))
+        out.fill(-round(2 * self._s))
+        ss = self.size
+
+        for i in range(round(self._s * self.size) + self._total_sz):
+            s = rgen.randint(0, ss)
+
+            out[sites[s]] += 2
+
+            if out[sites[s]] > round(2 * self._s - 1):
+                sites.pop(s)
+                ss -= 1
+
+    def random_state(self, *, batch=None, out=None, rgen=None):
         r"""Member function generating uniformely distributed local random states.
 
         Args:
@@ -74,31 +88,23 @@ class Spin(CustomHilbert):
            >>> print(rstate[0] in local_states)
            True
         """
+        shape = (batch, self._size) if batch is not None else (self._size,)
 
         if out is None:
-            out = _np.empty(self._size)
+            out = _np.empty(shape=shape)
 
         if rgen is None:
             rgen = _random
 
         if self._total_sz is None:
-            for i in range(self._size):
-                rs = rgen.randint(0, self._local_size)
-                out[i] = self.local_states[rs]
+            out[:] = rgen.choice(self.local_states, size=shape)
         else:
-            sites = list(range(self.size))
-
-            out.fill(-round(2 * self._s))
-            ss = self.size
-
-            for i in range(round(self._s * self.size) + self._total_sz):
-                s = rgen.randint(0, ss)
-
-                out[sites[s]] += 2
-
-                if out[sites[s]] > round(2 * self._s - 1):
-                    sites.pop(s)
-                    ss -= 1
+            # TODO: this can most likely be done more efficiently
+            if batch:
+                for b in range(batch):
+                    self._random_state_with_constraint(out[b], rgen)
+            else:
+                self._random_state_with_constraint(out, rgen)
 
         return out
 

--- a/netket/hilbert/spin.py
+++ b/netket/hilbert/spin.py
@@ -77,28 +77,10 @@ class Spin(CustomHilbert):
                 sites.pop(s)
                 ss -= 1
 
-    def random_state(self, *, batch=None, out=None, rgen=None):
-        r"""Member function generating uniformely distributed local random states.
-
-        Args:
-            out: If provided, the random quantum numbers will be inserted into this array.
-                 It should be of the appropriate shape and dtype.
-            rgen: The random number generator. If None, the global
-                  NetKet random number generator is used.
-
-        Examples:
-           Test that a new random state is a possible state for the hilbert
-           space.
-
-           >>> import netket as nk
-           >>> import numpy as np
-           >>> hi = nk.hilbert.Spin(N=4)
-           >>> rstate = hi.random_state()
-           >>> local_states = hi.local_states
-           >>> print(rstate[0] in local_states)
-           True
-        """
-        shape = (batch, self._size) if batch is not None else (self._size,)
+    def random_state(self, size=None, *, out=None, rgen=None):
+        if isinstance(size, int):
+            size = (size,)
+        shape = (*size, self._size) if size is not None else (self._size,)
 
         if out is None:
             out = _np.empty(shape=shape)
@@ -110,9 +92,10 @@ class Spin(CustomHilbert):
             out[:] = rgen.choice(self.local_states, size=shape)
         else:
             # TODO: this can most likely be done more efficiently
-            if batch:
-                for b in range(batch):
-                    self._random_state_with_constraint(out[b], rgen)
+            if size is not None:
+                out_r = out.reshape(-1, self._size)
+                for b in range(out_r.shape[0]):
+                    self._random_state_with_constraint(out_r[b], rgen)
             else:
                 self._random_state_with_constraint(out, rgen)
 

--- a/netket/hilbert/spin.py
+++ b/netket/hilbert/spin.py
@@ -69,7 +69,7 @@ class Spin(CustomHilbert):
         ss = self.size
 
         for i in range(round(self._s * self.size) + self._total_sz):
-            s = rgen.randint(0, ss)
+            s = rgen.randint(0, ss, size=())
 
             out[sites[s]] += 2
 

--- a/netket/hilbert/spin.py
+++ b/netket/hilbert/spin.py
@@ -53,7 +53,7 @@ class Spin(CustomHilbert):
 
         super().__init__(local_states, N, constraints)
 
-    def random_state(self, out=None, rgen=None):
+    def random_state(self, *, out=None, rgen=None):
         r"""Member function generating uniformely distributed local random states.
 
         Args:
@@ -69,8 +69,7 @@ class Spin(CustomHilbert):
            >>> import netket as nk
            >>> import numpy as np
            >>> hi = nk.hilbert.Spin(N=4)
-           >>> rstate = np.zeros(hi.size)
-           >>> hi.random_state(rstate)
+           >>> rstate = hi.random_state()
            >>> local_states = hi.local_states
            >>> print(rstate[0] in local_states)
            True

--- a/netket/machine/jax.py
+++ b/netket/machine/jax.py
@@ -164,7 +164,7 @@ class Jax(AbstractMachine):
         imaginary part.
         """
         if seed is None:
-            seed = _randint(0, 2 ** 32 - 2)
+            seed = _randint(0, 2 ** 32 - 2, size=())
 
         input_shape = (-1, self.input_size)
         output_shape, params = self._init_fn(jax.random.PRNGKey(seed), input_shape)

--- a/netket/random.py
+++ b/netket/random.py
@@ -47,7 +47,7 @@ def uniform(low=0.0, high=1.0):
 
 
 @jit
-def randint(low, high, size):
+def randint(low, high, size=()):
     """
     Generate random integers from low (inclusive) to high (exclusive).
 

--- a/netket/random.py
+++ b/netket/random.py
@@ -46,20 +46,20 @@ def uniform(low=0.0, high=1.0):
     return _np.random.uniform(low, high)
 
 
-@jit
-def randint(low, high):
+def randint(low, high, size=None):
     """
     Generate random integers from low (inclusive) to high (exclusive).
 
     Args:
         low (int): Lowest (signed) integer to be drawn from the distribution.
         high (int): One above the largest (signed) integer to be drawn from the distribution.
+        size: Output shape.
 
     Returns:
         int: A random integer uniformely distributed in [low,high).
 
     """
-    return _np.random.randint(low, high)
+    return _np.random.randint(low, high, size=size)
 
 
 def choice(a, size=None, replace=True, p=None):

--- a/netket/random.py
+++ b/netket/random.py
@@ -46,7 +46,8 @@ def uniform(low=0.0, high=1.0):
     return _np.random.uniform(low, high)
 
 
-def randint(low, high, size=None):
+@jit
+def randint(low, high, size):
     """
     Generate random integers from low (inclusive) to high (exclusive).
 
@@ -59,7 +60,10 @@ def randint(low, high, size=None):
         int: A random integer uniformely distributed in [low,high).
 
     """
-    return _np.random.randint(low, high, size=size)
+    # Ugly workaround for numba not being able to jit compile randint with size arg.
+    # size is also a required argument for numba reasons.
+    x = _np.random.rand(*size)
+    return _np.asarray(_np.floor(x * (high - low)) + low, dtype=_np.int64)
 
 
 def choice(a, size=None, replace=True, p=None):

--- a/netket/sampler/jax/exchange_kernel.py
+++ b/netket/sampler/jax/exchange_kernel.py
@@ -23,4 +23,4 @@ class _JaxExchangeKernel:
         return jax.ops.index_update(state_1, sj, state[si])
 
     def random_state(self, key, state):
-        return key, jax.numpy.asarray(self._hilbert.random_vals())
+        return key, jax.numpy.asarray(self._hilbert.random_state())

--- a/netket/sampler/jax/metropolis_hastings.py
+++ b/netket/sampler/jax/metropolis_hastings.py
@@ -15,7 +15,9 @@ class MetropolisHastings(AbstractSampler):
 
         self._rng_key = rng_key
         if rng_key is None:
-            self._rng_key = jax.random.PRNGKey(_random.randint(low=0, high=(2 ** 32)))
+            self._rng_key = jax.random.PRNGKey(
+                _random.randint(low=0, high=2 ** 32, size=()).item()
+            )
 
         self.machine_pow = 2
 

--- a/netket/sampler/numpy/custom_kernel.py
+++ b/netket/sampler/numpy/custom_kernel.py
@@ -86,4 +86,4 @@ class _CustomKernel:
     def random_state(self, state):
 
         for i in range(state.shape[0]):
-            self._hilbert.random_vals(out=state[i])
+            self._hilbert.random_state(out=state[i])

--- a/netket/sampler/numpy/exchange_kernel.py
+++ b/netket/sampler/numpy/exchange_kernel.py
@@ -34,4 +34,4 @@ class _ExchangeKernel:
     def random_state(self, state):
 
         for i in range(state.shape[0]):
-            self._hilbert.random_vals(out=state[i])
+            self._hilbert.random_state(out=state[i])

--- a/netket/sampler/numpy/exchange_kernel.py
+++ b/netket/sampler/numpy/exchange_kernel.py
@@ -18,7 +18,7 @@ class _ExchangeKernel:
             state_1[k] = state[k]
 
             # pick a random cluster
-            cl = _random.randint(0, clusters_size)
+            cl = _random.randint(0, clusters_size, size=())
 
             # sites to be exchanged
             si = clusters[cl][0]

--- a/netket/sampler/numpy/hamiltonian_kernel.py
+++ b/netket/sampler/numpy/hamiltonian_kernel.py
@@ -28,7 +28,7 @@ class _HamiltonianKernel:
     def random_state(self, state):
 
         for i in range(state.shape[0]):
-            self._hilbert.random_vals(out=state[i])
+            self._hilbert.random_state(out=state[i])
 
     @staticmethod
     @jit(nopython=True)

--- a/netket/sampler/numpy/hamiltonian_kernel.py
+++ b/netket/sampler/numpy/hamiltonian_kernel.py
@@ -35,7 +35,7 @@ class _HamiltonianKernel:
     def _choose(states, sections, out, w):
         low_range = 0
         for i, s in enumerate(sections):
-            n_rand = _random.randint(low_range, s)
+            n_rand = _random.randint(low_range, s, size=())
             out[i] = states[n_rand]
             w[i] = math.log(s - low_range)
             low_range = s

--- a/netket/sampler/numpy/local_kernel.py
+++ b/netket/sampler/numpy/local_kernel.py
@@ -16,9 +16,8 @@ class _LocalKernel:
         for i in range(state.shape[0]):
             state_1[i] = state[i]
 
-            si = _random.randint(0, self.size)
-
-            rs = _random.randint(0, self.n_states - 1)
+            si = _random.randint(0, self.size, size=())
+            rs = _random.randint(0, self.n_states - 1, size=())
 
             state_1[i, si] = self.local_states[
                 rs + (self.local_states[rs] >= state[i, si])
@@ -30,5 +29,5 @@ class _LocalKernel:
 
         for i in range(state.shape[0]):
             for si in range(state.shape[1]):
-                rs = _random.randint(0, self.n_states)
+                rs = _random.randint(0, self.n_states, size=())
                 state[i, si] = self.local_states[rs]

--- a/netket/sampler/numpy/metropolis_hastings_pt.py
+++ b/netket/sampler/numpy/metropolis_hastings_pt.py
@@ -178,7 +178,7 @@ class MetropolisHastingsPt(AbstractSampler):
         log_values, machine_pow, beta, proposed_beta, prob, beta_stats, accepted_samples
     ):
         # Choose a random swap order (odd/even swap)
-        swap_order = _random.randint(0, 2)
+        swap_order = _random.randint(0, 2, size=()).item()
 
         n_replicas = beta.shape[0]
 


### PR DESCRIPTION
This PR contains the following:

(a) Add an optional `batch` argument to `AbstractHilbert.random_state`. It is then possible to generate a batch of random states at once for convenience.
```python
>>> hi = Spin(s=1/2, N=8)
>>> hi.random_state(batch=4)
array([[-1., -1.,  1.,  1.,  1.,  1., -1.,  1.],
       [-1., -1., -1., -1.,  1.,  1.,  1.,  1.],
       [ 1., -1., -1.,  1., -1., -1.,  1.,  1.],
       [-1., -1.,  1., -1.,  1.,  1.,  1., -1.]])
```
By default, `random_state` still returns a `ndim=1` single configuration, to get a single conf with batch dim one has to call `random_state(batch=1)`.
```python
>>> hi.random_state()
array([-1., -1.,  1., -1., -1.,  1.,  1.,  1.])
>>> hi.random_state(batch=1)
array([[ 1., -1.,  1.,  1., -1.,  1.,  1., -1.]])
```

(b) Remove `random_vals` in favor of `random_state` (as the former is deprecated and equivalent to the later). We could alternatively keep it as an alias with a `FutureWarning` for now, if desired.

(c) Some minor interface changes (such as making the `random_state` arguments kw-only).

(d) Add optional `n_max` to `Boson.random_state`, which might be useful for unconstrained Boson spaces (where otherwise the method defaults to uniformly picking boson numbers in `range(INT_MAX)` which is rarely sensible).