### PR TITLE
Fix LocalOperator __radd__ infinite recursion

### DIFF
--- a/netket/operator/_local_operator.py
+++ b/netket/operator/_local_operator.py
@@ -263,7 +263,7 @@ class LocalOperator(AbstractOperator):
         return self.__mul__(other)
 
     def __radd__(self, other):
-        return self.__radd__(other)
+        return self.__add__(other)
 
     def _init_zero(self):
         self._operators = []


### PR DESCRIPTION
Before, doing 
```python
0 + LocalOperator()...
```

would trigger an infinite recursion on radd.

Now it does not anymore.