### PR TITLE
SR with precomputed gradients

### DIFF
--- a/Test/Optimizer/test_sr_itersolve.py
+++ b/Test/Optimizer/test_sr_itersolve.py
@@ -24,6 +24,16 @@ SR_objects["GMRES(solve_method=incremental)"] = sr.SRLazyGMRES(
     solve_method="incremental"
 )
 
+SR_objects["JCG()"] = sr.SRJacobianCG()
+SR_objects["JCG(centered=True)"] = sr.SRJacobianCG(centered=True)
+SR_objects["JCG(maxiter=3)"] = sr.SRJacobianCG(maxiter=3)
+
+SR_objects["JGMRES()"] = sr.SRJacobianGMRES()
+SR_objects["JGMRES(restart=5)"] = sr.SRJacobianGMRES(restart=5)
+SR_objects["JGMRES(solve_method=incremental)"] = sr.SRJacobianGMRES(
+    solve_method="incremental"
+)
+
 dtypes = {"float": float, "complex": complex}
 
 

--- a/netket/optimizer/__init__.py
+++ b/netket/optimizer/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .sr import SR, SRLazyCG, SRLazyGMRES
+from .sr import SR, SRLazyCG, SRLazyGMRES, SRJacobianCG, SRJacobianGMRES
 
 ## Optimisers
 

--- a/netket/optimizer/sr/__init__.py
+++ b/netket/optimizer/sr/__init__.py
@@ -23,6 +23,9 @@ from .s_lazy import AbstractLazySMatrix
 # Lazy OnTheFly implementation of S matrix
 from .sr_onthefly import SRLazyCG, SRLazyGMRES
 
+# Semi-lazy implementation of S matrix with precomputed gradients
+from .sr_jacobian import SRJacobianCG, SRJacobianGMRES
+
 
 from netket.utils import _hide_submodules
 

