### PR TITLE
Some usability improvements for operators

### DIFF
--- a/Test/GroundState/test_vmc.py
+++ b/Test/GroundState/test_vmc.py
@@ -35,6 +35,14 @@ def _setup_vmc(lsq_solver=None):
     return ha, sx, ma, sa, driver
 
 
+def test_before_first_step():
+    ha, *_, driver = _setup_vmc()
+    with raises(RuntimeError):
+        doesnotwork = driver.estimate(ha)
+    driver.advance(1)
+    driver.estimate(ha)
+
+
 def test_vmc_functions():
     ha, sx, ma, sampler, driver = _setup_vmc()
     driver.advance(500)

--- a/Test/Operator/test_local_operator.py
+++ b/Test/Operator/test_local_operator.py
@@ -252,3 +252,14 @@ def test_truediv():
     sx0sy1 = sx0sy1_hat.to_dense()
     sx0sy1_hat /= 3.0
     assert np.allclose(sx0sy1_hat.to_dense(), sx0sy1 / 3.0)
+
+
+def test_copy():
+    for name, op in herm_operators.items():
+        print(name)
+        op_copy = op.copy()
+        assert op_copy is not op
+        for o1, o2 in zip(op._operators, op_copy._operators):
+            assert o1 is not o2
+            assert np.all(o1 == o2)
+        same_matrices(op, op_copy)

--- a/Test/Operator/test_operator.py
+++ b/Test/Operator/test_operator.py
@@ -170,3 +170,4 @@ def test_Heisenberg():
 def test_repr():
     for op in operators.values():
         assert type(op).__name__ in repr(op)
+

--- a/Test/Operator/test_operator.py
+++ b/Test/Operator/test_operator.py
@@ -165,3 +165,8 @@ def test_Heisenberg():
         assert not g.is_bipartite()
 
         ha = nk.operator.Heisenberg(hi, graph=g, sign_rule=True)
+
+
+def test_repr():
+    for op in operators.values():
+        assert type(op).__name__ in repr(op)

--- a/Test/Operator/test_operator.py
+++ b/Test/Operator/test_operator.py
@@ -170,4 +170,3 @@ def test_Heisenberg():
 def test_repr():
     for op in operators.values():
         assert type(op).__name__ in repr(op)
-

--- a/netket/_vmc.py
+++ b/netket/_vmc.py
@@ -184,6 +184,12 @@ class Vmc(AbstractVariationalDriver):
         return self._loss_stats
 
     def _estimate_stats(self, obs):
+        if self._samples is None:
+            raise RuntimeError(
+                "Vmc driver needs to perform a step before .estimate() can be "
+                "called. To get VMC estimates outside of optimization, use "
+                "netket.variational.estimate_expectations instead."
+            )
         return self._get_mc_stats(obs)[1]
 
     def reset(self):

--- a/netket/operator/_abstract_operator.py
+++ b/netket/operator/_abstract_operator.py
@@ -150,3 +150,6 @@ class AbstractOperator(abc.ABC):
 
     def to_linear_operator(self):
         return self.to_sparse()
+
+    def __repr__(self):
+        return f"{type(self).__name__}(hilbert={self.hilbert})"

--- a/netket/operator/_graph_operator.py
+++ b/netket/operator/_graph_operator.py
@@ -5,87 +5,86 @@ import numpy as _np
 from numba import jit
 
 
-def GraphOperator(hilbert, graph, site_ops=[], bond_ops=[], bond_ops_colors=[]):
-    r"""
-    A graph-based quantum operator. In its simplest terms, this is the sum of
-    local operators living on the edge of an arbitrary graph.
+class GraphOperator(LocalOperator):
+    def __init__(self, hilbert, graph, site_ops=[], bond_ops=[], bond_ops_colors=[]):
+        r"""
+        A graph-based quantum operator. In its simplest terms, this is the sum of
+        local operators living on the edge of an arbitrary graph.
 
-    A ``GraphOperator`` is constructed giving a hilbert space and either a
-    list of operators acting on sites or a list acting on the bonds.
-    Users can specify the color of the bond that an operator acts on, if
-    desired. If none are specified, the bond operators act on all edges.
+        A ``GraphOperator`` is constructed giving a hilbert space and either a
+        list of operators acting on sites or a list acting on the bonds.
+        Users can specify the color of the bond that an operator acts on, if
+        desired. If none are specified, the bond operators act on all edges.
 
