### PR TITLE
Add Jastrow model (and some cleanup)

### DIFF
--- a/Examples/Ising1d/ising1d_jastrow.py
+++ b/Examples/Ising1d/ising1d_jastrow.py
@@ -1,0 +1,50 @@
+# Copyright 2021 The NetKet Authors - All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#    http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import netket as nk
+import numpy as np
+
+# 1D Lattice
+L = 64
+
+g = nk.graph.Hypercube(length=L, n_dim=1, pbc=True)
+
+# Hilbert space of spins on the graph
+hi = nk.hilbert.Spin(s=1 / 2, N=g.n_nodes)
+
+# Ising spin hamiltonian
+ha = nk.operator.Ising(hilbert=hi, graph=g, h=0.0)
+
+# RBM Spin Machine
+ma = nk.models.Jastrow(dtype=np.float64)
+
+# Metropolis Local Sampling
+sa = nk.sampler.MetropolisLocal(hi, n_chains=16)
+
+# Optimizer
+op = nk.optimizer.Sgd(learning_rate=0.05)
+sr = nk.optimizer.SR(diag_shift=0.01)
+
+# Variational monte carlo driver
+gs = nk.VMC(ha, op, sa, ma, n_samples=8000, sr=sr)
+
+# Run the optimization for 300 iterations
+gs.run(
+    n_iter=300,
+    out="test",
+    # stop if variance is essentially zero (= reached eigenstate)
+    callback=nk.callbacks.EarlyStopping(
+        monitor="variance", baseline=1e-12, patience=np.infty
+    ),
+)

--- a/docs/docs/api.rst
+++ b/docs/docs/api.rst
@@ -186,6 +186,7 @@ neural quantum states.
    netket.models.RBMMultiVal
    netket.models.RBMSymm
    netket.models.create_RBMSymm
+   netket.models.Jastrow
    netket.models.MPSPeriodic
    netket.models.NDM
 
@@ -329,6 +330,7 @@ Those are the loggers that can be used with the optimization drivers.
 
 
 .. _callbacks-api:
+   netket.callbacks.EarlyStopping
 
 Callbacks
 --------------

--- a/docs/docs/api.rst
+++ b/docs/docs/api.rst
@@ -330,7 +330,6 @@ Those are the loggers that can be used with the optimization drivers.
 
 
 .. _callbacks-api:
-   netket.callbacks.EarlyStopping
 
 Callbacks
 --------------

--- a/netket/callbacks/earlystopping.py
+++ b/netket/callbacks/earlystopping.py
@@ -48,7 +48,7 @@ class EarlyStopping:
         Returns:
             A boolean. If True, training continues, else, it does not.
         """
-        loss = np.real(log_data[driver._loss_name].__getattr__(self.monitor))
+        loss = np.real(getattr(log_data[driver._loss_name], self.monitor))
         if loss <= self._best_val:
             self._best_val = loss
             self._best_iter = step

--- a/netket/callbacks/earlystopping.py
+++ b/netket/callbacks/earlystopping.py
@@ -1,25 +1,40 @@
-from numpy import infty
+# Copyright 2020, 2021 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+from typing import Union
+
+import numpy as np
 
 
+@dataclass
 class EarlyStopping:
-    """A simple callback to stop NetKet if there are no improvements in the training"""
+    """A simple callback to stop NetKet if there are no more improvements in the training.
+    based on `driver._loss_name`."""
 
-    def __init__(self, min_delta=0, patience=0, baseline=None):
-        """
-        Constructs a new EarlyStopping object that monitors whether a driver is improving
-        over optimisation epochs based on `driver._loss_name`.
+    min_delta: float = 0.0
+    """Minimum change in the monitored quantity to qualify as an improvement."""
+    patience: Union[int, float] = 0
+    """Number of epochs with no improvement after which training will be stopped."""
+    baseline: float = None
+    """Baseline value for the monitored quantity. Training will stop if the driver hits the baseline."""
+    monitor: str = "mean"
+    """Loss statistic to monitor. Should be one of 'mean', 'variance', 'sigma'."""
 
-        Args:
-            min_delta: Minimum change in the monitored quantity to qualify as an improvement.
-            patience: Number of epochs with no improvement after which training will be stopped.
-            baseline: Baseline value for the monitored quantity. Training will stop if the driver
-                hits the baseline.
-        """
-        self.__min_delta = min_delta
-        self.__patience = patience
-        self.__baseline = baseline
-        self._best_val = infty
-        self.__best_iter = 0
+    def __post_init__(self):
+        self._best_val = np.infty
+        self._best_iter = 0
 
     def __call__(self, step, log_data, driver):
         """
