### PR TITLE
Warn if running under mpi but mpi4py/mpi4jax not installed

### DIFF
--- a/netket/utils/config_flags.py
+++ b/netket/utils/config_flags.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+from textwrap import dedent
 
 
 def bool_env(varname: str, default: bool) -> bool:
@@ -112,5 +113,18 @@ config.define(
     bool,
     default=False,
     help="Enable experimental features.",
+    runtime=False,
+)
+
+config.define(
+    "NETKET_MPI_WARNING",
+    bool,
+    default=True,
+    help=dedent(
+        """
+        Raise a warning when running python under MPI
+        without mpi4py and other mpi dependencies installed. 
+        """
+    ),
     runtime=False,
 )

--- a/netket/utils/mpi.py
+++ b/netket/utils/mpi.py
@@ -81,8 +81,8 @@ except ImportError:
                     by NetKet to enable MPI support are missing or cannot be loaded, so MPI support is
                     disabled.
 
-                    NetKet will not be taking advantage of MPI, and every MPI rank will execute the
-                    same code of the others.
+                    NetKet will not take advantage of MPI, and every MPI rank will execute the
+                    same code independently.
 
                     MPI dependencies are:
                       - mpi4py>=3.0.1     ....... {"available" if _mpi4py_loaded else "missing"}

--- a/netket/utils/mpi.py
+++ b/netket/utils/mpi.py
@@ -18,6 +18,8 @@ from textwrap import dedent
 
 from distutils.version import LooseVersion as _LooseVersion
 
+from .config_flags import config
+
 _mpi4py_loaded = False
 _mpi4jax_loaded = False
 
@@ -64,33 +66,36 @@ except ImportError:
     MPI = FakeMPI()
 
     # Try to detect if we are running under MPI and warn that mpi4py is not installed
-    _MPI_ENV_VARIABLES = [
-        "OMPI_COMM_WORLD_SIZE",
-        "I_MPI_HYDRA_HOST_FILE",
-        "MPI_LOCALRANKID",
-    ]
-    for varname in _MPI_ENV_VARIABLES:
-        if varname in os.environ:
-            warnings.warn(
-                dedent(
-                    f"""
-                MPI WARNING: It seems you might be running Python with MPI, but dependencies required
-                by NetKet to enable MPI support are missing or cannot be loaded, so MPI support is
-                disabled.
+    if config.FLAGS["NETKET_MPI_WARNING"]:
+        _MPI_ENV_VARIABLES = [
+            "OMPI_COMM_WORLD_SIZE",
+            "I_MPI_HYDRA_HOST_FILE",
+            "MPI_LOCALRANKID",
+        ]
+        for varname in _MPI_ENV_VARIABLES:
+            if varname in os.environ:
+                warnings.warn(
+                    dedent(
+                        f"""
+                    MPI WARNING: It seems you might be running Python with MPI, but dependencies required
+                    by NetKet to enable MPI support are missing or cannot be loaded, so MPI support is
+                    disabled.
 
-                NetKet will not be taking advantage of MPI, and every MPI rank will execute the
-                same code of the others.
+                    NetKet will not be taking advantage of MPI, and every MPI rank will execute the
+                    same code of the others.
 
-                MPI dependencies are:
-                  - mpi4py>=3.0.1     ....... {"available" if _mpi4py_loaded else "missing"}
-                  - mpi4jax>=0.2.11   ....... {"available" if _mpi4jax_loaded else "missing"}
+                    MPI dependencies are:
+                      - mpi4py>=3.0.1     ....... {"available" if _mpi4py_loaded else "missing"}
+                      - mpi4jax>=0.2.11   ....... {"available" if _mpi4jax_loaded else "missing"}
 
-                To enable MPI support, install the missing dependencies.
-                To learn more about MPI and NetKet consult the documentation at 
-                https://www.netket.org/docs/getting_started.html
-                """
+                    To enable MPI support, install the missing dependencies.
+                    To learn more about MPI and NetKet consult the documentation at 
+                    https://www.netket.org/docs/getting_started.html
+
+                    To disable this warning, set the environment variable `NETKET_MPI_WARNING=0`
+                    """
+                    )
                 )
-            )
 
 
 if mpi_available:


### PR DESCRIPTION
This PR attempts to detect if netket is running under mpi when no mpi dependencies are installed, and raise a warning, as some users might not realise (aka, they don't read the documentation) that even if mpi is installed in the cluster, they need to install mpi4py in the environment.

The detection of MPI is very arbitrary. It checks a few known env variables. I suspect it will work reliably for OpenMPI, probably work for MPICH and maybe but who knows work for intel MPI.
Apparently there does not exist a way to detect this reliably.


Example output:

```bash
➜ mpirun -np 2 python Examples/Ising1d/ising1d_sr.py
/Users/filippovicentini/Dropbox/Ricerca/Codes/Python/netket/netket/utils/mpi.py:69: UserWarning:
MPI WARNING: It seems you might be running Python with MPI, but dependencies required
by NetKet to enable MPI support are missing or cannot be loaded, so MPI support is
disabled.

NetKet will not be taking advantage of MPI, and every MPI rank will execute the
same code of the others.

MPI dependencies are:
  - mpi4py>=3.0.1     ....... available
  - mpi4jax>=0.2.11   ....... missing

To enable MPI support, install the missing dependencies.
To learn more about MPI and NetKet consult the documentation at
https://www.netket.org/docs/getting_started.html

  warnings.warn(dedent(
  0%|          | 0/300 [00:00<?, ?it/s]/Users/filippovicentini/Dropbox/Ricerca/Codes/Python/netket/netket/utils/mpi.py:69: UserWarning:
MPI WARNING: It seems you might be running Python with MPI, but dependencies required
by NetKet to enable MPI support are missing or cannot be loaded, so MPI support is
disabled.

NetKet will not be taking advantage of MPI, and every MPI rank will execute the
same code of the others.

MPI dependencies are:
  - mpi4py>=3.0.1     ....... available
  - mpi4jax>=0.2.11   ....... missing

To enable MPI support, install the missing dependencies.
To learn more about MPI and NetKet consult the documentation at
https://www.netket.org/docs/getting_started.html

  warnings.warn(dedent(
  5%|▌         | 16/300 [00:28<09:23,  1.98s/it, Energy=-50.7913 ± 0.0087 [σ²=0.4800, R̂=1.0009]]^C[mpiexec@MacBook-Pro-di-Filippo.local] Sending Ctrl-C to processes as requested
[mpiexec@MacBook-Pro-di-Filippo.local] Press Ctrl-C again to force abort
  5%|▌         | 16/300 [00:30<09:09,  1.94s/it, Energy=-50.7913 ± 0.0087 [σ²=0.4800, R̂=1.0009]]No output specified (out=[apath|nk.logging.JsonLogger(...)]).Running the optimization but not saving the output.
```