### PR TITLE
[RFC] Add option to store the parameters during the optimization

### DIFF
--- a/Test/Logging/test_state_log.py
+++ b/Test/Logging/test_state_log.py
@@ -1,0 +1,116 @@
+import pytest
+
+import jax
+import jax.numpy as jnp
+import jax.flatten_util
+import numpy as np
+from functools import partial
+import itertools
+
+import tarfile
+import glob
+
+import netket as nk
+
+
+@pytest.fixture()
+def vstate(request):
+    N = 8
+    hi = nk.hilbert.Spin(1 / 2, N)
+    g = nk.graph.Chain(N)
+
+    ma = nk.models.RBM(
+        alpha=1,
+        dtype=float,
+        hidden_bias_init=nk.nn.initializers.normal(),
+        visible_bias_init=nk.nn.initializers.normal(),
+    )
+
+    return nk.variational.MCState(
+        nk.sampler.MetropolisLocal(hi),
+        ma,
+    )
+
+
+def test_tar(vstate, tmp_path):
+    path = str(tmp_path) + "/dir1/dir2"
+
+    # check that overwriting works
+    for k in range(1, 3):
+        log = nk.logging.StateLog(path, "w", tar=True, save_every=k)
+
+        for i in range(10):
+            log(i, None, vstate)
+
+        log.close()
+        tfile = tarfile.TarFile(path + ".tar", "r")
+        files = tfile.getnames()
+
+        assert len(files) == 10 / k
+        assert log._file_step == len(files)
+
+        for file in files:
+            assert file.endswith(".mpack")
+
+    # check that x fails
+    with pytest.raises(ValueError):
+        log = nk.logging.StateLog(path, "x", tar=True)
+
+    tfile = tarfile.TarFile(path + ".tar", "r")
+    files = tfile.getnames()
+
+    # test appending
+    log = nk.logging.StateLog(path, "a", tar=True)
+    log._init_output()
+    assert log._file_step == 5
+    for i in range(10):
+        log(i, None, vstate)
+
+    assert log._file_step == 10 + 5
+
+    del log
+    tfile = tarfile.TarFile(path + ".tar", "r")
+    files = tfile.getnames()
+
+    assert len(files) == 10 + 5
+
+    for file in files:
+        assert file.endswith(".mpack")
+
+
+def test_dir(vstate, tmp_path):
+    path = str(tmp_path) + "/dir1/dir2"
+
+    # check that overwriting works
+    for k in range(1, 3):
+        log = nk.logging.StateLog(path, "w", tar=False, save_every=k)
+
+        for i in range(10):
+            log(i, None, vstate)
+
+        files = glob.glob(path + "/*.mpack")
+        assert len(files) == 10 / k
+        assert log._file_step == len(files)
+
+        for file in files:
+            assert file.endswith(".mpack")
+
+    # check that x fails
+    with pytest.raises(ValueError):
+        log = nk.logging.StateLog(path, "x", tar=False)
+
+    # test appending
+    log = nk.logging.StateLog(path, "a", tar=False)
+    log._init_output()
+    assert log._file_step == 5
+    for i in range(10):
+        log(i, None, vstate)
+
+    assert log._file_step == 10 + 5
+
+    files = glob.glob(path + "/*.mpack")
+
+    assert len(files) == 10 + 5
+
+    for file in files:
+        assert file.endswith(".mpack")

