### PR TITLE
Stop using numpy.typing in favour of our types and lower numpy compat bound

### DIFF
--- a/netket/hilbert/abstract_hilbert.py
+++ b/netket/hilbert/abstract_hilbert.py
@@ -184,7 +184,7 @@ class AbstractHilbert(abc.ABC):
             size: If provided, returns a batch of configurations of the form :code:`(size, N)` if size
                   is an integer or :code:`(*size, N)` if it is a tuple and where :math:`N` is the Hilbert space size.
                   By default, a single random configuration with shape :code:`(#,)` is returned.
-            dtype: Dtype of the resulting vector.
+            dtype: DType of the resulting vector.
             out: Deprecated. Will be removed in v3.1
             rgen: Deprecated. Will be removed in v3.1
 

--- a/netket/jax/_expect.py
+++ b/netket/jax/_expect.py
@@ -21,11 +21,10 @@ import jax
 from jax import numpy as jnp
 
 from netket.stats import statistics as mpi_statistics, mean as mpi_mean, Stats
+from netket.utils.types import PyTree
 
 from ._grad import grad
 from ._vjp import vjp as nkvjp
-
-PyTree = Any
 
 
 def expect(

--- a/netket/jax/utils.py
+++ b/netket/jax/utils.py
@@ -31,8 +31,8 @@ from jax.util import as_hashable_function
 from jax.dtypes import dtype_real
 
 from netket.utils import MPI, n_nodes, rank, random_seed
+from netket.utils.types import PyTree
 
-PyTree = Any
 PRNGKeyType = jnp.ndarray
 
 

--- a/netket/jax/utils.py
+++ b/netket/jax/utils.py
@@ -31,9 +31,7 @@ from jax.util import as_hashable_function
 from jax.dtypes import dtype_real
 
 from netket.utils import MPI, n_nodes, rank, random_seed
-from netket.utils.types import PyTree
-
-PRNGKeyType = jnp.ndarray
+from netket.utils.types import PyTree, PRNGKeyT, SeedT
 
 
 def tree_ravel(pytree: PyTree) -> Tuple[jnp.ndarray, Callable]:
@@ -162,8 +160,8 @@ class HashablePartial(partial):
 
 
 def PRNGKey(
-    seed: Optional[Union[int, PRNGKeyType]] = None, root: int = 0, comm=MPI.COMM_WORLD
-) -> PRNGKeyType:
+    seed: Optional[SeedT] = None, root: int = 0, comm=MPI.COMM_WORLD
+) -> PRNGKeyT:
     """
     Initialises a PRNGKey using an optional starting seed.
     The same seed will be distributed to all processes.
@@ -183,7 +181,7 @@ def PRNGKey(
     return key
 
 
-def mpi_split(key, root=0, comm=MPI.COMM_WORLD) -> PRNGKeyType:
+def mpi_split(key, root=0, comm=MPI.COMM_WORLD) -> PRNGKeyT:
     """
     Split a key across MPI nodes in the communicator.
     Only the input key on the root process matters.
