### PR TITLE
New logging 

### DIFF
--- a/Examples/Ising1d/plot_ising.py
+++ b/Examples/Ising1d/plot_ising.py
@@ -1,0 +1,58 @@
+import numpy as np
+import matplotlib.pyplot as plt
+import json
+
+plt.ion()
+
+# N=20
+exact = -1.274549484318e00 * 20
+
+# N=80
+# exact=-1.273321360724e+00*80
+
+while True:
+    plt.clf()
+    plt.ylabel("Energy")
+    plt.xlabel("Iteration #")
+
+    data = json.load(open("test.log"))
+    iters = data["Energy"]["Mean"]["iters"]
+    energy = data["Energy"]["Mean"]["values"]
+    sigma = data["Energy"]["Sigma"]["values"]
+    evar = data["Energy"]["Variance"]["values"]
+
+    nres = len(iters)
+    cut = 60
+    if nres > cut:
+
+        fitx = iters[-cut:-1]
+        fity = energy[-cut:-1]
+        z = np.polyfit(fitx, fity, deg=0)
+        p = np.poly1d(z)
+
+        plt.xlim([nres - cut, nres])
+        maxval = np.max(energy[-cut:-1])
+        plt.ylim([exact - (np.abs(exact) * 0.01), maxval + np.abs(maxval) * 0.01])
+        error = (z[0] - exact) / -exact
+        plt.gca().text(
+            0.95,
+            0.8,
+            "Relative Error : " + "{:.2e}".format(error),
+            verticalalignment="bottom",
+            horizontalalignment="right",
+            color="green",
+            fontsize=15,
+            transform=plt.gca().transAxes,
+        )
+
+        plt.plot(fitx, p(fitx))
+
+    plt.errorbar(iters, energy, yerr=sigma, color="red")
+    plt.axhline(y=exact, xmin=0, xmax=iters[-1], linewidth=2, color="k", label="Exact")
+
+    plt.legend(frameon=False)
+    plt.pause(1)
+    # plt.draw()
+
+plt.ioff()
+plt.show()

--- a/netket/drivers/abstract_variational_driver.py
+++ b/netket/drivers/abstract_variational_driver.py
@@ -259,6 +259,8 @@ class AbstractVariationalDriver(abc.ABC):
         for logger in loggers:
             logger.flush(self.state)
 
