### PR TITLE
Numba4jax: Numba in HamiltonianSampler

### DIFF
--- a/Examples/Ising1d/ising1d.py
+++ b/Examples/Ising1d/ising1d.py
@@ -29,7 +29,7 @@ ha = nk.operator.Ising(hilbert=hi, graph=g, h=1.0)
 ma = nk.models.RBM(alpha=1, use_visible_bias=True, dtype=float)
 
 # Metropolis Local Sampling
-sa = nk.sampler.MetropolisLocal(hi, n_chains=16)
+sa = nk.sampler.MetropolisHamiltonian(hi, ha, n_chains=16)
 
 # Optimizer
 op = nk.optimizer.Sgd(learning_rate=0.1)

--- a/Test/Sampler/test_sampler.py
+++ b/Test/Sampler/test_sampler.py
@@ -63,6 +63,12 @@ samplers["Metropolis(Hamiltonian): Spin"] = nk.sampler.MetropolisHamiltonian(
     reset_chain=True,
 )
 
+samplers["Metropolis(Hamiltonian,Jax): Spin"] = nk.sampler.MetropolisSampler(
+    hi,
+    rule=nk.sampler.rules.HamiltonianRule(ha.to_local_operator()),
+    reset_chain=True,
+)
+
 samplers["Metropolis(Custom: Sx): Spin"] = nk.sampler.MetropolisCustom(
     hi, move_operators=move_op
 )

--- a/netket/jax/__init__.py
+++ b/netket/jax/__init__.py
@@ -33,6 +33,8 @@ from ._grad import grad, value_and_grad
 
 from ._expect import expect
 
+from .jambax import numba_to_jax, njit4jax
+
 from netket.utils import _hide_submodules
 
 _hide_submodules(__name__)

--- a/netket/jax/__init__.py
+++ b/netket/jax/__init__.py
@@ -33,7 +33,7 @@ from ._grad import grad, value_and_grad
 
 from ._expect import expect
 
-from .jambax import numba_to_jax, njit4jax
+from .numba4jax import numba_to_jax, njit4jax
 
 from netket.utils import _hide_submodules
 

--- a/netket/jax/jambax.py
+++ b/netket/jax/jambax.py
@@ -87,7 +87,14 @@ from jaxlib import xla_extension
 import numba
 from numba import types as nb_types
 import numba.typed as nb_typed
-import numpy as onp
+import numpy as np
+
+
+def _shape_size(shape):
+    sz = 1
+    for dim in shape:
+        sz *= dim
+    return sz
 
 
 def _xla_shape_to_abstract(xla_shape):
@@ -109,10 +116,8 @@ def _create_xla_target_capsule(ptr):
 
 def _np_evaluation_rule(call_fn, abstract_eval_fn, *args, **kwargs):
     output_shapes = abstract_eval_fn(*args)
-    outputs = tuple(
-        onp.empty(shape.shape, dtype=shape.dtype) for shape in output_shapes
-    )
-    inputs = tuple(onp.asarray(arg) for arg in args)
+    outputs = tuple(np.empty(shape.shape, dtype=shape.dtype) for shape in output_shapes)
+    inputs = tuple(np.asarray(arg) for arg in args)
     call_fn(outputs + inputs, **kwargs)
     return tuple(outputs)
 
@@ -124,7 +129,7 @@ def _naive_batching(call_fn, args, batch_axes):
     return tuple(jax.lax.map(lambda x: call_fn(*x), args)), batch_axes
 
 
-def _xla_translation(numba_fn, abstract_eval_fn, xla_builder, *args):
+def _xla_translation_cpu(numba_fn, abstract_eval_fn, xla_builder, *args):
     """Returns the XLA CustomCall for the given numba function.
 
     Args:
@@ -135,6 +140,7 @@ def _xla_translation(numba_fn, abstract_eval_fn, xla_builder, *args):
     Returns:
       The XLA CustomCall operation calling into the numba function.
     """
+    print("encoding jamax cpu")
     input_shapes = [xla_builder.get_shape(arg) for arg in args]
     # TODO(josipd): Check that the input layout is the numpy default.
     output_abstract_arrays = abstract_eval_fn(
@@ -145,7 +151,7 @@ def _xla_translation(numba_fn, abstract_eval_fn, xla_builder, *args):
         dim for array in output_abstract_arrays for dim in array.shape
     )
     output_ndims = tuple(array.ndim for array in output_abstract_arrays)
-    output_ndims_offsets = tuple(onp.cumsum(onp.concatenate([[0], output_ndims])))
+    output_ndims_offsets = tuple(np.cumsum(np.concatenate([[0], output_ndims])))
     output_dtypes = tuple(array.dtype for array in output_abstract_arrays)
     layout_for_shape = lambda shape: range(len(shape) - 1, -1, -1)
     output_layouts = map(layout_for_shape, output_shapes)
@@ -165,7 +171,8 @@ def _xla_translation(numba_fn, abstract_eval_fn, xla_builder, *args):
     n_in = len(input_dimensions)
 
     xla_call_sig = nb_types.void(
-        nb_types.CPointer(nb_types.voidptr), nb_types.CPointer(nb_types.voidptr)
+        nb_types.CPointer(nb_types.voidptr),  # output_ptrs
+        nb_types.CPointer(nb_types.voidptr),  # input_ptrs
     )
 
     @numba.cfunc(xla_call_sig)
@@ -222,7 +229,8 @@ def _xla_translation(numba_fn, abstract_eval_fn, xla_builder, *args):
 
     target_name = xla_custom_call_target.native_name.encode("ascii")
     capsule = _create_xla_target_capsule(xla_custom_call_target.address)
-    xla_extension.register_custom_call_target(target_name, capsule, "Host")
+    xla_client.register_custom_call_target(target_name, capsule, "cpu")
+    # xla_extension.register_custom_call_target(target_name, capsule, "Host")
     return xla_client.ops.CustomCallWithLayout(
         xla_builder,
         target_name,
@@ -230,6 +238,197 @@ def _xla_translation(numba_fn, abstract_eval_fn, xla_builder, *args):
         shape_with_layout=xla_output_shape,
         operand_shapes_with_layout=input_shapes,
     )
