### PR TITLE
Use default Plum dispatcher object

### DIFF
--- a/netket/graph/grid.py
+++ b/netket/graph/grid.py
@@ -17,14 +17,15 @@ from dataclasses import dataclass
 from functools import partial
 from typing import Callable, List, Sequence, Tuple, Union
 
-from netket.utils.semigroup import Element, Identity, dispatch
-
-
-from .symmetry import SymmGroup
-from .graph import NetworkX
+from plum import dispatch
 
 import numpy as _np
 import networkx as _nx
+
+from netket.utils.semigroup import Element, Identity
+
+from .symmetry import SymmGroup
+from .graph import NetworkX
 
 
 @dataclass(frozen=True)

--- a/netket/utils/semigroup.py
+++ b/netket/utils/semigroup.py
@@ -17,13 +17,12 @@ import inspect
 import itertools
 from typing import Any, Callable, List, Optional, Tuple
 
+from plum import dispatch
+
 import numpy as np
-import plum
 
 from netket.utils import HashableArray
 from netket.utils.types import Array, DType
-
-dispatch = plum.Dispatcher()
 
 
 class ElementBase(Callable):


### PR DESCRIPTION
Let's just use the default dispatcher so we don't have to always import the same from a central point, and it will make easier for other packages to extend netket in the future.