### PR TITLE
Only run the cleanup action on closed PR, not on master

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,13 +1,11 @@
-name: "Website/Docs"
+name: "Cleanup Docs Preview"
+
+# This Github Action deletes the website preview generated
+# from pull requests that are closed.
 
 on:
   pull_request:
     types: [closed]
-
-  push:
-    branches:
-      - master
-
 
 jobs:
   docs-preview:
@@ -21,8 +19,7 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-    # Publish built docs to gh-pages branch.
-    # ===============================
+    # Delete the published preview and.
     - name: Delete website preview
       run: |
         git clone https://github.com/netket/netket.git --branch gh-pages --single-branch gh-pages

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-name: "Website/Docs"
+name: "Website"
 
 on:
   pull_request:


### PR DESCRIPTION
small leftover fixes for the GitHub Actions introduced in nk3