### PR TITLE
Add HashableArray utility class

### DIFF
--- a/Test/Graph/test_graph.py
+++ b/Test/Graph/test_graph.py
@@ -252,7 +252,7 @@ def test_automorphisms():
             autom_g = graph.automorphisms()
             dim = len(autom_g)
             for i in range(dim):
-                assert autom_g[i].permutation.tolist() in autom
+                assert np.asarray(autom_g[i]).tolist() in autom
 
 
 def _check_symmgroup(graph, symmgroup):

--- a/Test/Models/test_nn.py
+++ b/Test/Models/test_nn.py
@@ -33,7 +33,7 @@ def _setup_symm(symmetries, N):
         # All chain automorphisms, N_symm = 2 N_sites
         perms = g.automorphisms()
 
-    return g, hi, np.asarray(perms)
+    return g, hi, perms
 
 
 @pytest.mark.parametrize("symmetries", ["trans", "autom"])
@@ -41,7 +41,7 @@ def _setup_symm(symmetries, N):
 def test_DenseSymm(symmetries, use_bias):
     g, hi, perms = _setup_symm(symmetries, N=8)
 
-    ma = nk.nn.create_DenseSymm(
+    ma = nk.nn.DenseSymm(
         symmetries=perms,
         features=8,
         use_bias=use_bias,
@@ -50,7 +50,7 @@ def test_DenseSymm(symmetries, use_bias):
     pars = ma.init(nk.jax.PRNGKey(), hi.random_state(1))
 
     v = hi.random_state(3)
-    vals = [ma.apply(pars, v[..., p]) for p in perms]
+    vals = [ma.apply(pars, v[..., p]) for p in np.asarray(perms)]
     for val in vals:
         assert jnp.allclose(jnp.sum(val, -1), jnp.sum(vals[0], -1))
 
@@ -83,4 +83,6 @@ def test_symmetrizer(symmetries, features):
     # and data is [1., ..., 1.]. Only cols is non-trivial.
     assert np.all(symmetrizer.row == np.arange(symmetrizer.shape[0]))
     assert np.all(symmetrizer.data == 1.0)
-    assert np.all(symmetrizer.col == linear._symmetrizer_col(perms, features))
+    assert np.all(
+        symmetrizer.col == linear._symmetrizer_col(np.asarray(perms), features)
+    )

--- a/Test/Models/test_rbm.py
+++ b/Test/Models/test_rbm.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import netket as nk
+import numpy as np
 import jax.numpy as jnp
 
 from test_nn import _setup_symm
@@ -39,7 +40,7 @@ def test_RBMSymm(use_hidden_bias, use_visible_bias, symmetries):
     print(pars)
 
     v = hi.random_state(3)
-    vals = [ma.apply(pars, v[..., p]) for p in perms]
+    vals = [ma.apply(pars, v[..., p]) for p in np.asarray(perms)]
 
     for val in vals:
         assert jnp.allclose(val, vals[0])
@@ -70,9 +71,6 @@ def test_RBMSymm_creation():
     with pytest.raises(ValueError):
         check_init(lambda: nk.models.RBMSymm(symmetries=perms[0]))
 
-    # init with graph
-    check_init(lambda: nk.models.RBMSymm(symmetries=nk.graph.Chain(8), alpha=2))
-
     # init with SymmGroup
     check_init(
         lambda: nk.models.RBMSymm(symmetries=nk.graph.Chain(8).translations(), alpha=2)
@@ -81,7 +79,9 @@ def test_RBMSymm_creation():
     # alpha too small
     with pytest.raises(ValueError):
         check_init(
-            lambda: nk.models.RBMSymm(symmetries=nk.graph.Hypercube(8, 2), alpha=1)
+            lambda: nk.models.RBMSymm(
+                symmetries=nk.graph.Hypercube(8, 2).automorphisms(), alpha=1
+            )
         )
 
 

--- a/Test/Utils/test_utils.py
+++ b/Test/Utils/test_utils.py
@@ -13,8 +13,13 @@
 # limitations under the License.
 
 from netket.jax import PRNGKey, PRNGSeq
+from netket.utils import HashableArray
 
+import pytest
+import numpy as np
 import jax.numpy as jnp
+
+from numpy.testing import assert_equal
 
 
 def test_PRNGSeq():
@@ -31,3 +36,23 @@ def test_PRNGSeq():
     seq1 = PRNGSeq(12)
     seq2 = PRNGSeq(12)
     assert jnp.all(seq1.take(10) == seq2.take(10))
+
+
+@pytest.mark.parametrize("numpy", [np, jnp])
+def test_HashableArray(numpy):
+    a = numpy.asarray(np.random.rand(256, 128))
+    b = 2 * a
+
+    wa = HashableArray(a)
+    wa2 = HashableArray(a.copy())
+    wb = HashableArray(b)
+
+    assert hash(wa) == hash(wa2)
+    assert wa == wa2
+
+    assert hash(wb) == hash(wb)
+    assert wb == wb
+
+    assert wa != wb
+
+    assert_equal(wa.wrapped, np.asarray(wa))

--- a/docs/docs/api.rst
+++ b/docs/docs/api.rst
@@ -331,6 +331,19 @@ Those are the loggers that can be used with the optimization drivers.
    netket.logging.TBLog
 
 
+.. _utils-api:
+
+Utils
+-----
+
+Utility functions and classes.
+
+.. autosummary::
+   :toctree: _generated/utils
+   :nosignatures:
+
+   netket.utils.HashableArray
+
 .. _callbacks-api:
 
 Callbacks

--- a/netket/models/__init__.py
+++ b/netket/models/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .rbm import RBM, RBMModPhase, RBMMultiVal, create_RBMSymm as RBMSymm
+from .rbm import RBM, RBMModPhase, RBMMultiVal, RBMSymm
 from .jastrow import Jastrow
 from .mps import MPSPeriodic
 

--- a/netket/models/rbm.py
+++ b/netket/models/rbm.py
@@ -197,7 +197,9 @@ class RBMSymm(nn.Module):
     """A symmetrized RBM using the :ref:`netket.nn.DenseSymm` layer internally."""
 
     symmetries: Union[HashableArray, SymmGroup]
-    """A group of symmetry operations (or array of permutation indices) over which the layer should be invariant."""
+    """A group of symmetry operations (or array of permutation indices) over which the layer should be invariant.
+    Numpy/Jax arrays must be wrapped into an :class:`netket.utils.HashableArray`.
+    """
     dtype: Any = np.float64
     """The dtype of the weights."""
     activation: Any = nknn.logcosh

--- a/netket/models/rbm.py
+++ b/netket/models/rbm.py
@@ -196,8 +196,8 @@ class RBMMultiVal(nn.Module):
 class RBMSymm(nn.Module):
     """A symmetrized RBM using the :ref:`netket.nn.DenseSymm` layer internally."""
 
-    symmetries: HashableArray
-    """See documentation of :ref:`netket.nn.DenseSymm`."""
+    symmetries: Union[HashableArray, SymmGroup]
+    """A group of symmetry operations (or array of permutation indices) over which the layer should be invariant."""
     dtype: Any = np.float64
     """The dtype of the weights."""
     activation: Any = nknn.logcosh
@@ -250,34 +250,3 @@ class RBMSymm(nn.Module):
             return x + out_bias
         else:
             return x
-
-
-def create_RBMSymm(
-    symmetries: Union[AbstractGraph, Array],
-    *args,
-    **kwargs,
-):
-    """A symmetrized RBM using the :ref:`netket.nn.DenseSymm` layer internally.
-
-    Attributes:
-        symmetries: See documentation of :func:`~netket.nn.create_DenseSymm`.
-        dtype: The dtype of the weights.
-        activation: The nonlinear activation function.
-        alpha: Feature density. Number of features equal to alpha * input.shape[-1]
-        use_hidden_bias: if True uses a bias in the dense layer (hidden layer bias).
-        use_visible_bias: if True adds a bias to the input not passed through the nonlinear layer.
-        percision: numerical precision of the computation see `jax.lax.Precision`for details.
-        kernel_init: Initializer for the Dense layer matrix.
-        hidden_bias_init: Initializer for the hidden bias.
-        visible_bias_init: Initializer for the visible bias.
-    """
-    if isinstance(symmetries, AbstractGraph):
-        symmetries = np.asarray(symmetries.automorphisms())
-    else:
-        symmetries = np.asarray(symmetries)
-        if not symmetries.ndim == 2:
-            raise ValueError(
-                "symmetries must be an array of shape (#symmetries, #sites)."
-            )
-
-    return RBMSymm(symmetries=HashableArray(symmetries), *args, **kwargs)

--- a/netket/nn/__init__.py
+++ b/netket/nn/__init__.py
@@ -50,7 +50,6 @@ from .linear import (
     Dense,
     DenseGeneral,
     DenseSymm,
-    create_DenseSymm,
 )
 from .module import Module
 from flax.linen.module import compact, enable_named_call, disable_named_call, Variable

--- a/netket/nn/linear.py
+++ b/netket/nn/linear.py
@@ -239,12 +239,10 @@ class DenseSymm(Module):
     """A symmetrized linear transformation applied over the last dimension of the input.
     This layer uses a reduced number of parameters, which are arranged so that the full
     affine transformation is invariant under all of the given permutations when applied to s.
-
-    See :func:`~netket.nn.create_DenseSymm` for a more convenient constructor.
     """
 
-    symmetries: HashableArray
-    """Callable returning a sequence of symmetry operations over which the layer should be invariant."""
+    symmetries: Union[HashableArray, SymmGroup]
+    """A group of symmetry operations (or array of permutation indices) over which the layer should be invariant."""
     features: int
     """The number of symmetry-reduced features. The full output size is len(symmetries) * features."""
     use_bias: bool = True
@@ -312,38 +310,6 @@ class DenseSymm(Module):
             y += bias
 
         return y
-
-
-def create_DenseSymm(
-    symmetries: Union[AbstractGraph, Array],
-    *args,
-    **kwargs,
-):
-    """A symmetrized linear transformation applied over the last dimension of the input.
-    This layer uses a reduced number of parameters, which are arranged so that the full
-    affine transformation is invariant under all of the given permutations when applied to s.
-
-    This is a convenience wrapper for creating a :ref:`netket.nn.DenseSymm` layer.
-
-    Arguments:
-      symmetries: Sequence of permutations over which the layer should be invariant.
-        Should be either an array-like object of shape (n_permutations, input_size)
-        (note that this includes to :ref:`netket.graph.SymmGroup`), or
-        :ref:`netket.graph.AbstractGraph`, in which case the `graph.automorphisms()`
-        is used.
-
-    See :ref:`netket.nn.DenseSymm` for the remaining parameters.
-    """
-    if isinstance(symmetries, AbstractGraph):
-        symmetries = np.asarray(symmetries.automorphisms())
-    else:
-        symmetries = np.asarray(symmetries)
-        if not symmetries.ndim == 2:
-            raise ValueError(
-                "symmetries must be an array of shape (#symmetries, #sites)."
-            )
-
-    return DenseSymm(symmetries=HashableArray(symmetries), *args, **kwargs)
 
 
 class Conv(Module):

--- a/netket/nn/linear.py
+++ b/netket/nn/linear.py
@@ -242,7 +242,9 @@ class DenseSymm(Module):
     """
 
     symmetries: Union[HashableArray, SymmGroup]
-    """A group of symmetry operations (or array of permutation indices) over which the layer should be invariant."""
+    """A group of symmetry operations (or array of permutation indices) over which the layer should be invariant.
+        Numpy/Jax arrays must be wrapped into an :class:`netket.utils.HashableArray`.
+    """
     features: int
     """The number of symmetry-reduced features. The full output size is len(symmetries) * features."""
     use_bias: bool = True

--- a/netket/utils/__init__.py
+++ b/netket/utils/__init__.py
@@ -14,6 +14,7 @@
 
 from .config_flags import config
 
+from .array import HashableArray
 from .jax import jit_if_singleproc, get_afun_if_module
 from .mpi import (
     mpi_available,

--- a/netket/utils/array.py
+++ b/netket/utils/array.py
@@ -1,0 +1,50 @@
+# Copyright 2021 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from .types import Array, DType
+
+
+@dataclass(frozen=True)
+class HashableArray:
+    """
+    This class wraps a numpy or jax array in order to make it hashable and
+    equality comparable (which is necessary since a well-defined hashable object
+    needs to satisfy :code:`obj1 == obj2` whenever :code:`hash(obj1) == hash(obj2)`.
+
+    The underlying array can also be accessed using :code:`numpy.asarray(self)`.
+    """
+
+    wrapped: Array
+    """The wrapped array. Note that this array is read-only and modifying it without
+    recreating `HashableArray` will result in incorrect behavior."""
+
+    def __post_init__(self):
+        if isinstance(self.wrapped, np.ndarray):
+            self.wrapped.flags.writeable = False
+        object.__setattr__(self, "_HashableArray__hash", hash(self.wrapped.tobytes()))
+
+    def __hash__(self):
+        return self.__hash
+
+    def __eq__(self, other):
+        return np.all(self.wrapped == other.wrapped)
+
+    def __array__(self, dtype: DType = None):
+        if dtype is None:
+            dtype = self.wrapped.dtype
+        return self.wrapped.__array__(dtype)

--- a/netket/utils/semigroup.py
+++ b/netket/utils/semigroup.py
@@ -20,7 +20,8 @@ from typing import Any, Callable, List, Optional, Tuple
 import numpy as np
 import plum
 
-from netket.utils.types import Array
+from netket.utils import HashableArray
+from netket.utils.types import Array, DType
 
 dispatch = plum.Dispatcher()
 
@@ -117,23 +118,25 @@ class NamedElement(Element):
 
 class Permutation(Element):
     def __init__(self, permutation: Array):
-        self.permutation = np.array(permutation)
-        self.__hash = hash(self.permutation.tobytes())
+        self.permutation = HashableArray(np.array(permutation))
 
     def __call__(self, x):
         return x[..., self.permutation]
 
     def __hash__(self):
-        return self.__hash
+        return hash(self.permutation)
 
     def __eq__(self, other):
         if isinstance(other, Permutation):
-            return np.all(self.permutation == other.permutation)
+            return self.permutation == other.permutation
         else:
             return False
 
     def __repr__(self):
         return f"Permutation({self.permutation})"
+
+    def __array__(self, dtype: DType = None):
+        return np.asarray(self.permutation, dtype)
 
 
 @dispatch(Permutation, Permutation)


### PR DESCRIPTION
This PR introduces a hashable wrapper around array types in order to make it possible to use them as model attributes.