### PR TITLE
raise warnings in MetropolisHamiltonian if the Hilbert!=operator.hilbert

### DIFF
--- a/Test/Sampler/test_sampler.py
+++ b/Test/Sampler/test_sampler.py
@@ -57,15 +57,15 @@ samplers["Metropolis(Exchange): Fock-1particle)"] = nk.sampler.MetropolisExchang
     hib, n_chains=16, graph=g
 )
 
-samplers["Metropolis(Hamiltonian): Spin"] = nk.sampler.MetropolisHamiltonian(
+samplers["Metropolis(Hamiltonian,Jax): Spin"] = nk.sampler.MetropolisHamiltonian(
     hi,
     hamiltonian=ha,
     reset_chain=True,
 )
 
-samplers["Metropolis(Hamiltonian,Jax): Spin"] = nk.sampler.MetropolisSampler(
+samplers["Metropolis(Hamiltonian,Numpy): Spin"] = nk.sampler.MetropolisHamiltonianNumpy(
     hi,
-    rule=nk.sampler.rules.HamiltonianRule(ha.to_local_operator()),
+    hamiltonian=ha,
     reset_chain=True,
 )
 
@@ -246,3 +246,34 @@ def test_correct_sampling(sampler_c, rbm_and_weights, set_pdf_power):
 
     s, pval = combine_pvalues(pvalues, method="fisher")
     assert pval > 0.01 or np.max(pvalues) > 0.01
+
+
+def test_throwing(rbm_and_weights):
+    with pytest.raises(TypeError):
+        nk.sampler.MetropolisHamiltonian(
+            hi,
+            hamiltonian=10,
+            reset_chain=True,
+        )
+
+    with pytest.raises(ValueError):
+        sampler = nk.sampler.MetropolisHamiltonian(
+            nk.hilbert.DoubledHilbert(hi),
+            hamiltonian=ha,
+            reset_chain=True,
+        )
+
+        ma, w = rbm_and_weights(hi)
+
+        sampler_state = sampler.init_state(ma, w, seed=SAMPLER_SEED)
+
+    with pytest.raises(ValueError):
+        sampler = nk.sampler.MetropolisHamiltonianNumpy(
+            nk.hilbert.DoubledHilbert(hi),
+            hamiltonian=ha,
+            reset_chain=True,
+        )
+
+        ma, w = rbm_and_weights(hi)
+
+        sampler_state = sampler.init_state(ma, w, seed=SAMPLER_SEED)

--- a/netket/sampler/rules/custom_numpy.py
+++ b/netket/sampler/rules/custom_numpy.py
@@ -36,27 +36,29 @@ class CustomRuleState:
 
 @struct.dataclass
 class CustomRuleNumpy(MetropolisRule):
-    Ô: Any = struct.field(pytree_node=False)
+    operator: Any = struct.field(pytree_node=False)
     weight_list: Any = struct.field(pytree_node=False, default=None)
 
     def __post_init__(self):
         # Raise errors if hilbert is not an Hilbert
-        if not isinstance(self.Ô, AbstractOperator):
+        if not isinstance(self.operator, AbstractOperator):
             raise TypeError(
-                "Argument to HamiltonianRuleNumpy must be a valid operator.".format(
+                "Argument to CustomRuleNumpy must be a valid operator.".format(
                     type(operator)
                 )
             )
-        _check_operators(self.Ô.operators)
+        _check_operators(self.operator.operators)
 
         if self.weight_list is not None:
-            if self.weight_list.shape != (self.Ô.n_operators,):
+            if self.weight_list.shape != (self.operator.n_operators,):
                 raise ValueError("move_weights have the wrong shape")
             if self.weight_list.min() < 0:
                 raise ValueError("move_weights must be positive")
         else:
             object.__setattr__(
-                self, "weight_list", np.ones(self.Ô.n_operators, dtype=np.float32)
+                self,
+                "weight_list",
+                np.ones(self.operator.n_operators, dtype=np.float32),
             )
 
         object.__setattr__(
@@ -79,7 +81,7 @@ class CustomRuleNumpy(MetropolisRule):
             out=rule_state.rand_op_n,
         )
 
-        σ_conns, mels = rule.Ô.get_conn_filtered(
+        σ_conns, mels = rule.operator.get_conn_filtered(
             state.σ, rule_state.sections, rule_state.rand_op_n
         )
 

--- a/netket/sampler/rules/hamiltonian.py
+++ b/netket/sampler/rules/hamiltonian.py
@@ -51,7 +51,7 @@ class HamiltonianRule(MetropolisRule):
     """The (hermitian) operator giving the transition amplitudes."""
 
     def init_state(rule, sampler, machine, params, key):
-        if sampler.hilbert != rule.Ô.hilbert:
+        if sampler.hilbert != rule.operator.hilbert:
             raise ValueError(
                 f"""
             The hilbert space of the sampler ({sampler.hilbert}) and the hilbert space

--- a/netket/sampler/rules/hamiltonian.py
+++ b/netket/sampler/rules/hamiltonian.py
@@ -53,6 +53,16 @@ class HamiltonianRule(MetropolisRule):
 
     Ô: AbstractOperator = struct.field(pytree_node=False)
 
+    def init_state(rule, sampler, machine, params, key):
+        if sampler.hilbert != rule.Ô.hilbert:
+            raise ValueError(
+                f"""
+            The hilbert space of the sampler ({sampler.hilbert}) and the hilbert space
+            of the operator ({rule.Ô.hilbert}) for HamiltonianRule must be the same.
+            """
+            )
+        return super().init_state(rule, sampler, machine, params, key)
+
     def __post_init__(self):
         # Raise errors if hilbert is not an Hilbert
         if not isinstance(self.Ô, AbstractOperator):

--- a/netket/sampler/rules/hamiltonian.py
+++ b/netket/sampler/rules/hamiltonian.py
@@ -47,36 +47,36 @@ class HamiltonianRule(MetropolisRule):
     :class:`netket.sampler.MetropolisSamplerNumpy`.
 
     Attributes:
-        Ô: The (hermitian) operator giving the transition amplitudes.
+        Ô: The (hermitian) operator giving the transition amplitudes.
 
     """
 
-    Ô: AbstractOperator = struct.field(pytree_node=False)
+    Ô: AbstractOperator = struct.field(pytree_node=False)
 
     def init_state(rule, sampler, machine, params, key):
-        if sampler.hilbert != rule.Ô.hilbert:
+        if sampler.hilbert != rule.Ô.hilbert:
             raise ValueError(
                 f"""
             The hilbert space of the sampler ({sampler.hilbert}) and the hilbert space
-            of the operator ({rule.Ô.hilbert}) for HamiltonianRule must be the same.
+            of the operator ({rule.Ô.hilbert}) for HamiltonianRule must be the same.
             """
             )
-        return super().init_state(rule, sampler, machine, params, key)
+        return super().init_state(sampler, machine, params, key)
 
     def __post_init__(self):
         # Raise errors if hilbert is not an Hilbert
-        if not isinstance(self.Ô, AbstractOperator):
+        if not isinstance(self.Ô, AbstractOperator):
             raise TypeError(
                 "Argument to HamiltonianRule must be a valid operator.".format(
-                    type(self.Ô)
+                    type(self.Ô)
                 )
             )
 
     def transition(rule, sampler, machine, parameters, state, key, σ):
 
         hilbert = sampler.hilbert
-        get_conn_flattened = rule.Ô._get_conn_flattened_closure()
-        n_conn_from_sections = rule.Ô._n_conn_from_sections
+        get_conn_flattened = rule.Ô._get_conn_flattened_closure()
+        n_conn_from_sections = rule.Ô._n_conn_from_sections
 
         @njit4jax(
             (
@@ -113,7 +113,7 @@ class HamiltonianRule(MetropolisRule):
         return σp, log_prob_correction
 
     def __repr__(self):
-        return f"HamiltonianRule({self.Ô})"
+        return f"HamiltonianRule({self.Ô})"
 
 
 @jit(nopython=True)

--- a/netket/sampler/rules/hamiltonian.py
+++ b/netket/sampler/rules/hamiltonian.py
@@ -55,7 +55,7 @@ class HamiltonianRule(MetropolisRule):
             raise ValueError(
                 f"""
             The hilbert space of the sampler ({sampler.hilbert}) and the hilbert space
-            of the operator ({rule.Ô.hilbert}) for HamiltonianRule must be the same.
+            of the operator ({rule.operator.hilbert}) for HamiltonianRule must be the same.
             """
             )
         return super().init_state(sampler, machine, params, key)

--- a/netket/sampler/rules/hamiltonian.py
+++ b/netket/sampler/rules/hamiltonian.py
@@ -39,19 +39,16 @@ class HamiltonianRule(MetropolisRule):
     In this case, the transition matrix is taken to be:
 
     .. math::
+
        T( \\mathbf{s} \\rightarrow \\mathbf{s}^\\prime) = \\frac{1}{\\mathcal{N}(\\mathbf{s})}\\theta(|H_{\\mathbf{s},\\mathbf{s}^\\prime}|),
 
     This rule only works on CPU! If you want to use it on GPU, you
     must use the numpy variant :class:`netket.sampler.rules.HamiltonianRuleNumpy`
-    together with the numpy metropolis sampler
-    :class:`netket.sampler.MetropolisSamplerNumpy`.
-
-    Attributes:
-        Ô: The (hermitian) operator giving the transition amplitudes.
-
+    together with the numpy metropolis sampler :class:`netket.sampler.MetropolisSamplerNumpy`.
     """
 
-    Ô: AbstractOperator = struct.field(pytree_node=False)
+    operator: AbstractOperator = struct.field(pytree_node=False)
+    """The (hermitian) operator giving the transition amplitudes."""
 
     def init_state(rule, sampler, machine, params, key):
         if sampler.hilbert != rule.Ô.hilbert:
@@ -65,18 +62,18 @@ class HamiltonianRule(MetropolisRule):
 
     def __post_init__(self):
         # Raise errors if hilbert is not an Hilbert
-        if not isinstance(self.Ô, AbstractOperator):
+        if not isinstance(self.operator, AbstractOperator):
             raise TypeError(
                 "Argument to HamiltonianRule must be a valid operator.".format(
-                    type(self.Ô)
+                    type(self.operator)
                 )
             )
 
     def transition(rule, sampler, machine, parameters, state, key, σ):
 
         hilbert = sampler.hilbert
-        get_conn_flattened = rule.Ô._get_conn_flattened_closure()
-        n_conn_from_sections = rule.Ô._n_conn_from_sections
+        get_conn_flattened = rule.operator._get_conn_flattened_closure()
+        n_conn_from_sections = rule.operator._n_conn_from_sections
 
         @njit4jax(
             (
@@ -113,7 +110,7 @@ class HamiltonianRule(MetropolisRule):
         return σp, log_prob_correction
 
     def __repr__(self):
-        return f"HamiltonianRule({self.Ô})"
+        return f"HamiltonianRule({self.operator})"
 
 
 @jit(nopython=True)

--- a/netket/sampler/rules/hamiltonian_numpy.py
+++ b/netket/sampler/rules/hamiltonian_numpy.py
@@ -60,6 +60,14 @@ class HamiltonianRuleNumpy(MetropolisRule):
             )
 
     def init_state(rule, sampler, machine, params, key):
+        if sampler.hilbert != rule.Ô.hilbert:
+            raise ValueError(
+                f"""
+            The hilbert space of the sampler ({sampler.hilbert}) and the hilbert space
+            of the operator ({rule.Ô.hilbert}) for HamiltonianRule must be the same.
+            """
+            )
+
         return HamiltonianRuleState(
             sections=np.empty(sampler.n_batches, dtype=np.int32)
         )

--- a/netket/sampler/rules/hamiltonian_numpy.py
+++ b/netket/sampler/rules/hamiltonian_numpy.py
@@ -59,11 +59,11 @@ class HamiltonianRuleNumpy(MetropolisRule):
             )
 
     def init_state(rule, sampler, machine, params, key):
-        if sampler.hilbert != rule.Ô.hilbert:
+        if sampler.hilbert != rule.operator.hilbert:
             raise ValueError(
                 f"""
             The hilbert space of the sampler ({sampler.hilbert}) and the hilbert space
-            of the operator ({rule.Ô.hilbert}) for HamiltonianRule must be the same.
+            of the operator ({rule.operator.hilbert}) for HamiltonianRule must be the same.
             """
             )
 

--- a/netket/sampler/rules/hamiltonian_numpy.py
+++ b/netket/sampler/rules/hamiltonian_numpy.py
@@ -41,18 +41,17 @@ class HamiltonianRuleNumpy(MetropolisRule):
     In this case, the transition matrix is taken to be:
 
     .. math::
-       T( \\mathbf{s} \\rightarrow \\mathbf{s}^\\prime) = \\frac{1}{\\mathcal{N}(\\mathbf{s})}\\theta(|H_{\\mathbf{s},\\mathbf{s}^\\prime}|),
 
-    Attributes:
-        Ô: The (hermitian) operator giving the transition amplitudes.
+       T( \\mathbf{s} \\rightarrow \\mathbf{s}^\\prime) = \\frac{1}{\\mathcal{N}(\\mathbf{s})}\\theta(|H_{\\mathbf{s},\\mathbf{s}^\\prime}|),
 
     """
 
-    Ô: AbstractOperator = struct.field(pytree_node=False)
+    operator: AbstractOperator = struct.field(pytree_node=False)
+    """The (hermitian) operator giving the transition amplitudes."""
 
     def __post_init__(self):
         # Raise errors if hilbert is not an Hilbert
-        if not isinstance(self.Ô, AbstractOperator):
+        if not isinstance(self.operator, AbstractOperator):
             raise TypeError(
                 "Argument to HamiltonianRuleNumpy must be a valid operator.".format(
                     type(operator)
@@ -78,16 +77,16 @@ class HamiltonianRuleNumpy(MetropolisRule):
         log_prob_corr = state.log_prob_corr
 
         sections = state.rule_state.sections
-        σp = rule.Ô.get_conn_flattened(σ, sections)[0]
+        σp = rule.operator.get_conn_flattened(σ, sections)[0]
 
         rand_vec = rng.uniform(0, 1, size=σ.shape[0])
 
         _choose(σp, sections, σ1, log_prob_corr, rand_vec)
-        rule.Ô.n_conn(σ1, sections)
+        rule.operator.n_conn(σ1, sections)
         log_prob_corr -= np.log(sections)
 
     def __repr__(self):
-        return f"HamiltonianRuleNumpy({self.Ô})"
+        return f"HamiltonianRuleNumpy({self.operator})"
 
 
 @jit(nopython=True)


### PR DESCRIPTION
I just finished hunting down why my code was throwing mysterious numba exceptions.
well. Here it is.
I had an operator in doubled Hilbert space sampling the diagonal of a density matrix, but didn't realise.

This simply makes the sampler throw informative messages if this happens.
Saving sanity to poor users.
Amen