### PR TITLE
Superop fix

### DIFF
--- a/Test/Operator/test_liouvillian.py
+++ b/Test/Operator/test_liouvillian.py
@@ -62,12 +62,16 @@ def test_lindblad_form():
         hnh_mat -= 0.5j * j_mat.H * j_mat
 
     # Compute the left and right product with identity
-    lind_mat = -1j * sparse.kron(idmat, hnh_mat) + 1j * sparse.kron(hnh_mat.H, idmat)
+    lind_mat = -1j * sparse.kron(hnh_mat, idmat) + 1j * sparse.kron(
+        idmat, hnh_mat.conj()
+    )
     # add jump operators
     for j_op in j_ops:
         j_mat = j_op.to_sparse()
-        lind_mat += sparse.kron(j_mat.conj(), j_mat)
+        lind_mat += sparse.kron(j_mat, j_mat.conj())
 
+    print(lind_mat.shape)
+    print(lind.to_dense().shape)
     np.testing.assert_allclose(lind_mat.todense(), lind.to_dense())
 
 
@@ -78,7 +82,7 @@ def test_liouvillian_no_dissipators():
     idmat = sparse.eye(2 ** L)
     h_mat = ha.to_sparse()
 
-    lind_mat = -1j * sparse.kron(idmat, h_mat) + 1j * sparse.kron(h_mat, idmat)
+    lind_mat = -1j * sparse.kron(h_mat, idmat) + 1j * sparse.kron(idmat, h_mat.conj())
 
     np.testing.assert_allclose(lind.to_dense(), lind_mat.todense())
 

--- a/docs/docs/superop.rst
+++ b/docs/docs/superop.rst
@@ -1,0 +1,86 @@
+============================
+The Lindblad Master Equation
+============================
+
+In short: Many-body states in NetKet are stored in `big-endian format <https://en.wikipedia.org/wiki/Endianness#Bi-endianness>`_, and that applies to super-operators too.
+
+This means that, if the local basis of your Hilbert space is :code:`[0,1]`, the joint Hilbert space
+composed of two sites will have 4 states, indexed in the following order: :code:`[00,01,10,11]`. 
+This format is called Big-Endian because increasing the first element in the array will increase the 
+index within the hilbert space more than increasing the last element in the array.
+
+This format is also the most natural in row-column languages such as Python/Numpy, as opposed to Julia 
+and Fortran which are column-major.
+It is the format that arises if you take the kronecker product with numpy.
+
+This same ordering is then used when representing operators, as they inherit the ordering of the hilbert
+space along both of their dimensions.
+
+The Density Matrix and the Liouvillian
+--------------------------------------
+
+The lindblad master equation that is encoded in the Liouvillian is:
+
+.. math ::
+
+    \mathcal{L} = -i \left[ \hat{H}, \hat{\rho}\right] + \sum_i \left[ \hat{L}_i\hat{\rho}\hat{L}_i^\dagger -
+        \left\{ \hat{L}_i^\dagger\hat{L}_i, \hat{\rho} \right\} \right]
+
+The liouvillian is a rank-4 tensor obtained by taking the kronecker product of 
+two objects in the operator-space, and one can again choose row-stacking or column-stacking
+to represent it.
+
+Qutip and QuantumOptics.jl both use column-stacking, the first for historical reasons (due to 
+their Matlab origins), the other to leverage the column-major nature of Julia. In NetKet 3 we 
+switched to a row-major (row-stacking) encoding as it is more natural in Python and it simplifies
+working with operators. 
+
+For performance reasons we pack together the Unitary and anti-Unitary terms into a single
+non hermitian Hamiltonian :math:`\hat{H}_{nh}`, which allows us to rewrite the formula above as
+
+That is then composed with the jump operators in the inner kernel with the formula:
+
+.. math ::
+
+    \mathcal{L} = -i \hat{H}_{nh}\hat{\rho} +i\hat{\rho}\hat{H}_{nh}^\dagger + \sum_i \hat{L}_i\hat{\rho}\hat{L}_i^\dagger
+
+Where :math:`\hat{H}_{nh}` is given by the formula:
+
+.. math ::
+
+    \hat{H}_{nh} = \hat{H} - \sum_i \frac{i}{2}\hat{L}_i^\dagger\hat{L}_i
+
+
+The row-stacked, matrix-representation of the Liouvillian is then given by the following formula:
+
+.. math ::
+	\hat{\mathcal{L}} = -i \hat{H}_{nh} \otimes \hat{I} + i \hat{I} \otimes \hat{H}_{nh}^\star
+	+ \sum_i  \hat{L}_i\otimes\hat{L}_i^\star
+
+An intuitive derivation of the formula above can be had by trying to compute the connected elements of
+:math:`\langle \sigma | \hat{\mathcal{L}}(\hat{\rho})|\eta\rangle` connecting to 
+:math:`\langle x | \hat{\rho} | y \rangle`.
+
+Alternatively, a formal derivation of the formula above is laied out by my fellow Fabrizio in the appendix 
+A1 of `this article <https://arxiv.org/pdf/1909.11619.pdf#page=16>`_.
+
+
+
+Computing Observables
+---------------------
+
+Expectation values of operators can be computed on a mixed state according to the well known formula
+
+.. math ::
+	\langle \hat{O} \rangle &= \mathrm{Tr}[\hat{O}\hat{\rho}]  \\
+			&= \sum_{\sigma,\eta} \langle \sigma | \hat{O} |\eta\rangle \langle\eta |\hat{\rho} |\sigma \rangle \\
+			& = \sum_{\sigma,\eta} \frac{\langle \sigma | \hat{\rho} | \sigma\rangle}{\langle \sigma | \hat{\rho} | \sigma\rangle}\langle \sigma | \hat{O} |\eta\rangle \langle\eta |\hat{\rho} |\sigma \rangle\\
+			&= \sum_{\sigma} \langle \sigma | \hat{\rho} | \sigma\rangle \left(\sum_\eta \langle \sigma | \hat{O} |\eta\rangle \frac{\langle\eta |\hat{\rho} |\sigma \rangle}{\langle \sigma | \hat{\rho} | \sigma\rangle}\right)
+
+And since the diagonal elements of the density matrix are positive, real and normalized to 1, they form a well defined probability distribution that we can sample and use to estimate observables.
+
+The only downside of this approach is that the Markov-Chain that is needed to sample the diagonal elements
+is not the same as the one that can be used to sample the whole density matrix, which is used during optimization of the steady-state.
+
+
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -112,6 +112,7 @@
 
    docs/getting_started
    docs/whats_new