--- a/Test/Variational/test_experimental.py
+++ b/Test/Variational/test_experimental.py
@@ -1,0 +1,97 @@
+import pytest
+
+import jax
+import jax.numpy as jnp
+import jax.flatten_util
+import numpy as np
+from functools import partial
+import itertools
+
+import tarfile
+import glob
+from io import BytesIO
+
+from flax import serialization
+
+import netket as nk
+
+SEED = 111
+
+
+@pytest.fixture()
+def vstate(request):
+    N = 8
+    hi = nk.hilbert.Spin(1 / 2, N)
+    g = nk.graph.Chain(N)
+
+    ma = nk.models.RBM(
+        alpha=1,
+        dtype=float,
+        hidden_bias_init=nk.nn.initializers.normal(),
+        visible_bias_init=nk.nn.initializers.normal(),
+    )
+
+    return nk.variational.MCState(
+        nk.sampler.MetropolisLocal(hi),
+        ma,
+    )
+
+
+def test_variables_from_file(vstate, tmp_path):
+    fname = str(tmp_path) + "/file.mpack"
+
+    with open(fname, "wb") as f:
+        f.write(serialization.to_bytes(vstate.variables))
+
+    for name in [fname, fname[:-6]]:
+        vstate2 = nk.variational.MCState(
+            vstate.sampler, vstate.model, n_samples=10, seed=SEED + 100
+        )
+
+        vstate2.variables = nk.variational.experimental.variables_from_file(
+            name, vstate2.variables
+        )
+
+        # check
+        jax.tree_multimap(
+            np.testing.assert_allclose, vstate.parameters, vstate2.parameters
+        )
+
+
+def test_variables_from_tar(vstate, tmp_path):
+    fname = str(tmp_path) + "/file.tar"
+
+    with tarfile.TarFile(fname, "w") as f:
+        for i in range(10):
+            save_binary_to_tar(
+                f, serialization.to_bytes(vstate.variables), f"{i}.mpack"
+            )
+
+    for name in [fname, fname[:-4]]:
+        vstate2 = nk.variational.MCState(
+            vstate.sampler, vstate.model, n_samples=10, seed=SEED + 100
+        )
+
+        for j in [0, 3, 8]:
+            vstate2.variables = nk.variational.experimental.variables_from_tar(
+                name, vstate2.variables, j
+            )
+
+            # check
+            jax.tree_multimap(
+                np.testing.assert_allclose, vstate.parameters, vstate2.parameters
+            )
+
+        with pytest.raises(KeyError):
+            nk.variational.experimental.variables_from_tar(name, vstate2.variables, 15)
+
+
+def save_binary_to_tar(tar_file, byte_data, name):
+    abuf = BytesIO(byte_data)
+
+    # Contruct the info object with the correct length
+    info = tarfile.TarInfo(name=name)
+    info.size = len(abuf.getbuffer())
+
+    # actually save the data to the tar file
+    tar_file.addfile(tarinfo=info, fileobj=abuf)

--- a/docs/docs/api.rst
+++ b/docs/docs/api.rst
@@ -327,8 +327,9 @@ Those are the loggers that can be used with the optimization drivers.
    :toctree: _generated/driver
    :nosignatures:
 
-   netket.logging.JsonLog
    netket.logging.RuntimeLog
+   netket.logging.JsonLog
+   netket.logging.TarStateLog
    netket.logging.TBLog
 
 

--- a/docs/docs/api.rst
+++ b/docs/docs/api.rst
@@ -329,7 +329,7 @@ Those are the loggers that can be used with the optimization drivers.
 
    netket.logging.RuntimeLog
    netket.logging.JsonLog
-   netket.logging.TarStateLog
+   netket.logging.StateLog
    netket.logging.TBLog
 
 

--- a/netket/logging/__init__.py
+++ b/netket/logging/__init__.py
@@ -14,7 +14,7 @@
 
 from .runtime_log import RuntimeLog
 from .json_log import JsonLog
-from .tar_log import TarLog
+from .tar_log import TarStateLog
 from .tensorboard import TBLog
 
 from .json_log_old import JsonLog as JsonLogOld

--- a/netket/logging/__init__.py
+++ b/netket/logging/__init__.py
@@ -14,6 +14,7 @@
 
 from .runtime_log import RuntimeLog
 from .json_log import JsonLog
+from .tar_log import TarLog
 from .tensorboard import TBLog
 
 from .json_log_old import JsonLog as JsonLogOld

--- a/netket/logging/__init__.py
+++ b/netket/logging/__init__.py
@@ -14,7 +14,7 @@
 
 from .runtime_log import RuntimeLog
 from .json_log import JsonLog