+
+
+##
+
+try:
+    import ctypes
+    from numba.extending import get_cython_function_address
+    import cupy_backends
+
+    addr = get_cython_function_address("cupy_backends.cuda.api.runtime", "memcpy")
+    functype = ctypes.CFUNCTYPE(
+        ctypes.c_int, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t, ctypes.c_int
+    )
+    cudaMemcpy = functype(addr)
+
+    #
+    addr = get_cython_function_address("cupy_backends.cuda.api.runtime", "memcpyAsync")
+    functype = ctypes.CFUNCTYPE(
+        ctypes.c_int,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_size_t,
+        ctypes.c_int,
+        ctypes.c_void_p,
+    )
+    cudaMemcpyAsync = functype(addr)
+
+    #
+    addr = get_cython_function_address(
+        "cupy_backends.cuda.api.runtime", "streamSynchronize"
+    )
+    functype = ctypes.CFUNCTYPE(ctypes.c_int, ctypes.c_void_p)
+    cudaStreamSynchronize = functype(addr)
+
+    has_cupy = True
+
+    def _xla_translation_gpu(numba_fn, abstract_eval_fn, xla_builder, *args):
+        """Returns the XLA CustomCall for the given numba function.
+
+        Args:
+          numba_fn: A numba function. For its signature, see the module docstring.
+          abstract_eval_fn: The abstract shape evaluation function.
+          xla_builder: The XlaBuilder instance.
+          *args: The positional arguments to be passed to `numba_fn`.
+        Returns:
+          The XLA CustomCall operation calling into the numba function.
+        """
+        print("encoding jambax gpu")
+        input_shapes = [xla_builder.get_shape(arg) for arg in args]
+        input_dtypes = tuple(shape.element_type() for shape in input_shapes)
+        input_dimensions = tuple(shape.dimensions() for shape in input_shapes)
+        input_byte_size = tuple(
+            np.prod(shape) * dtype.itemsize
+            for (shape, dtype) in zip(input_dimensions, input_dtypes)
+        )
+
+        input_i = tuple(i for i in range(len(input_dimensions)))
+        n_in = len(input_dimensions)
+
+        # TODO(josipd): Check that the input layout is the numpy default.
+        output_abstract_arrays = abstract_eval_fn(
+            *[_xla_shape_to_abstract(shape) for shape in input_shapes]
+        )
+        output_shapes = tuple(array.shape for array in output_abstract_arrays)
+
+        output_ndims = tuple(array.ndim for array in output_abstract_arrays)
+        output_ndims_offsets = tuple(np.cumsum(np.concatenate([[0], output_ndims])))
+        output_dtypes = tuple(array.dtype for array in output_abstract_arrays)
+        output_byte_size = tuple(
+            np.prod(shape) * dtype.itemsize
+            for (shape, dtype) in zip(output_shapes, output_dtypes)
+        )
+
+        layout_for_shape = lambda shape: range(len(shape) - 1, -1, -1)
+        output_layouts = map(layout_for_shape, output_shapes)
+        xla_output_shapes = [
+            xla_client.Shape.array_shape(*arg)
+            for arg in zip(output_dtypes, output_shapes, output_layouts)
+        ]
+        xla_output_shape = xla_client.Shape.tuple_shape(xla_output_shapes)
+
+        output_i = tuple(i for i in range(len(output_shapes)))
+
+        n_out = len(output_shapes)
+
+        xla_call_sig = nb_types.void(
+            nb_types.voidptr,  # cudaStream_t* stream
+            nb_types.CPointer(nb_types.voidptr),  # void** buffers
+            nb_types.voidptr,  # const char* opaque
+            nb_types.uint64,  # size_t opaque_len
+        )
+
+        print(f"With N_in={n_in} and n_out={n_out}")
+
+        @numba.cfunc(xla_call_sig)
+        def xla_custom_call_target(stream, inout_gpu_ptrs, opaque, opaque_len):
+            # manually unroll input and output args because numba is
+            # relatively dummb and cannot always infer getitem on inhomogeneous tuples
+            if n_out == 1:
+                args_out = (np.empty(output_shapes[0], dtype=output_dtypes[0]),)
+            elif n_out == 2:
+                args_out = (
+                    np.empty(output_shapes[0], dtype=output_dtypes[0]),
+                    np.empty(output_shapes[1], dtype=output_dtypes[1]),
+                )
+            elif n_out == 3:
+                args_out = (
+                    np.empty(output_shapes[0], dtype=output_dtypes[0]),
+                    np.empty(output_shapes[1], dtype=output_dtypes[1]),
+                    np.empty(output_shapes[2], dtype=output_dtypes[2]),
+                )
+            elif n_out == 4:
+                args_out = (
+                    np.empty(output_shapes[0], dtype=output_dtypes[0]),
+                    np.empty(output_shapes[1], dtype=output_dtypes[1]),
+                    np.empty(output_shapes[2], dtype=output_dtypes[2]),
+                    np.empty(output_shapes[3], dtype=output_dtypes[3]),
+                )
+
+            if n_in == 1:
+                args_in = (np.empty(input_dimensions[0], dtype=input_dtypes[0]),)
+            #    cudaMemcpy(args_in[0].ctypes.data, inout_gpu_ptrs[0], input_byte_size[0], nb_types.int32(cupy_backends.cuda.api.runtime.memcpyDeviceToHost))
+            elif n_in == 2:
+                args_in = (
+                    np.empty(input_dimensions[0], dtype=input_dtypes[0]),
+                    np.empty(input_dimensions[1], dtype=input_dtypes[1]),
+                )
+                cudaMemcpy(
+                    args_in[0].ctypes.data,
+                    inout_gpu_ptrs[0],
+                    1,
+                    nb_types.int32(cupy_backends.cuda.api.runtime.memcpyDeviceToHost),
+                )
+                cudaMemcpy(
+                    args_in[1].ctypes.data,
+                    inout_gpu_ptrs[1],
+                    1,
+                    nb_types.int32(cupy_backends.cuda.api.runtime.memcpyDeviceToHost),
+                )
+            elif n_in == 3:
+                args_in = (
+                    np.empty(input_dimensions[0], dtype=input_dtypes[0]),
+                    np.empty(input_dimensions[1], dtype=input_dtypes[1]),
+                    np.empty(input_dimensions[2], dtype=input_dtypes[2]),
+                )
+            #    cudaMemcpy(args_in[0].ctypes.data, inout_gpu_ptrs[0], input_byte_size[0], nb_types.int32(cupy_backends.cuda.api.runtime.memcpyDeviceToHost))
+            #    cudaMemcpy(args_in[1].ctypes.data, inout_gpu_ptrs[1], input_byte_size[1], nb_types.int32(cupy_backends.cuda.api.runtime.memcpyDeviceToHost))
+            #    cudaMemcpy(args_in[2].ctypes.data, inout_gpu_ptrs[2], input_byte_size[2], nb_types.int32(cupy_backends.cuda.api.runtime.memcpyDeviceToHost))
+            elif n_in == 4:
+                args_in = (
+                    np.empty(input_dimensions[0], dtype=input_dtypes[0]),
+                    np.empty(input_dimensions[1], dtype=input_dtypes[1]),
+                    np.empty(input_dimensions[2], dtype=input_dtypes[2]),
+                    np.empty(input_dimensions[3], dtype=input_dtypes[3]),
+                )
+            #    cudaMemcpy(args_in[0].ctypes.data, inout_gpu_ptrs[0], input_byte_size[0], nb_types.int32(cupy_backends.cuda.api.runtime.memcpyDeviceToHost))
+            #    cudaMemcpy(args_in[1].ctypes.data, inout_gpu_ptrs[1], input_byte_size[1], nb_types.int32(cupy_backends.cuda.api.runtime.memcpyDeviceToHost))
+            #    cudaMemcpy(args_in[2].ctypes.data, inout_gpu_ptrs[2], input_byte_size[2], nb_types.int32(cupy_backends.cuda.api.runtime.memcpyDeviceToHost))
+            #    cudaMemcpy(args_in[3].ctypes.data, inout_gpu_ptrs[3], input_byte_size[3], nb_types.int32(cupy_backends.cuda.api.runtime.memcpyDeviceToHost))
+
+            # numba_fn(args_out + args_in)
+
+            # if n_out == 1:
+            #    cudaMemcpy(inout_gpu_ptrs[n_in+0], args_out[0].ctypes.data, output_byte_size[0], nb_types.int32(cupy_backends.cuda.api.runtime.memcpyHostToDevice))
+            # elif n_out == 2:
+            #    cudaMemcpy(inout_gpu_ptrs[n_in+0], args_out[0].ctypes.data, output_byte_size[0], nb_types.int32(cupy_backends.cuda.api.runtime.memcpyHostToDevice))
+            #    cudaMemcpy(inout_gpu_ptrs[n_in+1], args_out[1].ctypes.data, output_byte_size[1], nb_types.int32(cupy_backends.cuda.api.runtime.memcpyHostToDevice))
+            # elif n_out == 3:
+            #    cudaMemcpy(inout_gpu_ptrs[n_in+0], args_out[0].ctypes.data, output_byte_size[0], nb_types.int32(cupy_backends.cuda.api.runtime.memcpyHostToDevice))
+            #    cudaMemcpy(inout_gpu_ptrs[n_in+1], args_out[1].ctypes.data, output_byte_size[1], nb_types.int32(cupy_backends.cuda.api.runtime.memcpyHostToDevice))
+            #    cudaMemcpy(inout_gpu_ptrs[n_in+2], args_out[2].ctypes.data, output_byte_size[2], nb_types.int32(cupy_backends.cuda.api.runtime.memcpyHostToDevice))
+            # elif n_out == 4:
+            #    cudaMemcpy(inout_gpu_ptrs[n_in+0], args_out[0].ctypes.data, output_byte_size[0], nb_types.int32(cupy_backends.cuda.api.runtime.memcpyHostToDevice))
+            #    cudaMemcpy(inout_gpu_ptrs[n_in+1], args_out[1].ctypes.data, output_byte_size[1], nb_types.int32(cupy_backends.cuda.api.runtime.memcpyHostToDevice))
+            #    cudaMemcpy(inout_gpu_ptrs[n_in+2], args_out[2].ctypes.data, output_byte_size[2], nb_types.int32(cupy_backends.cuda.api.runtime.memcpyHostToDevice))
+            #    cudaMemcpy(inout_gpu_ptrs[n_in+3], args_out[3].ctypes.data, output_byte_size[3], nb_types.int32(cupy_backends.cuda.api.runtime.memcpyHostToDevice))
+
+        target_name = xla_custom_call_target.native_name.encode("ascii")
+        capsule = _create_xla_target_capsule(xla_custom_call_target.address)
+        xla_client.register_custom_call_target(target_name, capsule, "gpu")
+        return xla_client.ops.CustomCallWithLayout(
+            xla_builder,
+            target_name,
+            operands=args,
+            shape_with_layout=xla_output_shape,
+            operand_shapes_with_layout=input_shapes,
+        )
+
+
+except:
+    has_cupy = False
 
 
 def numba_to_jax(name: str, numba_fn, abstract_eval_fn, batching_fn=None):