--- a/netket/optimizer/sr/api.py
+++ b/netket/optimizer/sr/api.py
@@ -47,9 +47,11 @@ def SR(
         diag_shift: Diagonal shift added to the S matrix
         method: (cg, gmres) The specific method.
         iterative: Whever to use an iterative method or not.
-        jacobian: Differentiation mode to precompute Jacobian
+        jacobian: Differentiation mode to precompute gradients
                   can be "holomorphic", "R2R", "R2C", 
-                         None (if Jacobian shouldn't be precomputed)
+                         None (if they shouldn't be precomputed)
+        rescale_shift: Whether to rescale the diagonal offsets in SR according
+                       to diagonal entries (only with precomputed gradients)
 
     Returns:
         The SR parameter structure.

--- a/netket/optimizer/sr/api.py
+++ b/netket/optimizer/sr/api.py
@@ -47,6 +47,9 @@ def SR(
         diag_shift: Diagonal shift added to the S matrix
         method: (cg, gmres) The specific method.
         iterative: Whever to use an iterative method or not.
+        jacobian: Differentiation mode to precompute Jacobian
+                  can be "holomorphic", "R2R", "R2C", 
+                         None (if Jacobian shouldn't be precomputed)
 
     Returns:
         The SR parameter structure.

--- a/netket/optimizer/sr/api.py
+++ b/netket/optimizer/sr/api.py
@@ -48,7 +48,7 @@ def SR(
         method: (cg, gmres) The specific method.
         iterative: Whever to use an iterative method or not.
         jacobian: Differentiation mode to precompute gradients
-                  can be "holomorphic", "R2R", "R2C", 
+                  can be "holomorphic", "R2R", "R2C",
                          None (if they shouldn't be precomputed)
         rescale_shift: Whether to rescale the diagonal offsets in SR according
                        to diagonal entries (only with precomputed gradients)

--- a/netket/optimizer/sr/s_jacobian_mat.py
+++ b/netket/optimizer/sr/s_jacobian_mat.py
@@ -1,0 +1,203 @@
+# Copyright 2021 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Callable, Optional, Union, Tuple, Any
+from functools import partial
+
+from jax import numpy as jnp
+from flax import struct
+
+from netket.utils.types import PyTree
+
+from .base import AbstractSMatrix
+
+
+@struct.dataclass
+class JacobianSMatrix(AbstractSMatrix):
+    """
+    Semi-lazy representation of an S Matrix behaving like a linear operator.
+
+    The matrix of gradients O is computed on initialisation, but not S, 
+    which can be computed by calling :code:`to_dense`.
+    The details on how the ⟨S⟩⁻¹⟨F⟩ system is solved are contaianed in
+    the field `sr`.
+    """
+
+    sr: SRJacobian
+    """Parameters for the solution of the system."""
+
+    O: jnp.ndarray
+    """Gradients O_ij = ∂log ψ(σ_i)/∂p_j of the neural network 
+    for all samples σ_i at given values of the parameters p_j
+    Average <O_j> subtracted for each parameter
+    Divided through by sqrt(#samples) to normalise S matrix
+    If scale is not None, normalised to unit magnitude"""
+
+    scale: Optional[jnp.ndarray] = None
+    """If not None, gives scale factors with which O is normalised"""
+
+    x0: Optional[PyTree] = None
+    """Optional initial guess for the iterative solution."""
+
+    @jax.jit
+    def __matmul__(self, vec: Union[PyTree, jnp.ndarray]) -> Union[PyTree, jnp.ndarray]:
+        if not hasattr(vec, "ndim"):
+            vec, unravel = nkjax.tree_ravel(vec)
+        else:
+            unravel = lambda x: x
+
+        return unravel(
+            jnp.transpose(jnp.conj(jnp.transpose(jnp.conj(S.O @ vec)) @ S.O))
+            + S.sr.diag_shift * vec
+        )
+
+    @jax.jit
+    def solve(self, y: PyTree, x0: Optional[PyTree] = None) -> PyTree:
+        """
+        Solve the linear system x=⟨S⟩⁻¹⟨y⟩ with the chosen iterataive solver.
+
+        Args:
+            y: the vector y in the system above.
+            x0: optional initial guess for the solution.
+
+        Returns:
+            x: the PyTree solving the system.
+            info: optional additional informations provided by the solver. Might be
+                None if there are no additional informations provided.
+        """
+
+        # Ravel input PyTrees, record unravelling function too
+        grad, unravel = nkjax.tree_ravel(grad)
+        
+        if x0 is None:
+            x0 = self.x0
+        if x0 is not None:
+            x0, _ = nkjax.tree_ravel(x0)
+            if self.scale is not None:
+                x0 = x0 / self.scale
+
+        if self.scale is not None:
+            grad = grad * self.scale
+
+        solve_fun = self.sr.solve_fun()
+        _mat_vec = lambda x: self @ x
+        out, info = solve_fun(_mat_vec, grad, x0=x0)
+
+        if self.scale is not None:
+            out = out * self.scale
+
+        return unravel(out), info
+
+    @jax.jit
+    def to_dense(self) -> jnp.ndarray:
+        """
+        Convert the lazy matrix representation to a dense matrix representation.
+
+        Returns:
+            A dense matrix representation of this S matrix.
+        """
+        return jnp.transpose(jnp.conj(self.O)) @ self.O + self.sr.diag_shift * jnp.eye(
+            self.O.shape[1]
+        )
+
+
+
+@partial(jax.jit, static_argnums=(0, 4, 5))
+def gradients(
+    apply_fun: Callable[[PyTree, jnp.ndarray], jnp.ndarray],
+    params: PyTree,
+    samples: jnp.ndarray,
+    model_state: Optional[PyTree],
+    mode: str,
+    rescale_shift: bool,
+):
+    """Calculates the gradients O_ij by backpropagating every sample separately,
+    vectorising the loop using vmap
+    If rescale_shift is True, columns of O are rescaled to unit magnitude, and
+    scale factor [1/sqrt(S_kk)] returned as a separate vector for
+    scale-invariant regularisation as per Becca & Sorella p. 143."""
+    # Ravel the parameter PyTree and obtain the unravelling function
+    params, unravel = nkjax.tree_ravel(params)
+
+    if jnp.ndim(samples) != 2:
+        samples = jnp.reshape(samples, (-1, samples.shape[-1]))
+    n_samples = samples.shape[0]
+
+    if mode == "holomorphic":
+        # Preapply the model state so that when computing gradient
+        # we only get gradient of parameters
+        # Also divide through sqrt(n_samples) to normalise S matrix in the end
+        def fun(W, σ):
+            return (
+                apply_fun({"params": unravel(W), **model_state}, σ[jnp.newaxis, :])[0]
+                / n_samples ** 0.5
+            )
+
+        grads = _grad_vmap_minus_mean(fun, params, samples, True)
+    elif mode == "R2R":
+
+        def fun(W, σ):
+            return (
+                apply_fun({"params": unravel(W), **model_state}, σ[jnp.newaxis, :])[0].real
+                / n_samples ** 0.5
+            )
+
+        grads = _grad_vmap_minus_mean(fun, params, samples, False)
+    elif mode == "R2C":
+
+        def fun1(W, σ):
+            return (
+                apply_fun({"params": unravel(W), **model_state}, σ[jnp.newaxis, :])[0].real
+                / n_samples ** 0.5
+            )
+
+        def fun2(W, σ):
+            return (
+                apply_fun({"params": unravel(W), **model_state}, σ[jnp.newaxis, :])[0].imag
+                / n_samples ** 0.5
+            )
+
+        # Stack real and imaginary parts as real matrixes along the "sample"
+        # axis to get Re(O†O) directly
+        grads = jnp.concatenate(
+            (
+                _grad_vmap_minus_mean(fun1, params, samples, False),
+                _grad_vmap_minus_mean(fun2, params, samples, False),
+            ),
+            axis=0,
+        )
+    else:
+        raise Exception(
+            "Differentation mode must be holomorphic, R2R or R2C, got {}".format(mode)
+        )
+
+    if rescale_shift:
+        sqrt_Skk = jnp.linalg.norm(grads, axis=0, keepdims=True)
+        return grads / sqrt_Skk, 1 / jnp.ravel(sqrt_Skk)
+    else:
+        return grads
+
+
+@partial(jax.jit, static_argnums=(0, 3))
+def _grad_vmap_minus_mean(
+    fun: Callable, params: jnp.ndarray, samples: jnp.ndarray, holomorphic: bool
+):
+    """Calculates the gradient of a neural network for a number of samples
+    efficiently using vmap(grad),
+    subtracts their mean for each parameter, i.e., each column,
+    and divides through with sqrt(#samples) to normalise the S matrix"""
+    grads = jax.vmap(
+        jax.grad(fun, holomorphic=holomorphic), in_axes=(None, 0), out_axes=0
+    )(params, samples)
+    return grads - jnp.sum(grads, axis=0, keepdims=True) / grads.shape[0]

--- a/netket/optimizer/sr/s_jacobian_mat.py
+++ b/netket/optimizer/sr/s_jacobian_mat.py
@@ -15,10 +15,12 @@
 from typing import Callable, Optional, Union, Tuple, Any
 from functools import partial
 
+import jax
 from jax import numpy as jnp
 from flax import struct
 
 from netket.utils.types import PyTree
+import netket.jax as nkjax
 
 from .base import AbstractSMatrix
 

--- a/netket/optimizer/sr/sr_jacobian.py
+++ b/netket/optimizer/sr/sr_jacobian.py
@@ -39,6 +39,17 @@ class SRJacobian(SR):
     :code:`norm(residual) <= max(tol*norm(b), atol)`
     """
 
+    mode: str = struct.field(pytree_node=False)
+    """Differentiation mode to precompute Jacobian
+    * "holomorphic": C->C holomorphic function
+        `grad` is called on the full network output with `holomorphic=True`
+    * "R2R": real-valued wave function with real parameters
+        `grad` is called on the real part of the network output with `holomorphic=False`
+    * "R2C": complex-valued wave function with real parameters
+        the real and imaginary parts of the network output are treated as independent 
+        R->R functions and `grad` is called separately on them with `holomorphic=False`
+    """
+
     tol: float = 1.0e-5
     """Relative tolerance for convergences."""
 
@@ -54,17 +65,6 @@ class SRJacobian(SR):
     """Preconditioner for A. The preconditioner should approximate the inverse of A. 
     Effective preconditioning dramatically improves the rate of convergence, which implies 
     that fewer iterations are needed to reach a given error tolerance.
-    """
-
-    mode: str = struct.field(pytree_node=False)
-    """Differentiation mode to precompute Jacobian
-    * "holomorphic": C->C holomorphic function
-        `grad` is called on the full network output with `holomorphic=True`
-    * "R2R": real-valued wave function with real parameters
-        `grad` is called on the real part of the network output with `holomorphic=False`
-    * "R2C": complex-valued wave function with real parameters
-        the real and imaginary parts of the network output are treated as independent 
-        R->R functions and `grad` is called separately on them with `holomorphic=False`
     """
 
     rescale_shift: bool = struct.field(pytree_node=False, default=False)

--- a/netket/optimizer/sr/sr_jacobian.py
+++ b/netket/optimizer/sr/sr_jacobian.py
@@ -28,8 +28,6 @@ from .s_jacobian_mat import JacobianSMatrix, gradients
 
 from .base import SR
 
-import numpy as np
-
 
 @struct.dataclass
 class SRJacobian(SR):

--- a/netket/optimizer/sr/sr_jacobian.py
+++ b/netket/optimizer/sr/sr_jacobian.py
@@ -72,10 +72,10 @@ class SRJacobian(SR):
 
     def create(self, *args, **kwargs):
         if rescale_shift:
-            O, scale = gradients(apply_fun, params, samples, model_state, mode, True)
+            O, scale = gradients(apply_fun, params, samples, model_state, self.mode, True)
             return JacobianSMatrix(sr=sr, x0=x0, O=O, scale=scale)
         else:
-            O = gradients(apply_fun, params, samples, model_state, mode, False)
+            O = gradients(apply_fun, params, samples, model_state, self.mode, False)
             return JacobianSMatrix(sr=sr, x0=x0, O=O)
 
 

--- a/netket/optimizer/sr/sr_jacobian.py
+++ b/netket/optimizer/sr/sr_jacobian.py
@@ -1,0 +1,223 @@
+# Copyright 2021 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Callable, Optional, Union, Tuple, Any
+from functools import partial
+
+import jax
+import flax
+from jax import numpy as jnp
+from flax import struct
+
+from netket.utils.types import PyTree, Array
+from netket.utils import rename_class
+import netket.jax as nkjax
+
+from .base import SR
+
+import numpy as np
+
+@struct.dataclass
+class JacobianSMatrix:
+    """
+    Semi-lazy representation of an S Matrix behaving like a linear operator.
+
+    The Jacobian O is computed on initialisation, but not S, which can be
+    computed by calling :code:`to_dense`.
+    The details on how the ⟨S⟩⁻¹⟨F⟩ system is solved are contaianed in
+    the field `sr`.
+    """
+
+    sr: SRLazy
+    """Parameters for the solution of the system."""
+
+    O: jnp.ndarray
+    """Gradients O_ij = ∂log ψ(σ_i)/∂p_j of the neural network 
+    for all samples σ_i at given values of the parameters p_j
+    Average <O_j> subtracted for each parameter
+    Divided through by sqrt(#samples) to normalise S matrix
+    If scale is not None, normalised to unit magnitude"""
+
+    scale: Optional[jnp.ndarray] = None
+    """If not None, gives scale factors with which O is normalised"""
+
+    x0: Optional[PyTree] = None
+    """Optional initial guess for the iterative solution."""
+    
+    def __matmul__(self, vec: Union[PyTree, jnp.ndarray]
+    ) -> Union[PyTree, jnp.ndarray]:
+        return jacsmatrix_mat_treevec(self, vec)
+
+    def __rtruediv__(self, y):
+        return self.solve(y)
+
+    def solve(self, y: PyTree, x0: Optional[PyTree] = None) -> PyTree:
+        """
+        Solve the linear system x=⟨S⟩⁻¹⟨y⟩ with the chosen iterataive solver.
+
+        Args:
+            y: the vector y in the system above.
+            x0: optional initial guess for the solution.
+
+        Returns:
+            x: the PyTree solving the system.
+            info: optional additional informations provided by the solver. Might be
+                None if there are no additional informations provided.
+        """
+        if x0 is None:
+            x0 = self.x0
+        return jacsmatrix_solve(self,y,x0)
+
+    @jax.jit
+    def to_dense(self) -> jnp.ndarray:
+        """
+        Convert the lazy matrix representation to a dense matrix representation.
+
+        Returns:
+            A dense matrix representation of this S matrix.
+        """
+        return jnp.transpose(jnp.conj(self.O)) @ self.O \
+            + self.sr.diag_shift * jnp.eye(self.O.shape[1])
+
+def makeJacobianSMatrix(
+        apply_fun: Callable[[PyTree, jnp.ndarray], jnp.ndarray],
+        params: PyTree,
+        samples: jnp.ndarray,
+        sr: SRLazy,
+        model_state: Optional[PyTree] = None,
+        x0: Optional[PyTree] = None,
+        mode: str = "holomorphic",
+        rescale_shift: bool = False
+):
+    if rescale_shift:
+        O, scale = gradients(apply_fun, params, samples, model_state,
+                             mode, True)
+        return JacobianSMatrix(sr = sr, x0 = x0, O = O, scale = scale)
+    else:
+        return JacobianSMatrix(
+            sr = sr, x0 = x0,
+            O = gradients(apply_fun, params, samples, model_state, mode, False)
+        )
+
+@partial(jax.jit, static_argnums=(0,4,5))
+def gradients(
+        apply_fun: Callable[[PyTree, jnp.ndarray], jnp.ndarray],
+        params: PyTree,
+        samples: jnp.ndarray,
+        model_state: Optional[PyTree],
+        mode: str,
+        rescale_shift: bool
+        ):
+    """Calculates the gradients O_ij by backpropagating every sample separately,
+    vectorising the loop using vmap
+    If rescale_shift is True, columns of O are rescaled to unit magnitude, and
+    scale factor [1/sqrt(S_kk)] returned as a separate vector for 
+    scale-invariant regularisation as per Becca & Sorella p. 143."""
+    # Ravel the parameter PyTree and obtain the unravelling function
+    params, unravel = nkjax.tree_ravel(params)
+
+    if jnp.ndim(samples) != 2:
+        samples = jnp.reshape(samples, (-1, samples.shape[-1]))
+    n_samples = samples.shape[0]
+
+    if mode == "holomorphic":
+        # Preapply the model state so that when computing gradient
+        # we only get gradient of parameters
+        # Also divide through sqrt(n_samples) to normalise S matrix in the end
+        def fun(W, σ):
+            return apply_fun({"params": unravel(W), **model_state},
+                             σ[jnp.newaxis,:])[0] / n_samples**0.5
+        grads = _grad_vmap_minus_mean(fun, params, samples, True)
+    elif mode == "R2R":
+        def fun(W, σ):
+            return apply_fun({"params": unravel(W), **model_state},
+                             σ[jnp.newaxis,:])[0].real / n_samples**0.5
+        grads = _grad_vmap_minus_mean(fun, params, samples, False)
+    elif mode == "R2C":
+        def fun1(W, σ):
+            return apply_fun({"params": unravel(W), **model_state},
+                             σ[jnp.newaxis,:])[0].real / n_samples**0.5
+        def fun2(W, σ):
+            return apply_fun({"params": unravel(W), **model_state},
+                             σ[jnp.newaxis,:])[0].imag / n_samples**0.5
+        # Stack real and imaginary parts as real matrixes along the "sample"
+        # axis to get Re(O†O) directly
+        grads = jnp.concatenate(
+            (_grad_vmap_minus_mean(fun1, params, samples, False),
+             _grad_vmap_minus_mean(fun2, params, samples, False)),
+            axis = 0)
+    else:
+        raise Exception("Differentation mode must be holomorphic, R2R or R2C, got {}".format(mode))
+
+    if rescale_shift:
+        sqrt_Skk = jnp.linalg.norm(grads, axis=0, keepdims=True)
+        return grads/sqrt_Skk, 1/jnp.ravel(sqrt_Skk)
+    else:
+        return grads
+        
+@partial(jax.jit, static_argnums=(0,3))
+def _grad_vmap_minus_mean(
+        fun: Callable,
+        params: jnp.ndarray,
+        samples: jnp.ndarray,
+        holomorphic: bool
+        ):
+    """Calculates the gradient of a neural network for a number of samples 
+    efficiently using vmap(grad),
+    subtracts their mean for each parameter, i.e., each column,
+    and divides through with sqrt(#samples) to normalise the S matrix"""
+    grads = jax.vmap(jax.grad(fun, holomorphic=holomorphic), in_axes=(None,0),
+                     out_axes=0)(params, samples)
+    return grads - jnp.sum(grads, axis=0, keepdims=True) / grads.shape[0]
+
+@jax.jit
+def jacsmatrix_mat_treevec(
+    S: JacobianSMatrix, vec: Union[PyTree, jnp.ndarray]
+) -> Union[PyTree, jnp.ndarray]:
+    """
+    Perform the semi-lazy mat-vec product, where vec is either a tree with 
+    the same structure as params or a ravelled vector
+    """
+    if not hasattr(vec, "ndim"):
+        vec, unravel = nkjax.tree_ravel(vec)
+    else:
+        unravel = lambda x: x
+        
+    return unravel(
+        jnp.transpose(jnp.conj( jnp.transpose(jnp.conj(S.O @ vec)) @ S.O)) +
+        S.sr.diag_shift * vec)
+
+@jax.jit
+def jacsmatrix_solve(
+    S: JacobianSMatrix, grad: PyTree, x0: Optional[PyTree]
+) -> PyTree:
+    # Ravel input PyTrees, record unravelling function too
+    grad, unravel = nkjax.tree_ravel(grad)
+    if x0 is not None:
+        x0, _ = nkjax.tree_ravel(x0)
+        if S.scale is not None:
+            x0 = x0 / S.scale
+
+    if S.scale is not None:
+        grad = grad * S.scale
+        
+    solve_fun = S.sr.solve_fun()
+    _mat_vec = lambda x: S @ x
+    out, info = solve_fun(_mat_vec, grad, x0=x0)
+
+    if S.scale is not None:
+        out = out * S.scale
+        
+    return unravel(out), info
+    

--- a/netket/optimizer/sr/sr_jacobian.py
+++ b/netket/optimizer/sr/sr_jacobian.py
@@ -72,11 +72,17 @@ class SRJacobian(SR):
     """Whether scale-invariant regularisation should be used"""
 
     def __post_init__(self):
-        if self.mode not in {'R2R','R2C','holomorphic'}:
-            raise NotImplementedError('Differentiation mode must be one of "R2R", "R2C", "holomorphic", got "{}"'.format(self.mode))
+        if self.mode not in {"R2R", "R2C", "holomorphic"}:
+            raise NotImplementedError(
+                'Differentiation mode must be one of "R2R", "R2C", "holomorphic", got "{}"'.format(
+                    self.mode
+                )
+            )
 
     def create(self, *args, **kwargs):
-        O, scale = gradients(apply_fun, params, samples, model_state, self.mode, self.rescale_shift)
+        O, scale = gradients(
+            apply_fun, params, samples, model_state, self.mode, self.rescale_shift
+        )
         return JacobianSMatrix(sr=sr, x0=x0, O=O, scale=scale)
 
 
@@ -140,4 +146,3 @@ class SRJacobianGMRES(SRJacobian):
             restart=self.restart,
             solve_method=self.solve_method,
         )
-

--- a/netket/optimizer/sr/sr_jacobian.py
+++ b/netket/optimizer/sr/sr_jacobian.py
@@ -56,18 +56,16 @@ class SRJacobian(SR):
     that fewer iterations are needed to reach a given error tolerance.
     """
 
-    centered: bool = struct.field(pytree_node=False, default=True)
-    """Uses S=⟨ΔÔᶜΔÔ⟩ if True (default), S=⟨ÔᶜΔÔ⟩ otherwise. The two forms are 
-    mathematically equivalent, but might lead to different results due to numerical
-    precision. The non-centered variaant should bee approximately 33% faster.
-    """
-
-    diffmode: Optional[str] = struct.field(pytree_node=False, default=None)
+    mode: str = struct.field(pytree_node=False)
     """Differentiation mode to precompute Jacobian
     * "holomorphic": C->C holomorphic function
+        `grad` is called on the full network output with `holomorphic=True`
     * "R2R": real-valued wave function with real parameters
+        `grad` is called on the real part of the network output with `holomorphic=False`
     * "R2C": complex-valued wave function with real parameters
-    * None: do not precompute Jacobian (default)"""
+        the real and imaginary parts of the network output are treated as independent 
+        R->R functions and `grad` is called separately on them with `holomorphic=False`
+    """
 
     rescale_shift: bool = struct.field(pytree_node=False, default=False)
     """Whether scale-invariant regularisation should be used"""

--- a/netket/optimizer/sr/sr_jacobian.py
+++ b/netket/optimizer/sr/sr_jacobian.py
@@ -71,12 +71,8 @@ class SRJacobian(SR):
     """Whether scale-invariant regularisation should be used"""
 
     def create(self, *args, **kwargs):
-        if rescale_shift:
-            O, scale = gradients(apply_fun, params, samples, model_state, self.mode, True)
-            return JacobianSMatrix(sr=sr, x0=x0, O=O, scale=scale)
-        else:
-            O = gradients(apply_fun, params, samples, model_state, self.mode, False)
-            return JacobianSMatrix(sr=sr, x0=x0, O=O)
+        O, scale = gradients(apply_fun, params, samples, model_state, self.mode, rescale_shift)
+        return JacobianSMatrix(sr=sr, x0=x0, O=O, scale=scale)
 
 
 @struct.dataclass

--- a/netket/optimizer/sr/sr_jacobian.py
+++ b/netket/optimizer/sr/sr_jacobian.py
@@ -71,9 +71,9 @@ class SRJacobian(SR):
     rescale_shift: bool = struct.field(pytree_node=False, default=False)
     """Whether scale-invariant regularisation should be used"""
 
-    def __post_init__():
-        if mode not in {'R2R','R2C','holomorphic'}:
-            raise NotImplementedError('Differentiation mode must be one of "R2R", "R2C", "holomorphic", got "{}"'.format(mode))
+    def __post_init__(self):
+        if self.mode not in {'R2R','R2C','holomorphic'}:
+            raise NotImplementedError('Differentiation mode must be one of "R2R", "R2C", "holomorphic", got "{}"'.format(self.mode))
 
     def create(self, *args, **kwargs):
         O, scale = gradients(apply_fun, params, samples, model_state, self.mode, self.rescale_shift)

--- a/netket/optimizer/sr/sr_onthefly.py
+++ b/netket/optimizer/sr/sr_onthefly.py
@@ -103,7 +103,7 @@ class SRLazyGMRES(SROnTheFlyIterative):
     for more informations.
     """
 
-    restart: int = 20
+    restart: int = struct.field(pytree_node=False, default=20)
     """Size of the Krylov subspace (“number of iterations”) built between restarts. 
     GMRES works by approximating the true solution x as its projection into a Krylov 
     space of this dimension - this parameter therefore bounds the maximum accuracy 

--- a/netket/optimizer/sr/sr_onthefly.py
+++ b/netket/optimizer/sr/sr_onthefly.py
@@ -103,7 +103,7 @@ class SRLazyGMRES(SROnTheFlyIterative):
     for more informations.
     """
 
-    restart: int = struct.field(pytree_node=False, default=20)
+    restart: int = 20
     """Size of the Krylov subspace (“number of iterations”) built between restarts. 
     GMRES works by approximating the true solution x as its projection into a Krylov 
     space of this dimension - this parameter therefore bounds the maximum accuracy 


### PR DESCRIPTION
I have implemented the SR algorithm with precomputed gradients. This is less elegant than the lazy `vjp/jvp`-based implementation in `LazySMatrix`, but has practical advantages:

- It has minimal memory overhead: precomputing the gradients requires the same amount of memory as a single pass of `vjp` since the different samples on which the neural network is run are independent, so we only need to compute one of them to get a row of the Jacobian. (I.e., instead of looping through `vjp` with `vmap` as `jacrev` does, we can loop through `grad`.) Storing the matrix of gradients is guaranteed to take up less memory: backpropagation has to store a lot of internal information about the forward pass, which takes up many times the memory needed for the gradients in a deep network (In my experiments, they were 40 MB vs 1.2 GB). The bottom line is that if there is enough memory for a single `vjp`, there is enough memory for this too.
- It yields a massive speedup: the gradient matrix can again be calculated in the same asymptotic time as a single `vjp` (it will of course be a bit slower because `vmap` is used, but not by large factors); afterwards, we only need matrix-vector multiplications, which are way faster than a full backpropagation of a complex neural network. In my experiments (on 20 CPUs), I could reduce the time of an SR step from 8x that with Adam to about 1.2x.
- It allows for regularising the S matrix in a scale-invariant way by factoring out the magnitude of diagonal elements, as described in Becca & Sorella, p. 143. This has minimal overhead and can be crucial for heterogeneous networks that may have very different gradients in different parts.

Unfortunately, calculating the full Jacobian cannot be done as dtype-agnostically as a VJP, so some information about the network structure needs to be passed. This is done through the `jacobian` parameter, which is implemented for the values `"R2R"` (both the network entries and the wave function are real), `"R2C"` (real entries, complex wave function), and `"holomorphic"` (holomorphic function of complex parameters), `None` (uses a `LazySMatrix`). 
- The parameter could use a better name, but `jacobian` also signifies it is a switch for using this code vs. the original one
- It may be possible to automate this choice, although it's not trivial (e.g., R2R is the right choice even if the wave function has negative entries, which makes the output complex...)
- A few more cases might be implemented, e.g. non-holomorphic C2C, although that is just sugar for R2C...

The boolean parameter `rescale_shift`specifies whether the scale-invariant regularisation should be used.