### PR TITLE
Speed up DenseSymm by removing dense matvec product

### DIFF
--- a/Test/Models/test_nn.py
+++ b/Test/Models/test_nn.py
@@ -1,0 +1,61 @@
+# Copyright 2021 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import netket as nk
+import netket.nn.linear as linear
+
+import numpy as np
+import scipy.sparse
+
+import pytest
+
+
+@pytest.mark.parametrize("permutations", ["trans", "autom"])
+@pytest.mark.parametrize("features", [1, 2, 5])
+def test_symmetrizer(permutations, features):
+    N = 16
+
+    g = nk.graph.Chain(N)
+    if permutations == "trans":
+        # Only translations, N_symm = N_sites
+        perms = g.periodic_translations()
+    else:
+        # All chain automorphisms, N_symm = 2 N_sites
+        perms = g.automorphisms()
+    perms = np.array(perms)
+
+    n_symm, n_sites = perms.shape
+    n_hidden = features * n_symm
+
+    # symmetrization tensor entries
+    def symmetrizer_ijkl(i, j, k, l):
+        jsymm = np.floor_divide(j, n_symm)
+        cond_k = k == np.asarray(perms)[j % n_symm, i]
+        cond_l = l == jsymm
+        return np.asarray(np.logical_and(cond_k, cond_l), dtype=int)
+
+    symmetrizer = np.asarray(
+        np.fromfunction(
+            symmetrizer_ijkl,
+            shape=(n_sites, n_hidden, n_sites, features),
+            dtype=np.intp,
+        ),
+    ).reshape(-1, features * n_sites)
+    symmetrizer = scipy.sparse.coo_matrix(symmetrizer)
+
+    # Of the COO matrix attributes, rows is just a range [0, ..., n_rows)
+    # and data is [1., ..., 1.]. Only cols is non-trivial.
+    assert np.all(symmetrizer.row == np.arange(symmetrizer.shape[0]))
+    assert np.all(symmetrizer.data == 1.0)
+    assert np.all(symmetrizer.col == linear._symmetrizer_col(perms, features))

--- a/Test/Models/test_rbm.py
+++ b/Test/Models/test_rbm.py
@@ -15,6 +15,8 @@
 import netket as nk
 import jax.numpy as jnp
 
+from test_nn import _setup_symm
+
 import pytest
 
 
@@ -22,16 +24,7 @@ import pytest
 @pytest.mark.parametrize("use_visible_bias", [True, False])
 @pytest.mark.parametrize("permutations", ["trans", "autom"])
 def test_RBMSymm(use_hidden_bias, use_visible_bias, permutations):
-    N = 8
-    hi = nk.hilbert.Spin(1 / 2, N)
-
-    g = nk.graph.Chain(N)
-    if permutations == "trans":
-        # Only translations, N_symm = N_sites
-        perms = g.periodic_translations()
-    else:
-        # All chain automorphisms, N_symm = 2 N_sites
-        perms = g.automorphisms()
+    g, hi, perms = _setup_symm(permutations, N=8)
 
     ma = nk.models.RBMSymm(
         permutations=perms,

--- a/netket/models/rbm.py
+++ b/netket/models/rbm.py
@@ -271,9 +271,9 @@ def create_RBMSymm(
     if isinstance(permutations, Callable):
         perm_fn = permutations
     elif isinstance(permutations, AbstractGraph):
-        perm_fn = lambda: jnp.asarray(permutations.automorphisms())
+        perm_fn = lambda: np.asarray(permutations.automorphisms())
     else:
-        permutations = jnp.asarray(permutations)
+        permutations = np.asarray(permutations)
         if not permutations.ndim == 2:
             raise ValueError(
                 "permutations must be an array of shape (#permutations, #sites)."

--- a/netket/nn/linear.py
+++ b/netket/nn/linear.py
@@ -29,7 +29,6 @@ import jax
 from jax import lax
 import jax.numpy as jnp
 import numpy as np
-import scipy.sparse
 
 
 PRNGKey = Any

--- a/netket/nn/linear.py
+++ b/netket/nn/linear.py
@@ -219,6 +219,9 @@ def _symmetrizer_col(perms, features):
     case S[ij][kl] == 1. Thus, this method only returns the array of indices `col`
     of shape (n_sites×n_hidden,) satisfying
         W[ij] = w[col[ij]]  <=>  W = w[col].
+
+    See Test/Models/test_nn.py:test_symmetrizer for how this relates to the
+    matrix form of the symmetrizer.
     """
     n_symm, n_sites = perms.shape
     n_hidden = features * n_symm

--- a/netket/nn/linear.py
+++ b/netket/nn/linear.py
@@ -25,7 +25,6 @@ from netket.nn.initializers import lecun_normal, normal, variance_scaling, zeros
 from netket import jax as nkjax
 from netket.graph import AbstractGraph
 
-import jax
 from jax import lax
 import jax.numpy as jnp
 import numpy as np
@@ -264,7 +263,7 @@ class DenseSymm(Module):
         self.n_symm, self.n_sites = perms.shape
         self.n_hidden = self.features * self.n_symm
 
-        self.symm_cols = jax.device_put(_symmetrizer_col(perms, self.features))
+        self.symm_cols = jnp.asarray(_symmetrizer_col(perms, self.features))
 
     def full_kernel(self, kernel):
         """


### PR DESCRIPTION
The `symmetrizer` in `DenseSymm` is a very sparse matrix. While `jax` does not yet support sparse operations, we can just do this manually (and more efficiently) in this case.

In fact, `symmetrizer` is a COO matrix with
```python
rows = arange(sites * n_hidden)
cols = ...
data = [1., ..., 1.]
```
so only `cols` need to be stored and the "matrix-vector product" to map reduced to full weights reduces to
```python
full_kernel = (kernel.reshape(-1)[cols]).reshape(self.n_sites, -1)
```
This saves memory for storing `symmetrizer`, which becomes important in larger systems, and is also faster:
At least on the CPU, the comparison looks very much in favor of the indexing version (`n_sites=100`, `features=8`):
```python
In[1]: f1 = jax.jit(lambda w: (w.reshape(-1)[symm_cols]).reshape(n_sites, -1))
In[2]: f2 = jax.jit(lambda w: jnp.matmul(symmetrizer, w.reshape(-1)).reshape(n_sites, -1))
In[3]: f1(kernel); f2(kernel); # pre-jit
In[4]: %timeit f1(kernel).block_until_ready()
101 µs ± 1.78 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
In[5]: %timeit f2(kernel).block_until_ready()
15.7 ms ± 144 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

Still todo:
- [x] The code constructs the full `symmetrizer` and then converts it to a COO matrix. This is of course redundant - that code can be rewritten to just create `cols` directly. I'll do that soon; it just requires some more fiddling with indices.