@@ -275,8 +474,14 @@ def numba_to_jax(name: str, numba_fn, abstract_eval_fn, batching_fn=None):
             _naive_batching, _primitive_bind
         )
     xla.backend_specific_translations["cpu"][primitive] = partial(
-        _xla_translation, numba_fn, abstract_eval_fn_always
+        _xla_translation_cpu, numba_fn, abstract_eval_fn_always
     )
+
+    if has_cupy:
+        xla.backend_specific_translations["gpu"][primitive] = partial(
+            _xla_translation_gpu, numba_fn, abstract_eval_fn_always
+        )
+
     return _primitive_bind
 
 

--- a/netket/jax/jambax.py
+++ b/netket/jax/jambax.py
@@ -1,0 +1,293 @@
+"""Call Numba from jitted JAX functions.
+
+# The interface
+
+To call your Numba function from JAX, you have to implement:
+
+  1. A Numba function following our calling convention.
+  2. A function for abstractly evaluating the function, i.e., for specifying
+     the output shapes and dtypes from the input ones.
+
+## 1. The Numba function
+
+The Numba function has to accept a *single* tuple argument and do not return
+anythin, i.e. have type `Callable[tuple[numba.carray], None]`. The output and
+input arguments are stored consecutively in the tuple. For example, if you want
+to implement a function that takes three arrays and returns two, the Numba
+function should look like:
+
+```py
+@numba.jit
+def add_and_mul(args):
+  output_1, output_2, input_1, input_2, input_3 = args
+  # Now edit output_1 and output_2 *in place*.
+  output_1.fill(0)
+  output_2.fill(0)
+  output_1 += input_1 + input_2
+  output_2 += input_1 * input_3
+```
+
+Note that the output arguments have to be modified *in-place*. These arrays are
+allocated and owned by XLA.
+
+## 2. The abstract evaluation function
+
+You also have to implement a function that tells JAX how to compute the shapes
+and types of the outputs from the inputs.For more information, please refer to
+
+https://jax.readthedocs.io/en/latest/notebooks/How_JAX_primitives_work.html#Abstract-evaluation-rules
+
+For example, for the above function, the corresponding abstract eval function is
+
+```py
+def add_and_mul_shape_fn(input_1, input_2, input_3):
+  assert input_1.shape == input_2.shape
+  assert input_1.shape == input_3.shape
+  return (jax.abstract_arrays.ShapedArray(input_1.shape, input_1.dtype),
+          jax.abstract_arrays.ShapedArray(input_1.shape, input_1.dtype))
+```
+
+# Conversion
+
+Now, what is left is to convert the function:
+
+```py
+add_and_mul_jax = jax.experimental.jambax.numba_to_jax(
+    "add_and_mul", add_and_mul, add_and_mul_shape_fn)
+```
+
+You can JIT compile the function as
+```py
+add_and_mul_jit = jax.jit(add_and_mul_jax)
+```
+
+# Optional
+## Derivatives
+
+You can define a gradient for your function as if you were definining a custom
+gradient for any other JAX function. You can follow the tutorial at:
+
+https://jax.readthedocs.io/en/latest/notebooks/Custom_derivative_rules_for_Python_code.html
+
+## Batching / vmap
+
+Batching along the first axes is implemented via jax.lax.map. To implement your
+own bathing rule, see the documentation of `numba_to_jax`.
+"""
+
+import collections
+import ctypes
+from functools import partial  # pylint:disable=g-importing-member
+
+import jax
+from jax.interpreters import batching
+from jax.interpreters import xla
+from jax.lib import xla_client
+from jaxlib import xla_extension
+import numba
+from numba import types as nb_types
+import numba.typed as nb_typed
+import numpy as onp
+
+
+def _xla_shape_to_abstract(xla_shape):
+    return jax.abstract_arrays.ShapedArray(
+        xla_shape.dimensions(), xla_shape.element_type()
+    )
+
+
+def _create_xla_target_capsule(ptr):
+    xla_capsule_magic = b"xla._CUSTOM_CALL_TARGET"
+    ctypes.pythonapi.PyCapsule_New.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_char_p,
+        ctypes.c_void_p,
+    ]
+    ctypes.pythonapi.PyCapsule_New.restype = ctypes.py_object
+    return ctypes.pythonapi.PyCapsule_New(ptr, xla_capsule_magic, None)
+
+
+def _np_evaluation_rule(call_fn, abstract_eval_fn, *args, **kwargs):
+    output_shapes = abstract_eval_fn(*args)
+    outputs = tuple(
+        onp.empty(shape.shape, dtype=shape.dtype) for shape in output_shapes
+    )
+    inputs = tuple(onp.asarray(arg) for arg in args)
+    call_fn(outputs + inputs, **kwargs)
+    return tuple(outputs)
+
+
+def _naive_batching(call_fn, args, batch_axes):
+    # TODO(josipd): Check that the axes are all zeros. Add support when only a
+    #               subset of the arguments have to be batched.
+    # TODO(josipd): Do this smarter than n CustomCalls.
+    return tuple(jax.lax.map(lambda x: call_fn(*x), args)), batch_axes
+
+
+def _xla_translation(numba_fn, abstract_eval_fn, xla_builder, *args):
+    """Returns the XLA CustomCall for the given numba function.
+
+    Args:
+      numba_fn: A numba function. For its signature, see the module docstring.
+      abstract_eval_fn: The abstract shape evaluation function.
+      xla_builder: The XlaBuilder instance.
+      *args: The positional arguments to be passed to `numba_fn`.
+    Returns:
+      The XLA CustomCall operation calling into the numba function.
+    """
+    input_shapes = [xla_builder.get_shape(arg) for arg in args]
+    # TODO(josipd): Check that the input layout is the numpy default.
+    output_abstract_arrays = abstract_eval_fn(
+        *[_xla_shape_to_abstract(shape) for shape in input_shapes]
+    )
+    output_shapes = tuple(array.shape for array in output_abstract_arrays)
+    output_shapes_flattened = tuple(
+        dim for array in output_abstract_arrays for dim in array.shape
+    )
+    output_ndims = tuple(array.ndim for array in output_abstract_arrays)
+    output_ndims_offsets = tuple(onp.cumsum(onp.concatenate([[0], output_ndims])))
+    output_dtypes = tuple(array.dtype for array in output_abstract_arrays)
+    layout_for_shape = lambda shape: range(len(shape) - 1, -1, -1)
+    output_layouts = map(layout_for_shape, output_shapes)
+    xla_output_shapes = [
+        xla_client.Shape.array_shape(*arg)
+        for arg in zip(output_dtypes, output_shapes, output_layouts)
+    ]
+    xla_output_shape = xla_client.Shape.tuple_shape(xla_output_shapes)
+
+    input_dtypes = tuple(shape.element_type() for shape in input_shapes)
+    input_dimensions = tuple(shape.dimensions() for shape in input_shapes)
+
+    output_i = tuple(i for i in range(len(output_shapes)))
+    input_i = tuple(i for i in range(len(input_dimensions)))
+
+    n_out = len(output_shapes)
+    n_in = len(input_dimensions)
+
+    xla_call_sig = nb_types.void(
+        nb_types.CPointer(nb_types.voidptr), nb_types.CPointer(nb_types.voidptr)
+    )
+
+    @numba.cfunc(xla_call_sig)
+    def xla_custom_call_target(output_ptrs, input_ptrs):
+        # manually unroll input and output args because numba is
+        # relatively dummb and cannot always infer getitem on inhomogeneous tuples
+        if n_out == 1:
+            args_out = (
+                numba.carray(output_ptrs[0], output_shapes[0], dtype=output_dtypes[0]),
+            )
+        elif n_out == 2:
+            args_out = (
+                numba.carray(output_ptrs[0], output_shapes[0], dtype=output_dtypes[0]),
+                numba.carray(output_ptrs[1], output_shapes[1], dtype=output_dtypes[1]),
+            )
+        elif n_out == 3:
+            args_out = (
+                numba.carray(output_ptrs[0], output_shapes[0], dtype=output_dtypes[0]),
+                numba.carray(output_ptrs[1], output_shapes[1], dtype=output_dtypes[1]),
+                numba.carray(output_ptrs[2], output_shapes[2], dtype=output_dtypes[2]),
+            )
+        elif n_out == 4:
+            args_out = (
+                numba.carray(output_ptrs[0], output_shapes[0], dtype=output_dtypes[0]),
+                numba.carray(output_ptrs[1], output_shapes[1], dtype=output_dtypes[1]),
+                numba.carray(output_ptrs[2], output_shapes[2], dtype=output_dtypes[2]),
+                numba.carray(output_ptrs[3], output_shapes[3], dtype=output_dtypes[3]),
+            )
+
+        if n_in == 1:
+            args_in = (
+                numba.carray(input_ptrs[0], input_dimensions[0], dtype=input_dtypes[0]),
+            )
+        elif n_in == 2:
+            args_in = (
+                numba.carray(input_ptrs[0], input_dimensions[0], dtype=input_dtypes[0]),
+                numba.carray(input_ptrs[1], input_dimensions[1], dtype=input_dtypes[1]),
+            )
+        elif n_in == 3:
+            args_in = (
+                numba.carray(input_ptrs[0], input_dimensions[0], dtype=input_dtypes[0]),
+                numba.carray(input_ptrs[1], input_dimensions[1], dtype=input_dtypes[1]),
+                numba.carray(input_ptrs[2], input_dimensions[2], dtype=input_dtypes[2]),
+            )
+        elif n_in == 4:
+            args_in = (
+                numba.carray(input_ptrs[0], input_dimensions[0], dtype=input_dtypes[0]),
+                numba.carray(input_ptrs[1], input_dimensions[1], dtype=input_dtypes[1]),
+                numba.carray(input_ptrs[2], input_dimensions[2], dtype=input_dtypes[2]),
+                numba.carray(input_ptrs[3], input_dimensions[3], dtype=input_dtypes[3]),
+            )
+
+        numba_fn(args_out + args_in)
+
+    target_name = xla_custom_call_target.native_name.encode("ascii")
+    capsule = _create_xla_target_capsule(xla_custom_call_target.address)
+    xla_extension.register_custom_call_target(target_name, capsule, "Host")
+    return xla_client.ops.CustomCallWithLayout(
+        xla_builder,
+        target_name,
+        operands=args,
+        shape_with_layout=xla_output_shape,
+        operand_shapes_with_layout=input_shapes,
+    )
+
+
+def numba_to_jax(name: str, numba_fn, abstract_eval_fn, batching_fn=None):
+    """Create a jittable JAX function for the given Numba function.
+
+    Args:
+      name: The name under which the primitive will be registered.
+      numba_fn: The function that can be compiled with Numba.
+      abstract_eval_fn: The abstract evaluation function.
+      batching_fn: If set, this function will be used when vmap-ing the returned
+        function.
+    Returns:
+      A jitable JAX function.
+    """
+    primitive = jax.core.Primitive(name)
+    primitive.multiple_results = True
+
+    def abstract_eval_fn_always(*args, **kwargs):
+        # Special-casing when only a single tensor is returned.
+        shapes = abstract_eval_fn(*args, **kwargs)
+        if not isinstance(shapes, collections.abc.Collection):
+            return [shapes]
+        else:
+            return shapes
+
+    primitive.def_abstract_eval(abstract_eval_fn_always)
+    primitive.def_impl(partial(_np_evaluation_rule, numba_fn, abstract_eval_fn_always))
+
+    def _primitive_bind(*args):
+        result = primitive.bind(*args)
+        output_shapes = abstract_eval_fn(*args)
+        # Special-casing when only a single tensor is returned.
+        if not isinstance(output_shapes, collections.abc.Collection):
+            assert len(result) == 1
+            return result[0]
+        else:
+            return result
+
+    if batching_fn is not None:
+        batching.primitive_batchers[primitive] = batching_fn
+    else:
+        batching.primitive_batchers[primitive] = partial(
+            _naive_batching, _primitive_bind
+        )
+    xla.backend_specific_translations["cpu"][primitive] = partial(
+        _xla_translation, numba_fn, abstract_eval_fn_always
+    )
+    return _primitive_bind
+
+
+def njit4jax(output_shapes):
+
+    abstract_eval = lambda *args: output_shapes
+
+    def decorator(fun):
+        jitted_fun = numba.njit(fun)
+        fn_name = "numba_fun_{}".format(hash(jitted_fun))
+        print("jambax:", fn_name)
+        return numba_to_jax(fn_name, jitted_fun, abstract_eval)
+
+    return decorator