+   docs/superop
    docs/varstate
    docs/drivers
    docs/custom_models

--- a/netket/operator/_local_cost_functions.py
+++ b/netket/operator/_local_cost_functions.py
@@ -211,6 +211,6 @@ def local_value_cost(logpsi, pars, vp, mel, v):
 @partial(define_local_cost_function, static_argnums=0, batch_axes=(None, None, 0, 0, 0))
 def local_value_op_op_cost(logpsi, pars, σp, mel, σ):
 
-    σ_σp = jax.vmap(lambda σ, σp: jnp.hstack((σ, σp)), in_axes=(None, 0))(σ, σp)
+    σ_σp = jax.vmap(lambda σp, σ: jnp.hstack((σp, σ)), in_axes=(0, None))(σp, σ)
     σ_σ = jnp.hstack((σ, σ))
     return jnp.sum(mel * jnp.exp(logpsi(pars, σ_σp) - logpsi(pars, σ_σ)))

--- a/netket/operator/_local_liouvillian.py
+++ b/netket/operator/_local_liouvillian.py
@@ -58,7 +58,7 @@ class LocalLiouvillian(AbstractSuperOperator):
 
     .. math ::
 
-        \\mathcal{L} = -i \\hat{H}\\hat{\\rho} +i\\hat{\\rho}\\hat{H}^\\dagger + \\sum_i \\hat{L}_i\\hat{\\rho}\\hat{L}_i^\\dagger
+        \\mathcal{L} = -i \\hat{H}_{nh}\\hat{\\rho} +i\\hat{\\rho}\\hat{H}_{nh}^\\dagger + \\sum_i \\hat{L}_i\\hat{\\rho}\\hat{L}_i^\\dagger
 
     """
 

--- a/netket/operator/_local_liouvillian.py
+++ b/netket/operator/_local_liouvillian.py
@@ -408,7 +408,7 @@ class LocalLiouvillian(AbstractSuperOperator):
 
                 drho = np.zeros((M, M), dtype=rho.dtype)
 
-                drho += rho @ iHnh + iHnh.conj().T @ rho
+                drho += iHnh @ rho + rho @ iHnh.conj().T
                 for J, J_c in zip(J_ops, J_ops_c):
                     drho += (J @ rho) @ J_c
 
@@ -433,7 +433,7 @@ class LocalLiouvillian(AbstractSuperOperator):
                 out = np.zeros((M ** 2 + 1), dtype=rho.dtype)
                 drho = out[:-1].reshape((M, M))
 
-                drho += rho @ iHnh + iHnh.conj().T @ rho
+                drho += iHnh @ rho + rho @ iHnh.conj().T
                 for J, J_c in zip(J_ops, J_ops_c):
                     drho += (J @ rho) @ J_c
 

--- a/netket/operator/_local_liouvillian.py
+++ b/netket/operator/_local_liouvillian.py
@@ -109,7 +109,8 @@ class LocalLiouvillian(AbstractSuperOperator):
         max_conn_size = 0
         for L in self._jump_ops:
             Hnh = Hnh - 0.5j * L.conjugate().transpose() @ L
-            max_conn_size += (L.n_operators * L._max_op_size) ** 2
+            dim = L.n_operators * L._max_op_size
+            max_conn_size += dim ** 2 + 2 * dim
 
         self._max_dissipator_conn_size = max_conn_size
 

--- a/netket/operator/_local_liouvillian.py
+++ b/netket/operator/_local_liouvillian.py
@@ -73,7 +73,6 @@ class LocalLiouvillian(AbstractSuperOperator):
         self._H = ham
         self._jump_ops = [op.copy(dtype=dtype) for op in jump_ops]  # to accept dicts
         self._Hnh = ham
-        self._Hnh_dag = ham.H
         self._max_dissipator_conn_size = 0
         self._max_conn_size = 0
 
@@ -115,7 +114,6 @@ class LocalLiouvillian(AbstractSuperOperator):
         self._max_dissipator_conn_size = max_conn_size
 
         self._Hnh = Hnh.collect()
-        self._Hnh_dag = Hnh.H.collect()
 
         max_conn_size = (
             self._max_dissipator_conn_size + Hnh.n_operators * Hnh._max_op_size
@@ -149,16 +147,16 @@ class LocalLiouvillian(AbstractSuperOperator):
         xr, xc = x[0:n_sites], x[n_sites : 2 * n_sites]
         i = 0
 
-        xrp, mel_r = self._Hnh_dag.get_conn(xr)
+        xrp, mel_r = self._Hnh.get_conn(xr)
         self._xrv[i : i + len(mel_r), :] = xrp
         self._xcv[i : i + len(mel_r), :] = xc
-        self._mels[i : i + len(mel_r)] = mel_r * 1j
+        self._mels[i : i + len(mel_r)] = -1j * mel_r
         i = i + len(mel_r)
 
         xcp, mel_c = self._Hnh.get_conn(xc)
         self._xrv[i : i + len(mel_c), :] = xr
         self._xcv[i : i + len(mel_c), :] = xcp
-        self._mels[i : i + len(mel_r)] = mel_c * (-1j)
+        self._mels[i : i + len(mel_r)] = 1j * np.conj(mel_c)
         i = i + len(mel_c)
 
         for L in self._jump_ops:
@@ -171,7 +169,7 @@ class LocalLiouvillian(AbstractSuperOperator):
             for r in range(nr):
                 self._xrv[i : i + nc, :] = L_xrp[r, :]
                 self._xcv[i : i + nc, :] = L_xcp
-                self._mels[i : i + nc] = np.conj(L_mel_r[r]) * L_mel_c
+                self._mels[i : i + nc] = L_mel_r[r] * np.conj(L_mel_c)
                 i = i + nc
 
         return np.copy(self._xprime[0:i, :]), np.copy(self._mels[0:i])
@@ -192,7 +190,7 @@ class LocalLiouvillian(AbstractSuperOperator):
         # Compute all flattened connections of each term
         sections_r = np.empty(batch_size, dtype=np.int64)
         sections_c = np.empty(batch_size, dtype=np.int64)
-        xr_prime, mels_r = self._Hnh_dag.get_conn_flattened(xr, sections_r)
+        xr_prime, mels_r = self._Hnh.get_conn_flattened(xr, sections_r)
         xc_prime, mels_c = self._Hnh.get_conn_flattened(xc, sections_c)
 
         if pad:
@@ -323,7 +321,7 @@ class LocalLiouvillian(AbstractSuperOperator):
             n_hr = n_hr_f - n_hr_i
             xs[off : off + n_hr, 0:N] = xr_prime[n_hr_i:n_hr_f, :]
             xs[off : off + n_hr, N : 2 * N] = xc[i, :]
-            mels[off : off + n_hr] = 1j * mels_r[n_hr_i:n_hr_f]
+            mels[off : off + n_hr] = -1j * mels_r[n_hr_i:n_hr_f]
             off += n_hr
             n_hr_i = n_hr_f
 
@@ -331,7 +329,7 @@ class LocalLiouvillian(AbstractSuperOperator):
             n_hc = n_hc_f - n_hc_i
             xs[off : off + n_hc, N : 2 * N] = xc_prime[n_hc_i:n_hc_f, :]
             xs[off : off + n_hc, 0:N] = xr[i, :]
-            mels[off : off + n_hc] = -1j * mels_c[n_hc_i:n_hc_f]
+            mels[off : off + n_hc] = 1j * np.conj(mels_c[n_hc_i:n_hc_f])
             off += n_hc
             n_hc_i = n_hc_f
 
@@ -349,8 +347,8 @@ class LocalLiouvillian(AbstractSuperOperator):
                 for r in range(n_Lr):
                     xs[off : off + n_Lc, 0:N] = L_xrp[n_Lr_i + r, :]
                     xs[off : off + n_Lc, N : 2 * N] = L_xcp[n_Lc_i:n_Lc_f, :]
-                    mels[off : off + n_Lc] = (
-                        np.conj(L_mel_r[n_Lr_i + r]) * L_mel_c[n_Lc_i:n_Lc_f]
+                    mels[off : off + n_Lc] = L_mel_r[n_Lr_i + r] * np.conj(
+                        L_mel_c[n_Lc_i:n_Lc_f]
                     )
                     off = off + n_Lc
 

--- a/netket/variational/base.py
+++ b/netket/variational/base.py
@@ -247,12 +247,17 @@ class VariationalMixedState(VariationalState):
         self,
         Ô: AbstractOperator,
         mutable: bool = None,
+        is_hermitian: Optional[bool] = None,
     ) -> Tuple[Stats, PyTree]:
         # do the computation in super-operator space
         if self.hilbert == Ô.hilbert:
-            return super().expect_and_grad(Ô, mutable=mutable)
+            return super().expect_and_grad(
+                Ô, mutable=mutable, is_hermitian=is_hermitian
+            )
         elif self.hilbert_physical == Ô.hilbert:
-            return super().expect_and_grad(Ô, mutable=mutable)
+            return super().expect_and_grad(
+                Ô, mutable=mutable, is_hermitian=is_hermitian
+            )
         else:
             return NotImplemented
 


### PR DESCRIPTION
Closes #607 

This PR switches our representation of super-operators so stacked-rows (which is what you would have by doing `np.kron(a,b)`, and the most natural for numpy/python since it is row-major). 

I was previously using `stacked-columns` mainly because I was comparing to qutip (which is stacked-columns for historical reasons)  and with my old Julia code (which is column major). 
The errors rised in #607 where due to the fact that stacked-columns required us to take a matrix transpose at some point.

This should make it more natural to work with our density matrices in the future, but it makes our representation incompatible with qutip, so we should add some conversion methods...