### PR TITLE
Jax improvements + remove outdtype

### DIFF
--- a/Test/Sampler/test_sampler.py
+++ b/Test/Sampler/test_sampler.py
@@ -166,6 +166,7 @@ if test_jax:
         return init_fun, apply_fun
 
     ma = nk.machine.Jax(hi, Jastrow(), dtype=float)
+    ma.init_random_parameters(sigma=0.2)
     samplers["Metropolis Jastrow Jax"] = nk.sampler.MetropolisLocal(ma, n_chains=16)
 
 

--- a/netket/machine/_jax_utils.py
+++ b/netket/machine/_jax_utils.py
@@ -33,21 +33,30 @@ forward_apply = jax.jit(
 
 ##
 def tree_leaf_iscomplex(pars):
-    #  Returns true if x is complex
+    """
+    Returns true if at least one leaf in the tree has complex dtype.
+    """
+
     def _has_complex_dtype(x):
+        #  Returns true if x is complex
         return jnp.issubdtype(x.dtype, jnp.complexfloating)
 
-    #  True if at least one parameter is complex
     return any(jax.tree_leaves(jax.tree_map(_has_complex_dtype, pars)))
 
 
 def outdtype(forward_fn, pars, v):
+    """
+    Returns the dtype of forward_fn(pars, v)
+    """
     if v.ndim > 1:
         v = v.reshape(-1, v.shape[-1])[0, :]
     return forward_scalar(pars, forward_fn, v).dtype
 
 
 def outdtype_iscomplex(forward_fn, pars, v):
+    """
+    Returns true if forward_fn(pars, v) is complex
+    """
     return jnp.issubdtype(outdtype(forward_fn, pars, v), jnp.complexfloating)
 
 

--- a/netket/machine/_jax_utils.py
+++ b/netket/machine/_jax_utils.py
@@ -17,7 +17,13 @@ from functools import partial
 
 import numpy as _np
 from jax import numpy as jnp
-from jax.tree_util import tree_flatten, tree_unflatten, tree_map, tree_multimap
+from jax.tree_util import (
+    tree_flatten,
+    tree_unflatten,
+    tree_map,
+    tree_multimap,
+    tree_leaves,
+)
 
 
 def forward_scalar(pars, forward_fn, x):
@@ -32,6 +38,15 @@ forward_apply = jax.jit(
 )
 
 ##
+@jax.jit
+def tree_size(tree):
+    """
+    Returns the sum of the size of all leaves in the tree.
+    It's equivalent to the number of scalars in the pytree.
+    """
+    return sum(tree_leaves(tree_map(lambda x: x.size, tree)))
+
+
 def tree_leaf_iscomplex(pars):
     """
     Returns true if at least one leaf in the tree has complex dtype.

--- a/netket/machine/abstract_machine.py
+++ b/netket/machine/abstract_machine.py
@@ -5,20 +5,13 @@ import numpy as _np
 class AbstractMachine(abc.ABC):
     """Abstract class for NetKet machines"""
 
-    def __init__(self, hilbert, dtype=complex, outdtype=None):
+    def __init__(self, hilbert, dtype=complex):
         super().__init__()
         self.hilbert = hilbert
 
         if dtype is not float and dtype is not complex:
             raise TypeError("dtype must be either float or complex")
 
-        if outdtype is None:
-            outdtype = dtype
-
-        elif outdtype is not float and outdtype is not complex:
-            raise TypeError("outdtype must be either float or complex or None")
-
-        self._outdtype = outdtype
         self._dtype = dtype
 
     @abc.abstractmethod
@@ -161,10 +154,6 @@ class AbstractMachine(abc.ABC):
     @property
     def dtype(self):
         return self._dtype
-
-    @property
-    def outdtype(self):
-        return self._outdtype
 
     @property
     def has_complex_parameters(self):

--- a/netket/machine/density_matrix/abstract_density_matrix.py
+++ b/netket/machine/density_matrix/abstract_density_matrix.py
@@ -7,8 +7,8 @@ import numpy as _np
 class AbstractDensityMatrix(AbstractMachine):
     """Abstract class for NetKet density matrices"""
 
-    def __init__(self, hilbert, dtype, outdtype=complex):
-        super().__init__(hilbert, dtype, outdtype)
+    def __init__(self, hilbert, dtype):
+        super().__init__(hilbert, dtype)
 
     @abc.abstractmethod
     def log_val(self, xr, xc=None, out=None):

--- a/netket/machine/density_matrix/diagonal.py
+++ b/netket/machine/density_matrix/diagonal.py
@@ -8,7 +8,6 @@ class Diagonal(AbstractMachine):
         super().__init__(
             density_matrix.hilbert,
             dtype=density_matrix.dtype,
-            outdtype=density_matrix.outdtype,
         )
 
     def log_val(self, x, out=None):

--- a/netket/machine/density_matrix/jax.py
+++ b/netket/machine/density_matrix/jax.py
@@ -22,7 +22,7 @@ from functools import partial
 
 
 class Jax(JaxPure, AbstractDensityMatrix):
-    def __init__(self, hilbert, module, dtype=complex, outdtype=complex):
+    def __init__(self, hilbert, module, dtype=complex):
         """
         Wraps a stax network (which is a tuple of `init_fn` and `predict_fn`)
         so that it can be used as a NetKet density matrix.
@@ -35,8 +35,8 @@ class Jax(JaxPure, AbstractDensityMatrix):
             dtype: either complex or float, is the type used for the weights.
                 In both cases the module must have a single output.
         """
-        AbstractDensityMatrix.__init__(self, hilbert, dtype, outdtype)
-        JaxPure.__init__(self, hilbert, module, dtype, outdtype)
+        AbstractDensityMatrix.__init__(self, hilbert, dtype)
+        JaxPure.__init__(self, hilbert, module, dtype)
 
         assert self.input_size == self.hilbert.size * 2
 
@@ -188,7 +188,6 @@ def NdmSpin(hilbert, alpha, beta, use_hidden_bias=True):
             SumLayer,
         ),
         dtype=float,
-        outdtype=complex,
     )
 
 
@@ -424,7 +423,7 @@ def NdmSpinPhase(hilbert, alpha, beta, use_hidden_bias=True, use_visible_bias=Tr
             stax.FanInSum,
         )
 
-    return Jax(hilbert, net, dtype=float, outdtype=complex)
+    return Jax(hilbert, net, dtype=float)
 
 
 def JaxRbmSpin(hilbert, alpha, dtype=complex):
@@ -432,5 +431,4 @@ def JaxRbmSpin(hilbert, alpha, dtype=complex):
         hilbert,
         stax.serial(stax.Dense(alpha * hilbert.size * 2), LogCoshLayer, SumLayer),
         dtype=dtype,
-        outdtype=dtype,
     )

--- a/netket/machine/density_matrix/rbm.py
+++ b/netket/machine/density_matrix/rbm.py
@@ -14,7 +14,7 @@ class RbmSpin(AbstractDensityMatrix):
         automorphisms=None,
         dtype=complex,
     ):
-        super().__init__(hilbert, dtype=dtype, outdtype=complex)
+        super().__init__(hilbert, dtype=dtype)
 
         if automorphisms is not None:
             if isinstance(automorphisms, netket.graph.AbstractGraph):

--- a/netket/machine/jax.py
+++ b/netket/machine/jax.py
@@ -29,7 +29,7 @@ from ._jax_utils import forward_apply, grad, vjp
 
 
 class Jax(AbstractMachine):
-    def __init__(self, hilbert, module, dtype=complex, outdtype=None):
+    def __init__(self, hilbert, module, dtype=complex):
         """
         Wraps a stax network (which is a tuple of `init_fn` and `predict_fn`)
         so that it can be used as a NetKet machine.
@@ -42,7 +42,7 @@ class Jax(AbstractMachine):
             dtype: either complex or float, is the type used for the weights.
                 In both cases the network must have a single output.
         """
-        super().__init__(hilbert=hilbert, dtype=dtype, outdtype=outdtype)
+        super().__init__(hilbert=hilbert, dtype=dtype)
 
         self._npdtype = _np.complex128 if dtype is complex else _np.float64
 
@@ -502,5 +502,4 @@ def JaxRbmSpinPhase(hilbert, alpha, dtype=float):
             FanInSum2ModPhase,
         ),
         dtype=dtype,
-        outdtype=complex,
     )

--- a/netket/machine/jax.py
+++ b/netket/machine/jax.py
@@ -25,7 +25,7 @@ from jax import random
 from netket.random import randint as _randint
 from jax.tree_util import tree_flatten, tree_unflatten, tree_map
 
-from ._jax_utils import forward_apply, grad_CC, grad_RC, grad_RR, vjp_CC, vjp_RC, vjp_RR
+from ._jax_utils import forward_apply, grad, vjp
 
 
 class Jax(AbstractMachine):
@@ -50,20 +50,8 @@ class Jax(AbstractMachine):
 
         self._forward_fn = lambda pars, x: forward_apply(pars, self._forward_fn_nj, x)
 
-        # C-> C
-        if self._dtype is complex and self._outdtype is complex:
-            self._perex_grads = grad_CC
-            self._vjp_fun = vjp_CC
-        # R->R
-        elif self._dtype is float and self._outdtype is float:
-            self._perex_grads = grad_RR
-            self._vjp_fun = vjp_RR
-        # R->C
-        elif self._dtype is float and self._outdtype is complex:
-            self._perex_grads = grad_RC
-            self._vjp_fun = vjp_RC
-        else:
-            raise ValueError("We do not support C->R wavefunctions.")
+        self._vjp_fun = vjp
+        self._perex_grads = grad
 
         self.jax_init_parameters()
 

--- a/netket/machine/rbm.py
+++ b/netket/machine/rbm.py
@@ -736,7 +736,7 @@ class RbmSpinPhase(AbstractMachine):
 
         self._n_par = self._rbm_a.n_par + self._rbm_p.n_par
 
-        super().__init__(hilbert, dtype=float, outdtype=complex)
+        super().__init__(hilbert, dtype=float)
 
     @property
     def n_par(self):

--- a/netket/machine/torch.py
+++ b/netket/machine/torch.py
@@ -19,7 +19,7 @@ def _get_differentiable_parameters(m):
 
 
 class Torch(AbstractMachine):
-    def __init__(self, module, hilbert, dtype=float, outdtype=None, use_backpack=False):
+    def __init__(self, module, hilbert, dtype=float, use_backpack=False):
         self._module = _torch.jit.load(module) if isinstance(module, str) else module
         self._module.double()
         self._n_par = _get_number_parameters(self._module)
@@ -30,7 +30,7 @@ class Torch(AbstractMachine):
                 raise RuntimeError("BackPACK was not successfully imported")
             self._module = backpack.extend(self._module)
         # TODO check that module has input shape compatible with hilbert size
-        super().__init__(hilbert, dtype=dtype, outdtype=outdtype)
+        super().__init__(hilbert, dtype=dtype)
 
     @property
     def parameters(self):


### PR DESCRIPTION
This is extracted from #490, as it is more general.

This PR does mainly two things:
 - Remove all the logic to select the correct R->R, R->C, C->C vjp/grad kernel from JaxMachine and puts it in the jvp kernel itself.
   - Before, when declaring a jax machine you had to declare the (homogeneous) type of all parameters as well as the expected output type. With this PR, both are inferred automatically. 
   - An added benefit is that our custom `vjp` now supports any arbitrary mix of real and complex parameters!
   - All this inference logic is used inside `@jit` blocks, so it has no runtime cost.

- Remove all machine member `outdtype`, as it is no longer needed (as described above, it's inferred when needed).

An extra change is in the way `netket.vmc_common.tree_map` is defined: if there is no jax, then we still use our definition, but if jax is present we use jax's version, which is slightly more general and will allow us to work with Flax and other frameworks.

While this PR does not yet allow us to use arbitrary weights, it brings us almost at the finish line.