-from .tar_log import TarStateLog
+from .state_log import StateLog
 from .tensorboard import TBLog
 
 from .json_log_old import JsonLog as JsonLogOld

--- a/netket/logging/json_log.py
+++ b/netket/logging/json_log.py
@@ -95,7 +95,8 @@ class JsonLog(RuntimeLog):
                 - `[w]rite`: (default) overwrites file if it already exists;
                 - `[a]ppend`: appends to the file if it exists, overwise creates a new file;
                 - `[x]` or `fail`: fails if file already exists;
-            save_params: bool flag indicating whever parameters should be serialized
+            save_params: bool flag indicating whever variables of the variational state should be serialized
+                at some interval. The output file is overwritten every time variables are saved again.
             autoflush_cost: Maximum fraction of runtime that can be dedicated to serializing data. Defaults to
                 0.005 (0.5 per cent)
         """
@@ -137,16 +138,25 @@ class JsonLog(RuntimeLog):
             os.makedirs(dir_name, exist_ok=True)
 
         self._prefix = output_prefix
+        self._file_mode = mode
+
         self._write_every = write_every
         self._save_params_every = save_params_every
         self._old_step = 0
         self._steps_notflushed_write = 0
         self._steps_notflushed_pars = 0
         self._save_params = save_params
+        self._files_open = [output_prefix + ".log", output_prefix + ".mpack"]
 
         self._autoflush_cost = autoflush_cost
         self._last_flush_time = time.time()
         self._last_flush_runtime = 0.0
+
+        self._flush_log_time = 0.0
+        self._flush_pars_time = 0.0
+
+    def __del__(self):
+        self.flush()
 
     def __call__(self, step, item, variational_state):
         old_step = self._old_step
@@ -182,16 +192,20 @@ class JsonLog(RuntimeLog):
 
         # Time how long flushing data takes.
         self._last_flush_runtime = time.time() - self._last_flush_time
+        self._flush_log_time += self._last_flush_runtime
 
     def _flush_params(self, variational_state):
         if not self._save_params:
             return
+
+        _time = time.time()
 
         binary_data = serialization.to_bytes(variational_state.variables)
         with open(self._prefix + ".mpack", "wb") as outfile:
             outfile.write(binary_data)
 
         self._steps_notflushed_pars = 0
+        self._flush_pars_time += time.time() - _time
 
     def flush(self, variational_state):
         """
@@ -204,3 +218,10 @@ class JsonLog(RuntimeLog):
 
         if variational_state is not None:
             self._flush_params(variational_state)
+
+    def __repr__(self):
+        _str = f"JsonLog('{self._prefix}', mode={self._file_mode}, autoflush_cost={self._autoflush_cost})"
+        _str = _str + f"\n  Runtime cost:"
+        _str = _str + f"\n  \tLog:    {self._flush_log_time}"
+        _str = _str + f"\n  \tParams: {self._flush_pars_time}"
+        return _str

--- a/netket/logging/json_log.py
+++ b/netket/logging/json_log.py
@@ -155,9 +155,6 @@ class JsonLog(RuntimeLog):
         self._flush_log_time = 0.0
         self._flush_pars_time = 0.0
 
-    def __del__(self):
-        self.flush()
-
     def __call__(self, step, item, variational_state):
         old_step = self._old_step
         super().__call__(step, item, variational_state)
@@ -207,7 +204,7 @@ class JsonLog(RuntimeLog):
         self._steps_notflushed_pars = 0
         self._flush_pars_time += time.time() - _time
 
-    def flush(self, variational_state):
+    def flush(self, variational_state=None):
         """
         Writes to file the content of this logger.
 

--- a/netket/logging/state_log.py
+++ b/netket/logging/state_log.py
@@ -17,6 +17,8 @@ import dataclasses
 import tarfile
 import time
 from io import BytesIO
+import shutil
+import glob
 
 import os
 from os import path as _path
@@ -37,7 +39,7 @@ def save_binary_to_tar(tar_file, byte_data, name):
     tar_file.addfile(tarinfo=info, fileobj=abuf)
 
 
-class TarStateLog:
+class StateLog:
     """
         Tar Logger, serializing the variables of the variational state during a run.
 