+        return loggers
+
     def estimate(self, observables):
         """
         Return MCMC statistics for the expectation value of observables in the

--- a/netket/logging/__init__.py
+++ b/netket/logging/__init__.py
@@ -1,6 +1,12 @@
-from ._json_log import JsonLog
+from .json_log import JsonLog
+from .json_log_old import JsonLog as JsonLogOld
+from .runtime_log import RuntimeLog
+from netket.utils import tensorboard_available as _tensorboard_available
 
-from ..utils import tensorboard_available
-
-if tensorboard_available:
+if _tensorboard_available:
     from .tensorboard import TBLog
+
+
+from netket.utils import _hide_submodules
+
+_hide_submodules(__name__)

--- a/netket/logging/json_log.py
+++ b/netket/logging/json_log.py
@@ -1,0 +1,153 @@
+import json
+import dataclasses
+import orjson
+
+import os
+from os import path as _path
+import numpy as np
+import jax
+
+from flax import serialization
+
+from jax.tree_util import tree_map
+
+from .runtime_log import RuntimeLog
+
+
+def _exists_json(prefix):
+    return _path.exists(prefix + ".log") or _path.exists(prefix + ".mpack")
+
+
+def default(obj):
+    if hasattr(obj, "to_json"):
+        return obj.to_json()
+    elif hasattr(obj, "to_dict"):
+        return obj.to_dict()
+    elif isinstance(obj, np.ndarray):
+        if np.issubdtype(obj.dtype, np.complexfloating):
+            return {"real": obj.real, "imag": obj.imag}
+        else:
+            if obj.ndim == 0:
+                return obj.item()
+            elif obj.ndim == 1:
+                return obj.tolist()
+            else:
+                raise TypeError
+
+    elif hasattr(obj, "_device"):
+        return np.array(obj)
+    elif isinstance(obj, complex):
+        return {"real": obj.real, "imag": obj.imag}
+
+    raise TypeError
+
+
+class JsonLog(RuntimeLog):
+    """
+    Creates a Json Logger sink object, that can be passed with keyword argument `logger` to Monte
+    Carlo drivers in order to serialize the outpit data of the simulation.
+
+    If the model state is serialized, then it is serialized using the msgpack protocol of flax.
+    For more information on how to de-serialize the output, see
+    `here <https://flax.readthedocs.io/en/latest/flax.serialization.html>`_
+
+    Args:
+        output_prefix: the name of the output files before the extension
+        save_params_every: every how many iterations should machine parameters be flushed to file
+        write_every: every how many iterations should data be flushed to file
+        mode: Specify the behaviour in case the file already exists at this output_prefix. Options
+        are
+        - `[w]rite`: (default) overwrites file if it already exists;
+        - `[a]ppend`: appends to the file if it exists, overwise creates a new file;
+        - `[x]` or `fail`: fails if file already exists;
+    """
+
+    def __init__(
+        self, output_prefix, mode="write", save_params_every=50, write_every=50
+    ):
+        super().__init__()
+
+        # Shorthands for mode
+        if mode == "w":
+            mode = "write"
+        elif mode == "a":
+            mode = "append"
+        elif mode == "x":
+            mode = "fail"
+
+        if not ((mode == "write") or (mode == "append") or (mode == "fail")):
+            raise ValueError(
+                "Mode not recognized: should be one of `[w]rite`, `[a]ppend` or `[x]`(fail)."
+            )
+
+        file_exists = _exists_json(output_prefix)
+
+        starting_json_content = {"Output": []}
+
+        if file_exists and mode == "append":
+            # if there is only the .mpacck file but not the json one, raise an error
+            if not _path.exists(output_prefix + ".log"):
+                raise ValueError(
+                    "History file does not exists, but wavefunction file does. Please change `output_prefix or set mode=`write`."
+                )
+
+            starting_json_content = json.load(open(output_prefix + ".log"))
+
+        elif file_exists and mode == "fail":
+            raise ValueError(
+                "Output file already exists. Either delete it manually or change `output_prefix`."
+            )
+
+        dir_name = _path.dirname(output_prefix)
+        if dir_name is not "":
+            os.makedirs(dir_name, exist_ok=True)
+
+        self._prefix = output_prefix
+        self._write_every = write_every
+        self._save_params_every = save_params_every
+        self._old_step = 0
+        self._steps_notflushed_write = 0
+        self._steps_notflushed_pars = 0
+
+    def __call__(self, step, item, variational_state):
+        old_step = self._old_step
+        super().__call__(step, item, variational_state)
+
+        if (
+            self._steps_notflushed_write % self._write_every == 0
+            or step == old_step - 1
+        ):
+            self._flush_log()
+        if (
+            self._steps_notflushed_pars % self._save_params_every == 0
+            or step == old_step - 1
+        ):
+            self._flush_params(variational_state)
+
+        self._old_step = step
+        self._steps_notflushed_write += 1
+        self._steps_notflushed_pars += 1
+
+    def _flush_log(self):
+        with open(self._prefix + ".log", "wb") as outfile:
+
+            outfile.write(orjson.dumps(self.data, default=default))
+            self._steps_notflushed_write = 0
+
+    def _flush_params(self, variational_state):
+        binary_data = serialization.to_bytes(variational_state.variables)
+        with open(self._prefix + ".mpack", "wb") as outfile:
+            outfile.write(binary_data)
+
+        self._steps_notflushed_pars = 0
+
+    def flush(self, variational_state):
+        """
+        Writes to file the content of this logger.
+
+        :param machine: optionally also writes the parameters of the machine.
+        """
+        self._flush_log()
+
+        if variational_state is not None:
+            self._flush_params(variational_state)

--- a/netket/logging/json_log.py
+++ b/netket/logging/json_log.py
@@ -99,7 +99,7 @@ class JsonLog(RuntimeLog):
             )
 
         dir_name = _path.dirname(output_prefix)
-        if dir_name is not "":
+        if dir_name != "":
             os.makedirs(dir_name, exist_ok=True)
 
         self._prefix = output_prefix

--- a/netket/logging/runtime_log.py
+++ b/netket/logging/runtime_log.py
@@ -1,0 +1,49 @@
+import dataclasses
+from functools import partial
+
+from os import path as _path
+
+from flax import serialization
+
+from jax.tree_util import tree_map
+
+from netket.utils import History, accum_histories_in_tree
+
+
+class RuntimeLog:
+    """
+    Creates a Json Logger sink object, that can be passed with keyword argument `logger` to Monte
+    Carlo drivers in order to serialize the outpit data of the simulation.
+
+    If the model state is serialized, then it is serialized using the msgpack protocol of flax.
+    For more information on how to de-serialize the output, see
+    `here <https://flax.readthedocs.io/en/latest/flax.serialization.html>`_
+
+    Args:
+        output_prefix: the name of the output files before the extension
+        save_params_every: every how many iterations should machine parameters be flushed to file
+        write_every: every how many iterations should data be flushed to file
+        mode: Specify the behaviour in case the file already exists at this output_prefix. Options
+        are
+        - `[w]rite`: (default) overwrites file if it already exists;
+        - `[a]ppend`: appends to the file if it exists, overwise creates a new file;
+        - `[x]` or `fail`: fails if file already exists;
+    """
+
+    def __init__(self):
+        self._data = None
+        self._old_step = 0
+
+    def __call__(self, step, item, variational_state):
+        self._data = accum_histories_in_tree(self._data, item, step=step)
+        self._old_step = step
+
+    @property
+    def data(self):
+        return self._data
+
+    def __getitem__(self, key):
+        return self.data[key]
+
+    def flush(self, variational_state):
+        pass

--- a/netket/operator/boson.py
+++ b/netket/operator/boson.py
@@ -2,10 +2,12 @@ from numpy.typing import DTypeLike
 
 from netket.hilbert import AbstractHilbert
 
+from ._local_operator import LocalOperator as _LocalOperator
+
 
 def destroy(
     hilbert: AbstractHilbert, site: int, dtype: DTypeLike = float
-) -> "LocalOperator":
+) -> _LocalOperator:
     """
     Builds the boson destruction operator acting on the `site`-th of the
      Hilbert space `hilbert`.