@@ -214,7 +212,7 @@ class PRNGSeq:
     A sequence of PRNG keys genrated based on an initial key.
     """
 
-    def __init__(self, base_key: Optional[Union[int, PRNGKeyType]] = None):
+    def __init__(self, base_key: Optional[SeedT] = None):
         if base_key is None:
             base_key = PRNGKey()
         elif isinstance(base_key, int):

--- a/netket/models/jastrow.py
+++ b/netket/models/jastrow.py
@@ -17,13 +17,13 @@ import jax.numpy as jnp
 
 import netket as nk
 from netket.nn.initializers import normal
-from netket.utils.types import Dtype, Array, NNInitFunc
+from netket.utils.types import DType, Array, NNInitFunc
 
 
 class Jastrow(nn.Module):
     """Jastrow wave function :math:`\Psi(s) = \exp(\sum_{ij} s_i W_{ij} s_j)`."""
 
-    dtype: Dtype = jnp.complex128
+    dtype: DType = jnp.complex128
     """The dtype of the weights."""
     kernel_init: NNInitFunc = normal()
     """Initializer for the weights."""

--- a/netket/models/mps.py
+++ b/netket/models/mps.py
@@ -25,7 +25,7 @@ from netket.nn.initializers import lecun_normal, variance_scaling, zeros
 
 from netket.hilbert import AbstractHilbert
 from netket.graph import AbstractGraph
-from netket.utils.types import PRNGKey, Shape, DType, Array, NNInitFunc
+from netket.utils.types import PRNGKeyT, Shape, DType, Array, NNInitFunc
 
 default_kernel_init = lecun_normal()
 

--- a/netket/models/mps.py
+++ b/netket/models/mps.py
@@ -25,7 +25,7 @@ from netket.nn.initializers import lecun_normal, variance_scaling, zeros
 
 from netket.hilbert import AbstractHilbert
 from netket.graph import AbstractGraph
-from netket.utils.types import PRNGKey, Shape, Dtype, Array, NNInitFunc
+from netket.utils.types import PRNGKey, Shape, DType, Array, NNInitFunc
 
 default_kernel_init = lecun_normal()
 

--- a/netket/models/ndm.py
+++ b/netket/models/ndm.py
@@ -22,7 +22,7 @@ from flax import linen as nn
 
 from netket.hilbert import AbstractHilbert
 from netket.graph import AbstractGraph
-from netket.utils.types import PRNGKey, Shape, DType, Array, NNInitFunc
+from netket.utils.types import PRNGKeyT, Shape, DType, Array, NNInitFunc
 
 from netket import nn as nknn
 from netket.nn.initializers import lecun_normal, variance_scaling, zeros, normal

--- a/netket/models/ndm.py
+++ b/netket/models/ndm.py
@@ -22,7 +22,7 @@ from flax import linen as nn
 
 from netket.hilbert import AbstractHilbert
 from netket.graph import AbstractGraph
-from netket.utils.types import PRNGKey, Shape, Dtype, Array, NNInitFunc
+from netket.utils.types import PRNGKey, Shape, DType, Array, NNInitFunc
 
 from netket import nn as nknn
 from netket.nn.initializers import lecun_normal, variance_scaling, zeros, normal

--- a/netket/models/rbm.py
+++ b/netket/models/rbm.py
@@ -22,7 +22,7 @@ from flax import linen as nn
 
 from netket.hilbert import AbstractHilbert
 from netket.graph import AbstractGraph
-from netket.utils.types import PRNGKey, Shape, DType, Array, NNInitFunc
+from netket.utils.types import PRNGKeyT, Shape, DType, Array, NNInitFunc
 
 from netket import nn as nknn
 from netket.nn.initializers import lecun_normal, variance_scaling, zeros, normal

--- a/netket/models/rbm.py
+++ b/netket/models/rbm.py
@@ -22,7 +22,7 @@ from flax import linen as nn
 
 from netket.hilbert import AbstractHilbert
 from netket.graph import AbstractGraph
-from netket.utils.types import PRNGKey, Shape, Dtype, Array, NNInitFunc
+from netket.utils.types import PRNGKey, Shape, DType, Array, NNInitFunc
 
 from netket import nn as nknn
 from netket.nn.initializers import lecun_normal, variance_scaling, zeros, normal

--- a/netket/operator/_abstract_operator.py
+++ b/netket/operator/_abstract_operator.py
@@ -17,7 +17,7 @@ from typing import Optional, Tuple, List
 
 import numpy as np
 import jax.numpy as jnp
-from netket.utils.types import Dtype
+from netket.utils.types import DType
 
 from scipy.sparse import csr_matrix as _csr_matrix
 from numba import jit
@@ -81,7 +81,7 @@ class AbstractOperator(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def dtype(self) -> Dtype:
+    def dtype(self) -> DType:
         """The dtype of the operator's matrix elements ⟨σ|Ô|σ'⟩."""
         raise NotImplementedError
 

--- a/netket/operator/_abstract_operator.py
+++ b/netket/operator/_abstract_operator.py
@@ -17,7 +17,7 @@ from typing import Optional, Tuple, List
 
 import numpy as np
 import jax.numpy as jnp
-from numpy.typing import DTypeLike
+from netket.utils.types import Dtype
 
 from scipy.sparse import csr_matrix as _csr_matrix
 from numba import jit
@@ -81,7 +81,7 @@ class AbstractOperator(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def dtype(self) -> DTypeLike:
+    def dtype(self) -> Dtype:
         """The dtype of the operator's matrix elements ⟨σ|Ô|σ'⟩."""
         raise NotImplementedError
 

--- a/netket/operator/_graph_operator.py
+++ b/netket/operator/_graph_operator.py
@@ -15,7 +15,7 @@
 from numba import jit
 
 import numpy as np
-from numpy.typing import DTypeLike
+from netket.utils.types import Dtype
 
 from netket.graph import AbstractGraph
 from netket.hilbert import Fock, AbstractHilbert
@@ -37,7 +37,7 @@ class GraphOperator(LocalOperator):
         site_ops=[],
         bond_ops=[],
         bond_ops_colors=[],
-        dtype: DTypeLike = None,
+        dtype: Dtype = None,
     ):
         r"""
         A graph-based quantum operator. In its simplest terms, this is the sum of

--- a/netket/operator/_graph_operator.py
+++ b/netket/operator/_graph_operator.py
@@ -15,7 +15,7 @@
 from numba import jit
 
 import numpy as np
-from netket.utils.types import Dtype
+from netket.utils.types import DType
 
 from netket.graph import AbstractGraph
 from netket.hilbert import Fock, AbstractHilbert
@@ -37,7 +37,7 @@ class GraphOperator(LocalOperator):
         site_ops=[],
         bond_ops=[],
         bond_ops_colors=[],
-        dtype: Dtype = None,
+        dtype: DType = None,
     ):
         r"""
         A graph-based quantum operator. In its simplest terms, this is the sum of

--- a/netket/operator/_hamiltonian.py
+++ b/netket/operator/_hamiltonian.py
@@ -19,7 +19,7 @@ import math
 
 from netket.graph import AbstractGraph, Graph
 from netket.hilbert import AbstractHilbert, Fock
-from netket.utils.types import Dtype
+from netket.utils.types import DType
 
 from . import spin, boson
 from ._local_operator import LocalOperator
@@ -115,7 +115,7 @@ class Ising(SpecialHamiltonian):
         graph: AbstractGraph,
         h: float,
         J: float = 1.0,
-        dtype: Dtype = float,
+        dtype: DType = float,
     ):
         r"""
         Constructs the Ising Operator from an hilbert space and a
@@ -168,7 +168,7 @@ class Ising(SpecialHamiltonian):
         return True
 
     @property
-    def dtype(self) -> Dtype:
+    def dtype(self) -> DType:
         return self._dtype
 
     def conjugate(self, *, concrete=True):
@@ -447,7 +447,7 @@ class BoseHubbard(SpecialHamiltonian):
         V: float = 0.0,
         J: float = 1.0,
         mu: float = 0.0,