@@ -58,6 +60,7 @@ class TarStateLog:
         output_prefix: str,
         mode: str = "write",
         save_every: int = 1,
+        tar: bool = False,
     ):
         """
         Construct a Tar Logger.
@@ -85,18 +88,16 @@ class TarStateLog:
                 "Mode not recognized: should be one of `[w]rite`, `[a]ppend` or `[x]`(fail)."
             )
 
-        file_exists = _path.exists(output_prefix + ".tar")
+        if tar is True:
+            file_exists = _path.exists(output_prefix + ".tar")
+        else:
+            if output_prefix[-1] != "/":
+                output_prefix = output_prefix + "/"
+            file_exists = _path.exists(output_prefix)
 
-        if file_exists and mode == "append":
-            # if there is only the .mpacck file but not the json one, raise an error
-            if not _path.exists(output_prefix + ".log"):
-                raise ValueError(
-                    "History file does not exists, but wavefunction file does. Please change `output_prefix or set mode=`write`."
-                )
-
-        elif file_exists and mode == "fail":
+        if file_exists and mode == "fail":
             raise ValueError(
-                "Output file already exists. Either delete it manually or change `output_prefix`."
+                "Output file/folder already exists. Either delete it manually or change `output_prefix`."
             )
 
         dir_name = _path.dirname(output_prefix)
@@ -109,19 +110,42 @@ class TarStateLog:
         self._save_every = save_every
         self._old_step = 0
         self._steps_notsaved = 0
+        self._init = False
 
         self._runtime_taken = 0.0
 
         # tar
+        self._tar = tar
         self._tar_file = None
         self._closed = False
+
+    def _init_output(self):
+        if self._tar:
+            self._create_tar_file()
+        else:
+            self._check_output_folder()
+        self._init = True
 
     def _create_tar_file(self):
         if self._tar_file is None:
             self._tar_file = tarfile.TarFile(self._prefix + ".tar", self._file_mode[0])
-            self._tar_step = 0
-            if self._file_mode == "a":
-                self._tar_step = int(self._tar_file.getnames()[-1]) + 1
+            self._file_step = 0
+            if self._file_mode == "append":
+                files = self._tar_file.getnames()
+                file_numbers = [int(file[:-6]) for file in files]
+                file_numbers.sort()
+                self._file_step = file_numbers[-1] + 1
+
+    def _check_output_folder(self):
+        self._file_step = 0
+        if self._file_mode == "write":
+            shutil.rmtree(self._prefix)
+            os.makedirs(self._prefix, exist_ok=True)
+        elif self._file_mode == "append":
+            files = glob.glob(self._prefix + "*.mpack")
+            file_numbers = [int(_path.basename(file)[:-6]) for file in files]
+            file_numbers.sort()
+            self._file_step = file_numbers[-1] + 1
 
     def close(self):
         if not self._closed and self._tar_file is not None:
@@ -138,13 +162,20 @@ class TarStateLog:
         self._steps_notsaved += 1
 
     def _save_variables(self, variational_state):
-        if self._tar_file is None:
-            self._create_tar_file()
+        if self._init is False:
+            self._init_output()
 
         _time = time.time()
         binary_data = serialization.to_bytes(variational_state.variables)
-        save_binary_to_tar(self._tar_file, binary_data, str(self._tar_step) + ".mpack")
-        self._tar_step += 1
+        if self._tar:
+            save_binary_to_tar(
+                self._tar_file, binary_data, str(self._file_step) + ".mpack"
+            )
+        else:
+            with open(self._prefix + str(self._file_step) + ".mpack", "wb") as f:
+                f.write(binary_data)
+
+        self._file_step += 1
         self._runtime_taken += time.time() - _time
 
     def __del__(self):

--- a/netket/logging/state_log.py
+++ b/netket/logging/state_log.py
@@ -41,18 +41,12 @@ def save_binary_to_tar(tar_file, byte_data, name):
 
 class StateLog:
     """
