### PR TITLE
LocalOperator: Don't return the diagonal element if it is zero

### DIFF
--- a/netket/operator/_abstract_operator.py
+++ b/netket/operator/_abstract_operator.py
@@ -124,6 +124,11 @@ class AbstractOperator(abc.ABC):
         """
         raise NotImplementedError
 
+    @property
+    def max_conn_size(self) -> int:
+        """The maximum number of non zero ⟨x|O|x'⟩ for every x."""
+        raise NotImplementedError
+
     def get_conn_padded(self, x: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
         r"""Finds the connected elements of the Operator.
         Starting from a batch of quantum numbers x={x_1, ... x_n} of size B x M

--- a/netket/operator/_hamiltonian.py
+++ b/netket/operator/_hamiltonian.py
@@ -202,6 +202,11 @@ class Ising(SpecialHamiltonian):
 
         return out
 
+    @property
+    def max_conn_size(self) -> int:
+        """The maximum number of non zero ⟨x|O|x'⟩ for every x."""
+        return self.size + 1
+
     def copy(self):
         graph = Graph(edges=[list(edge) for edge in self.edges])
         return Ising(hilbert=self.hilbert, graph=graph, J=self.J, h=self.h)
@@ -585,6 +590,12 @@ class BoseHubbard(SpecialHamiltonian):
         self._U -= other.U
         self._J -= other.J
         self._V -= other.V
+
+    @property
+    def max_conn_size(self) -> int:
+        """The maximum number of non zero ⟨x|O|x'⟩ for every x."""
+        # 1 diagonal element + 2 for every coupling
+        return 1 + 2 * len(self._edges)
 
     def get_conn(self, x):
         r"""Finds the connected elements of the Operator. Starting

--- a/netket/operator/_local_liouvillian.py
+++ b/netket/operator/_local_liouvillian.py
@@ -106,19 +106,14 @@ class LocalLiouvillian(AbstractSuperOperator):
     def _compute_hnh(self):
         # There is no i here because it's inserted in the kernel
         Hnh = 1.0 * self._H
-        max_conn_size = 0
+        self._max_dissipator_conn_size = 0
         for L in self._jump_ops:
             Hnh = Hnh - 0.5j * L.conjugate().transpose() @ L
-            dim = L.n_operators * L._max_op_size
-            max_conn_size += dim ** 2 + 2 * dim
-
-        self._max_dissipator_conn_size = max_conn_size
+            self._max_dissipator_conn_size += L.max_conn_size ** 2
 
         self._Hnh = Hnh.collect()
 
-        max_conn_size = (
-            self._max_dissipator_conn_size + Hnh.n_operators * Hnh._max_op_size
-        )
+        max_conn_size = self._max_dissipator_conn_size + Hnh.max_conn_size
         self._max_conn_size = max_conn_size
         self._xprime = np.empty((max_conn_size, self.hilbert.size))
         self._xr_prime = np.empty((max_conn_size, self.hilbert.physical.size))

--- a/netket/operator/_local_operator.py
+++ b/netket/operator/_local_operator.py
@@ -70,8 +70,8 @@ def has_nonzero_diagonal(op: "LocalOperator") -> bool:
         np.any(np.abs(op._diag_mels) >= op.mel_cutoff)
         or np.abs(op._constant) >= op.mel_cutoff
     )
-  
-  
+
+
 def _is_sorted(a):
     for i in range(len(a) - 1):
         if a[i + 1] < a[i]:

--- a/netket/operator/_local_operator.py
+++ b/netket/operator/_local_operator.py
@@ -379,7 +379,7 @@ class LocalOperator(AbstractOperator):
         for _op in self._operators:
             _op *= other
 
-        op._nonzero_diagonal = has_nonzero_diagonal(self)
+        self._nonzero_diagonal = has_nonzero_diagonal(self)
 
         return self
 

--- a/netket/operator/_local_operator.py
+++ b/netket/operator/_local_operator.py
@@ -760,6 +760,18 @@ class LocalOperator(AbstractOperator):
             constant=np.conjugate(self._constant),
         )
 
+    @property
+    def max_conn_size(self) -> int:
+        """The maximum number of non zero ⟨x|O|x'⟩ for every x."""
+        max_size = self.n_operators
+        for op in self._operators:
+            nnz_mat = np.abs(op) > self.mel_cutoff
+            nnz_mat[np.diag_indices(nnz_mat.shape[0])] = False
+            nnz_rows = np.sum(nnz_mat, axis=1)
+            max_size += np.max(nnz_rows)
+
+        return max_size
+
     def get_conn_flattened(self, x, sections, pad=False):
         r"""Finds the connected elements of the Operator. Starting
         from a given quantum number x, it finds all other quantum numbers x' such

--- a/netket/operator/_pauli_strings.py
+++ b/netket/operator/_pauli_strings.py
@@ -171,6 +171,12 @@ class PauliStrings(AbstractOperator):
         """Returns true if this operator is hermitian."""
         return self._is_hermitian
 
+    @property
+    def max_conn_size(self) -> int:
+        """The maximum number of non zero ⟨x|O|x'⟩ for every x."""
+        # 1 connection for every operator X, Y, Z...
+        return self._n_operators
+
     @staticmethod
     @jit(nopython=True)
     def _flattened_kernel(


### PR DESCRIPTION
This PR does two things. The main thing of the PR is the following:

 - If the diagonal of a LocalOperator is zero, meaning that all the diagonal elements of all operators are 0 and the constant shift is zero, then we no longer return `x` with `mel=0` when calling `get_conn(x)`.

While this is negligible in the case of hamiltonians, as it's only 1 nonzero element, in the case of liouvillians we have terms like `\sum_i L_i\otimes L_i` where L usually has no diagonal elements, so in the best case scenario we were getting `4N` nonzero elements where actually only `N` are potentially nonzero.

This PR leads to a speedup of 20% so I think it's a good thing.
The points where we have to compute whever those elements are nonzero are several, and it's messy, but I hope to address this in the future by rewriting localoperator...

-- 
- The other thing that this PR does is giving a method to compute the maximum number of nonzero elements in an operator. This is useful for Liouvillians to preallocate the space needed before calling `get_conn`.  


todo: tests