-        dtype: Dtype = float,
+        dtype: DType = float,
     ):
         r"""
         Constructs a new BoseHubbard operator given a hilbert space, a graph

--- a/netket/operator/_local_operator.py
+++ b/netket/operator/_local_operator.py
@@ -14,7 +14,7 @@
 
 import numbers
 from typing import Union, Tuple, List, Optional
-from netket.utils.types import Dtype, Array
+from netket.utils.types import DType, Array
 
 import numpy as np
 from numba import jit
@@ -49,7 +49,7 @@ def is_hermitian(a: np.ndarray, rtol=1e-05, atol=1e-08) -> bool:
     return np.allclose(a, a.T.conj(), rtol=rtol, atol=atol)
 
 
-def _dtype(obj: Union[numbers.Number, Array, "LocalOperator"]) -> Dtype:
+def _dtype(obj: Union[numbers.Number, Array, "LocalOperator"]) -> DType:
     if isinstance(obj, numbers.Number):
         return type(obj)
     elif isinstance(obj, AbstractOperator):
@@ -63,7 +63,7 @@ def _dtype(obj: Union[numbers.Number, Array, "LocalOperator"]) -> Dtype:
 def resize(
     arr: Array,
     shape: List[int],
-    dtype: Optional[Dtype] = None,
+    dtype: Optional[DType] = None,
     init: Optional[numbers.Number] = None,
 ) -> Array:
     """
@@ -171,7 +171,7 @@ class LocalOperator(AbstractOperator):
         operators: Union[List[Array], Array] = [],
         acting_on: Union[List[int], List[List[int]]] = [],
         constant: numbers.Number = 0,
-        dtype: Optional[Dtype] = None,
+        dtype: Optional[DType] = None,
     ):
         r"""
         Constructs a new ``LocalOperator`` given a hilbert space and (if
@@ -240,7 +240,7 @@ class LocalOperator(AbstractOperator):
         return actions
 
     @property
-    def dtype(self) -> Dtype:
+    def dtype(self) -> DType:
         return self._dtype
 
     @property

--- a/netket/operator/_local_operator.py
+++ b/netket/operator/_local_operator.py
@@ -14,7 +14,7 @@
 
 import numbers
 from typing import Union, Tuple, List, Optional
-from numpy.typing import DTypeLike, ArrayLike
+from netket.utils.types import Dtype, Array
 
 import numpy as np
 from numba import jit
@@ -49,7 +49,7 @@ def is_hermitian(a: np.ndarray, rtol=1e-05, atol=1e-08) -> bool:
     return np.allclose(a, a.T.conj(), rtol=rtol, atol=atol)
 
 
-def _dtype(obj: Union[numbers.Number, ArrayLike, "LocalOperator"]) -> DTypeLike:
+def _dtype(obj: Union[numbers.Number, Array, "LocalOperator"]) -> Dtype:
     if isinstance(obj, numbers.Number):
         return type(obj)
     elif isinstance(obj, AbstractOperator):
@@ -61,11 +61,11 @@ def _dtype(obj: Union[numbers.Number, ArrayLike, "LocalOperator"]) -> DTypeLike:
 
 
 def resize(
-    arr: ArrayLike,
+    arr: Array,
     shape: List[int],
-    dtype: Optional[DTypeLike] = None,
+    dtype: Optional[Dtype] = None,
     init: Optional[numbers.Number] = None,
-) -> ArrayLike:
+) -> Array:
     """
     resizes the input array to the new shape that must be larger than the old.
 
@@ -168,10 +168,10 @@ class LocalOperator(AbstractOperator):
     def __init__(
         self,
         hilbert: AbstractHilbert,
-        operators: Union[List[ArrayLike], ArrayLike] = [],
+        operators: Union[List[Array], Array] = [],
         acting_on: Union[List[int], List[List[int]]] = [],
         constant: numbers.Number = 0,
-        dtype: Optional[DTypeLike] = None,
+        dtype: Optional[Dtype] = None,
     ):
         r"""
         Constructs a new ``LocalOperator`` given a hilbert space and (if
@@ -240,7 +240,7 @@ class LocalOperator(AbstractOperator):
         return actions
 
     @property
-    def dtype(self) -> DTypeLike:
+    def dtype(self) -> Dtype:
         return self._dtype
 
     @property
@@ -453,7 +453,7 @@ class LocalOperator(AbstractOperator):
         operators = [np.copy(op) for op in self._operators]
         return operators
 
-    def _add_operator(self, operator: ArrayLike, acting_on: List[int]):
+    def _add_operator(self, operator: Array, acting_on: List[int]):
         if not np.can_cast(operator, self.dtype, casting="same_kind"):
             raise ValueError(f"Cannot cast type {operator.dtype} to {self.dtype}")
 

--- a/netket/operator/_pauli_strings.py
+++ b/netket/operator/_pauli_strings.py
@@ -14,7 +14,7 @@
 
 import re
 from typing import List, Union
-from netket.utils.types import Dtype
+from netket.utils.types import DType
 
 import numpy as np
 from numba import jit
@@ -32,7 +32,7 @@ class PauliStrings(AbstractOperator):
         operators: List[str],
         weights: List[Union[float, complex]],
         cutoff: float = 1.0e-10,
-        dtype: Dtype = complex,
+        dtype: DType = complex,
     ):
         """
         Constructs a new ``PauliStrings`` operator given a set of Pauli operators.
@@ -162,7 +162,7 @@ class PauliStrings(AbstractOperator):
         self._is_hermitian = np.allclose(self._weights.imag, 0.0)
 
     @property
