### PR TITLE
Liouvillian cleanup

### DIFF
--- a/Test/Operator/test_liouvillian.py
+++ b/Test/Operator/test_liouvillian.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import netket.legacy as nk
+import netket as nk
 import numpy as np
 import networkx as nx
 from scipy import sparse
@@ -68,7 +68,19 @@ def test_lindblad_form():
         j_mat = j_op.to_sparse()
         lind_mat += sparse.kron(j_mat.conj(), j_mat)
 
-    assert (lind_mat.todense() == lind.to_dense()).all()
+    np.testing.assert_allclose(lind_mat.todense(), lind.to_dense())
+
+
+def test_liouvillian_no_dissipators():
+    lind = nk.operator.LocalLiouvillian(ha)
+
+    ## Construct the lindbladian by hand:
+    idmat = sparse.eye(2 ** L)
+    h_mat = ha.to_sparse()
+
+    lind_mat = -1j * sparse.kron(idmat, h_mat) + 1j * sparse.kron(h_mat, idmat)
+
+    np.testing.assert_allclose(lind.to_dense(), lind_mat.todense())
 
 
 def test_lindblad_zero_eigenvalue():

--- a/docs/docs/api.rst
+++ b/docs/docs/api.rst
@@ -55,6 +55,7 @@ Operators
    netket.operator.LocalOperator
    netket.operator.Ising
    netket.operator.Heisenberg
+   netket.operator.LocalLiouvillian
 
 
 Pre-defined operators

--- a/netket/operator/__init__.py
+++ b/netket/operator/__init__.py
@@ -6,7 +6,8 @@ from ._pauli_strings import PauliStrings
 from ._lazy import Adjoint, Transpose, Squared
 from ._hamiltonian import Ising, Heisenberg, BoseHubbard
 
-from ._local_liouvillian import AbstractSuperOperator, LocalLiouvillian
+from ._abstract_super_operator import AbstractSuperOperator
+from ._local_liouvillian import LocalLiouvillian
 
 from . import spin, boson
 

--- a/netket/operator/_abstract_super_operator.py
+++ b/netket/operator/_abstract_super_operator.py
@@ -1,0 +1,33 @@
+import numbers
+from typing import List
+
+import numpy as np
+
+from ._abstract_operator import AbstractOperator
+from ._local_operator import LocalOperator
+from netket.hilbert import DoubledHilbert, AbstractHilbert
+
+
+class AbstractSuperOperator(AbstractOperator):
+    """
+    Generic base class for super-operators acting on the tensor product (DoubledHilbert)
+    space ℋ⊗ℋ, where ℋ is the physical space.
+
+    Behaves on :ref:`netket.variational.VariationalMixedState` as normal operators behave
+    on :ref:`netket.variational.VariationalState`.
+    Cannot be used to act upon pure states.
+    """
+
+    def __init__(self, hilbert):
+        """
+        Initialize a super-operator by passing it the physical hilbert space on which it acts.
+
+        This init method constructs the doubled-hilbert space and pass it down to the fundamental
+        abstractoperator.
+        """
+        super().__init__(DoubledHilbert(hilbert))
+
+    @property
+    def hilbert_physical(self) -> AbstractHilbert:
+        """The physical hilbert space on which this super-operator acts."""
+        return self.hilbert.physical

--- a/netket/operator/_local_liouvillian.py
+++ b/netket/operator/_local_liouvillian.py
@@ -193,10 +193,13 @@ class LocalLiouvillian(AbstractSuperOperator):
                 max_conns_c = sections_c[0]
             max_conns_Lrc = 0
 
-        L_xrps = List()
-        L_xcps = List()
-        L_mel_rs = List()
-        L_mel_cs = List()
+        #  Must type those lists otherwise, if they are empty, numba
+        # cannot infer their type
+        L_xrps = List.empty_list(numba.typeof(x.dtype)[:, :])
+        L_xcps = List.empty_list(numba.typeof(x.dtype)[:, :])
+        L_mel_rs = List.empty_list(numba.typeof(self.dtype())[:])
+        L_mel_cs = List.empty_list(numba.typeof(self.dtype())[:])
+
         sections_Lr = np.empty(batch_size * n_jops, dtype=np.int32)
         sections_Lc = np.empty(batch_size * n_jops, dtype=np.int32)
         for (i, L) in enumerate(self._jump_ops):
@@ -370,15 +373,19 @@ class LocalLiouvillian(AbstractSuperOperator):
         """
         M = self.hilbert.physical.n_states
 
-        iHnh = -1j * self.ham_nh
+        iHnh = -1j * self.hamiltonian_nh
         if sparse:
             iHnh = iHnh.to_sparse()
-            J_ops = [j.to_sparse() for j in self.jump_ops]
-            J_ops_c = [j.conjugate().transpose().to_sparse() for j in self.jump_ops]
+            J_ops = [j.to_sparse() for j in self.jump_operators]
+            J_ops_c = [
+                j.conjugate().transpose().to_sparse() for j in self.jump_operators
+            ]
         else:
             iHnh = iHnh.to_dense()
-            J_ops = [j.to_dense() for j in self.jump_ops]
-            J_ops_c = [j.conjugate().transpose().to_dense() for j in self.jump_ops]
+            J_ops = [j.to_dense() for j in self.jump_operators]
+            J_ops_c = [
+                j.conjugate().transpose().to_dense() for j in self.jump_operators
+            ]
 
         if not append_trace:
             op_size = M ** 2

--- a/netket/operator/_local_liouvillian.py
+++ b/netket/operator/_local_liouvillian.py
@@ -169,7 +169,7 @@ class LocalLiouvillian(AbstractSuperOperator):
     def get_conn_flattened(self, x, sections, pad=False):
         batch_size = x.shape[0]
         N = x.shape[1] // 2
-        n_jops = len(self.jump_ops)
+        n_jops = len(self.jump_operators)
         assert sections.shape[0] == batch_size
 
         # Separate row and column inputs


### PR DESCRIPTION
Create a base AbstractSuperOperator class and move it to a new file.
adds docstring with the definition used for liouvillian to its docs.
fix a bug where if 0 dissipators the super-operator could not be converted to a sparse matrix.