### PR TITLE
Added SR_solving.py with code for benchmarks

### DIFF
--- a/Benchmarks/SR_solving.py
+++ b/Benchmarks/SR_solving.py
@@ -1,0 +1,53 @@
+# Copyright 2021 The NetKet Authors - All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#    http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import netket as nk
+import pytest
+
+
+# This might need to be refactored into a separate file since the files would have a lot of common code from the below
+# class
+class Example:
+    def __init__(self, L, n_samp, alpha, dimensions):
+        self.lattice = nk.graph.Hypercube(length=L, n_dim=dimensions, pbc=True)
+        self.hilbertSpace = nk.hilbert.Spin(s=1 / 2, N=self.lattice.n_nodes)
+        # self.operator = nk.operator.Ising(hilbert=self.hilbertSpace, graph=self.lattice, h=1.0)  # Is this even needed?
+        self.rbmachine = nk.models.RBM(alpha=alpha, dtype=complex)
+        self.sampler = nk.sampler.MetropolisLocal(self.hilbertSpace, n_chains=32)
+        self.state = nk.variational.MCState(
+            self.sampler, self.rbmachine, n_samples=n_samp, seed=123
+        )
+
+
+@pytest.fixture(scope="module", params=[[64, 1024, 1, 1]])
+def example(request):
+    return Example(
+        L=request.param[0],
+        n_samp=request.param[1],
+        alpha=request.param[2],
+        dimensions=request.param[3],
+    )
+
+
+@pytest.mark.parametrize("centered", [True, False])
+@pytest.mark.benchmark(min_rounds=10)
+def test_sr_solver(example, benchmark, centered):
+    @benchmark
+    def sr_solver():
+        qgt = example.state.quantum_geometric_tensor(
+            nk.optimizer.SR(diag_shift=0.01, centered=centered)
+        )
+        return (qgt @ example.state.parameters)["Dense"]["kernel"].block_until_ready()
+
+    assert True


### PR DESCRIPTION
Sorry for the previous PR. Added a file "SR_solving.py" in the Benchmarks folder. Mostly uses the code in [this comment](https://github.com/netket/netket/pull/557#issuecomment-798568917) together with pytest-benchmark style code. This is what running it looks like:

```bash
pytest -n0 SR_solving.py 
=========================================================================================================== test session starts ============================================================================================================
platform darwin -- Python 3.7.9, pytest-6.2.2, py-1.10.0, pluggy-0.13.1 -- /Users/bharath/Dev/OpenSourceContributions/netket/.venv/bin/python3
cachedir: .pytest_cache
benchmark: 3.2.3 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /Users/bharath/Dev/OpenSourceContributions/netket, configfile: pyproject.toml
plugins: xdist-2.2.1, benchmark-3.2.3, forked-1.3.0
collected 2 items                                                                                                                                                                                                                          

SR_solving.py::test_sr_solver[example0-True] PASSED                                                                                                                                                                                  [ 50%]
SR_solving.py::test_sr_solver[example0-False] PASSED                                                                                                                                                                                 [100%]


-------------------------------------------------------------------------------------- benchmark: 2 tests -------------------------------------------------------------------------------------
Name (time in ms)                     Min               Max              Mean            StdDev            Median               IQR            Outliers       OPS            Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_sr_solver[example0-False]     3.3662 (1.0)      3.8675 (1.0)      3.6413 (1.0)      0.1631 (1.37)     3.5968 (1.0)      0.2572 (2.09)          3;0  274.6307 (1.0)          10           1
test_sr_solver[example0-True]      4.4655 (1.33)     4.8771 (1.26)     4.7138 (1.29)     0.1187 (1.0)      4.7145 (1.31)     0.1230 (1.0)           2;1  212.1427 (0.77)         10           1
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Legend:
  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
  OPS: Operations Per Second, computed as 1 / Mean
============================================================================================================ slowest durations =============================================================================================================
5.45s call     Benchmarks/SR_solving.py::test_sr_solver[example0-True]
2.67s setup    Benchmarks/SR_solving.py::test_sr_solver[example0-True]
0.55s call     Benchmarks/SR_solving.py::test_sr_solver[example0-False]

(3 durations < 0.005s hidden.  Use -vv to show these durations.)
============================================================================================================ 2 passed in 11.50s ============================================================================================================

```

A couple of minor things need to be ironed out -
1. Pytest-benchmark does not support multiple benchmarks, in the sense that the data is presented under the assumption that if two tests were performed, both the tests are the same. Thus when multiple tests are performed, it ranks them not by order, but by mean-time. Case in point, it can be seen that the test was run for True first and then for False, but the table shows False first and then True. It also colour codes the tests in a similar fashion, with red being the slowest and green being the fastest (not shown). Although this is more of an aesthetic issue, it would be good to sort it out
2. The final assert statement has been set to True, primarily because I am not aware of what the result should be compared with. Would be good if someone pitches in on it.