-    def dtype(self) -> Dtype:
+    def dtype(self) -> DType:
         """The dtype of the operator's matrix elements ⟨σ|Ô|σ'⟩."""
         return self._dtype
 

--- a/netket/operator/boson.py
+++ b/netket/operator/boson.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from netket.utils.types import Dtype
+from netket.utils.types import DType
 
 from netket.hilbert import AbstractHilbert
 
@@ -20,7 +20,7 @@ from ._local_operator import LocalOperator as _LocalOperator
 
 
 def destroy(
-    hilbert: AbstractHilbert, site: int, dtype: Dtype = float
+    hilbert: AbstractHilbert, site: int, dtype: DType = float
 ) -> _LocalOperator:
     """
     Builds the boson destruction operator :math:`\\hat{a}` acting on the `site`-th of the
@@ -45,7 +45,7 @@ def destroy(
     return _LocalOperator(hilbert, mat, [site], dtype=dtype)
 
 
-def create(hilbert: AbstractHilbert, site: int, dtype: Dtype = float) -> _LocalOperator:
+def create(hilbert: AbstractHilbert, site: int, dtype: DType = float) -> _LocalOperator:
     """
     Builds the boson creation operator :math:`\\hat{a}^\\dagger` acting on the `site`-th of the
      Hilbert space `hilbert`.
@@ -69,7 +69,7 @@ def create(hilbert: AbstractHilbert, site: int, dtype: Dtype = float) -> _LocalO
     return _LocalOperator(hilbert, mat, [site], dtype=dtype)
 
 
-def number(hilbert: AbstractHilbert, site: int, dtype: Dtype = float) -> _LocalOperator:
+def number(hilbert: AbstractHilbert, site: int, dtype: DType = float) -> _LocalOperator:
     """
     Builds the number operator :math:`\\hat{a}^\\dagger\\hat{a}`  acting on the `site`-th of the
     Hilbert space `hilbert`.
@@ -94,7 +94,7 @@ def number(hilbert: AbstractHilbert, site: int, dtype: Dtype = float) -> _LocalO
 
 
 def proj(
-    hilbert: AbstractHilbert, site: int, n: int, dtype: Dtype = float
+    hilbert: AbstractHilbert, site: int, n: int, dtype: DType = float
 ) -> _LocalOperator:
     """
     Builds the projector operator :math:`|n\\rangle\\langle n |` acting on the `site`-th of the

--- a/netket/operator/boson.py
+++ b/netket/operator/boson.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from numpy.typing import DTypeLike
+from netket.utils.types import Dtype
 
 from netket.hilbert import AbstractHilbert
 
@@ -20,7 +20,7 @@ from ._local_operator import LocalOperator as _LocalOperator
 
 
 def destroy(
-    hilbert: AbstractHilbert, site: int, dtype: DTypeLike = float
+    hilbert: AbstractHilbert, site: int, dtype: Dtype = float
 ) -> _LocalOperator:
     """
     Builds the boson destruction operator :math:`\\hat{a}` acting on the `site`-th of the
@@ -45,9 +45,7 @@ def destroy(
     return _LocalOperator(hilbert, mat, [site], dtype=dtype)
 
 
-def create(
-    hilbert: AbstractHilbert, site: int, dtype: DTypeLike = float
-) -> _LocalOperator:
+def create(hilbert: AbstractHilbert, site: int, dtype: Dtype = float) -> _LocalOperator:
     """
     Builds the boson creation operator :math:`\\hat{a}^\\dagger` acting on the `site`-th of the
      Hilbert space `hilbert`.
