### PR TITLE
Fix #635

### DIFF
--- a/Test/Variational/test_variational.py
+++ b/Test/Variational/test_variational.py
@@ -157,6 +157,23 @@ def test_init_parameters(vstate):
         pytest.param(
             op,
             id=name,
+        )
+        for name, op in operators.items()
+    ],
+)
+def test_expect_numpysampler_works(vstate, operator):
+    sampl = nk.sampler.MetropolisLocalNumpy(vstate.hilbert)
+    vstate.sampler = sampl
+    out = vstate.expect(operator)
+    assert isinstance(out, nk.stats.Stats)
+
+
+@pytest.mark.parametrize(
+    "operator",
+    [
+        pytest.param(
+            op,
+            id=name,
             marks=pytest.mark.xfail(
                 reason="MUSTFIX: Non hermitian gradient is known to be wrong"
             )

--- a/Test/Variational/test_variational_mixed.py
+++ b/Test/Variational/test_variational_mixed.py
@@ -163,3 +163,20 @@ def test_serialization(vstate):
     assert vstate.n_discard == vstate_new.n_discard
     assert vstate.n_samples_diag == vstate_new.n_samples_diag
     assert vstate.n_discard_diag == vstate_new.n_discard_diag
+
+
+@pytest.mark.parametrize(
+    "operator",
+    [
+        pytest.param(
+            op,
+            id=name,
+        )
+        for name, op in operators.items()
+    ],
+)
+def test_expect_numpysampler_works(vstate, operator):
+    sampl = nk.sampler.MetropolisLocalNumpy(vstate.hilbert)
+    vstate.sampler = sampl
+    out = vstate.expect(operator)
+    assert isinstance(out, nk.stats.Stats)

--- a/netket/operator/_local_liouvillian.py
+++ b/netket/operator/_local_liouvillian.py
@@ -103,6 +103,11 @@ class LocalLiouvillian(AbstractSuperOperator):
         """The list of local operators in this Liouvillian"""
         return self._jump_ops
 
+    @property
+    def max_conn_size(self) -> int:
+        """The maximum number of non zero ⟨x|O|x'⟩ for every x."""
+        return self._max_conn_size
+
     def _compute_hnh(self):
         # There is no i here because it's inserted in the kernel
         Hnh = 1.0 * self._H
@@ -113,7 +118,7 @@ class LocalLiouvillian(AbstractSuperOperator):
 
         self._Hnh = Hnh.collect()
 
-        max_conn_size = self._max_dissipator_conn_size + Hnh.max_conn_size
+        max_conn_size = self._max_dissipator_conn_size + 2 * Hnh.max_conn_size
         self._max_conn_size = max_conn_size
         self._xprime = np.empty((max_conn_size, self.hilbert.size))
         self._xr_prime = np.empty((max_conn_size, self.hilbert.physical.size))

--- a/netket/variational/mc_state.py
+++ b/netket/variational/mc_state.py
@@ -402,7 +402,7 @@ class MCState(VariationalState):
         σp, mels = Ô.get_conn_padded(np.asarray(σ).reshape((-1, σ.shape[-1])))
 
         return _expect(
-            self.sampler,
+            self.sampler.machine_pow,
             self._apply_fun,
             kernel,
             self.parameters,

--- a/netket/variational/mc_state.py
+++ b/netket/variational/mc_state.py
@@ -368,8 +368,13 @@ class MCState(VariationalState):
 
     def log_value(self, σ: jnp.ndarray) -> jnp.ndarray:
         """
-        Evaluate the variational state for a batch of states and return
-        the logarithm of the probability amplitude for those inputs.
+        Evaluate the variational state for a batch of states and returns
+        the logarithm of the amplitude of the quantum state. For pure states,
+        this is :math:`log(<σ|ψ>)`, whereas for mixed states this is
+        :math:`log(<σr|ρ|σc>)`, where ψ and ρ are respectively a pure state
+        (wavefunction) and a mixed state (density matrix).
+        For the density matrix, the left and right-acting states (row and column)
+        are obtained as :code:`σr=σ[::,0:N]` and :code:`σc=σ[::,N:]`.
 
         Given a batch of inputs (Nb, N), returns a batch of outputs (Nb,).
         """


### PR DESCRIPTION
Closes #635 .
Was an oversight on my part, as Numpy samplers are not jax structures.
Probably could make them jax-compatible but this should work in the meantime.

Also fixed the docstring of log_value cc @gcarleo  