-        Tar Logger, serializing the variables of the variational state during a run.
+    A logger which serializes the variables of the variational state during a run.
 
-    : bool flag indicating whever to store variables in a tar file. The tar archive will
-                    contain a file with numbers going from 0 to N, and every file corresponds to the variables of
-                    the variational state at that step.
-
-
-        Data is serialized to a tar archive as many files named `[0.mpack, 1.mpack, ...]`, where
-        the number increases by 1 every time it's called.
-
-        The tar file inside is not flushed to disk (closed) until this object is deleted or python
-        is shut down.
+    The data is saved either to a directory or tar archive in a sequence of files named
+    `[0.mpack, 1.mpack, ...]` where the filename is incremented every time the logger is called.
+    The tar file inside is not flushed to disk (closed) until this object is deleted or python
+    is shut down.
     """
 
     def __init__(
@@ -63,7 +57,7 @@ class StateLog:
         tar: bool = False,
     ):
         """
-        Construct a Tar Logger.
+        Initialize the :code:`StateLogger`.
 
         Args:
             output_prefix: the name of the output file before the extension (if tar=True) or of the

--- a/netket/logging/state_log.py
+++ b/netket/logging/state_log.py
@@ -66,12 +66,14 @@ class StateLog:
         Construct a Tar Logger.
 
         Args:
-            output_prefix: the name of the output files before the extension
+            output_prefix: the name of the output file before the extension (if tar=True) or of the
+                output folder.
             save_every: every how many iterations the variables should be saved. (default 1)
             mode: Specify the behaviour in case the file already exists at this output_prefix. Options are
