### PR TITLE
Make the acceptance rate a property of the sampler state

### DIFF
--- a/netket/sampler/metropolis.py
+++ b/netket/sampler/metropolis.py
@@ -138,11 +138,15 @@ class MetropolisSamplerState(SamplerState):
     n_accepted: int = 0
     """Number of accepted transitions along the chains since the last reset."""
 
+    @property
+    def acceptance_ratio(self) -> float:
+        """The percentage of accepted moves since the last reset."""
+        return self.n_accepted / self.n_samples * 100
+
     def __repr__(self):
         if self.n_samples > 0:
-            acceptance_rate = self.n_accepted / self.n_samples * 100
             acc_string = "# accepted = {}/{} ({}%), ".format(
-                self.n_accepted, self.n_samples, acceptance_rate
+                self.n_accepted, self.n_samples, self.acceptance_ratio
             )
         else:
             acc_string = ""

--- a/netket/sampler/metropolis.py
+++ b/netket/sampler/metropolis.py
@@ -158,9 +158,9 @@ class MetropolisSamplerState(SamplerState):
         return self.n_steps_proc * n_nodes
 
     @property
-    def n_steps(self) -> int:
+    def n_accepted(self) -> int:
         """Total number of moves accepted across all processes since the last reset."""
-        return sum_inplace(self.n_steps_proc)
+        return sum_inplace(self.n_accepted_proc)
 
     def __repr__(self):
         if self.n_steps > 0:

--- a/netket/sampler/metropolis.py
+++ b/netket/sampler/metropolis.py
@@ -21,6 +21,8 @@ from jax.experimental import loops
 from flax import struct
 
 from netket.hilbert import AbstractHilbert
+from netket.utils import n_nodes
+from netket.stats import sum_inplace
 
 from .base import Sampler, SamplerState
 
@@ -140,8 +142,15 @@ class MetropolisSamplerState(SamplerState):
 
     @property
     def acceptance_ratio(self) -> float:
-        """The percentage of accepted moves since the last reset."""
-        return self.n_accepted / self.n_samples * 100
+        """The percentage of accepted moves across all chains and MPI processes.
+
+        The rate is computed since the last reset of the sampler.
+        Will return None if no sampling has been performed since then.
+        """
+        if self.n_samples is 0:
+            return None
+
+        return sum_inplace(self.n_accepted / self.n_samples * 100) / n_nodes
 
     def __repr__(self):
         if self.n_samples > 0:

--- a/netket/sampler/metropolis.py
+++ b/netket/sampler/metropolis.py
@@ -147,7 +147,7 @@ class MetropolisSamplerState(SamplerState):
         The rate is computed since the last reset of the sampler.
         Will return None if no sampling has been performed since then.
         """
-        if self.n_samples is 0:
+        if self.n_samples == 0:
             return None
 
         return sum_inplace(self.n_accepted / self.n_samples * 100) / n_nodes

--- a/netket/sampler/metropolis_numpy.py
+++ b/netket/sampler/metropolis_numpy.py
@@ -24,6 +24,8 @@ from jax import numpy as jnp
 import jax
 
 from netket.hilbert import AbstractHilbert
+from netket.utils import n_nodes
+from netket.stats import sum_inplace
 
 from .metropolis import MetropolisSampler
 
@@ -58,8 +60,15 @@ class MetropolisNumpySamplerState:
 
     @property
     def acceptance_ratio(self) -> float:
-        """The percentage of accepted moves since the last reset."""
-        return self.n_accepted / self.n_samples * 100
+        """The percentage of accepted moves across all chains and MPI processes.
+
+        The rate is computed since the last reset of the sampler.
+        Will return None if no sampling has been performed since then.
+        """
+        if self.n_samples is 0:
+            return None
+
+        return sum_inplace(self.n_accepted / self.n_samples * 100) / n_nodes
 
     def __repr__(self):
         if self.n_samples > 0:

--- a/netket/sampler/metropolis_numpy.py
+++ b/netket/sampler/metropolis_numpy.py
@@ -53,10 +53,10 @@ class MetropolisNumpySamplerState:
     rng: Any
     """A numpy random generator."""
 
-    n_samples: int = 0
-    """Number of moves performed along the chains since the last reset."""
-    n_accepted: int = 0
-    """Number of accepted transitions along the chains since the last reset."""
+    n_steps_proc: int = 0
+    """Number of moves performed along the chains in this process since the last reset."""
+    n_accepted_proc: int = 0
+    """Number of accepted transitions among the chains in this process since the last reset."""
 
     @property
     def acceptance_ratio(self) -> float:
@@ -65,25 +65,30 @@ class MetropolisNumpySamplerState:
         The rate is computed since the last reset of the sampler.
         Will return None if no sampling has been performed since then.
         """