--- a/netket/jax/numba4jax.py
+++ b/netket/jax/numba4jax.py
@@ -78,23 +78,20 @@ own bathing rule, see the documentation of `numba_to_jax`.
 import collections
 import ctypes
 from functools import partial  # pylint:disable=g-importing-member
+from textwrap import dedent
 
 import jax
 from jax.interpreters import batching
 from jax.interpreters import xla
 from jax.lib import xla_client
 from jaxlib import xla_extension
+
 import numba
 from numba import types as nb_types
 import numba.typed as nb_typed
 import numpy as np
 
-
-def _shape_size(shape):
-    sz = 1
-    for dim in shape:
-        sz *= dim
-    return sz
+from netket import config
 
 
 def _xla_shape_to_abstract(xla_shape):
@@ -140,7 +137,10 @@ def _xla_translation_cpu(numba_fn, abstract_eval_fn, xla_builder, *args):
     Returns:
       The XLA CustomCall operation calling into the numba function.
     """
-    print("encoding jamax cpu")
+
+    if config.FLAGS["NETKET_DEBUG"]:
+        print("Encoding the CPU variant of numba4jax function")
+
     input_shapes = [xla_builder.get_shape(arg) for arg in args]
     # TODO(josipd): Check that the input layout is the numpy default.
     output_abstract_arrays = abstract_eval_fn(
@@ -240,195 +240,28 @@ def _xla_translation_cpu(numba_fn, abstract_eval_fn, xla_builder, *args):
     )
 
 
-##
+def _xla_translation_gpu(numba_fn, abstract_eval_fn, xla_builder, *args):
 
-try:
-    import ctypes
-    from numba.extending import get_cython_function_address
-    import cupy_backends
+    if config.FLAGS["NETKET_DEBUG"]:
+        print("Encoding the GPU variant of numba4jax function")
 
-    addr = get_cython_function_address("cupy_backends.cuda.api.runtime", "memcpy")
-    functype = ctypes.CFUNCTYPE(
-        ctypes.c_int, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t, ctypes.c_int
+    raise RuntimeError(
+        dedent(
+            """
+                       The numba4jax module, which allows calling numba
+                       functions from jax-jitted functions, is not 
+                       supported on the GPU.
+
+                       Most probably you were using a Sampler Transition
+                       rule that only works on CPU. Use the version of this
+                       sampler instead.
+
+                       If you are a hardcore developer and are not scared
+                       of CUDA, C and LLVM, get in touch with us to make
+                       it work.
+                       """
+        )
     )
-    cudaMemcpy = functype(addr)
-
-    #
-    addr = get_cython_function_address("cupy_backends.cuda.api.runtime", "memcpyAsync")
-    functype = ctypes.CFUNCTYPE(
-        ctypes.c_int,
-        ctypes.c_void_p,
-        ctypes.c_void_p,
-        ctypes.c_size_t,
-        ctypes.c_int,
-        ctypes.c_void_p,
-    )
-    cudaMemcpyAsync = functype(addr)
-
-    #
-    addr = get_cython_function_address(
-        "cupy_backends.cuda.api.runtime", "streamSynchronize"
-    )
-    functype = ctypes.CFUNCTYPE(ctypes.c_int, ctypes.c_void_p)
-    cudaStreamSynchronize = functype(addr)
-
-    has_cupy = True
-
-    def _xla_translation_gpu(numba_fn, abstract_eval_fn, xla_builder, *args):
-        """Returns the XLA CustomCall for the given numba function.
-
-        Args:
-          numba_fn: A numba function. For its signature, see the module docstring.
-          abstract_eval_fn: The abstract shape evaluation function.
-          xla_builder: The XlaBuilder instance.
-          *args: The positional arguments to be passed to `numba_fn`.
-        Returns:
-          The XLA CustomCall operation calling into the numba function.
-        """
-        print("encoding jambax gpu")
-        input_shapes = [xla_builder.get_shape(arg) for arg in args]
-        input_dtypes = tuple(shape.element_type() for shape in input_shapes)
-        input_dimensions = tuple(shape.dimensions() for shape in input_shapes)
-        input_byte_size = tuple(
-            np.prod(shape) * dtype.itemsize
-            for (shape, dtype) in zip(input_dimensions, input_dtypes)
-        )
-
-        input_i = tuple(i for i in range(len(input_dimensions)))
-        n_in = len(input_dimensions)
-
-        # TODO(josipd): Check that the input layout is the numpy default.
-        output_abstract_arrays = abstract_eval_fn(
-            *[_xla_shape_to_abstract(shape) for shape in input_shapes]
-        )
-        output_shapes = tuple(array.shape for array in output_abstract_arrays)
-
-        output_ndims = tuple(array.ndim for array in output_abstract_arrays)
-        output_ndims_offsets = tuple(np.cumsum(np.concatenate([[0], output_ndims])))
-        output_dtypes = tuple(array.dtype for array in output_abstract_arrays)
-        output_byte_size = tuple(
-            np.prod(shape) * dtype.itemsize
-            for (shape, dtype) in zip(output_shapes, output_dtypes)
-        )
-
-        layout_for_shape = lambda shape: range(len(shape) - 1, -1, -1)
-        output_layouts = map(layout_for_shape, output_shapes)
-        xla_output_shapes = [
-            xla_client.Shape.array_shape(*arg)
-            for arg in zip(output_dtypes, output_shapes, output_layouts)
-        ]
-        xla_output_shape = xla_client.Shape.tuple_shape(xla_output_shapes)
-
-        output_i = tuple(i for i in range(len(output_shapes)))
-
-        n_out = len(output_shapes)
-
-        xla_call_sig = nb_types.void(
-            nb_types.voidptr,  # cudaStream_t* stream
-            nb_types.CPointer(nb_types.voidptr),  # void** buffers
-            nb_types.voidptr,  # const char* opaque
-            nb_types.uint64,  # size_t opaque_len
-        )
-
-        print(f"With N_in={n_in} and n_out={n_out}")
-
-        @numba.cfunc(xla_call_sig)
-        def xla_custom_call_target(stream, inout_gpu_ptrs, opaque, opaque_len):
-            # manually unroll input and output args because numba is
-            # relatively dummb and cannot always infer getitem on inhomogeneous tuples
-            if n_out == 1:
-                args_out = (np.empty(output_shapes[0], dtype=output_dtypes[0]),)
-            elif n_out == 2:
-                args_out = (
-                    np.empty(output_shapes[0], dtype=output_dtypes[0]),
-                    np.empty(output_shapes[1], dtype=output_dtypes[1]),
-                )
-            elif n_out == 3:
-                args_out = (
-                    np.empty(output_shapes[0], dtype=output_dtypes[0]),
-                    np.empty(output_shapes[1], dtype=output_dtypes[1]),
-                    np.empty(output_shapes[2], dtype=output_dtypes[2]),
-                )
-            elif n_out == 4:
-                args_out = (
-                    np.empty(output_shapes[0], dtype=output_dtypes[0]),
-                    np.empty(output_shapes[1], dtype=output_dtypes[1]),
-                    np.empty(output_shapes[2], dtype=output_dtypes[2]),
-                    np.empty(output_shapes[3], dtype=output_dtypes[3]),
-                )
-
-            if n_in == 1:
-                args_in = (np.empty(input_dimensions[0], dtype=input_dtypes[0]),)
-            #    cudaMemcpy(args_in[0].ctypes.data, inout_gpu_ptrs[0], input_byte_size[0], nb_types.int32(cupy_backends.cuda.api.runtime.memcpyDeviceToHost))
-            elif n_in == 2:
-                args_in = (
-                    np.empty(input_dimensions[0], dtype=input_dtypes[0]),
-                    np.empty(input_dimensions[1], dtype=input_dtypes[1]),
-                )
-                cudaMemcpy(
-                    args_in[0].ctypes.data,
-                    inout_gpu_ptrs[0],
-                    1,
-                    nb_types.int32(cupy_backends.cuda.api.runtime.memcpyDeviceToHost),
-                )
-                cudaMemcpy(
-                    args_in[1].ctypes.data,
-                    inout_gpu_ptrs[1],
-                    1,
-                    nb_types.int32(cupy_backends.cuda.api.runtime.memcpyDeviceToHost),
-                )
-            elif n_in == 3:
-                args_in = (
-                    np.empty(input_dimensions[0], dtype=input_dtypes[0]),
-                    np.empty(input_dimensions[1], dtype=input_dtypes[1]),
-                    np.empty(input_dimensions[2], dtype=input_dtypes[2]),
-                )
-            #    cudaMemcpy(args_in[0].ctypes.data, inout_gpu_ptrs[0], input_byte_size[0], nb_types.int32(cupy_backends.cuda.api.runtime.memcpyDeviceToHost))
-            #    cudaMemcpy(args_in[1].ctypes.data, inout_gpu_ptrs[1], input_byte_size[1], nb_types.int32(cupy_backends.cuda.api.runtime.memcpyDeviceToHost))
-            #    cudaMemcpy(args_in[2].ctypes.data, inout_gpu_ptrs[2], input_byte_size[2], nb_types.int32(cupy_backends.cuda.api.runtime.memcpyDeviceToHost))
-            elif n_in == 4:
-                args_in = (
-                    np.empty(input_dimensions[0], dtype=input_dtypes[0]),
-                    np.empty(input_dimensions[1], dtype=input_dtypes[1]),
-                    np.empty(input_dimensions[2], dtype=input_dtypes[2]),
-                    np.empty(input_dimensions[3], dtype=input_dtypes[3]),
-                )
-            #    cudaMemcpy(args_in[0].ctypes.data, inout_gpu_ptrs[0], input_byte_size[0], nb_types.int32(cupy_backends.cuda.api.runtime.memcpyDeviceToHost))
-            #    cudaMemcpy(args_in[1].ctypes.data, inout_gpu_ptrs[1], input_byte_size[1], nb_types.int32(cupy_backends.cuda.api.runtime.memcpyDeviceToHost))
-            #    cudaMemcpy(args_in[2].ctypes.data, inout_gpu_ptrs[2], input_byte_size[2], nb_types.int32(cupy_backends.cuda.api.runtime.memcpyDeviceToHost))
-            #    cudaMemcpy(args_in[3].ctypes.data, inout_gpu_ptrs[3], input_byte_size[3], nb_types.int32(cupy_backends.cuda.api.runtime.memcpyDeviceToHost))
-
-            # numba_fn(args_out + args_in)
-
-            # if n_out == 1:
-            #    cudaMemcpy(inout_gpu_ptrs[n_in+0], args_out[0].ctypes.data, output_byte_size[0], nb_types.int32(cupy_backends.cuda.api.runtime.memcpyHostToDevice))
-            # elif n_out == 2:
-            #    cudaMemcpy(inout_gpu_ptrs[n_in+0], args_out[0].ctypes.data, output_byte_size[0], nb_types.int32(cupy_backends.cuda.api.runtime.memcpyHostToDevice))
-            #    cudaMemcpy(inout_gpu_ptrs[n_in+1], args_out[1].ctypes.data, output_byte_size[1], nb_types.int32(cupy_backends.cuda.api.runtime.memcpyHostToDevice))
-            # elif n_out == 3:
-            #    cudaMemcpy(inout_gpu_ptrs[n_in+0], args_out[0].ctypes.data, output_byte_size[0], nb_types.int32(cupy_backends.cuda.api.runtime.memcpyHostToDevice))
-            #    cudaMemcpy(inout_gpu_ptrs[n_in+1], args_out[1].ctypes.data, output_byte_size[1], nb_types.int32(cupy_backends.cuda.api.runtime.memcpyHostToDevice))
-            #    cudaMemcpy(inout_gpu_ptrs[n_in+2], args_out[2].ctypes.data, output_byte_size[2], nb_types.int32(cupy_backends.cuda.api.runtime.memcpyHostToDevice))
-            # elif n_out == 4:
-            #    cudaMemcpy(inout_gpu_ptrs[n_in+0], args_out[0].ctypes.data, output_byte_size[0], nb_types.int32(cupy_backends.cuda.api.runtime.memcpyHostToDevice))
-            #    cudaMemcpy(inout_gpu_ptrs[n_in+1], args_out[1].ctypes.data, output_byte_size[1], nb_types.int32(cupy_backends.cuda.api.runtime.memcpyHostToDevice))
-            #    cudaMemcpy(inout_gpu_ptrs[n_in+2], args_out[2].ctypes.data, output_byte_size[2], nb_types.int32(cupy_backends.cuda.api.runtime.memcpyHostToDevice))
-            #    cudaMemcpy(inout_gpu_ptrs[n_in+3], args_out[3].ctypes.data, output_byte_size[3], nb_types.int32(cupy_backends.cuda.api.runtime.memcpyHostToDevice))
-
-        target_name = xla_custom_call_target.native_name.encode("ascii")
-        capsule = _create_xla_target_capsule(xla_custom_call_target.address)
-        xla_client.register_custom_call_target(target_name, capsule, "gpu")
-        return xla_client.ops.CustomCallWithLayout(
-            xla_builder,
-            target_name,
-            operands=args,
-            shape_with_layout=xla_output_shape,
-            operand_shapes_with_layout=input_shapes,
-        )
-
-
-except:
-    has_cupy = False
 
 
 def numba_to_jax(name: str, numba_fn, abstract_eval_fn, batching_fn=None):
@@ -477,22 +310,34 @@ def numba_to_jax(name: str, numba_fn, abstract_eval_fn, batching_fn=None):
         _xla_translation_cpu, numba_fn, abstract_eval_fn_always
     )
 
-    if has_cupy:
-        xla.backend_specific_translations["gpu"][primitive] = partial(
-            _xla_translation_gpu, numba_fn, abstract_eval_fn_always
-        )
+    xla.backend_specific_translations["gpu"][primitive] = partial(
+        _xla_translation_gpu, numba_fn, abstract_eval_fn_always
+    )
 
     return _primitive_bind
 
 
 def njit4jax(output_shapes):
+    """Create a jittable JAX function for the given Numba function.
 
