### PR TITLE
Fix pauli strings

### DIFF
--- a/docs/docs/api.rst
+++ b/docs/docs/api.rst
@@ -38,6 +38,7 @@ Hilbert
    netket.hilbert.Qubit
    netket.hilbert.Spin
    netket.hilbert.CustomHilbert
+   netket.hilbert.PauliStrings
    netket.hilbert.DoubledHilbert
 
 .. _operators-api:

--- a/netket/operator/_pauli_strings.py
+++ b/netket/operator/_pauli_strings.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 import re
+from typing import List, Union
+from netket.utils.types import Dtype
 
 import numpy as np
 from numba import jit
@@ -25,7 +27,13 @@ from ._abstract_operator import AbstractOperator
 class PauliStrings(AbstractOperator):
     """A Hamiltonian consisiting of the sum of products of Pauli operators."""
 
-    def __init__(self, operators, weights, cutoff=1.0e-10, dtype=complex):
+    def __init__(
+        self,
+        operators: List[str],
+        weights: List[Union[float, complex]],
+        cutoff: float = 1.0e-10,
+        dtype: Dtype = complex,
+    ):
         """
         Constructs a new ``PauliStrings`` operator given a set of Pauli operators.
 
@@ -154,7 +162,8 @@ class PauliStrings(AbstractOperator):
         self._is_hermitian = np.allclose(self._weights.imag, 0.0)
 
     @property
-    def dtype(self):
+    def dtype(self) -> Dtype:
+        """The dtype of the operator's matrix elements ⟨σ|Ô|σ'⟩."""
         return self._dtype
 
     @property

--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,9 @@ setup(
     url="http://github.com/netket/netket",
     author_email="netket@netket.org",
     license="Apache 2.0",
-    long_description="""NetKet is an open - source project delivering cutting - edge
-         methods for the study of many - body quantum systems with artificial
+    summmary="Netket : Machine Learning techniques for many-body quantum systems.",
+    long_description="""NetKet is an open-source project delivering cutting-edge
+         methods for the study of many-body quantum systems with artificial
          neural networks and machine learning techniques.""",
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
Closes #580 

Since we are not testing PauliStrings with anything really, I had missed that they needed methods to work with MetropolisHamiltonian, as well as `is_hermitian` defined to dispatch to the right gradient method.

This is still missing tests.

(Also adds a short description line to setup.py which is now required for recipes on conda...)