-        if self.n_samples == 0:
+        if self.n_steps == 0:
             return None
 
-        return sum_inplace(self.n_accepted / self.n_samples * 100) / n_nodes
+        return self.n_accepted / self.n_steps * 100
+
+    @property
+    def n_steps(self) -> int:
+        """Total number of moves performed across all processes since the last reset."""
+        return self.n_steps_proc * n_nodes
+
+    @property
+    def n_steps(self) -> int:
+        """Total number of moves accepted across all processes since the last reset."""
+        return sum_inplace(self.n_steps_proc)
 
     def __repr__(self):
-        if self.n_samples > 0:
+        if self.n_steps > 0:
             acc_string = "# accepted = {}/{} ({}%), ".format(
-                self.n_accepted, self.n_samples, self.acceptance_ratio
+                self.n_accepted, self.n_steps, self.acceptance_ratio
             )
         else:
             acc_string = ""
 
-        text = (
-            "MetropolisNumpySamplerState("
-            + acc_string
-            + "rng state={})".format(self.rng)
-        )
-        return text
+        return f"MetropolisNumpySamplerState({acc_string}rng state={self.rng})"
 
 
 @partial(jax.jit, static_argnums=0)
@@ -190,8 +195,8 @@ class MetropolisSamplerNumpy(MetropolisSampler):
                 random_uniform,
             )
 
-        state.n_samples += sampler.n_sweeps * sampler.n_chains
-        state.n_accepted += accepted
+        state.n_steps_proc += sampler.n_sweeps * sampler.n_chains
+        state.n_accepted_proc += accepted
 
         return state, state.σ
 

--- a/netket/sampler/metropolis_numpy.py
+++ b/netket/sampler/metropolis_numpy.py
@@ -76,9 +76,9 @@ class MetropolisNumpySamplerState:
         return self.n_steps_proc * n_nodes
 
     @property
-    def n_steps(self) -> int:
+    def n_accepted(self) -> int:
         """Total number of moves accepted across all processes since the last reset."""
-        return sum_inplace(self.n_steps_proc)
+        return sum_inplace(self.n_accepted_proc)
 
     def __repr__(self):
         if self.n_steps > 0:

--- a/netket/sampler/metropolis_numpy.py
+++ b/netket/sampler/metropolis_numpy.py
@@ -56,6 +56,26 @@ class MetropolisNumpySamplerState:
     n_accepted: int = 0
     """Number of accepted transitions along the chains since the last reset."""
 
+    @property
+    def acceptance_ratio(self) -> float:
+        """The percentage of accepted moves since the last reset."""
+        return self.n_accepted / self.n_samples * 100
+
+    def __repr__(self):
+        if self.n_samples > 0:
+            acc_string = "# accepted = {}/{} ({}%), ".format(
+                self.n_accepted, self.n_samples, self.acceptance_ratio
+            )
+        else:
+            acc_string = ""
+
+        text = (
+            "MetropolisNumpySamplerState("
+            + acc_string
+            + "rng state={})".format(self.rng)
+        )
+        return text
+
 
 @partial(jax.jit, static_argnums=0)
 def apply_model(machine, pars, weights):

--- a/netket/sampler/metropolis_numpy.py
+++ b/netket/sampler/metropolis_numpy.py
@@ -65,7 +65,7 @@ class MetropolisNumpySamplerState:
         The rate is computed since the last reset of the sampler.
         Will return None if no sampling has been performed since then.
         """
-        if self.n_samples is 0:
+        if self.n_samples == 0:
             return None
 
         return sum_inplace(self.n_accepted / self.n_samples * 100) / n_nodes


### PR DESCRIPTION
This makes it easy to log it during optimisation.

Currently this will raise a divideby0warning if you call it before having sampled.
We should maybe chose if it should return `None` or `0` in those cases?