### PR TITLE
Add PRNGSeq type and some tests

### DIFF
--- a/Test/MPI/test_mpi_utils.py
+++ b/Test/MPI/test_mpi_utils.py
@@ -1,0 +1,33 @@
+# Copyright 2021 The NetKet Authors - All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#    http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import jax.numpy as jnp
+from mpi4py import MPI
+import pytest
+
+import netket as nk
+
+size = MPI.COMM_WORLD.size
+
+
+@pytest.mark.skipif(size < 2, reason="need at least 2 processes to test MPI")
+def test_key_split():
+    key = nk.jax.PRNGKey(1256)
+
+    keys = MPI.COMM_WORLD.allgather(key)
+    assert all([jnp.all(k == key) for k in keys])
+
+    key = nk.jax.mpi_split(key)
+    keys = MPI.COMM_WORLD.allgather(key)
+    assert all([not jnp.all(k == keys) for k in keys])

--- a/Test/Utils/test_utils.py
+++ b/Test/Utils/test_utils.py
@@ -18,9 +18,8 @@ import jax.numpy as jnp
 
 
 def test_PRNGSeq():
-    k = PRNGKey()
-
-    seq = PRNGSeq(k)
+    k = PRNGKey(44)
+    seq = PRNGSeq()
     k1 = next(seq)
     k2 = next(seq)
 
@@ -29,6 +28,6 @@ def test_PRNGSeq():
     keys = seq.take(4)
     assert keys.shape == (4, 2)
 
-    seq1 = PRNGSeq(k)
-    seq2 = PRNGSeq(k)
+    seq1 = PRNGSeq(12)
+    seq2 = PRNGSeq(12)
     assert jnp.all(seq1.take(10) == seq2.take(10))

--- a/Test/Utils/test_utils.py
+++ b/Test/Utils/test_utils.py
@@ -12,27 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .utils import (
-    tree_ravel,
-    is_complex,
-    is_complex_dtype,
-    tree_size,
-    eval_shape,
-    tree_leaf_iscomplex,
-    dtype_complex,
-    dtype_real,
-    maybe_promote_to_complex,
-    HashablePartial,
-    mpi_split,
-    PRNGKey,
-    PRNGSeq,
-)
+from netket.jax import PRNGKey, PRNGSeq
 
-from ._vjp import vjp
-from ._grad import grad, value_and_grad
+import jax.numpy as jnp
 
-from ._expect import expect
 
-from netket.utils import _hide_submodules
+def test_PRNGSeq():
+    k = PRNGKey()
 
-_hide_submodules(__name__)
+    seq = PRNGSeq(k)
+    k1 = next(seq)
+    k2 = next(seq)
+
+    assert k is not k1 and k1 is not k2
+
+    keys = seq.take(4)
+    assert keys.shape == (4, 2)
+
+    seq1 = PRNGSeq(k)
+    seq2 = PRNGSeq(k)
+    assert jnp.all(seq1.take(10) == seq2.take(10))

--- a/netket/jax/utils.py
+++ b/netket/jax/utils.py
@@ -214,9 +214,11 @@ class PRNGSeq:
     A sequence of PRNG keys genrated based on an initial key.
     """
 
-    def __init__(self, base_key: Optional[PRNGKeyType] = None):
+    def __init__(self, base_key: Optional[Union[int, PRNGKeyType]] = None):
         if base_key is None:
             base_key = PRNGKey()
+        elif isinstance(base_key, int):
+            base_key = PRNGKey(base_key)
         self._current = base_key
 
     def __iter__(self):

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ DEV_DEPENDENCIES = [
     "pre-commit",
     "black==20.8b1",
 ]
-MPI_DEPENDENCIES = ["mpi4py>=3.0.1", "mpi4jax>=0.2.9"]
+MPI_DEPENDENCIES = ["mpi4py>=3.0.1", "mpi4jax>=0.2.10"]
 TENSORBOARD_DEPENDENCIES = ["tensorboardx>=2.0.0"]
 BASE_DEPENDENCIES = [
     "numpy>=1.20",


### PR DESCRIPTION
In order to make it a bit more convenient to derive `PRNGKey`s from one initial key, this PR adds a `PRNGSeq` type (inspired by Haiku's `PRNGSequence`, though it does not share the implementation -- I think this simpler implementation should be sufficient for our purposes).
```python
>>> hi = netket.hilbert.Spin(s=1/2, N=10)
>>> rseq = netket.jax.PRNGSeq(12)
>>> hi.random_state(next(rseq))
DeviceArray([ 1., -1., -1., -1., -1., -1.,  1., -1., -1., -1.], dtype=float32)
>>> nk.variational.MCState(..., seed=next(rseq))
```

(This is a PR on branch `nk3`, if it is merged into `master` soon it can of course be retargeted.)

This also bumps the required version of `mpi4jax>=0.2.10`, since the test of `mpi_split` added here was failing for me without it.