-    Args:
-     hilbert: Hilbert space the operator acts on.
-     graph: The graph upon which the hamiltonian is defined
-     graph: The graph whose vertices and edges are considered to construct the
-            operator. If None, the graph is deduced from the hilbert object.
-     site_ops: A list of operators in matrix form that act
-            on the nodes of the graph.
-            The default is an empty list. Note that if no site_ops are
-            specified, the user must give a list of bond operators.
-     bond_ops: A list of operators that act on the edges of the graph.
-         The default is None. Note that if no bond_ops are
-         specified, the user must give a list of site operators.
-     bond_ops_colors: A list of edge colors, specifying the color each
-         bond operator acts on. The defualt is an empty list.
+        Args:
+         hilbert: Hilbert space the operator acts on.
+         graph: The graph whose vertices and edges are considered to construct the
+                operator
+         site_ops: A list of operators in matrix form that act
+                on the nodes of the graph.
+                The default is an empty list. Note that if no site_ops are
+                specified, the user must give a list of bond operators.
+         bond_ops: A list of operators that act on the edges of the graph.
+             The default is None. Note that if no bond_ops are
+             specified, the user must give a list of site operators.
+         bond_ops_colors: A list of edge colors, specifying the color each
+             bond operator acts on. The defualt is an empty list.
 
-    Examples:
-     Constructs a ``BosGraphOperator`` operator for a 2D system.
+        Examples:
+         Constructs a ``GraphOperator`` operator for a 2D system.
 
-     >>> import netket as nk
-     >>> sigmax = [[0, 1], [1, 0]]
-     >>> mszsz = [[1, 0, 0, 0], [0, -1, 0, 0], [0, 0, -1, 0], [0, 0, 0, 1]]
-     >>> edges = [[0, 1], [1, 2], [2, 3], [3, 4], [4, 5], [5, 6], [6, 7], [7, 8],
-     ... [8, 9], [9, 10], [10, 11], [11, 12], [12, 13], [13, 14], [14, 15],
-     ... [15, 16], [16, 17], [17, 18], [18, 19], [19, 0]]
-     >>> g = nk.graph.CustomGraph(edges=edges)
-     >>> hi = nk.hilbert.CustomHilbert(local_states=[-1, 1], graph=g)
-     >>> op = nk.operator.GraphOperator(
-     ... hi, site_ops=[sigmax], bond_ops=[mszsz])
-     >>> print(op.hilbert.size)
-     20
-    """
+         >>> import netket as nk
+         >>> sigmax = [[0, 1], [1, 0]]
+         >>> mszsz = [[1, 0, 0, 0], [0, -1, 0, 0], [0, 0, -1, 0], [0, 0, 0, 1]]
+         >>> edges = [[0, 1], [1, 2], [2, 3], [3, 4], [4, 5], [5, 6], [6, 7], [7, 8],
+         ... [8, 9], [9, 10], [10, 11], [11, 12], [12, 13], [13, 14], [14, 15],
+         ... [15, 16], [16, 17], [17, 18], [18, 19], [19, 0]]
+         >>> g = nk.graph.CustomGraph(edges=edges)
+         >>> hi = nk.hilbert.CustomHilbert(local_states=[-1, 1], graph=g)
+         >>> op = nk.operator.GraphOperator(
+         ... hi, site_ops=[sigmax], bond_ops=[mszsz])
+         >>> print(op.hilbert.size)
+         20
+        """
 
-    assert (
-        graph.n_nodes == hilbert.size
-    ), "The size of the graph must match the hilbert space"
+        assert (
+            graph.n_nodes == hilbert.size
+        ), "The size of the graph must match the hilbert space"
 
-    size = graph.n_nodes
+        self.graph = graph
+        size = graph.n_nodes
 
-    # Create the local operator as the sum of all site and bond operators
+        # Create the local operator as the sum of all site and bond operators
 
-    # Ensure that at least one of SiteOps and BondOps was initialized
-    if len(bond_ops) == 0 and len(site_ops) == 0:
-        raise InvalidInputError("Must input at least site_ops or bond_ops.")
+        # Ensure that at least one of SiteOps and BondOps was initialized
+        if len(bond_ops) == 0 and len(site_ops) == 0:
+            raise InvalidInputError("Must input at least site_ops or bond_ops.")
 
-    this_operator = LocalOperator(hilbert)
+        super().__init__(hilbert)
 
-    # Site operators
-    if len(site_ops) > 0:
-        for i in range(size):
-            for j, site_op in enumerate(site_ops):
-                this_operator += LocalOperator(hilbert, site_op, [i])
+        # Site operators
+        if len(site_ops) > 0:
+            for i in range(size):
+                for j, site_op in enumerate(site_ops):
+                    self += LocalOperator(hilbert, site_op, [i])
 