+    Args:
+      name: The name under which the primitive will be registered.
+      numba_fn: The function that can be compiled with Numba.
+      abstract_eval_fn: The abstract evaluation function.
+      batching_fn: If set, this function will be used when vmap-ing the returned
+        function.
+    Returns:
+      A jitable JAX function.
+    """
     abstract_eval = lambda *args: output_shapes
 
     def decorator(fun):
         jitted_fun = numba.njit(fun)
         fn_name = "numba_fun_{}".format(hash(jitted_fun))
-        print("jambax:", fn_name)
+
+        if config.FLAGS["NETKET_DEBUG"]:
+            print("Constructing CustomCall function numbaa4jax:", fn_name)
+
         return numba_to_jax(fn_name, jitted_fun, abstract_eval)
 
     return decorator

--- a/netket/operator/_abstract_operator.py
+++ b/netket/operator/_abstract_operator.py
@@ -277,6 +277,17 @@ class AbstractOperator(abc.ABC):
     def to_linear_operator(self):
         return self.to_sparse()
 
+    def _get_conn_flattened_closure(self):
+        raise NotImplementedError(
+            """
+            _get_conn_flattened_closure not implemented for this operator type.
+            You were probably trying to use an operator with a sampler.
+            Please report this bug.
+            
+            numba4jax won't work.
+            """
+        )
+
     def __repr__(self):
         return f"{type(self).__name__}(hilbert={self.hilbert})"
 

--- a/netket/operator/_hamiltonian.py
+++ b/netket/operator/_hamiltonian.py
@@ -320,6 +320,17 @@ class Ising(SpecialHamiltonian):
             self._J,
         )
 
+    def numba_get_conn_flattened_fun(self):
+        _edges = self._edges
+        _h = self._h
+        _J = self._J
+        fun = self._flattened_kernel
+
+        def gccf_fun(x, sections):
+            return fun(x, sections, _edges, _h, _J)
+
+        return jit(nopython=True)(gccf_fun)
+
     def __repr__(self):
         return f"Ising(J={self._J}, h={self._h}; dim={self.hilbert.size})"
 

--- a/netket/operator/_hamiltonian.py
+++ b/netket/operator/_hamiltonian.py
@@ -320,7 +320,7 @@ class Ising(SpecialHamiltonian):
             self._J,
         )
 
-    def numba_get_conn_flattened_fun(self):
+    def _get_conn_flattened_closure(self):
         _edges = self._edges
         _h = self._h
         _J = self._J
@@ -715,3 +715,32 @@ class BoseHubbard(SpecialHamiltonian):
             self._n_max,
             self._max_conn,
         )
+
+    def _get_conn_flattened_closure(self):
+        _edges = (self._edges,)
+        _max_mels = (self._max_mels,)
+        _max_xprime = (self._max_xprime,)
+        _U = (self._U,)
+        _V = (self._V,)
+        _J = (self._J,)
+        _mu = (self._mu,)
+        _n_max = (self._n_max,)
+        _max_conn = (self._max_conn,)
+        fun = self._flattened_kernel
+
+        def gccf_fun(x, sections):
+            return fun(
+                x,
+                sections,
+                _edges,
+                _max_mels,
+                _max_xprime,
+                _U,
+                _V,
+                _J,
+                _mu,
+                _n_max,
+                _max_conn,
+            )
+
+        return jit(nopython=True)(gccf_fun)

--- a/netket/operator/_local_operator.py
+++ b/netket/operator/_local_operator.py
@@ -784,7 +784,7 @@ class LocalOperator(AbstractOperator):
             pad,
         )
 
-    def numba_get_conn_flattened_fun(self):
+    def _get_conn_flattened_closure(self):
         _local_states = self._local_states
         _basis = self._basis
         _constant = self._constant

--- a/netket/operator/_local_operator.py
+++ b/netket/operator/_local_operator.py
@@ -784,6 +784,35 @@ class LocalOperator(AbstractOperator):
             pad,
         )
 
+    def numba_get_conn_flattened_fun(self):
+        _local_states = self._local_states
+        _basis = self._basis
+        _constant = self._constant
+        _diag_mels = self._diag_mels
+        _n_conns = self._n_conns
+        _mels = self._mels
+        _x_prime = self._x_prime
+        _acting_on = self._acting_on
+        _acting_size = self._acting_size
+        fun = self._get_conn_flattened_kernel
+
+        def gccf_fun(x, sections):
+            return fun(
+                x,
+                sections,
+                _local_states,
+                _basis,
+                _constant,
+                _diag_mels,
+                _n_conns,
+                _mels,
+                _x_prime,
+                _acting_on,
+                _acting_size,
+            )
+
+        return jit(nopython=True)(gccf_fun)
+
     @staticmethod
     @jit(nopython=True)
     def _get_conn_flattened_kernel(

--- a/netket/operator/_pauli_strings.py
+++ b/netket/operator/_pauli_strings.py
@@ -146,8 +146,8 @@ class PauliStrings(AbstractOperator):
     @jit(nopython=True)
     def _flattened_kernel(
         x,
-        x_prime,
         sections,
+        x_prime,
         mels,
         sites,
         ns,
@@ -209,8 +209,8 @@ class PauliStrings(AbstractOperator):
 
         return self._flattened_kernel(
             x,
-            self._x_prime_max,
             sections,
+            self._x_prime_max,
             self._mels_max,
             self._sites,
             self._ns,
@@ -221,3 +221,34 @@ class PauliStrings(AbstractOperator):
             self._cutoff,
             self._n_operators,
         )
+
+    def _get_conn_flattened_closure(self):
+        _x_prime_max = self._x_prime_max
+        _mels_max = self._mels_max
+        _sites = self._sites
+        _ns = self._ns
+        _n_op = self._n_op
+        _weights = self._weights
+        _nz_check = self._nz_check
+        _z_check = self._z_check
+        _cutoff = self._cutoff
+        _n_operators = self._n_operators
+        fun = self._get_conn_flattened_kernel
+
+        def gccf_fun(x, sections):
+            return fun(
+                x,
+                sections,
+                _x_prime_max,
+                _mels_max,
+                _sites,
+                _ns,
+                _n_op,
+                _weights,
+                _nz_check,
+                _z_check,
+                _cutoff,
+                _n_operators,
+            )
+
+        return jit(nopython=True)(gccf_fun)

--- a/netket/sampler/__init__.py
+++ b/netket/sampler/__init__.py
@@ -31,7 +31,7 @@ from .metropolis import (
     MetropolisExchange,
     MetropolisRule,
     MetropolisSamplerState,
-    #    MetropolisHamiltonian,
+    MetropolisHamiltonian,
 )
 
 from .metropolis_numpy import (
@@ -55,7 +55,7 @@ MetropolisPt = MetropolisPtSampler
 MetropolisNumpy = MetropolisSamplerNumpy
 
 # Replacements for effficiency
-MetropolisHamiltonian = MetropolisHamiltonianNumpy
+# MetropolisHamiltonian = MetropolisHamiltonianNumpy
 MetropolisCustom = MetropolisCustomNumpy
 
 from netket.utils import _hide_submodules

--- a/netket/sampler/__init__.py
+++ b/netket/sampler/__init__.py
@@ -29,6 +29,8 @@ from .metropolis import (
     MetropolisSampler,
     MetropolisLocal,
     MetropolisExchange,
+    MetropolisRule,
+    MetropolisSamplerState,
     #    MetropolisHamiltonian,
 )
 

--- a/netket/sampler/exact.py
+++ b/netket/sampler/exact.py
@@ -38,10 +38,10 @@ class ExactSamplerState(SamplerState):
 @struct.dataclass
 class ExactSampler(Sampler):
     """