-                - `[w]rite`: (default) overwrites file if it already exists;
-                - `[a]ppend`: appends to the file if it exists, overwise creates a new file;
-                - `[x]` or `fail`: fails if file already exists;
+                - `[w]rite`: (default) overwrites file/delete the folder if it already exists;
+                - `[a]ppend`: appends to the file/folder if it exists, overwise creates a new file;
+                - `[x]` or `fail`: fails if file/folder already exists;
+            tar: if True creates a tar archive instead of a folder.
         """
         super().__init__()
 
@@ -139,7 +141,8 @@ class StateLog:
     def _check_output_folder(self):
         self._file_step = 0
         if self._file_mode == "write":
-            shutil.rmtree(self._prefix)
+            for file in glob.glob(self._prefix + "*.mpack"):
+                os.remove(file)
             os.makedirs(self._prefix, exist_ok=True)
         elif self._file_mode == "append":
             files = glob.glob(self._prefix + "*.mpack")

--- a/netket/logging/tar_log.py
+++ b/netket/logging/tar_log.py
@@ -1,0 +1,163 @@
+# Copyright 2021 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import dataclasses
+import tarfile
+import time
+from io import BytesIO
+
+import os
+from os import path as _path
+import numpy as np
+import jax
+
+from flax import serialization
+
+
+def save_binary_to_tar(tar_file, byte_data, name):
+    abuf = BytesIO(byte_data)
+
+    # Contruct the info object with the correct length
+    info = tarfile.TarInfo(name=name)
+    info.size = len(abuf.getbuffer())
+
+    # actually save the data to the tar file
+    tar_file.addfile(tarinfo=info, fileobj=abuf)
+
+
+class TarLog:
+    """
+        Tar Logger, serializing the variables of the variational state during a run.
+
+    : bool flag indicating whever to store variables in a tar file. The tar archive will
+                    contain a file with numbers going from 0 to N, and every file corresponds to the variables of
+                    the variational state at that step.
+
+
+        Data is serialized to a tar archive as many files named `[0.mpack, 1.mpack, ...]`, where
+        the number increases by 1 every time it's called.
+
+        The tar file inside is not flushed to disk (closed) until this object is deleted or python
+        is shut down.
+    """
+
+    def __init__(
+        self,
+        output_prefix: str,
+        mode: str = "write",
+        save_every: int = 1,
+    ):
+        """
+        Construct a Tar Logger.
+
+        Args:
+            output_prefix: the name of the output files before the extension
+            save_every: every how many iterations the variables should be saved. (default 1)
+            mode: Specify the behaviour in case the file already exists at this output_prefix. Options are
+                - `[w]rite`: (default) overwrites file if it already exists;
+                - `[a]ppend`: appends to the file if it exists, overwise creates a new file;
+                - `[x]` or `fail`: fails if file already exists;
+        """
+        super().__init__()
+
+        # Shorthands for mode
+        if mode == "w":
+            mode = "write"
+        elif mode == "a":
+            mode = "append"
+        elif mode == "x":
+            mode = "fail"
+
+        if not ((mode == "write") or (mode == "append") or (mode == "fail")):
+            raise ValueError(
+                "Mode not recognized: should be one of `[w]rite`, `[a]ppend` or `[x]`(fail)."
+            )
+
+        file_exists = _path.exists(output_prefix + ".tar")
+
+        if file_exists and mode == "append":
+            # if there is only the .mpacck file but not the json one, raise an error
+            if not _path.exists(output_prefix + ".log"):
+                raise ValueError(
+                    "History file does not exists, but wavefunction file does. Please change `output_prefix or set mode=`write`."
+                )
+
+        elif file_exists and mode == "fail":
+            raise ValueError(
+                "Output file already exists. Either delete it manually or change `output_prefix`."
+            )
+
+        dir_name = _path.dirname(output_prefix)
+        if dir_name != "":
+            os.makedirs(dir_name, exist_ok=True)
+
+        self._prefix = output_prefix
+        self._file_mode = mode
+
+        self._save_every = save_every
+        self._old_step = 0
+        self._steps_notsaved = 0
+
+        self._runtime_taken = 0.0
+
+        # tar
+        self._tar_file = None
+        self._closed = False
+
+    def _create_tar_file(self):
+        if self._tar_file is None:
+            self._tar_file = tarfile.TarFile(self._prefix + ".tar", self._file_mode[0])
+            self._tar_step = 0
+            if self._file_mode == "a":
+                self._tar_step = int(self._tar_file.getnames()[-1]) + 1
+
+    def close(self):
+        if not self._closed and self._tar_file is not None:
+            self._tar_file.close()
+            self._closed = True
+
+    def __call__(self, step, item, variational_state):
+        old_step = self._old_step
+
+        if self._steps_notsaved % self._save_every == 0 or step == old_step - 1:
+            self._save_variables(variational_state)
+
+        self._old_step = step
+        self._steps_notsaved += 1
+
+    def _save_variables(self, variational_state):
+        if self._tar_file is None:
+            self._create_tar_file()
+
+        _time = time.time()
+        binary_data = serialization.to_bytes(variational_state.variables)
+        save_binary_to_tar(self._tar_file, binary_data, str(self._tar_step) + ".mpack")
+        self._tar_step += 1
+        self._runtime_taken += time.time() - _time
+
+    def __del__(self):
+        if hasattr(self, "_closed"):
+            self.close()
+
+    def flush(self, variational_state):
+        pass
+
+    def __repr__(self):
+        return f"TarLog('{self._prefix}', mode={self._file_mode})"
+
+    def __str__(self):
+        _str = self.__repr__()
+        _str = _str + f"\n  Runtime cost: {self._runtime_taken}"
+        return _str

--- a/netket/logging/tar_log.py
+++ b/netket/logging/tar_log.py
@@ -37,7 +37,7 @@ def save_binary_to_tar(tar_file, byte_data, name):
     tar_file.addfile(tarinfo=info, fileobj=abuf)
 
 
-class TarLog:
+class TarStateLog:
     """
         Tar Logger, serializing the variables of the variational state during a run.
 