@@ -33,16 +48,16 @@ class EarlyStopping:
         Returns:
             A boolean. If True, training continues, else, it does not.
         """
-        loss = log_data[driver._loss_name].mean.real
+        loss = np.real(log_data[driver._loss_name].__getattr__(self.monitor))
         if loss <= self._best_val:
             self._best_val = loss
-            self.__best_iter = step
-        if self.__baseline is not None:
-            if loss <= self.__baseline:
+            self._best_iter = step
+        if self.baseline is not None:
+            if loss <= self.baseline:
                 return False
         if (
-            step - self.__best_iter >= self.__patience
-            and loss > self._best_val - self.__min_delta
+            step - self._best_iter >= self.patience
+            and loss > self._best_val - self.min_delta
         ):
             return False
         else:

--- a/netket/models/jastrow.py
+++ b/netket/models/jastrow.py
@@ -21,7 +21,7 @@ from netket.utils.types import Dtype, Array, NNInitFunc
 
 
 class Jastrow(nn.Module):
-    """Jastrow wave function :math:`\Psi(s) = exp(\sum_{ij} s_i W_{ij} s_j)`."""
+    """Jastrow wave function :math:`\Psi(s) = \exp(\sum_{ij} s_i W_{ij} s_j)`."""
 
     dtype: Dtype = jnp.complex128
     """The dtype of the weights."""

--- a/netket/models/jastrow.py
+++ b/netket/models/jastrow.py
@@ -1,0 +1,41 @@
+# Copyright 2021 The NetKet Authors - All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#    http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import flax.linen as nn
+import jax.numpy as jnp
+
+import netket as nk
+from netket.nn.initializers import normal
+from netket.utils.types import Dtype, Array, NNInitFunc
+
+
+class Jastrow(nn.Module):
+    """Jastrow wave function :math:`\Psi(s) = exp(\sum_{ij} s_i W_{ij} s_j)`."""
+
+    dtype: Dtype = jnp.complex128
+    """The dtype of the weights."""
+    kernel_init: NNInitFunc = normal()
+    """Initializer for the weights."""
+
+    @nn.compact
+    def __call__(self, x_in: Array):
+        nv = x_in.shape[-1]
+
+        dtype = jnp.promote_types(x_in.dtype, self.dtype)
+        x_in = jnp.asarray(x_in, dtype=dtype)
+
+        kernel = self.param("kernel", self.kernel_init, (nv, nv), self.dtype)
+        y = jnp.einsum("...i,ij,...j", x_in, kernel, x_in)
+
+        return y

--- a/netket/models/mps.py
+++ b/netket/models/mps.py
@@ -25,12 +25,7 @@ from netket.nn.initializers import lecun_normal, variance_scaling, zeros
 
 from netket.hilbert import AbstractHilbert
 from netket.graph import AbstractGraph
-
-
-PRNGKey = Any
-Shape = Tuple[int]
-Dtype = Any  # this could be a real type?
-Array = Any
+from netket.utils.types import PRNGKey, Shape, Dtype, Array
 
 default_kernel_init = lecun_normal()
 

--- a/netket/models/ndm.py
+++ b/netket/models/ndm.py
@@ -22,16 +22,12 @@ from flax import linen as nn
 
 from netket.hilbert import AbstractHilbert
 from netket.graph import AbstractGraph
+from netket.utils.types import PRNGKey, Shape, Dtype, Array
 
 from netket import nn as nknn
 from netket.nn.initializers import lecun_normal, variance_scaling, zeros, normal
 
 from .rbm import RBM
-
-PRNGKey = Any
-Shape = Tuple[int]
-Dtype = Any  # this could be a real type?
-Array = Any
 
 default_kernel_init = normal(stddev=0.001)
 

--- a/netket/models/rbm.py
+++ b/netket/models/rbm.py
@@ -22,15 +22,10 @@ from flax import linen as nn
 
 from netket.hilbert import AbstractHilbert
 from netket.graph import AbstractGraph
+from netket.utils.types import PRNGKey, Shape, Dtype, Array
 
 from netket import nn as nknn
 from netket.nn.initializers import lecun_normal, variance_scaling, zeros, normal
-
-
-PRNGKey = Any
-Shape = Tuple[int]
-Dtype = Any  # this could be a real type?
-Array = Any
 
 default_kernel_init = normal(stddev=0.01)
 

--- a/netket/utils/types.py
+++ b/netket/utils/types.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Tuple, Callable
+from typing import Any, Sequence, Callable
 
 PRNGKey = Any
-Shape = Tuple[int]
+Shape = Sequence[int]
 Dtype = Any  # this could be a real type?
 Array = Any
 

--- a/netket/utils/types.py
+++ b/netket/utils/types.py
@@ -3,21 +3,20 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .rbm import RBM, RBMModPhase, RBMMultiVal, RBMSymm, create_RBMSymm
-from .jastrow import Jastrow
-from .mps import MPSPeriodic
+from typing import Any, Tuple, Callable
 
-from .ndm import NDM
+PRNGKey = Any
+Shape = Tuple[int]
+Dtype = Any  # this could be a real type?
+Array = Any
 
-from netket.utils import _hide_submodules
-
-_hide_submodules(__name__)
+NNInitFunc = Callable[[PRNGKey, Shape, Dtype], Array]


### PR DESCRIPTION
For old times sake, this PR adds `netket.models.Jastrow` with test and example for Ising 1D.

There is also some cleanup in this PR, in particular the type aliases defined in each file in `models` are now in one location `netket.utils.types`.

Also, I've slightly extended `EarlyStopping` for the example, so it is possible to stop when an exact eigenstate is reached (through `variance ≈ 0`).