@@ -71,9 +69,7 @@ def create(
     return _LocalOperator(hilbert, mat, [site], dtype=dtype)
 
 
-def number(
-    hilbert: AbstractHilbert, site: int, dtype: DTypeLike = float
-) -> _LocalOperator:
+def number(hilbert: AbstractHilbert, site: int, dtype: Dtype = float) -> _LocalOperator:
     """
     Builds the number operator :math:`\\hat{a}^\\dagger\\hat{a}`  acting on the `site`-th of the
     Hilbert space `hilbert`.
@@ -98,7 +94,7 @@ def number(
 
 
 def proj(
-    hilbert: AbstractHilbert, site: int, n: int, dtype: DTypeLike = float
+    hilbert: AbstractHilbert, site: int, n: int, dtype: Dtype = float
 ) -> _LocalOperator:
     """
     Builds the projector operator :math:`|n\\rangle\\langle n |` acting on the `site`-th of the

--- a/netket/operator/spin.py
+++ b/netket/operator/spin.py
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 from netket.hilbert import AbstractHilbert
-from netket.utils.types import Dtype
+from netket.utils.types import DType
 
 from ._local_operator import LocalOperator as _LocalOperator
 
 
-def sigmax(hilbert: AbstractHilbert, site: int, dtype: Dtype = float) -> _LocalOperator:
+def sigmax(hilbert: AbstractHilbert, site: int, dtype: DType = float) -> _LocalOperator:
     """
     Builds the :math:`\\sigma^x` operator acting on the `site`-th of the Hilbert
     space `hilbert`.
@@ -41,7 +41,7 @@ def sigmax(hilbert: AbstractHilbert, site: int, dtype: Dtype = float) -> _LocalO
 
 
 def sigmay(
-    hilbert: AbstractHilbert, site: int, dtype: Dtype = complex
+    hilbert: AbstractHilbert, site: int, dtype: DType = complex
 ) -> _LocalOperator:
     """
     Builds the :math:`\\sigma^y` operator acting on the `site`-th of the Hilbert
@@ -64,7 +64,7 @@ def sigmay(
     return _LocalOperator(hilbert, mat, [site], dtype=dtype)
 
 
-def sigmaz(hilbert: AbstractHilbert, site: int, dtype: Dtype = float) -> _LocalOperator:
+def sigmaz(hilbert: AbstractHilbert, site: int, dtype: DType = float) -> _LocalOperator:
     """
     Builds the :math:`\\sigma^z` operator acting on the `site`-th of the Hilbert
     space `hilbert`.
@@ -86,7 +86,7 @@ def sigmaz(hilbert: AbstractHilbert, site: int, dtype: Dtype = float) -> _LocalO
     return _LocalOperator(hilbert, mat, [site], dtype=dtype)
 
 
-def sigmam(hilbert: AbstractHilbert, site: int, dtype: Dtype = float) -> _LocalOperator:
+def sigmam(hilbert: AbstractHilbert, site: int, dtype: DType = float) -> _LocalOperator:
     """
     Builds the :math:`\\sigma^{-} = \\sigma^x - i \\sigma^y` operator acting on the
     `site`-th of the Hilbert space `hilbert`.
@@ -109,7 +109,7 @@ def sigmam(hilbert: AbstractHilbert, site: int, dtype: Dtype = float) -> _LocalO
     return _LocalOperator(hilbert, mat, [site], dtype=dtype)
 
 
-def sigmap(hilbert: AbstractHilbert, site: int, dtype: Dtype = float) -> _LocalOperator:
+def sigmap(hilbert: AbstractHilbert, site: int, dtype: DType = float) -> _LocalOperator:
     """
     Builds the :math:`\\sigma^{+} = \\sigma^x + i \\sigma^y` operator acting on the
     `site`-th of the Hilbert space `hilbert`.

--- a/netket/operator/spin.py
+++ b/netket/operator/spin.py
@@ -13,14 +13,12 @@
 # limitations under the License.
 
 from netket.hilbert import AbstractHilbert
-from numpy.typing import DTypeLike
+from netket.utils.types import Dtype
 
 from ._local_operator import LocalOperator as _LocalOperator
 
 
-def sigmax(
-    hilbert: AbstractHilbert, site: int, dtype: DTypeLike = float
-) -> _LocalOperator:
+def sigmax(hilbert: AbstractHilbert, site: int, dtype: Dtype = float) -> _LocalOperator:
     """
     Builds the :math:`\\sigma^x` operator acting on the `site`-th of the Hilbert
     space `hilbert`.
@@ -43,7 +41,7 @@ def sigmax(
 
 
 def sigmay(
-    hilbert: AbstractHilbert, site: int, dtype: DTypeLike = complex
+    hilbert: AbstractHilbert, site: int, dtype: Dtype = complex
 ) -> _LocalOperator:
     """
     Builds the :math:`\\sigma^y` operator acting on the `site`-th of the Hilbert
@@ -66,9 +64,7 @@ def sigmay(
     return _LocalOperator(hilbert, mat, [site], dtype=dtype)
 
 
-def sigmaz(
-    hilbert: AbstractHilbert, site: int, dtype: DTypeLike = float
-) -> _LocalOperator:
+def sigmaz(hilbert: AbstractHilbert, site: int, dtype: Dtype = float) -> _LocalOperator:
     """
     Builds the :math:`\\sigma^z` operator acting on the `site`-th of the Hilbert
     space `hilbert`.
@@ -90,9 +86,7 @@ def sigmaz(
     return _LocalOperator(hilbert, mat, [site], dtype=dtype)
 
 
-def sigmam(
-    hilbert: AbstractHilbert, site: int, dtype: DTypeLike = float
-) -> _LocalOperator:
+def sigmam(hilbert: AbstractHilbert, site: int, dtype: Dtype = float) -> _LocalOperator:
     """
     Builds the :math:`\\sigma^{-} = \\sigma^x - i \\sigma^y` operator acting on the
     `site`-th of the Hilbert space `hilbert`.
@@ -115,9 +109,7 @@ def sigmam(
     return _LocalOperator(hilbert, mat, [site], dtype=dtype)
 
 
-def sigmap(
-    hilbert: AbstractHilbert, site: int, dtype: DTypeLike = float
-) -> _LocalOperator:
+def sigmap(hilbert: AbstractHilbert, site: int, dtype: Dtype = float) -> _LocalOperator:
     """
     Builds the :math:`\\sigma^{+} = \\sigma^x + i \\sigma^y` operator acting on the
     `site`-th of the Hilbert space `hilbert`.

--- a/netket/optimizer/sr/sr_onthefly.py
+++ b/netket/optimizer/sr/sr_onthefly.py
@@ -20,15 +20,13 @@ import flax
 from jax import numpy as jnp
 from flax import struct
 
+from netket.utils.types import PyTree, Array
 from netket.utils import rename_class
 import netket.jax as nkjax
 
 from .sr_onthefly_logic import mat_vec as mat_vec_onthefly, tree_cast
 
 from .base import SR
-
-Ndarray = Any
-PyTree = Any
 
 
 @struct.dataclass
@@ -52,7 +50,7 @@ class SRLazy(SR):
     if the specified tolerance has not been achieved.
     """
 
-    M: Optional[Union[Callable, Ndarray]] = None
+    M: Optional[Union[Callable, Array]] = None
     """Preconditioner for A. The preconditioner should approximate the inverse of A. 
     Effective preconditioning dramatically improves the rate of convergence, which implies 
     that fewer iterations are needed to reach a given error tolerance.

--- a/netket/sampler/base.py
+++ b/netket/sampler/base.py
@@ -67,7 +67,7 @@ class Sampler(abc.ABC):
     """Exponent of the pdf sampled"""
 
     dtype: type = struct.field(pytree_node=False, default=np.float64)
-    """Dtype of the states returned."""
+    """DType of the states returned."""
 
     def __post_init__(self):
         # Raise errors if hilbert is not an Hilbert

--- a/netket/sampler/base.py
+++ b/netket/sampler/base.py
@@ -27,11 +27,10 @@ from jax.experimental import loops
 from netket import jax as nkjax
 from netket.hilbert import AbstractHilbert
 from netket.utils import get_afun_if_module
+from netket.utils.types import PyTree, PRNGKey
 from netket.jax import HashablePartial
 
-PyTree = Any
-PRNGKeyType = jnp.ndarray
-SeedType = Union[int, PRNGKeyType]
+SeedType = Union[int, PRNGKey]
 
 
 @struct.dataclass

--- a/netket/sampler/base.py
+++ b/netket/sampler/base.py
@@ -27,10 +27,10 @@ from jax.experimental import loops
 from netket import jax as nkjax
 from netket.hilbert import AbstractHilbert
 from netket.utils import get_afun_if_module
-from netket.utils.types import PyTree, PRNGKey
+from netket.utils.types import PyTree, PRNGKeyT
 from netket.jax import HashablePartial
 
-SeedType = Union[int, PRNGKey]
+SeedType = Union[int, PRNGKeyT]
 
 
 @struct.dataclass

--- a/netket/sampler/metropolis.py
+++ b/netket/sampler/metropolis.py
@@ -23,11 +23,9 @@ from flax import struct
 from netket.hilbert import AbstractHilbert
 from netket.utils import n_nodes
 from netket.stats import sum_inplace
+from netket.utils.types import PyTree, PRNGKey
 
 from .base import Sampler, SamplerState
-
-PyTree = Any
-PRNGKey = jnp.ndarray
 
 
 @struct.dataclass

--- a/netket/sampler/metropolis.py
+++ b/netket/sampler/metropolis.py
@@ -23,7 +23,7 @@ from flax import struct
 from netket.hilbert import AbstractHilbert
 from netket.utils import n_nodes
 from netket.stats import sum_inplace
-from netket.utils.types import PyTree, PRNGKey
+from netket.utils.types import PyTree, PRNGKeyT
 
 from .base import Sampler, SamplerState
 
@@ -40,7 +40,7 @@ class MetropolisRule:
         sampler: Sampler,
         machine: Callable,
         params: PyTree,
-        key: PRNGKey,
+        key: PRNGKeyT,
     ) -> Optional[Any]:
         """
         Initialises the optional internal state of the Metropolis Sampler Transition
@@ -88,7 +88,7 @@ class MetropolisRule:
         machine: Callable,
         parameters: PyTree,
         state: SamplerState,
-        key: PRNGKey,
+        key: PRNGKeyT,
         σ: jnp.ndarray,
     ) -> jnp.ndarray:
 
@@ -100,7 +100,7 @@ class MetropolisRule:
         machine: Callable,
         parameters: PyTree,
         state: SamplerState,
-        key: PRNGKey,
+        key: PRNGKeyT,
     ):
         """
         Generates a random state compatible with this rule.

--- a/netket/sampler/metropolis_numpy.py
+++ b/netket/sampler/metropolis_numpy.py
@@ -26,11 +26,11 @@ import jax
 from netket.hilbert import AbstractHilbert
 from netket.utils import n_nodes
 from netket.stats import sum_inplace
-from netket.utils.types import PyTree, PRNGKey
+from netket.utils.types import PyTree, PRNGKeyT
 
 from .metropolis import MetropolisSampler
 
-SeedType = Union[int, PRNGKey]
+SeedType = Union[int, PRNGKeyT]
 
 
 @dataclass

--- a/netket/sampler/metropolis_numpy.py
+++ b/netket/sampler/metropolis_numpy.py
@@ -26,12 +26,11 @@ import jax
 from netket.hilbert import AbstractHilbert
 from netket.utils import n_nodes
 from netket.stats import sum_inplace
+from netket.utils.types import PyTree, PRNGKey
 
 from .metropolis import MetropolisSampler
 
-PyTree = Any
-PRNGKeyType = jnp.ndarray
-SeedType = Union[int, PRNGKeyType]
+SeedType = Union[int, PRNGKey]
 
 
 @dataclass

--- a/netket/sampler/metropolis_pt.py
+++ b/netket/sampler/metropolis_pt.py
@@ -27,7 +27,7 @@ from flax import struct
 
 from netket import config
 from netket.hilbert import AbstractHilbert
-from netket.utils.types import PyTree, PRNGKey
+from netket.utils.types import PyTree, PRNGKeyT
 
 from .base import Sampler, SamplerState
 from .metropolis import MetropolisSamplerState, MetropolisSampler, MetropolisRule
@@ -142,7 +142,7 @@ class MetropolisPtSampler(MetropolisSampler):
         return self.n_chains * self.n_replicas
 
     def _init_state(
-        sampler, machine, params: PyTree, key: PRNGKey
+        sampler, machine, params: PyTree, key: PRNGKeyT
     ) -> MetropolisPtSamplerState:
         key_state, key_rule = jax.random.split(key, 2)
         σ = jnp.zeros(

--- a/netket/sampler/metropolis_pt.py
+++ b/netket/sampler/metropolis_pt.py
@@ -25,14 +25,12 @@ from jax.experimental import host_callback as hcb
 
 from flax import struct
 
-from netket.hilbert import AbstractHilbert
 from netket import config
+from netket.hilbert import AbstractHilbert
+from netket.utils.types import PyTree, PRNGKey
 
 from .base import Sampler, SamplerState
 from .metropolis import MetropolisSamplerState, MetropolisSampler, MetropolisRule
-
-PyTree = Any
-PRNGKey = jnp.ndarray
 
 
 @struct.dataclass

--- a/netket/utils/types.py
+++ b/netket/utils/types.py
@@ -20,3 +20,5 @@ Dtype = Any  # this could be a real type?
 Array = Any
 
 NNInitFunc = Callable[[PRNGKey, Shape, Dtype], Array]
+
+PyTree = Any

--- a/netket/utils/types.py
+++ b/netket/utils/types.py
@@ -12,13 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Sequence, Callable
+from typing import Any, Sequence, Callable, Union
 
-PRNGKey = Any
+PRNGKeyT = Any
+SeedT = Union[int, PRNGKeyT]
+
 Shape = Sequence[int]
 DType = Any  # this could be a real type?
 Array = Any
 
-NNInitFunc = Callable[[PRNGKey, Shape, DType], Array]
+NNInitFunc = Callable[[PRNGKeyT, Shape, DType], Array]
 
 PyTree = Any

--- a/netket/utils/types.py
+++ b/netket/utils/types.py
@@ -16,9 +16,9 @@ from typing import Any, Sequence, Callable
 
 PRNGKey = Any
 Shape = Sequence[int]
-Dtype = Any  # this could be a real type?
+DType = Any  # this could be a real type?
 Array = Any
 
-NNInitFunc = Callable[[PRNGKey, Shape, Dtype], Array]
+NNInitFunc = Callable[[PRNGKey, Shape, DType], Array]
 
 PyTree = Any

--- a/netket/variational/base.py
+++ b/netket/variational/base.py
@@ -26,13 +26,8 @@ import netket.jax as nkjax
 import netket.nn as nknn
 from netket.operator import AbstractOperator, LocalLiouvillian
 from netket.hilbert import AbstractHilbert, DoubledHilbert
+from netket.utils.types import Dtype, Array, PyTree, PRNGKey, Shape, NNInitFunc
 from netket.stats import Stats
-
-PyTree = Any
-ShapeT = Tuple[int, ...]
-DTypeT = Any
-PRNGKey = jnp.ndarray
-InitFunType = Callable[[PRNGKey, ShapeT, DTypeT], jnp.ndarray]
 
 
 class VariationalState(abc.ABC):
@@ -107,7 +102,7 @@ class VariationalState(abc.ABC):
         self.model_state, self.parameters = vars.pop("params")
 
     def init_parameters(
-        self, init_fun: Optional[InitFunType] = None, *, seed: Optional[PRNGKey] = None
+        self, init_fun: Optional[NNInitFunc] = None, *, seed: Optional[PRNGKey] = None
     ):
         r"""
         Re-initializes all the parameters with the provided initialization function, defaulting to

--- a/netket/variational/base.py
+++ b/netket/variational/base.py
@@ -26,7 +26,7 @@ import netket.jax as nkjax
 import netket.nn as nknn
 from netket.operator import AbstractOperator, LocalLiouvillian
 from netket.hilbert import AbstractHilbert, DoubledHilbert
-from netket.utils.types import Dtype, Array, PyTree, PRNGKey, Shape, NNInitFunc
+from netket.utils.types import DType, Array, PyTree, PRNGKey, Shape, NNInitFunc
 from netket.stats import Stats
 
 

--- a/netket/variational/base.py
+++ b/netket/variational/base.py
@@ -26,7 +26,7 @@ import netket.jax as nkjax
 import netket.nn as nknn
 from netket.operator import AbstractOperator, LocalLiouvillian
 from netket.hilbert import AbstractHilbert, DoubledHilbert
-from netket.utils.types import DType, Array, PyTree, PRNGKey, Shape, NNInitFunc
+from netket.utils.types import DType, Array, PyTree, PRNGKeyT, Shape, NNInitFunc
 from netket.stats import Stats
 
 
@@ -102,7 +102,7 @@ class VariationalState(abc.ABC):
         self.model_state, self.parameters = vars.pop("params")
 
     def init_parameters(
-        self, init_fun: Optional[NNInitFunc] = None, *, seed: Optional[PRNGKey] = None
+        self, init_fun: Optional[NNInitFunc] = None, *, seed: Optional[PRNGKeyT] = None
     ):
         r"""
         Re-initializes all the parameters with the provided initialization function, defaulting to

--- a/netket/variational/mc_mixed_state.py
+++ b/netket/variational/mc_mixed_state.py
@@ -34,6 +34,7 @@ from netket.hilbert import AbstractHilbert
 from netket.sampler import Sampler, SamplerState, ExactSampler
 from netket.stats import Stats, statistics, mean, sum_inplace
 from netket.utils import flax as flax_utils, maybe_wrap_module
+from netket.utils.types import Dtype, Array, PyTree, PRNGKey, Shape, NNInitFunc
 from netket.optimizer import SR
 from netket.operator import (
     AbstractOperator,
@@ -46,11 +47,6 @@ from netket.operator import (
 from .base import VariationalState, VariationalMixedState
 from .mc_state import MCState
 
-PyTree = Any
-PRNGKey = jnp.ndarray
-InitFunType = Callable[
-    [nn.Module, Iterable[int], PRNGKey, np.dtype], Tuple[Optional[PyTree], PyTree]
-]
 AFunType = Callable[[nn.Module, PyTree, jnp.ndarray], jnp.ndarray]
 ATrainFunType = Callable[
     [nn.Module, PyTree, jnp.ndarray, Union[bool, PyTree]], jnp.ndarray

--- a/netket/variational/mc_mixed_state.py
+++ b/netket/variational/mc_mixed_state.py
@@ -34,7 +34,7 @@ from netket.hilbert import AbstractHilbert
 from netket.sampler import Sampler, SamplerState, ExactSampler
 from netket.stats import Stats, statistics, mean, sum_inplace
 from netket.utils import flax as flax_utils, maybe_wrap_module
-from netket.utils.types import DType, Array, PyTree, PRNGKey, Shape, NNInitFunc
+from netket.utils.types import DType, Array, PyTree, PRNGKeyT, Shape, NNInitFunc
 from netket.optimizer import SR
 from netket.operator import (
     AbstractOperator,

--- a/netket/variational/mc_mixed_state.py
+++ b/netket/variational/mc_mixed_state.py
@@ -34,7 +34,7 @@ from netket.hilbert import AbstractHilbert
 from netket.sampler import Sampler, SamplerState, ExactSampler
 from netket.stats import Stats, statistics, mean, sum_inplace
 from netket.utils import flax as flax_utils, maybe_wrap_module
-from netket.utils.types import Dtype, Array, PyTree, PRNGKey, Shape, NNInitFunc
+from netket.utils.types import DType, Array, PyTree, PRNGKey, Shape, NNInitFunc
 from netket.optimizer import SR
 from netket.operator import (
     AbstractOperator,

--- a/netket/variational/mc_state.py
+++ b/netket/variational/mc_state.py
@@ -35,6 +35,7 @@ from netket.hilbert import AbstractHilbert
 from netket.sampler import Sampler, SamplerState, ExactSampler
 from netket.stats import Stats, statistics, mean, sum_inplace
 from netket.utils import flax as flax_utils, n_nodes, maybe_wrap_module
+from netket.utils.types import PyTree, PRNGKey, Shape, NNInitFunc
 from netket.optimizer import SR
 from netket.operator import (
     AbstractOperator,
@@ -47,12 +48,7 @@ from netket.operator import (
 
 from .base import VariationalState
 
-PyTree = Any
-PRNGKey = jnp.ndarray
 SEED = Union[int, PRNGKey]
-InitFunType = Callable[
-    [nn.Module, Iterable[int], PRNGKey, np.dtype], Tuple[Optional[PyTree], PyTree]
-]
 AFunType = Callable[[nn.Module, PyTree, jnp.ndarray], jnp.ndarray]
 ATrainFunType = Callable[
     [nn.Module, PyTree, jnp.ndarray, Union[bool, PyTree]], jnp.ndarray
@@ -117,7 +113,7 @@ class MCState(VariationalState):
         n_samples: int = 1000,
         n_discard: Optional[int] = None,
         variables: Optional[PyTree] = None,
-        init_fun: InitFunType = None,
+        init_fun: NNInitFunc = None,
         apply_fun: Callable = None,
         sample_fun: Callable = None,
         seed: Optional[SEED] = None,

--- a/netket/variational/mc_state.py
+++ b/netket/variational/mc_state.py
@@ -35,7 +35,7 @@ from netket.hilbert import AbstractHilbert
 from netket.sampler import Sampler, SamplerState, ExactSampler
 from netket.stats import Stats, statistics, mean, sum_inplace
 from netket.utils import flax as flax_utils, n_nodes, maybe_wrap_module
-from netket.utils.types import PyTree, PRNGKey, Shape, NNInitFunc
+from netket.utils.types import PyTree, PRNGKeyT, SeedT, Shape, NNInitFunc
 from netket.optimizer import SR
 from netket.operator import (
     AbstractOperator,
@@ -48,7 +48,6 @@ from netket.operator import (
 
 from .base import VariationalState
 
-SEED = Union[int, PRNGKey]
 AFunType = Callable[[nn.Module, PyTree, jnp.ndarray], jnp.ndarray]
 ATrainFunType = Callable[
     [nn.Module, PyTree, jnp.ndarray, Union[bool, PyTree]], jnp.ndarray
@@ -116,8 +115,8 @@ class MCState(VariationalState):
         init_fun: NNInitFunc = None,
         apply_fun: Callable = None,
         sample_fun: Callable = None,
-        seed: Optional[SEED] = None,
-        sampler_seed: Optional[SEED] = None,
+        seed: Optional[SeedT] = None,
+        sampler_seed: Optional[SeedT] = None,
         mutable: bool = False,
         training_kwargs: Dict = {},
     ):

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ DEV_DEPENDENCIES = [
 MPI_DEPENDENCIES = ["mpi4py>=3.0.1", "mpi4jax>=0.2.11"]
 TENSORBOARD_DEPENDENCIES = ["tensorboardx>=2.0.0"]
 BASE_DEPENDENCIES = [
-    "numpy>=1.20",
+    "numpy>=1.18",
     "scipy>=1.5.2",
     "tqdm>=4.56.2",
     "numba>=0.52.0",


### PR DESCRIPTION
To numpy>=1.18.
In any case this is what jax/stax require so it makes no sense to go lower.
It was reported to me it was annoying on google colab bcause tensor flow requires numpy<1.20