### PR TITLE
Improvements: docstrings and netket.hilbert.random docstrings

### DIFF
--- a/netket/drivers/steady_state.py
+++ b/netket/drivers/steady_state.py
@@ -113,8 +113,10 @@ class SteadyState(AbstractVariationalDriver):
     #        super().reset()
 
     def __repr__(self):
-        return "SteadyState(step_count={}, n_samples={}, n_discard={})".format(
-            self.step_count, self.n_samples, self.n_discard
+        return (
+            "SteadyState("
+            + f"\n  step_count = {self.step_count},"
+            + f"\n  state = {self.state})"
         )
 
     def info(self, depth=0):

--- a/netket/drivers/vmc.py
+++ b/netket/drivers/vmc.py
@@ -116,8 +116,10 @@ class VMC(AbstractVariationalDriver):
         return self._loss_stats
 
     def __repr__(self):
-        return "Vmc(step_count={}, n_samples={}, n_discard={})".format(
-            self.step_count, self.state.n_samples, self.state.n_discard
+        return (
+            "Vmc("
+            + f"\n  step_count = {self.step_count},"
+            + f"\n  state = {self.state})"
         )
 
     def info(self, depth=0):

--- a/netket/hilbert/random/base.py
+++ b/netket/hilbert/random/base.py
@@ -72,7 +72,15 @@ def random_state_scalar(hilb, key, dtype):
     Generates a single random state-vector given an hilbert space and a rng key.
     """
     # Attempt to use the scalar method
-    raise NotImplementedError()
+    raise NotImplementedError(
+        f"""
+                              random_state_scalar(hilb, key, dtype) is not implemented
+                              for hilbert space of type {type(hilb)}. 
+
+                              See the documentation of 
+                              nk.hilbert.random.register_random_state_impl.
+                              """
+    )
 
 
 @singledispatch
@@ -81,7 +89,15 @@ def random_state_batch(hilb, key, size, dtype):
     Generates a batch of random state-vectors given an hilbert space and a rng key.
     """
     # Attempt to use the batch method
-    raise NotImplementedError()
+    raise NotImplementedError(
+        f"""
+                              random_state_batch(hilb, key, size, dtype) is not implemented
+                              for hilbert space of type {type(hilb)}. 
+
+                              See the documentation of 
+                              nk.hilbert.random.register_random_state_impl.
+                              """
+    )
 
 
 def _random_state_scalar_default_impl(hilb, key, dtype, batch_rule):
@@ -95,7 +111,29 @@ def _random_state_batch_default_impl(hilb, key, size, dtype, scalar_rule):
 
 
 def register_random_state_impl(clz=None, *, scalar=None, batch=None):
-    """"""
+    """
+    Register an implementation for the function generating random
+    state for the given Hilbert space class.
+
+    The rule can be implemented both as a scalar rule and as a batched
+    rule, but the best performance will be obtained by implementing
+    the batched version.
+
+    The missing rule will be auto-implemented from the over.
+
+    scalar must have signature
+        (hilb, key, dtype) -> vector
+    batch must have signature
+        (hilb, key, size, dtype) -> matrix of states
+
+    The function will be jit compiled, so make sure to use jax.numpy.
+    Hilbert is passed as a static object.
+
+    Arguments:
+        clz: The class of the hilbert space
+        scalar: The function computing a single random state
+        batch: the function computing batches of random states
+    """
     if scalar is None and batch is None:
         raise ValueError("You must at least provide a scalar or batch rule.")
 
@@ -122,16 +160,30 @@ def register_random_state_impl(clz=None, *, scalar=None, batch=None):
 ##############################
 
 
-# @partial(jax.jit, static_argnums=(0,))
 @singledispatch
 def flip_state_scalar(hilb, key, state, indx):
-    pass
+    raise NotImplementedError(
+        f"""
+                              flip_state_scalar(hilb, key, state, indx) is not implemented
+                              for hilbert space of type {type(hilb)}. 
+
+                              See the documentation of 
+                              nk.hilbert.random.register_flip_state_impl
+                              """
+    )
 
 
-# @partial(jax.jit, static_argnums=(0,))
 @singledispatch
 def flip_state_batch(hilb, key, states, indxs):
-    pass
+    raise NotImplementedError(
+        f"""
+                              flip_state_batch(hilb, key, states, indx) is not implemented
+                              for hilbert space of type {type(hilb)}. 
+
+                              See the documentation of 
+                              nk.hilbert.random.register_flip_state_impl
+                              """
+    )
 
 
 def _flip_state_scalar_default_impl(hilb, key, state, indx, batch_rule):
@@ -150,7 +202,29 @@ def _flip_state_batch_default_impl(hilb, key, states, indxs, scalar_rule):
 
 
 def register_flip_state_impl(clz=None, *, scalar=None, batch=None):
-    """"""
+    """
+    Register an implementation for the function generating and
+    applying random local states for the given Hilbert space class.
+
+    The rule can be implemented both as a scalar rule and as a batched
+    rule, but the best performance will be obtained by implementing
+    the batched version.
+
+    The missing rule will be auto-implemented from the over.
+
+    scalar must have signature
+        (hilb, key, state, indx) -> (new state, state[indx])
+    batch must have signature
+        (hilb, key, states, indxs) -> batch of scalar results
+
+    The function will be jit compiled, so make sure to use jax.numpy.
+    Hilbert is passed as a static object.
+
+    Arguments:
+        clz: The class of the hilbert space
+        scalar: The function computing a single entry
+        batch: the function computing batches
+    """
     if scalar is None and batch is None:
         raise ValueError("You must at least provide a scalar or batch rule.")
 

--- a/netket/sampler/exact.py
+++ b/netket/sampler/exact.py
@@ -31,6 +31,9 @@ class ExactSamplerState(SamplerState):
     pdf: Any
     rng: Any
 
+    def __repr__(self):
+        return f"ExactSamplerState(rng state={self.rng})"
+
 
 @struct.dataclass
 class ExactSampler(Sampler):
@@ -87,8 +90,16 @@ class ExactSampler(Sampler):
             "ExactSampler("
             + "\n  hilbert = {},".format(sampler.hilbert)
             + "\n  n_chains = {},".format(sampler.n_chains)
-            + "\n  machine_power = {})".format(sampler.machine_pow)
+            + "\n  machine_power = {},".format(sampler.machine_pow)
             + "\n  dtype = {})".format(sampler.dtype)
+        )
+
+    def __str__(sampler):
+        return (
+            "ExactSampler("
+            + "n_chains = {}, ".format(sampler.n_chains)
+            + "machine_power = {}, ".format(sampler.machine_pow)
+            + "dtype = {})".format(sampler.dtype)
         )
 
 

--- a/netket/sampler/metropolis.py
+++ b/netket/sampler/metropolis.py
@@ -142,7 +142,7 @@ class MetropolisSamplerState(SamplerState):
         else:
             acc_string = ""
 
-        text = "MetropolisSamplerState(" + acc_string + "rng state={}".format(self.rng)
+        text = "MetropolisSamplerState(" + acc_string + "rng state={})".format(self.rng)
         return text
 
 
@@ -302,8 +302,18 @@ class MetropolisSampler(Sampler):
             + "\n  machine_power = {},".format(sampler.machine_pow)
             + "\n  reset_chain = {},".format(sampler.reset_chain)
             + "\n  n_sweeps = {},".format(sampler.n_sweeps)
-            + "\n  dtype = {},".format(sampler.dtype)
+            + "\n  dtype = {}".format(sampler.dtype)
             + ")"
+        )
+
+    def __str__(sampler):
+        return (
+            "MetropolisSampler("
+            + "rule = {}, ".format(sampler.rule)
+            + "n_chains = {}, ".format(sampler.n_chains)
+            + "machine_power = {}, ".format(sampler.machine_pow)
+            + "n_sweeps = {}, ".format(sampler.n_sweeps)
+            + "dtype = {})".format(sampler.dtype)
         )
 
 

