### PR TITLE
Return info object when using SR iterative solvers.

### DIFF
--- a/netket/driver/steady_state.py
+++ b/netket/driver/steady_state.py
@@ -87,7 +87,7 @@ class SteadyState(AbstractVariationalDriver):
 
             # use the previous solution as an initial guess to speed up the solution of the linear system
             x0 = self._dp if self.sr_restart is False else None
-            self._dp = self._S.solve(self._loss_grad, x0=x0)
+            self._dp, self._sr_info = self._S.solve(self._loss_grad, x0=x0)
         else:
             # tree_map(lambda x, y: x if is_ccomplex(y) else x.real, self._grads, self.state.parameters)
             self._dp = self._loss_grad

--- a/netket/driver/steady_state.py
+++ b/netket/driver/steady_state.py
@@ -68,6 +68,8 @@ class SteadyState(AbstractVariationalDriver):
         self.sr_restart = sr_restart
 
         self._dp = None
+        self._S = None
+        self._sr_info = None
 
     def _forward_and_backward(self):
         """

--- a/netket/driver/vmc.py
+++ b/netket/driver/vmc.py
@@ -104,7 +104,7 @@ class VMC(AbstractVariationalDriver):
 
             # use the previous solution as an initial guess to speed up the solution of the linear system
             x0 = self._dp if self.sr_restart is False else None
-            self._dp = self._S.solve(self._loss_grad, x0=x0)
+            self._dp, self._sr_info = self._S.solve(self._loss_grad, x0=x0)
         else:
             # tree_map(lambda x, y: x if is_ccomplex(y) else x.real, self._grads, self.state.parameters)
             self._dp = self._loss_grad

--- a/netket/driver/vmc.py
+++ b/netket/driver/vmc.py
@@ -85,6 +85,8 @@ class VMC(AbstractVariationalDriver):
         self.sr_restart = sr_restart
 
         self._dp = None  # type: PyTree
+        self._S = None
+        self._sr_info = None
 
     def _forward_and_backward(self):
         """

--- a/netket/optimizer/sr/sr_onthefly.py
+++ b/netket/optimizer/sr/sr_onthefly.py
@@ -174,18 +174,20 @@ class LazySMatrix:
             x0: optional initial guess for the solution.
 
         Returns:
-            the PyTree solving thhe system.s
+            x: the PyTree solving the system.
+            info: optional additional informations provided by the solver. Might be
+                None if there are no additional informations provided.
         """
         if x0 is None:
             x0 = self.x0
 
-        out = apply_onthefly(
+        out, info = apply_onthefly(
             self,
             y,
             x0,
         )
 
-        return out
+        return out, info
 
     @jax.jit
     def to_dense(self) -> jnp.ndarray:
@@ -225,8 +227,8 @@ def apply_onthefly(S: LazySMatrix, grad: PyTree, x0: Optional[PyTree]) -> PyTree
         centered=S.sr.centered,
     )
     solve_fun = S.sr.solve_fun()
-    out, _ = solve_fun(_mat_vec, grad, x0=x0)
-    return out
+    out, info = solve_fun(_mat_vec, grad, x0=x0)
+    return out, info
 
 
 @jax.jit


### PR DESCRIPTION
When using `LazySR.solve()`we where trashing the additional informations returned by the solver, such as number of iterations and whoever it converged or not, so this PR simply propagates the informations out, and stores them in a hidden field in the driver (maybe we should make this field public?) so that it can be logged with custom callbacks.

However... right now Jax linear solvers don't return that information! They say that eventually they will. So it's rather useless...
But at least we get the correct api in place and as soon as they start giving us the info, Netket will support it.