--- a/netket/variational/__init__.py
+++ b/netket/variational/__init__.py
@@ -16,6 +16,8 @@ from .base import VariationalState, VariationalMixedState
 from .mc_state import MCState
 from .mc_mixed_state import MCMixedState
 
+from . import experimental
+
 from netket.utils import _hide_submodules
 
-_hide_submodules(__name__)
+_hide_submodules(__name__, ignore=["experimental"])

--- a/netket/variational/base.py
+++ b/netket/variational/base.py
@@ -73,6 +73,7 @@ class VariationalState(abc.ABC):
                 pars = flax.core.freeze(pars)
 
         self._parameters = pars
+        self.reset()
 
     @property
     def model_state(self) -> Optional[PyTree]:
@@ -86,6 +87,7 @@ class VariationalState(abc.ABC):
                 state = flax.core.freeze(state)
 
         self._model_state = state
+        self.reset()
 
     @property
     def variables(self) -> PyTree:

--- a/netket/variational/experimental.py
+++ b/netket/variational/experimental.py
@@ -1,0 +1,78 @@
+import tarfile as _tarfile
+from os import path as _path
+
+from flax import serialization as _serialization
+from netket.utils.types import PyTree as _PyTree
+
+
+def variables_from_file(filename: str, variables: _PyTree):
+    """
+    Loads the variables of a variational state from a `.mpack` file.
+
+    Args:
+        filename: the file containing the variables. Assumes a .mpack
+            extension and adds it if missing and no file exists.
+        variables: An object variables with the same structure and shape
+            of the object to be deserialized.
+
+    Returns:
+        a PyTree like variables
+
+    Examples:
+       Serializing the data:
+
+       >>> import netket as nk
+       >>> import flax
+       >>> # construct an RBM model on 10 spins
+       >>> vstate = nk.variational.MCState(
+                nk.sampler.MetropolisLocal(nk.hilbert.Spin(0.5)**10),
+                nk.models.RBM())
+       >>> with open("test.mpack", 'w') as file:
+       >>>     file.write(flax.serialization.to_bytes(vstate))
+
+       Deserializing the data:
+
+       >>> import netket as nk
+       >>> import flax
+       >>> # construct an RBM model on 10 spins
+       >>> vstate = nk.variational.MCState(
+                nk.sampler.MetropolisLocal(nk.hilbert.Spin(0.5)**10),
+                nk.models.RBM())
+       >>> # Load the data by passing the model
+       >>> vars = nk.variational.experimental.variables_from_file("test.mpack",
+                                                                  vstate.variables)
+       >>> # update the variables of vstate with the loaded data.
+       >>> vstate.variables = vars
+
+    """
+    if not _path.isfile(filename):
+        if filename[-6:] != ".mpack":
+            filename = filename + ".mpack"
+
+    with open(filename, "rb") as f:
+        return _serialization.from_bytes(variables, f.read())
+
+
+def variables_from_tar(filename: str, variables: _PyTree, i: int):
+    """
+    Loads the variables of a variational state from the i-th element of a `.tar`
+    archive.
+
+    Args:
+        filename: the tar archive name. Assumes a .tar
+            extension and adds it if missing and no file exists.
+        variables: An object variables with the same structure and shape
+            of the object to be deserialized.
+        i: the index of the variables to load
+
+    """
+    if not _path.isfile(filename):
+        if filename[-4:] != ".tar":
+            filename = filename + ".tar"
+
+    with _tarfile.TarFile(filename, "r") as file:
+        inner_files = file.getnames()
+
+        info = file.getmember(str(i) + ".mpack")
+        with file.extractfile(info) as f:
+            return _serialization.from_bytes(variables, f.read())


### PR DESCRIPTION
Add an option to JsonLog to store the parameters during the optimisation.
It will save them at every iteration when data is logged, inside a tar file with no compression.
(In the future we might activate compression but it is tricky)

Adds two experimental functions in netket.variational.experimental to read data from a file or a tar file.

I'd like opinions.