### PR TITLE
Update test_raises in samplers

### DIFF
--- a/Test/Sampler/test_sampler.py
+++ b/Test/Sampler/test_sampler.py
@@ -6,6 +6,7 @@ from pytest import approx
 from scipy.stats import power_divergence, combine_pvalues, chisquare
 
 import jax
+import flax
 from jax import numpy as jnp
 
 nk.config.update("NETKET_EXPERIMENTAL", True)
@@ -278,7 +279,7 @@ def test_throwing(rbm_and_weights):
 
         sampler_state = sampler.init_state(ma, w, seed=SAMPLER_SEED)
 
-    with pytest.raises():
+    with pytest.raises(flax.errors.ScopeParamShapeError):
         sampler = nk.sampler.MetropolisHamiltonianNumpy(
             nk.hilbert.DoubledHilbert(hi),
             hamiltonian=ha,

--- a/Test/Sampler/test_sampler.py
+++ b/Test/Sampler/test_sampler.py
@@ -269,7 +269,7 @@ def test_throwing(rbm_and_weights):
 
     with pytest.raises(ValueError):
         sampler = nk.sampler.MetropolisHamiltonianNumpy(
-            nk.hilbert.Fock(3)**hi.size,
+            nk.hilbert.Fock(3) ** hi.size,
             hamiltonian=ha,
             reset_chain=True,
         )

--- a/Test/Sampler/test_sampler.py
+++ b/Test/Sampler/test_sampler.py
@@ -269,6 +269,17 @@ def test_throwing(rbm_and_weights):
 
     with pytest.raises(ValueError):
         sampler = nk.sampler.MetropolisHamiltonianNumpy(
+            nk.hilbert.Fock(3)**hi.size,
+            hamiltonian=ha,
+            reset_chain=True,
+        )
+
+        ma, w = rbm_and_weights(hi)
+
+        sampler_state = sampler.init_state(ma, w, seed=SAMPLER_SEED)
+
+    with pytest.raises():
+        sampler = nk.sampler.MetropolisHamiltonianNumpy(
             nk.hilbert.DoubledHilbert(hi),
             hamiltonian=ha,
             reset_chain=True,


### PR DESCRIPTION
Because Flax 0.3.3 is raising an error before we do, so we must check for different types of errors