-    # Bond operators
-    if len(bond_ops_colors) > 0:
-        if len(bond_ops) != len(bond_ops_colors):
-            raise InvalidInputError(
-                """The GraphHamiltonian definition is inconsistent.
-                The sizes of bond_ops and bond_ops_colors do not match."""
-            )
+        # Bond operators
+        if len(bond_ops_colors) > 0:
+            if len(bond_ops) != len(bond_ops_colors):
+                raise InvalidInputError(
+                    """The GraphHamiltonian definition is inconsistent.
+                    The sizes of bond_ops and bond_ops_colors do not match."""
+                )
 
-        if len(bond_ops) > 0:
-            #  Use edge_colors to populate operators
-            for (u, v, color) in graph.edges(color=True):
-                edge = u, v
-                for c, bond_color in enumerate(bond_ops_colors):
-                    if bond_color == color:
-                        this_operator += LocalOperator(hilbert, bond_ops[c], edge)
-    else:
-        assert len(bond_ops) == 1
+            if len(bond_ops) > 0:
+                #  Use edge_colors to populate operators
+                for (u, v, color) in graph.edges(color=True):
+                    edge = u, v
+                    for c, bond_color in enumerate(bond_ops_colors):
+                        if bond_color == color:
+                            self += LocalOperator(hilbert, bond_ops[c], edge)
+        else:
+            assert len(bond_ops) == 1
 
-        for edge in graph.edges():
-            this_operator += LocalOperator(hilbert, bond_ops[0], edge)
-
-    return this_operator
+            for edge in graph.edges():
+                self += LocalOperator(hilbert, bond_ops[0], edge)

--- a/netket/operator/_hamiltonian.py
+++ b/netket/operator/_hamiltonian.py
@@ -149,6 +149,9 @@ class Ising(AbstractOperator):
 
         return self._flattened_kernel(x, sections, self._edges, self._h, self._J)
 
+    def __repr__(self):
+        return f"Ising(J={self._J}, h={self._h}; dim={self.hilbert.size})"
+
 
 def Heisenberg(hilbert, graph, J=1, sign_rule=None):
     """

--- a/netket/operator/_local_operator.py
+++ b/netket/operator/_local_operator.py
@@ -473,6 +473,15 @@ class LocalOperator(AbstractOperator):
 
         return operators, acting_on
 
+    def copy(self):
+        """Returns a copy of the operator."""
+        return LocalOperator(
+            hilbert=self._hilbert,
+            operators=[_np.copy(op) for op in self._operators],
+            acting_on=self._acting_on_list(),
+            constant=self._constant,
+        )
+
     def transpose(self):
         r"""LocalOperator: Returns the tranpose of this operator."""
 

--- a/netket/operator/_local_operator.py
+++ b/netket/operator/_local_operator.py
@@ -777,3 +777,10 @@ class LocalOperator(AbstractOperator):
                 c += n_conn_i
 
         return x_prime, mels
+
+    def __repr__(self):
+        ao = self._acting_on
+        acting_str = f"acting_on={ao.tolist()}"
+        if len(acting_str) > 55:
+            acting_str = f"#acting_on={ao.shape[0]}"
+        return f"{type(self).__name__}(dim={self.hilbert.size}, local_dim={ao.shape[1]}, {acting_str})"


### PR DESCRIPTION
This PR contains some usability improvements:

1. Add `__repr__`  for operators (cf. #472):
```python
>>> nk.operator.spin.sigmap(hi, 0) @ nk.operator.spin.sigmam(hi, 1)
LocalOperator(dim=16, local_dim=2, acting_on=[[0, 1]])
>>> nk.operator.Ising(hi, nk.graph.Chain(16), h=1.0)
Ising(J=1.0, h=1.0; dim=16)
>>> nk.operator.Heisenberg(hi, nk.graph.Chain(16))
Heisenberg(J=1, sign_rule=True; dim=16)
```

2. Add `copy` for local operator (can be useful if you construct some combination of local operators using `+=`/`*=` etc. and want to reuse some intermediate operator):
```python
>>> op = sigmaz(hi, 0)
>>> op2 = op.copy()
>>> op *= sigmaz(hi, 1)
>>> op, op2
(LocalOperator(dim=16, local_dim=2, acting_on=[[0, 1]]),
 LocalOperator(dim=16, local_dim=1, acting_on=[[0]]))
```

3. Adds a better error message if `Vmc.estimate` is called before the first step (which fails since there are no pre-computed MC samples).