--- a/netket/sampler/metropolis_numpy.py
+++ b/netket/sampler/metropolis_numpy.py
@@ -186,7 +186,7 @@ class MetropolisSamplerNumpy(MetropolisSampler):
 
     def __repr__(sampler):
         return (
-            "MetropolisNumpySampler("
+            "MetropolisSamplerNumpy("
             + "\n  hilbert = {},".format(sampler.hilbert)
             + "\n  rule = {},".format(sampler.rule)
             + "\n  n_chains = {},".format(sampler.n_chains)
@@ -195,6 +195,16 @@ class MetropolisSamplerNumpy(MetropolisSampler):
             + "\n  n_sweeps = {},".format(sampler.n_sweeps)
             + "\n  dtype = {},".format(sampler.dtype)
             + ")"
+        )
+
+    def __str__(sampler):
+        return (
+            "MetropolisSamplerNumpy("
+            + "rule = {}, ".format(sampler.rule)
+            + "n_chains = {}, ".format(sampler.n_chains)
+            + "machine_power = {}, ".format(sampler.machine_pow)
+            + "n_sweeps = {}, ".format(sampler.n_sweeps)
+            + "dtype = {})".format(sampler.dtype)
         )
 
 

--- a/netket/sampler/metropolis_pt.py
+++ b/netket/sampler/metropolis_pt.py
@@ -430,6 +430,17 @@ class MetropolisPtSampler(MetropolisSampler):
             + ")"
         )
 