-    This sampler generates i.i.d. samples from $|\Psi(s)|^2$.
+    This sampler generates i.i.d. samples from :math:`|\\Psi(\\sigma)|^2`.
 
-    In order to perform exact sampling, $|\Psi(s)|^2$ is precomputed an all
-    the possible values of the quantum numbers $$s$$. This sampler has thus an
+    In order to perform exact sampling, :math:`|\\Psi(\\sigma)|^2` is precomputed an all
+    the possible values of the quantum numbers :math:`\\sigma`. This sampler has thus an
     exponential cost with the number of degrees of freedom, and cannot be used
     for large systems, where Metropolis-based sampling are instead a viable
     option.

--- a/netket/sampler/metropolis.py
+++ b/netket/sampler/metropolis.py
@@ -447,7 +447,7 @@ def MetropolisHamiltonian(hilbert, hamiltonian, *args, **kwargs) -> MetropolisSa
     Notice that this sampler preserves by construction all the symmetries
     of the Hamiltonian. This is in generally not true for the local samplers instead.
 
-    This samapler only works on the CPU. To use the Hamiltonian smapler with GPUs,
+    This sampler only works on the CPU. To use the Hamiltonian smapler with GPUs,
     you should use :class:`netket.sampler.MetropolisHamiltonianNumpy`
 
     Args:

--- a/netket/sampler/metropolis.py
+++ b/netket/sampler/metropolis.py
@@ -447,6 +447,9 @@ def MetropolisHamiltonian(hilbert, hamiltonian, *args, **kwargs) -> MetropolisSa
     Notice that this sampler preserves by construction all the symmetries
     of the Hamiltonian. This is in generally not true for the local samplers instead.
 
+    This samapler only works on the CPU. To use the Hamiltonian smapler with GPUs,
+    you should use :class:`netket.sampler.MetropolisHamiltonianNumpy`
+
     Args:
        machine: A machine :math:`\Psi(s)` used for the sampling.
                 The probability distribution being sampled

--- a/netket/sampler/rules/hamiltonian.py
+++ b/netket/sampler/rules/hamiltonian.py
@@ -39,10 +39,19 @@ class HamiltonianRule(MetropolisRule):
     In this case, the transition matrix is taken to be:
 
     .. math::
-       T( \mathbf{s} \rightarrow \mathbf{s}^\prime) = \frac{1}{\mathcal{N}(\mathbf{s})}\theta(|H_{\mathbf{s},\mathbf{s}^\prime}|),
+       T( \\mathbf{s} \\rightarrow \\mathbf{s}^\\prime) = \\frac{1}{\\mathcal{N}(\\mathbf{s})}\\theta(|H_{\\mathbf{s},\\mathbf{s}^\\prime}|),
+
+    This rule only works on CPU! If you want to use it on GPU, you
+    must use the numpy variant :class:`netket.sampler.rules.HamiltonianRuleNumpy`
+    together with the numpy metropolis sampler
+    :class:`netket.sampler.MetropolisSamplerNumpy`.
+
+    Attributes:
+        Ô: The (hermitian) operator giving the transition amplitudes.
+
     """
 
-    Ô: Any = struct.field(pytree_node=False)
+    Ô: AbstractOperator = struct.field(pytree_node=False)
 
     def __post_init__(self):
         # Raise errors if hilbert is not an Hilbert

--- a/netket/sampler/rules/hamiltonian.py
+++ b/netket/sampler/rules/hamiltonian.py
@@ -56,7 +56,7 @@ class HamiltonianRule(MetropolisRule):
     def transition(rule, sampler, machine, parameters, state, key, σ):
 
         hilbert = sampler.hilbert
-        get_conn_flattened = rule.Ô.numba_get_conn_flattened_fun()
+        get_conn_flattened = rule.Ô._get_conn_flattened_closure()
         n_conn_from_sections = rule.Ô._n_conn_from_sections
 
         @njit4jax(

--- a/netket/sampler/rules/hamiltonian_numpy.py
+++ b/netket/sampler/rules/hamiltonian_numpy.py
@@ -41,10 +41,14 @@ class HamiltonianRuleNumpy(MetropolisRule):
     In this case, the transition matrix is taken to be:
 
     .. math::
-       T( \mathbf{s} \rightarrow \mathbf{s}^\prime) = \frac{1}{\mathcal{N}(\mathbf{s})}\theta(|H_{\mathbf{s},\mathbf{s}^\prime}|),
+       T( \\mathbf{s} \\rightarrow \\mathbf{s}^\\prime) = \\frac{1}{\\mathcal{N}(\\mathbf{s})}\\theta(|H_{\\mathbf{s},\\mathbf{s}^\\prime}|),
+
+    Attributes:
+        Ô: The (hermitian) operator giving the transition amplitudes.
+
     """
 
-    Ô: Any = struct.field(pytree_node=False)
+    Ô: AbstractOperator = struct.field(pytree_node=False)
 
     def __post_init__(self):
         # Raise errors if hilbert is not an Hilbert


### PR DESCRIPTION
This uses a trick to create on the fly a numba function inside of jax jitted functions and call it with almost-0 overhead.

This makes HamiltonianSampler be 5 times faster then the previous implementation that had to exit the jitted function and call back into jax. Now HamiltonianSampler is only 50% slower than MetropolisLocal.
Also, we can use the same trick in over places.

The limitation is that it only works for cpu-arrays, not gpu. But we can put a conversion before calling those functions. Besides, indexing in localoperators makes no sense/would be unbearably slow on gpus so that makes sense.

Also, to make this work i need to add a very ugly yet necessary function to operators returning a closure computing the get_conn_flattened with their internal fields inside the closure. That is because numba does not know how to deal with our operators.