### PR TITLE
Two small performance improvements

### DIFF
--- a/netket/operator/_hamiltonian.py
+++ b/netket/operator/_hamiltonian.py
@@ -145,7 +145,7 @@ class Ising(SpecialHamiltonian):
 
         self._h = dtype(h)
         self._J = dtype(J)
-        self._edges = np.asarray(list(graph.edges()))
+        self._edges = np.asarray(list(graph.edges()), dtype=np.intp)
 
         self._dtype = dtype
 

--- a/netket/operator/_local_liouvillian.py
+++ b/netket/operator/_local_liouvillian.py
@@ -244,7 +244,7 @@ class LocalLiouvillian(AbstractSuperOperator):
                 max_conns_Lrc += max_lr * max_lc
 
         # compose everything again
-        if self._xprime.shape[0] < self._max_conn_size * batch_size:
+        if self._xprime_f.shape[0] < self._max_conn_size * batch_size:
             # refcheck=False because otherwise this errors when testing
             self._xprime_f.resize(
                 self._max_conn_size * batch_size, self.hilbert.size, refcheck=False


### PR DESCRIPTION
The one in hamiltonian causes less compilation by numba in some cases,
the one in liouvillian was wrong and was allocating more often than needed.