+    def __str__(sampler):
+        return (
+            "MetropolisPTSampler("
+            + "rule = {}, ".format(sampler.rule)
+            + "n_chains = {}, ".format(sampler.n_chains)
+            + "machine_power = {}, ".format(sampler.machine_pow)
+            + "reset_chain = {}, ".format(sampler.reset_chain)
+            + "n_sweeps = {}, ".format(sampler.n_sweeps)
+            + "dtype = {})".format(sampler.dtype)
+        )
+
 
 from netket.utils import wraps_legacy
 from netket.legacy.machine import AbstractMachine

--- a/netket/sampler/rules/exchange.py
+++ b/netket/sampler/rules/exchange.py
@@ -77,6 +77,9 @@ class ExchangeRule_(MetropolisRule):
             None,
         )
 
+    def __repr__(self):
+        return f"ExchangeRule(# of clusters: {len(self.clusters)})"
+
 
 def compute_clusters(graph, d_max):
     clusters = []

--- a/netket/sampler/rules/hamiltonian.py
+++ b/netket/sampler/rules/hamiltonian.py
@@ -83,6 +83,9 @@ class HamiltonianRule(MetropolisRule):
 
         return σp, log_prob_correction
 
+    def __repr__(self):
+        return f"HamiltonianRule({self.Ô})"
+
 
 @jit(nopython=True)
 def _choose(σp, sections, rand_vec):

--- a/netket/sampler/rules/hamiltonian_numpy.py
+++ b/netket/sampler/rules/hamiltonian_numpy.py
@@ -74,6 +74,9 @@ class HamiltonianRuleNumpy(MetropolisRule):
         rule.Ô.n_conn(σ1, sections)
         log_prob_corr -= np.log(sections)
 
+    def __repr__(self):
+        return f"HamiltonianRuleNumpy({self.Ô})"
+
 
 @jit(nopython=True)
 def _choose(states, sections, out, w, rand_vec):

--- a/netket/sampler/rules/local.py
+++ b/netket/sampler/rules/local.py
@@ -52,3 +52,6 @@ class LocalRule(MetropolisRule):
         σp, _ = flip_state(hilb, key2, σ, indxs)
 
         return σp, None
