### PR TITLE
Speed up and simplify SR

### DIFF
--- a/Test/MPI/test_stats_ops.py
+++ b/Test/MPI/test_stats_ops.py
@@ -163,5 +163,5 @@ def test_subtract_mean():
     ref_mean = nk.stats.mean(mydata, axis=0)
     ref_data = mydata - ref_mean[np.newaxis, :, :]
 
-    nk.stats.subtract_mean(mydata, axis=0)
+    mydata = nk.stats.subtract_mean(mydata, axis=0)
     assert mydata == approx(ref_data)

--- a/Test/Optimizer/test_sr_onthefly_logic.py
+++ b/Test/Optimizer/test_sr_onthefly_logic.py
@@ -63,7 +63,7 @@ def random_split_like_tree(rng_key, target=None, treedef=None):
 def tree_random_normal_like(rng_key, target):
     keys_tree = random_split_like_tree(rng_key, target)
     return jax.tree_multimap(
-        # TODO remove astype once its fixed in jax
+        # TODO remove astype once its fixed in Jax#6052
         lambda l, k: jax.random.normal(k, l.shape, l.dtype).astype(l.dtype),
         target,
         keys_tree,

--- a/Test/Optimizer/test_sr_onthefly_logic.py
+++ b/Test/Optimizer/test_sr_onthefly_logic.py
@@ -164,7 +164,9 @@ def test_reassemble_complex(e):
 def test_vjp(e):
     actual = _sr_onthefly_logic.O_vjp(e.samples, e.params, e.w, e.f)
     expected = _sr_onthefly_logic.tree_conj(
-        reassemble_complex((e.w @ e.ok_real).real, target=e.target)
+        reassemble_complex(
+            (e.w @ e.ok_real).real.astype(e.params_real_flat.dtype), target=e.target
+        )
     )
     assert tree_allclose(actual, expected)
 
@@ -184,7 +186,8 @@ def test_mean(e):
 def test_OH_w(e):
     actual = _sr_onthefly_logic.OH_w(e.samples, e.params, e.w, e.f)
     expected = reassemble_complex(
-        (e.ok_real.conjugate().transpose() @ e.w).real, target=e.target
+        (e.ok_real.conjugate().transpose() @ e.w).real.astype(e.params_real_flat.dtype),
+        target=e.target,
     )
     assert tree_allclose(actual, expected)
 

--- a/Test/Optimizer/test_sr_onthefly_logic.py
+++ b/Test/Optimizer/test_sr_onthefly_logic.py
@@ -62,7 +62,10 @@ def random_split_like_tree(rng_key, target=None, treedef=None):
 def tree_random_normal_like(rng_key, target):
     keys_tree = random_split_like_tree(rng_key, target)
     return jax.tree_multimap(
-        lambda l, k: jax.random.normal(k, l.shape, l.dtype), target, keys_tree
+        # TODO remove astype once its fixed in jax
+        lambda l, k: jax.random.normal(k, l.shape, l.dtype).astype(l.dtype),
+        target,
+        keys_tree,
     )
 
 

--- a/netket/optimizer/sr/sr_onthefly.py
+++ b/netket/optimizer/sr/sr_onthefly.py
@@ -148,6 +148,7 @@ def lazysmatrix_mat_treevec(S, vec):
         params=S.params,
         samples=samples,
         diag_shift=S.sr.diag_shift,
+        centered=S.sr.centered,
     )
 
     res = mat_vec(vec)

--- a/netket/optimizer/sr/sr_onthefly_logic.py
+++ b/netket/optimizer/sr/sr_onthefly_logic.py
@@ -108,8 +108,7 @@ def O_mean(samples, params, forward_fn, **kwargs):
     i.e. the mean of the rows of the jacobian of forward_fn
     """
 
-    # determine the output type of the forward pass, because
-    # we need to cast the vectors in vjp to that type
+    # determine the output type of the forward pass
     dtype = jax.eval_shape(forward_fn, params, samples).dtype
 
     v = jnp.ones(samples.shape[0], dtype=dtype) * (1.0 / (samples.shape[0] * n_nodes))
@@ -117,17 +116,11 @@ def O_mean(samples, params, forward_fn, **kwargs):
     return O_vjp(samples, params, v, forward_fn, **kwargs)
 
 
-def OH_w(samples, params, w, forward_fn, *, cast=False, **kwargs):
+def OH_w(samples, params, w, forward_fn, **kwargs):
     r"""
     compute  O^H w
     (where ^H is the hermitian transpose)
     """
-
-    if cast:
-        # determine the output type of the forward pass, because
-        # we need to cast the vectors in vjp to that type
-        dtype = jax.eval_shape(forward_fn, params, samples).dtype
-        w = w.astype(dtype)
 
     # O^H w = (w^H O)^H
     # The transposition of the 1D arrays is omitted in the implementation:
@@ -160,8 +153,7 @@ def Odagger_O_v(samples, params, v, forward_fn, *, vjp_fun=None, center=False):
     if center:
         w = subtract_mean(w)  # w/ MPI
 
-    # TODO cast=True might be needed when the input and output are of different precision
-    return OH_w(samples, params, w, forward_fn, vjp_fun=vjp_fun, cast=False)
+    return OH_w(samples, params, w, forward_fn, vjp_fun=vjp_fun)
 
 
 Odagger_DeltaO_v = partial(Odagger_O_v, center=True)

--- a/netket/stats/mpi_stats.py
+++ b/netket/stats/mpi_stats.py
@@ -1,4 +1,3 @@
-import numpy as np
 import jax.numpy as jnp
 from ._sum_inplace import sum_inplace as mpi_sum
 
@@ -21,10 +20,11 @@ def subtract_mean(x, axis=None):
         The resulting array.
 
     """
-    x_mean = mean(x, axis=axis)
-    x -= x_mean
 
-    return x
+    # here we keep the dims, since automatic broadcasting of a scalar (shape () ) to an array produces errors
+    # when used inside of a function which is transposed with jax.linear_transpose
+    x_mean = mean(x, axis=axis, keepdims=True)
+    return x - x_mean  # automatic broadcasting of x_mean
 
 
 def mean(a, axis=None, keepdims: bool = False):


### PR DESCRIPTION
This implements the non-centered  Sv = ⟨Ô†ΔÔ⟩v with just ```1 jvp + 1 vjp```, instead of ```1 jvp + 2 vjp``` all while doing the same amount of communication. 
Results in a measurable speedup compared to before and also compared to the centered version (benchmarking just the matrix-vector product).

Also fixes and simplifies a few things and extends the test.


A derivation is coming soon™.