@@ -21,18 +23,17 @@ def destroy(
         The resulting Local Operator
     """
     import numpy as np
-    from ._local_operator import LocalOperator
 
     N = hilbert.size_at_index(site)
 
     D = np.array([np.sqrt(m) for m in np.arange(1, N)])
     mat = np.diag(D, 1)
-    return LocalOperator(hilbert, mat, [site], dtype=dtype)
+    return _LocalOperator(hilbert, mat, [site], dtype=dtype)
 
 
 def create(
     hilbert: AbstractHilbert, site: int, dtype: DTypeLike = float
-) -> "LocalOperator":
+) -> _LocalOperator:
     """
     Builds the boson creation operator acting on the `site`-th of the
      Hilbert space `hilbert`.
@@ -48,18 +49,17 @@ def create(
         The resulting Local Operator
     """
     import numpy as np
-    from ._local_operator import LocalOperator
 
     N = hilbert.size_at_index(site)
 
     D = np.array([np.sqrt(m) for m in np.arange(1, N)])
     mat = np.diag(D, -1)
-    return LocalOperator(hilbert, mat, [site], dtype=dtype)
+    return _LocalOperator(hilbert, mat, [site], dtype=dtype)
 
 
 def number(
     hilbert: AbstractHilbert, site: int, dtype: DTypeLike = float
-) -> "LocalOperator":
+) -> _LocalOperator:
     """
     Builds the number operator acting on the `site`-th of the
     Hilbert space `hilbert`.
@@ -75,18 +75,17 @@ def number(
         The resulting Local Operator
     """
     import numpy as np
-    from ._local_operator import LocalOperator
 
     N = hilbert.size_at_index(site)
 
     D = np.array([m for m in np.arange(0, N)])
     mat = np.diag(D, 0)
-    return LocalOperator(hilbert, mat, [site], dtype=dtype)
+    return _LocalOperator(hilbert, mat, [site], dtype=dtype)
 
 
 def proj(
     hilbert: AbstractHilbert, site: int, n: int, dtype: DTypeLike = float
-) -> "LocalOperator":
+) -> _LocalOperator:
     """
     Builds the projector operator acting on the `site`-th of the
     Hilbert space `hilbert` and collapsing on the state with `n` bosons.
@@ -103,7 +102,6 @@ def proj(
         the resulting operator
     """
     import numpy as np
-    from ._local_operator import LocalOperator
 
     N = hilbert.size_at_index(site)
 
@@ -113,7 +111,7 @@ def proj(
     D = np.array([0 for m in np.arange(0, N)])
     D[n] = 1
     mat = np.diag(D, 0)
-    return LocalOperator(hilbert, mat, [site], dtype=dtype)
+    return _LocalOperator(hilbert, mat, [site], dtype=dtype)
 
 
 # clean up the module

--- a/netket/operator/spin.py
+++ b/netket/operator/spin.py
@@ -1,8 +1,12 @@
 from netket.hilbert import AbstractHilbert
 from numpy.typing import DTypeLike
 
+from ._local_operator import LocalOperator as _LocalOperator
 
-def sigmax(hilbert: AbstractHilbert, site: int, dtype: DTypeLike = float):
+
+def sigmax(
+    hilbert: AbstractHilbert, site: int, dtype: DTypeLike = float
+) -> _LocalOperator:
     """
     Builds the sigma_x operator acting on the `site`-th of the Hilbert
     space `hilbert`.
@@ -15,17 +19,18 @@ def sigmax(hilbert: AbstractHilbert, site: int, dtype: DTypeLike = float):
     :return: a nk.operator.LocalOperator
     """
     import numpy as np
-    from ._local_operator import LocalOperator
 
     N = hilbert.size_at_index(site)
     S = (N - 1) / 2
 
     D = [np.sqrt((S + 1) * 2 * a - a * (a + 1)) for a in np.arange(1, N)]
     mat = np.diag(D, 1) + np.diag(D, -1)
-    return LocalOperator(hilbert, mat, [site], dtype=dtype)
+    return _LocalOperator(hilbert, mat, [site], dtype=dtype)
 
 
-def sigmay(hilbert: AbstractHilbert, site: int, dtype: DTypeLike = complex):
+def sigmay(
+    hilbert: AbstractHilbert, site: int, dtype: DTypeLike = complex
+) -> _LocalOperator:
     """
     Builds the sigma_y operator acting on the `site`-th of the Hilbert
     space `hilbert`.
@@ -38,17 +43,18 @@ def sigmay(hilbert: AbstractHilbert, site: int, dtype: DTypeLike = complex):
     :return: a nk.operator.LocalOperator
     """
     import numpy as np
-    from ._local_operator import LocalOperator
 
     N = hilbert.size_at_index(site)
     S = (N - 1) / 2
 
     D = np.array([1j * np.sqrt((S + 1) * 2 * a - a * (a + 1)) for a in np.arange(1, N)])
     mat = np.diag(D, -1) + np.diag(-D, 1)
-    return LocalOperator(hilbert, mat, [site], dtype=dtype)
+    return _LocalOperator(hilbert, mat, [site], dtype=dtype)
 
 
-def sigmaz(hilbert: AbstractHilbert, site: int, dtype: DTypeLike = float):
+def sigmaz(
+    hilbert: AbstractHilbert, site: int, dtype: DTypeLike = float
+) -> _LocalOperator:
     """
     Builds the sigma_z operator acting on the `site`-th of the Hilbert
     space `hilbert`.
@@ -61,17 +67,18 @@ def sigmaz(hilbert: AbstractHilbert, site: int, dtype: DTypeLike = float):
     :return: a nk.operator.LocalOperator
     """
     import numpy as np
-    from ._local_operator import LocalOperator
 
     N = hilbert.size_at_index(site)
     S = (N - 1) / 2
 
     D = np.array([2 * m for m in np.arange(S, -(S + 1), -1)])
     mat = np.diag(D, 0)
-    return LocalOperator(hilbert, mat, [site], dtype=dtype)
+    return _LocalOperator(hilbert, mat, [site], dtype=dtype)
 
 
-def sigmam(hilbert: AbstractHilbert, site: int, dtype: DTypeLike = float):
+def sigmam(
+    hilbert: AbstractHilbert, site: int, dtype: DTypeLike = float
+) -> _LocalOperator:
     """
     Builds the $sigma_- = sigma_x - im * sigma_y$ operator acting on the
     `site`-th of the Hilbert space `hilbert`.
@@ -84,7 +91,6 @@ def sigmam(hilbert: AbstractHilbert, site: int, dtype: DTypeLike = float):
     :return: a nk.operator.LocalOperator
     """
     import numpy as np
-    from ._local_operator import LocalOperator
 
     N = hilbert.size_at_index(site)
     S = (N - 1) / 2
@@ -92,10 +98,12 @@ def sigmam(hilbert: AbstractHilbert, site: int, dtype: DTypeLike = float):
     S2 = (S + 1) * S
     D = np.array([np.sqrt(S2 - m * (m - 1)) for m in np.arange(S, -S, -1)])
     mat = np.diag(D, -1)
-    return LocalOperator(hilbert, mat, [site], dtype=dtype)
+    return _LocalOperator(hilbert, mat, [site], dtype=dtype)
 
 
-def sigmap(hilbert: AbstractHilbert, site: int, dtype: DTypeLike = float):
+def sigmap(
+    hilbert: AbstractHilbert, site: int, dtype: DTypeLike = float
+) -> _LocalOperator:
     """
     Builds the $sigma_- = sigma_x + im * sigma_y$ operator acting on the
     `site`-th of the Hilbert space `hilbert`.
@@ -108,7 +116,6 @@ def sigmap(hilbert: AbstractHilbert, site: int, dtype: DTypeLike = float):
     :return: a nk.operator.LocalOperator
     """
     import numpy as np
-    from ._local_operator import LocalOperator
 
     N = hilbert.size_at_index(site)
     S = (N - 1) / 2
@@ -116,7 +123,7 @@ def sigmap(hilbert: AbstractHilbert, site: int, dtype: DTypeLike = float):
     S2 = (S + 1) * S
     D = np.array([np.sqrt(S2 - m * (m + 1)) for m in np.arange(S - 1, -(S + 1), -1)])
     mat = np.diag(D, 1)
-    return LocalOperator(hilbert, mat, [site], dtype=dtype)
+    return _LocalOperator(hilbert, mat, [site], dtype=dtype)
 
 
 # clean up the module

--- a/netket/stats/mc_stats.py
+++ b/netket/stats/mc_stats.py
@@ -54,6 +54,10 @@ class Stats:
         jsd["TauCorr"] = self.tau_corr.item()
         return jsd
 
+    def to_compound(self):
+        return "Mean", self.to_dict()
+
+    # Remove this method once we remove legacy.
     def to_json(self):
         jsd = {}
         jsd["Mean"] = float(self.mean.real)

--- a/netket/utils/__init__.py
+++ b/netket/utils/__init__.py
@@ -30,6 +30,8 @@ from .moduletools import _hide_submodules, rename_class
 
 from .model_frameworks import maybe_wrap_module
 
+from .history import History, accum_in_tree, accum_histories_in_tree
+
 jax_available = True
 flax_available = True
 mpi4jax_available = mpi_available

--- a/netket/utils/history.py
+++ b/netket/utils/history.py
@@ -1,0 +1,156 @@
+import numpy as np
+from numbers import Number
+
+
+class History:
+    """
+    A class to store a time-series of scalar data.
+
+    It has two member variables, `iter` and `values`.
+    The first stores the `time` of the time series, while `values`
+    stores the values at each iteration.
+    """
+
+    def __init__(self, values=[], iters=None, dtype=None, iter_dtype=None):
+        if isinstance(values, Number):
+            values = np.array([values], dtype=dtype)
+
+        if iters is None:
+            if iter_dtype is None:
+                iter_dtype = np.int32
+            iters = np.arange(len(values), dtype=iter_dtype)
+
+        elif isinstance(iters, Number):
+            iters = np.array([iters], dtype=iter_dtype)
+
+        if len(values) != len(iters):
+            raise ErrorException("Not matching lengths")
+
+        self.iters = np.array(iters, dtype=iter_dtype)
+        self.values = np.array(values, dtype=dtype)
+
+    def append(self, val, it=None):
+        """
+        Append another value to this history object.
+
+        Args:
+            val: the value in the next timestep
+            it: the time corresponding to this new value. If
+                not defined, increment by 1.
+        """
+        if isinstance(val, History):
+            self.values = np.concatenate([self.values, val.values])
+            self.iters = np.concatenate([self.iters, val.iters])
+            return
+
+        try:
+            self.values.resize(len(self.values) + 1)
+        except:
+            self.values = np.resize(self.values, (len(self.values) + 1))
+
+        try:
+            self.iters.resize(len(self.iters) + 1)
+        except:
+            self.iters = np.resize(self.iters, (len(self.iters) + 1))
+
+        if it is None:
+            it = self.iters[-1] - self.iters[-2]
+
+        self.values[-1] = val
+        self.iters[-1] = it
+
+    def get(self):
+        """
+        Returns a tuple containing times and values of this history object
+        """
+        return self.iters, self.values
+
+    def to_dict(self):
+        """
+        Converts the history object to dict.
+
+        Used for serialization
+        """
+        return {"iters": self.iters, "values": self.values}
+
+    def __array__(self, *args, **kwargs):
+        """
+        Automatically transform this object to a numpy array when calling
+        asarray, by only considering the values and neglecting the times.
+        """
+        return np.array(self.values, *args, **kwargs)
+
+    def __iter__(self):
+        """
+        You can iterate the values in history object.
+        """
+        """ Returns the Iterator object """
+        return iter(zip(self.iters, self.values))
+
+
+from functools import partial
+from jax.tree_util import tree_map
+
+
+def accum_in_tree(fun, tree_accum, tree, **kwargs):
+    """
+    Maps all the leafs in the two trees, applying the function with the leafs of tree1
+    as first argument and the leafs of tree2 as second argument
+    Any additional argument after the first two is forwarded to the function call.
+
+    This is usefull e.g. to sum the leafs of two trees
+
+    Args:
+        fun: the function to apply to all leafs
+        tree1: the structure containing leafs. This can also be just a leaf
+        tree2: the structure containing leafs. This can also be just a leaf
+        *args: additional positional arguments passed to fun
+        **kwargs: additional kw arguments passed to fun
+
+    Returns:
+        An equivalent tree, containing the result of the function call.
+    """
+    if tree is None:
+        return tree_accum
+
+    elif isinstance(tree, list):
+        if tree_accum is None:
+            tree_accum = [None for _ in range(len(tree))]
+
+        return [
+            accum_in_tree(fun, _accum, _tree, **kwargs)
+            for _accum, _tree in zip(tree_accum, tree)
+        ]
+    elif isinstance(tree, tuple):
+        if tree_accum is None:
+            tree_accum = (None for _ in range(len(tree)))
+
+        return tuple(
+            accum_in_tree(fun, _accum, _tree, **kwargs)
+            for _accum, _tree in zip(tree_accum, tree)
+        )
+    elif isinstance(tree, dict):
+        if tree_accum is None:
+            tree_accum = {}
+
+        for key in tree.keys():
+            tree_accum[key] = accum_in_tree(
+                fun, tree_accum.get(key, None), tree[key], **kwargs
+            )
+
+        return tree_accum
+    elif hasattr(tree, "to_dict"):
+        return accum_in_tree(fun, tree_accum, tree.to_dict(), **kwargs)
+    else:
+        return fun(tree_accum, tree, **kwargs)
+
+
+def accum_histories(accum, data, *, step=0):
+    if accum is None:
+        return History([data], step)
+    else:
+        accum.append(data, it=step)
+        return accum
+
+
+accum_histories_in_tree = partial(accum_in_tree, accum_histories)

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ BASE_DEPENDENCIES = [
     "jax>=0.2.9",
     "jaxlib>=0.1.57",
     "flax>=0.3.0",
+    "orjson>=3.4",
     "optax>=0.0.2",
 ]
 


### PR DESCRIPTION
This is my proposal for the new logging system, going alongside nk3

Things I disliked:
 - The output format previously was a json file with a single dict with a key, `output`, with a list of data logged at every iteration, and another key `iterations` with the iteration numbers.
 - To deserialise this format one has to determine the objects logged inside every iterations (some might not always be logged, such as objservables), initialise some accumulators, iterate through every element in `output` and add the right object to the right accumulator. Also, one has then to reconstruct the iteration numbers for objects that are not logged at every iteration

```
{`Output`: [
    { 'Energy': {'Mean': 0.3, 'Variance':....} ,
    { 'Energy': {'Mean': 0.2, 'Variance':....} ,
    { 'Energy': {'Mean': 0.1, 'Variance':....} ,
...
   ],
`Iters`:[1,2,3...]
}
```
Changes:
 - The new output format is still a json file, but now it's simply a dict of time series : 

```
{ 'Energy': {
    'Mean': {'iters':[1,2,3...] , 'values':[0.3, 0.2,0.1....]
    'Variance': {'iters':[1,2,3...] , 'values':[0.01, 0.02,0.01....]
    'Sigma': {'iters':[1,2,3...] , 'values':[0.01, 0.02,0.01....]
}
}
```

this makes it much easier to de-serialize, as simply deserialising with json gives a structure that can be plotted with:
```python
import Matplotlib.pyplot as plt

data = json.load(open("test.log"))

plt.plot(data['Energy']['Mean']['iters'], data['Energy']['Mean']['values']
```

internally, during runtime, all logged quantities are stored in a tree of `History` objects (time-series), that store both the iteration and the values at every iteration. They are then natively serialised to json...