+
+    def __repr__(self):
+        return "LocalRule()"

--- a/netket/sampler/rules/local_numpy.py
+++ b/netket/sampler/rules/local_numpy.py
@@ -43,6 +43,9 @@ class LocalRuleNumpy(MetropolisRule):
 
         _kernel(σ, σ1, si, rs, state.rule_state.local_states)
 
+    def __repr__(self):
+        return "LocalRuleNumpy()"
+
 
 @jit(nopython=True)
 def _kernel(σ, σ1, si, rs, local_states):

--- a/netket/variational/mc_mixed_state.py
+++ b/netket/variational/mc_mixed_state.py
@@ -250,3 +250,26 @@ class MCMixedState(VariationalMixedState, MCState):
         return netket.nn.to_matrix(
             self.hilbert, self._apply_fun, self.variables, normalize=normalize
         )
+
+    def __repr__(self):
+        return (
+            "MCMixedState("
+            + "\n  hilbert = {},".format(self.hilbert)
+            + "\n  sampler = {},".format(self.sampler)
+            + "\n  n_samples = {},".format(self.n_samples)
+            + "\n  n_discard = {},".format(self.n_discard)
+            + "\n  sampler_state = {},".format(self.sampler_state)
+            + "\n  sampler_diag = {},".format(self.sampler_diag)
+            + "\n  n_samples_diag = {},".format(self.n_samples_diag)
+            + "\n  n_discard_diag = {},".format(self.n_discard_diag)
+            + "\n  sampler_state_diag = {},".format(self.diagonal.sampler_state)
+            + "\n  n_parameters = {})".format(self.n_parameters)
+        )
+
+    def __str__(self):
+        return (
+            "MCMixedState("
+            + "hilbert = {}, ".format(self.hilbert)
+            + "sampler = {}, ".format(self.sampler)
+            + "n_samples = {})".format(self.n_samples)
+        )

--- a/netket/variational/mc_state.py
+++ b/netket/variational/mc_state.py
@@ -507,6 +507,25 @@ class MCState(VariationalState):
             self.hilbert, self._apply_fun, self.variables, normalize=normalize
         )
 
+    def __repr__(self):
+        return (
+            "MCState("
+            + "\n  hilbert = {},".format(self.hilbert)
+            + "\n  sampler = {},".format(self.sampler)
+            + "\n  n_samples = {},".format(self.n_samples)
+            + "\n  n_discard = {},".format(self.n_discard)
+            + "\n  sampler_state = {},".format(self.sampler_state)
+            + "\n  n_parameters = {})".format(self.n_parameters)
+        )
+
+    def __str__(self):
+        return (
+            "MCState("
+            + "hilbert = {}, ".format(self.hilbert)
+            + "sampler = {}, ".format(self.sampler)
+            + "n_samples = {})".format(self.n_samples)
+        )
+
 
 @partial(jax.jit, static_argnums=(1, 2))
 def _expect(


### PR DESCRIPTION
Now, if you implement a new Hilbert space but not the methods for sampling you get:

```python
    raise NotImplementedError(
NotImplementedError:
                              random_state_batch(hilb, key, size, dtype) is not implemented
                              for hilbert space of type <class 'netket.hilbert.spin.Spin'>.

                              See the documentation of
                              nk.hilbert.random.register_random_state_impl.
```

pointing you to the right direction on what to do.

Also, now __repr__ for states is better:
```python 
>>> gs.state
MCState(
  hilbert = Spin(s=1/2, N=20),
  sampler = MetropolisSampler(rule = LocalRule(), n_chains = 16, machine_power = 2, n_sweeps = 20, dtype = <class 'numpy.float32'>),
  n_samples = 1008,
  n_discard = 50,
  sampler_state = MetropolisSamplerState(# accepted = 7697/36160 (21.28595132743363%), rng state=[2722596017  821647436]),
  n_parameters = 440)
```