### PR TITLE
Publish wheels to PyPy

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,5 +34,5 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
 
         run: |
-          python setup.py sdist
+          python setup.py bdist_wheel sdist
           twine upload dist/*


### PR DESCRIPTION
This will slightly speed up installation but mostly its considered the right way to publish to pypy nowadays