### PR TITLE
[NFC] Make a more explicit SR and Matrix type hierarchy  + add SRJacobian (#648)

### DIFF
--- a/Test/Optimizer/test_sr_itersolve.py
+++ b/Test/Optimizer/test_sr_itersolve.py
@@ -29,22 +29,12 @@ SR_objects["GMRES(solve_method=incremental)"] = sr.SRLazyGMRES(
     solve_method="incremental"
 )
 
-SR_objects["JCG()"] = sr.SRJacobianCG()
-SR_objects["JCG(centered=True)"] = sr.SRJacobianCG(centered=True)
-SR_objects["JCG(maxiter=3)"] = sr.SRJacobianCG(maxiter=3)
-
-SR_objects["JGMRES()"] = sr.SRJacobianGMRES()
-SR_objects["JGMRES(restart=5)"] = sr.SRJacobianGMRES(restart=5)
-SR_objects["JGMRES(solve_method=incremental)"] = sr.SRJacobianGMRES(
-    solve_method="incremental"
-)
-
 dtypes = {"float": float, "complex": complex}
 
 
 @pytest.fixture(params=[pytest.param(dtype, id=name) for name, dtype in dtypes.items()])
 def vstate(request):
-    N = 8
+    N = 5
     hi = nk.hilbert.Spin(1 / 2, N)
     g = nk.graph.Chain(N)
 
@@ -111,3 +101,68 @@ def test_sr_matmul(sr, vstate, _mpi_size, _mpi_rank):
             x_all = S @ vstate.parameters
 
             jax.tree_multimap(lambda a, b: np.testing.assert_allclose(a, b), x, x_all)
+
+
+# TODO: this test only tests r2r and holo, but should also do r2c.
+# to add in a future rewrite
+def test_srjacobian_solve(vstate, _mpi_size, _mpi_rank):
+    for SRObj in [sr.SRJacobianCG, sr.SRJacobianGMRES]:
+        if vstate.model.dtype is float:
+            srobj = SRObj(mode="R2R")
+        else:
+            srobj = SRObj(mode="holomorphic")
+
+        S = vstate.quantum_geometric_tensor(srobj)
+        x, _ = S.solve(vstate.parameters)
+
+        if _mpi_size > 1:
+            # other check
+            with common.netket_disable_mpi():
+                import mpi4jax
+
+                samples, _ = mpi4jax.allgather(
+                    vstate.samples, comm=nk.utils.MPI_jax_comm
+                )
+                assert samples.shape == (_mpi_size, *vstate.samples.shape)
+                vstate._samples = samples.reshape((-1, *vstate.samples.shape[1:]))
+
+                S = vstate.quantum_geometric_tensor(srobj)
+                x_all, _ = S.solve(vstate.parameters)
+
+                jax.tree_multimap(
+                    lambda a, b: np.testing.assert_allclose(a, b), x, x_all
+                )
+
+
+# TODO: this test only tests r2r and holo, but should also do r2c.
+# to add in a future rewrite
+def test_srjacobian_matmul(vstate, _mpi_size, _mpi_rank):
+    for SRObj in [sr.SRJacobianCG, sr.SRJacobianGMRES]:
+        if vstate.model.dtype is float:
+            srobj = SRObj(mode="R2R")
+        else:
+            srobj = SRObj(mode="holomorphic")
+
+        S = vstate.quantum_geometric_tensor(srobj)
+        x = S @ vstate.parameters
+
+        if _mpi_size > 1:
+            # other check
+            with common.netket_disable_mpi():
+                import mpi4jax
+
+                samples, _ = mpi4jax.allgather(
+                    vstate.samples, comm=nk.utils.MPI_jax_comm
+                )
+                assert samples.shape == (_mpi_size, *vstate.samples.shape)
+                vstate._samples = samples.reshape((-1, *vstate.samples.shape[1:]))
+
+                S = vstate.quantum_geometric_tensor(srobj)
+                x_all = S @ vstate.parameters
+
+                jax.tree_multimap(
+                    lambda a, b: np.testing.assert_allclose(a, b), x, x_all
+                )
+
+
+# TODO add to_dense tests

--- a/Test/Optimizer/test_sr_itersolve.py
+++ b/Test/Optimizer/test_sr_itersolve.py
@@ -29,6 +29,16 @@ SR_objects["GMRES(solve_method=incremental)"] = sr.SRLazyGMRES(
     solve_method="incremental"
 )
 
+SR_objects["JCG()"] = sr.SRJacobianCG()
+SR_objects["JCG(centered=True)"] = sr.SRJacobianCG(centered=True)
+SR_objects["JCG(maxiter=3)"] = sr.SRJacobianCG(maxiter=3)
+
+SR_objects["JGMRES()"] = sr.SRJacobianGMRES()
+SR_objects["JGMRES(restart=5)"] = sr.SRJacobianGMRES(restart=5)
+SR_objects["JGMRES(solve_method=incremental)"] = sr.SRJacobianGMRES(
+    solve_method="incremental"
+)
+
 dtypes = {"float": float, "complex": complex}
 
 

--- a/docs/docs/api.rst
+++ b/docs/docs/api.rst
@@ -273,9 +273,10 @@ This module provides the following functionalities
    :nosignatures:
    
    netket.optimizer.SR
-   netket.optimizer.SRLazyCG
-   netket.optimizer.SRLazyGMRES
-   netket.optimizer.sr.LazySMatrix
+   netket.optimizer.sr.SRLazyCG
+   netket.optimizer.sr.SRLazyGMRES
+   netket.optimizer.sr.SRJacobianCG
+   netket.optimizer.sr.SRLazyGMRES
 
 This module also provides some optimisers from `optax <https://github.com/deepmind/optax>`_. 
 Check it out for up-to-date informations on available optimisers.

--- a/netket/optimizer/__init__.py
+++ b/netket/optimizer/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .sr import SR, SRLazyCG, SRLazyGMRES
+from .sr import SR, SRLazyCG, SRLazyGMRES, SRJacobianCG, SRJacobianGMRES
 
 ## Optimisers
 

--- a/netket/optimizer/sr/__init__.py
+++ b/netket/optimizer/sr/__init__.py
@@ -23,6 +23,9 @@ from .s_lazy import AbstractLazySMatrix
 # Lazy OnTheFly implementation of S matrix
 from .sr_onthefly import SRLazyCG, SRLazyGMRES
 
+# Semi-lazy implementation of S matrix with precomputed gradients
+from .sr_jacobian import SRJacobianCG, SRJacobianGMRES
+
 
 from netket.utils import _hide_submodules
 

--- a/netket/optimizer/sr/__init__.py
+++ b/netket/optimizer/sr/__init__.py
@@ -14,7 +14,15 @@
 
 from .api import SR
 
-from .sr_onthefly import LazySMatrix, SRLazyCG, SRLazyGMRES
+# Abstract base types for SR and S Matrices
+from .base import AbstractSMatrix
+
+# Abstract type for a lazy S matrix
+from .s_lazy import AbstractLazySMatrix
+
+# Lazy OnTheFly implementation of S matrix
+from .sr_onthefly import SRLazyCG, SRLazyGMRES
+
 
 from netket.utils import _hide_submodules
 

--- a/netket/optimizer/sr/api.py
+++ b/netket/optimizer/sr/api.py
@@ -47,6 +47,11 @@ def SR(
         diag_shift: Diagonal shift added to the S matrix
         method: (cg, gmres) The specific method.
         iterative: Whever to use an iterative method or not.
+        jacobian: Differentiation mode to precompute gradients
+                  can be "holomorphic", "R2R", "R2C",
+                         None (if they shouldn't be precomputed)
+        rescale_shift: Whether to rescale the diagonal offsets in SR according
+                       to diagonal entries (only with precomputed gradients)
 
     Returns:
         The SR parameter structure.

--- a/netket/optimizer/sr/base.py
+++ b/netket/optimizer/sr/base.py
@@ -13,14 +13,11 @@
 # limitations under the License.
 
 from typing import Callable, Optional, Union, Tuple, Any
-from functools import partial
 
-import jax
-import flax
 from jax import numpy as jnp
 from flax import struct
 
-Ndarray = Any
+from netket.utils.types import PyTree, Array
 
 
 @struct.dataclass
@@ -32,3 +29,85 @@ class SR:
 
     diag_shift: float = 0.01
     """Diagonal shift added to the S matrix."""
+
+    def create(self, vstate, **kwargs) -> "AbstractSMatrix":
+        """
+        Construct the Lazy representation of the S corresponding to this SR type.
+
+        Args:
+            vstate: The Variational State
+        """
+        raise NotImplementedError
+
+
+@struct.dataclass
+class AbstractSMatrix:
+    """
+    S matrix base class.
+    This can either be a jnp matrix, a lazy wrapper, or anything, as long as
+    it satisfies this basic API.
+
+    An AbstractSMatrix must support the following API:
+
+    - :code:`__matmul__(y)`, meaning you must be able to do S@vec, where vec is
+        either a PyTree of parameters or it's dense ravelling.
+    - :code:`solve(y, **kwargs)`, which must solve the linear system Sx=y with
+        any method available, usually but not necessarily defined inside the
+        sr object stored inside the AbstractSMatrix.
+        This function must accept arbitrary additional arguments.
+
+
+    Additionally, you get for free:
+    - :code:`__call__(y)`, meaning you must be able to do S(vec) = S@vec.
+        This is defined by the base class so you don't need to define it.
+        This guarantees that you can pass this matrix to sparse solvers.
+    - :code:`to_dense(self)`, that will concretize the dense representation.
+        You get a slow default fallback by default, you might specify a faster
+        override.
+
+    """
+
+    sr: SR
+    """Parameters for the solution of the system."""
+
+    # PUBLIC API: METHOD TO EXTEND IF YOU WANT TO DEFINE A NEW S object
+    def __matmul__(self, vec):
+        raise NotImplementedError()
+
+    # PUBLIC API: METHOD TO EXTEND IF YOU WANT TO DEFINE A NEW S object
+    def solve(self, y: PyTree, **kwargs) -> PyTree:
+        """
+        Solve the linear system x=⟨S⟩⁻¹⟨y⟩ with the chosen iterataive solver.
+
+        Args:
+            y: the vector y in the system above.
+            kwargs: Any additional kwargs, which might or might not be used depending
+                on the specific implementation.
+
+        Returns:
+            x: the PyTree solving the system.
+            info: optional additional informations provided by the solver. Might be
+                None if there are no additional informations provided.
+        """
+        raise NotImplementedError()
+
+    # PUBLIC API: METHOD TO EXTEND IF YOU WANT TO DEFINE A NEW S object
+    def to_dense(self) -> jnp.ndarray:
+        """
+        Convert the lazy matrix representation to a dense matrix representation.s
+
+        Returns:
+            A dense matrix representation of this S matrix.
+        """
+        raise NotImplementedError()
+
+    # PUBLIC API: Only override if you want to, but there should be no need.
+    def __call__(self, vec):
+        return self @ vec
+
+    # PUBLIC API: Only override if you want to, but there should be no need.
+    def __array__(self) -> jnp.ndarray:
+        return self.to_dense()
+
+    def __post_init__(self):
+        pass

--- a/netket/optimizer/sr/s_jacobian_mat.py
+++ b/netket/optimizer/sr/s_jacobian_mat.py
@@ -1,0 +1,241 @@
+# Copyright 2021 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Callable, Optional, Union, Tuple, Any
+from functools import partial
+
+import jax
+from jax import numpy as jnp
+from flax import struct
+
+from netket.utils.types import PyTree
+from netket.utils import n_nodes
+from netket.stats import sum_inplace
+import netket.jax as nkjax
+
+from .base import AbstractSMatrix
+
+
+@struct.dataclass
+class JacobianSMatrix(AbstractSMatrix):
+    """
+    Semi-lazy representation of an S Matrix behaving like a linear operator.
+
+    The matrix of gradients O is computed on initialisation, but not S,
+    which can be computed by calling :code:`to_dense`.
+    The details on how the ⟨S⟩⁻¹⟨F⟩ system is solved are contaianed in
+    the field `sr`.
+    """
+
+    O: jnp.ndarray
+    """Gradients O_ij = ∂log ψ(σ_i)/∂p_j of the neural network 
+    for all samples σ_i at given values of the parameters p_j
+    Average <O_j> subtracted for each parameter
+    Divided through with sqrt(#samples) to normalise S matrix
+    If scale is not None, columns normalised to unit norm
+    """
+
+    scale: Optional[jnp.ndarray] = None
+    """If not None, contains 2-norm of each column of the gradient matrix,
+    i.e., the sqrt of the diagonal elements of the S matrix
+    """
+
+    x0: Optional[PyTree] = None
+    """Optional initial guess for the iterative solution."""
+
+    @jax.jit
+    def __matmul__(self, vec: Union[PyTree, jnp.ndarray]) -> Union[PyTree, jnp.ndarray]:
+        if not hasattr(vec, "ndim"):
+            vec, unravel = nkjax.tree_ravel(vec)
+        else:
+            unravel = None
+
+        if self.scale is not None:
+            vec = vec * self.scale
+
+        result = (
+            sum_inplace(((self.O @ vec).T.conj() @ self.O).T.conj())
+            + self.sr.diag_shift * vec
+        )
+
+        if self.scale is not None:
+            result = result * self.scale
+
+        if unravel is None:
+            return result
+        else:
+            return unravel(result)
+
+    @jax.jit
+    def _unscaled_matmul(self, vec: jnp.ndarray) -> jnp.ndarray:
+        return (
+            sum_inplace(((self.O @ vec).T.conj() @ self.O).T.conj())
+            + self.sr.diag_shift * vec
+        )
+
+    @jax.jit
+    def solve(self, y: PyTree, x0: Optional[PyTree] = None) -> PyTree:
+        """
+        Solve the linear system x=⟨S⟩⁻¹⟨y⟩ with the chosen iterataive solver.
+
+        Args:
+            y: the vector y in the system above.
+            x0: optional initial guess for the solution.
+
+        Returns:
+            x: the PyTree solving the system.
+            info: optional additional informations provided by the solver. Might be
+                None if there are no additional informations provided.
+        """
+
+        # Ravel input PyTrees, record unravelling function too
+        grad, unravel = nkjax.tree_ravel(grad)
+
+        if x0 is None:
+            x0 = self.x0
+        if x0 is not None:
+            x0, _ = nkjax.tree_ravel(x0)
+            if self.scale is not None:
+                x0 = x0 * self.scale
+
+        if self.scale is not None:
+            grad = grad / self.scale
+
+        solve_fun = self.sr.solve_fun()
+        out, info = solve_fun(self._unscaled_matmul, grad, x0=x0)
+
+        if self.scale is not None:
+            out = out / self.scale
+
+        return unravel(out), info
+
+    @jax.jit
+    def to_dense(self) -> jnp.ndarray:
+        """
+        Convert the lazy matrix representation to a dense matrix representation.
+
+        Returns:
+            A dense matrix representation of this S matrix.
+        """
+        if scale is None:
+            O = self.O
+            diag = jnp.eye(self.O.shape[1])
+        else:
+            O = self.O * self.scale[jnp.newaxis, :]
+            diag = jnp.diag(self.scale ** 2)
+
+        return sum_inplace(O.T.conj() @ O) + self.sr.diag_shift * diag
+
+
+@partial(jax.jit, static_argnums=(0, 4, 5))
+def gradients(
+    apply_fun: Callable[[PyTree, jnp.ndarray], jnp.ndarray],
+    params: PyTree,
+    samples: jnp.ndarray,
+    model_state: Optional[PyTree],
+    mode: str,
+    rescale_shift: bool,
+):
+    """Calculates the gradients O_ij by backpropagating every sample separately,
+    vectorising the loop using vmap
+    If rescale_shift is True, columns of O are rescaled to unit norm, and
+    scale factor [1/sqrt(S_kk)] returned as a separate vector for
+    scale-invariant regularisation as per Becca & Sorella p. 143.
+    """
+    # Ravel the parameter PyTree and obtain the unravelling function
+    params, unravel = nkjax.tree_ravel(params)
+
+    if jnp.ndim(samples) != 2:
+        samples = jnp.reshape(samples, (-1, samples.shape[-1]))
+    n_samples = samples.shape[0] * n_nodes
+
+    if mode == "holomorphic":
+        # Preapply the model state so that when computing gradient
+        # we only get gradient of parameters
+        # Also divide through sqrt(n_samples) to normalise S matrix in the end
+        def fun(W, σ):
+            return (
+                apply_fun({"params": unravel(W), **model_state}, σ[jnp.newaxis, :])[0]
+                / n_samples ** 0.5
+            )
+
+        grads = _grad_vmap_minus_mean(fun, params, samples, True)
+    elif mode == "R2R":
+
+        def fun(W, σ):
+            return (
+                apply_fun({"params": unravel(W), **model_state}, σ[jnp.newaxis, :])[
+                    0
+                ].real
+                / n_samples ** 0.5
+            )
+
+        grads = _grad_vmap_minus_mean(fun, params, samples, False)
+    elif mode == "R2C":
+
+        def fun1(W, σ):
+            return (
+                apply_fun({"params": unravel(W), **model_state}, σ[jnp.newaxis, :])[
+                    0
+                ].real
+                / n_samples ** 0.5
+            )
+
+        def fun2(W, σ):
+            return (
+                apply_fun({"params": unravel(W), **model_state}, σ[jnp.newaxis, :])[
+                    0
+                ].imag
+                / n_samples ** 0.5
+            )
+
+        # Stack real and imaginary parts as real matrixes along the "sample"
+        # axis to get Re(O†O) directly
+        grads = jnp.concatenate(
+            (
+                _grad_vmap_minus_mean(fun1, params, samples, False),
+                _grad_vmap_minus_mean(fun2, params, samples, False),
+            ),
+            axis=0,
+        )
+    else:
+        raise NotImplementedError(
+            'Differentation mode must be one of "R2R", "R2C", "holomorphic", got "{}"'.format(
+                mode
+            )
+        )
+
+    if rescale_shift:
+        sqrt_Skk = (
+            sum_inplace(jnp.sum((grads * grads.conj()).real, axis=0, keepdims=True))
+            ** 0.5
+        )
+        return grads / sqrt_Skk, sqrt_Skk.flatten()
+    else:
+        return grads, None
+
+
+def _grad_vmap_minus_mean(
+    fun: Callable, params: jnp.ndarray, samples: jnp.ndarray, holomorphic: bool
+):
+    """Calculates the gradient of a neural network for a number of samples
+    efficiently using vmap(grad),
+    and subtracts their mean for each parameter, i.e., each column
+    """
+    grads = jax.vmap(
+        jax.grad(fun, holomorphic=holomorphic), in_axes=(None, 0), out_axes=0
+    )(params, samples)
+    return grads - sum_inplace(grads.sum(axis=0, keepdims=True)) / (
+        grads.shape[0] * n_nodes
+    )

--- a/netket/optimizer/sr/s_jacobian_mat.py
+++ b/netket/optimizer/sr/s_jacobian_mat.py
@@ -100,7 +100,7 @@ class JacobianSMatrix(AbstractSMatrix):
         """
 
         # Ravel input PyTrees, record unravelling function too
-        grad, unravel = nkjax.tree_ravel(grad)
+        grad, unravel = nkjax.tree_ravel(y)
 
         if x0 is None:
             x0 = self.x0

--- a/netket/optimizer/sr/s_lazy.py
+++ b/netket/optimizer/sr/s_lazy.py
@@ -1,0 +1,69 @@
+# Copyright 2021 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Callable, Optional, Union, Tuple, Any
+
+import jax
+import flax
+from jax import numpy as jnp
+from flax import struct
+
+from plum import dispatch
+
+from netket.utils.types import PyTree, Array
+
+from .base import AbstractSMatrix
+
+
+@struct.dataclass
+class AbstractLazySMatrix(AbstractSMatrix):
+    """
+    Lazy representation of an S Matrix behving like a linear operator.
+
+    The S matrix is not computed yet, but can be computed by calling
+    :code:`to_dense`.
+    The details on how the ⟨S⟩⁻¹⟨F⟩ system is solved are contaianed in
+    the field `sr`.
+
+    This is an abstract type that can be subclassed to define new lazy
+    S matrix representations.
+    To subclass this class, simply implement :code:`__matmul__(self, other)`
+    and :code:`solve(self, y, *kwargs)`
+    """
+
+    apply_fun: Callable[[PyTree, jnp.ndarray], jnp.ndarray] = struct.field(
+        pytree_node=False
+    )
+    """The forward pass of the Ansatz."""
+
+    params: PyTree
+    """The first input to apply_fun (parameters of the ansatz)."""
+
+    samples: jnp.ndarray
+    """The second input to apply_fun (points where the ansatz is evaluated)."""
+
+    model_state: Optional[PyTree] = None
+    """Optional state of the ansataz."""
+
+    @jax.jit
+    def to_dense(self) -> jnp.ndarray:
+        """
+        Convert the lazy matrix representation to a dense matrix representation.s
+
+        Returns:
+            A dense matrix representation of this S matrix.
+        """
+        Npars = nkjax.tree_size(self.params)
+        I = jax.numpy.eye(Npars)
+        return jax.vmap(lambda S, x: self @ x, in_axes=(None, 0))(self, I)

--- a/netket/optimizer/sr/s_onthefly_mat.py
+++ b/netket/optimizer/sr/s_onthefly_mat.py
@@ -1,0 +1,120 @@
+from typing import Callable, Optional, Union, Tuple, Any
+from functools import partial
+
+import jax
+import flax
+from jax import numpy as jnp
+from flax import struct
+
+from netket.utils.types import PyTree, Array
+import netket.jax as nkjax
+
+from .sr_onthefly_logic import mat_vec as mat_vec_onthefly, tree_cast
+
+from .base import SR
+from .s_lazy import AbstractLazySMatrix
+
+
+@struct.dataclass
+class SROnTheFly(SR):
+    """
+    Base class holding the parameters for the iterative solution of the
+    SR system x = ⟨S⟩⁻¹⟨F⟩, where S is a lazy linear operator
+
+    Tolerances are applied according to the formula
+    :code:`norm(residual) <= max(tol*norm(b), atol)`
+    """
+
+    centered: bool = struct.field(pytree_node=False, default=True)
+    """Uses S=⟨ΔÔᶜΔÔ⟩ if True (default), S=⟨ÔᶜΔÔ⟩ otherwise. The two forms are 
+    mathematically equivalent, but might lead to different results due to numerical
+    precision. The non-centered variant should be approximately 33% faster.
+    """
+
+    def create(self, vstate, **kwargs) -> "SMatrixOnTheFly":
+        """
+        Construct the Lazy representation of the S corresponding to this SR type.
+
+        Args:
+            vstate: The Variational State
+        """
+        return SMatrixOnTheFly(
+            apply_fun=vstate._apply_fun,
+            params=vstate.parameters,
+            samples=vstate.samples,
+            model_state=vstate.model_state,
+            sr=self,
+        )
+
+
+@struct.dataclass
+class SMatrixOnTheFly(AbstractLazySMatrix):
+    """
+    Lazy representation of an S Matrix computed by performing 2 jvp
+    and 1 vjp products, using the variational state's model, the
+    samples that have already been computed, and the vector.
+
+    The S matrix is not computed yet, but can be computed by calling
+    :code:`to_dense`.
+    The details on how the ⟨S⟩⁻¹⟨F⟩ system is solved are contaianed in
+    the field `sr`.
+    """
+
+    def __post_init__(self):
+        super().__post_init__()
+
+        if jnp.ndim(self.samples) != 2:
+            samples_r = self.samples.reshape((-1, self.samples.shape[-1]))
+            object.__setattr__(self, "samples", samples_r)
+
+    def __matmul__(self, y):
+        return lazysmatrix_mat_treevec(self, y)
+
+
+@jax.jit
+def lazysmatrix_mat_treevec(
+    S: SMatrixOnTheFly, vec: Union[PyTree, jnp.ndarray]
+) -> Union[PyTree, jnp.ndarray]:
+    """
+    Perform the lazy mat-vec product, where vec is either a tree with the same structure as
+    params or a ravelled vector
+    """
+
+    # if hasa ndim it's an array and not a pytree
+    if hasattr(vec, "ndim"):
+        if not vec.ndim == 1:
+            raise ValueError("Unsupported mat-vec for batches of vectors")
+        # If the input is a vector
+        if not nkjax.tree_size(S.params) == vec.size:
+            raise ValueError(
+                """Size mismatch between number of parameters ({nkjax.tree_size(S.params)}) 
+                                and vector size {vec.size}.
+                             """
+            )
+
+        _, unravel = nkjax.tree_ravel(S.params)
+        vec = unravel(vec)
+        ravel_result = True
+    else:
+        ravel_result = False
+
+    vec = tree_cast(vec, S.params)
+
+    def fun(W, σ):
+        return S.apply_fun({"params": W, **S.model_state}, σ)
+
+    mat_vec = partial(
+        mat_vec_onthefly,
+        forward_fn=fun,
+        params=S.params,
+        samples=S.samples,
+        diag_shift=S.sr.diag_shift,
+        centered=S.sr.centered,
+    )
+
+    res = mat_vec(vec)
+
+    if ravel_result:
+        res, _ = nkjax.tree_ravel(res)
+
+    return res

--- a/netket/optimizer/sr/sr_jacobian.py
+++ b/netket/optimizer/sr/sr_jacobian.py
@@ -79,11 +79,22 @@ class SRJacobian(SR):
                 )
             )
 
-    def create(self, *args, **kwargs):
+    def create(self, vstate, **kwargs) -> "LazySMatrixIterative":
+        """
+        Construct the Lazy representation of the S corresponding to this SR type.
+
+        Args:
+            vstate: The Variational State
+        """
         O, scale = gradients(
-            apply_fun, params, samples, model_state, self.mode, self.rescale_shift
+            vstate._apply_fun,
+            vstate.parameters,
+            vstate.samples,
+            vstate.model_state,
+            self.mode,
+            self.rescale_shift,
         )
-        return JacobianSMatrix(sr=sr, x0=x0, O=O, scale=scale)
+        return JacobianSMatrix(sr=self, O=O, scale=scale)
 
 
 @struct.dataclass

--- a/netket/optimizer/sr/sr_jacobian.py
+++ b/netket/optimizer/sr/sr_jacobian.py
@@ -1,0 +1,148 @@
+# Copyright 2021 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Callable, Optional, Union, Tuple, Any
+from functools import partial
+
+import jax
+import flax
+from jax import numpy as jnp
+from flax import struct
+
+from netket.utils.types import PyTree, Array
+from netket.utils import rename_class
+import netket.jax as nkjax
+
+from .s_jacobian_mat import JacobianSMatrix, gradients
+
+from .base import SR
+
+
+@struct.dataclass
+class SRJacobian(SR):
+    """
+    Base class holding the parameters for the iterative solution of the
+    SR system x = ⟨S⟩⁻¹⟨F⟩, where S is a lazy linear operator
+
+    Tolerances are applied according to the formula
+    :code:`norm(residual) <= max(tol*norm(b), atol)`
+    """
+
+    tol: float = 1.0e-5
+    """Relative tolerance for convergences."""
+
+    atol: float = 0.0
+    """Absolutes tolerance for convergences."""
+
+    maxiter: int = None
+    """Maximum number of iterations. Iteration will stop after maxiter steps even 
+    if the specified tolerance has not been achieved.
+    """
+
+    M: Optional[Union[Callable, Array]] = None
+    """Preconditioner for A. The preconditioner should approximate the inverse of A. 
+    Effective preconditioning dramatically improves the rate of convergence, which implies 
+    that fewer iterations are needed to reach a given error tolerance.
+    """
+
+    mode: str = struct.field(pytree_node=False, default="invalid")
+    """Differentiation mode to precompute Jacobian
+    * "holomorphic": C->C holomorphic function
+        `grad` is called on the full network output with `holomorphic=True`
+    * "R2R": real-valued wave function with real parameters
+        `grad` is called on the real part of the network output with `holomorphic=False`
+    * "R2C": complex-valued wave function with real parameters
+        the real and imaginary parts of the network output are treated as independent 
+        R->R functions and `grad` is called separately on them with `holomorphic=False`
+    * the default value "invalid" will trigger an error
+    """
+
+    rescale_shift: bool = struct.field(pytree_node=False, default=False)
+    """Whether scale-invariant regularisation should be used"""
+
+    def __post_init__(self):
+        if self.mode not in {"R2R", "R2C", "holomorphic"}:
+            raise NotImplementedError(
+                'Differentiation mode must be one of "R2R", "R2C", "holomorphic", got "{}"'.format(
+                    self.mode
+                )
+            )
+
+    def create(self, *args, **kwargs):
+        O, scale = gradients(
+            apply_fun, params, samples, model_state, self.mode, self.rescale_shift
+        )
+        return JacobianSMatrix(sr=sr, x0=x0, O=O, scale=scale)
+
+
+@struct.dataclass
+class SRJacobianCG(SRJacobian):
+    """
+    Computes x = ⟨S⟩⁻¹⟨F⟩ by using an iterative conjugate gradient method.
+
+    See `Jax docs <https://jax.readthedocs.io/en/latest/_autosummary/jax.scipy.sparse.linalg.cg.html#jax.scipy.sparse.linalg.cg>`_
+    for more informations.
+    """
+
+    ...
+
+    def solve_fun(self):
+        return partial(
+            jax.scipy.sparse.linalg.cg,
+            tol=self.tol,
+            atol=self.atol,
+            maxiter=self.maxiter,
+            M=self.M,
+        )
+
+
+@struct.dataclass
+class SRJacobianGMRES(SRJacobian):
+    """
+    Computes x = ⟨S⟩⁻¹⟨F⟩ by using an iterative GMRES method.
+
+    See `Jax docs <https://jax.readthedocs.io/en/latest/_autosummary/jax.scipy.sparse.linalg.gmres.html#jax.scipy.sparse.linalg.gmres>`_
+    for more informations.
+    """
+
+    restart: int = struct.field(pytree_node=False, default=20)
+    """Size of the Krylov subspace (“number of iterations”) built between restarts. 
+    GMRES works by approximating the true solution x as its projection into a Krylov 
+    space of this dimension - this parameter therefore bounds the maximum accuracy 
+    achievable from any guess solution. Larger values increase both number of iterations 
+    and iteration cost, but may be necessary for convergence. The algorithm terminates early 
+    if convergence is achieved before the full subspace is built. 
+    Default is 20
+    """
+
+    solve_method: str = struct.field(pytree_node=False, default="batched")
+    """(‘incremental’ or ‘batched’) – The ‘incremental’ solve method builds a QR 
+    decomposition for the Krylov subspace incrementally during the GMRES process 
+    using Givens rotations. This improves numerical stability and gives a free estimate 
+    of the residual norm that allows for early termination within a single “restart”. In 
+    contrast, the ‘batched’ solve method solves the least squares problem from scratch at 
+    the end of each GMRES iteration. It does not allow for early termination, but has much 
+    less overhead on GPUs.
+    """
+
+    def solve_fun(self):
+        return partial(
+            jax.scipy.sparse.linalg.gmres,
+            tol=self.tol,
+            atol=self.atol,
+            maxiter=self.maxiter,
+            M=self.M,
+            restart=self.restart,
+            solve_method=self.solve_method,
+        )

--- a/netket/optimizer/sr/sr_onthefly.py
+++ b/netket/optimizer/sr/sr_onthefly.py
@@ -20,17 +20,18 @@ import flax
 from jax import numpy as jnp
 from flax import struct
 
-from netket.utils.types import PyTree, Array
-from netket.utils import rename_class
-import netket.jax as nkjax
+from plum import dispatch
 
-from .sr_onthefly_logic import mat_vec as mat_vec_onthefly, tree_cast
+from netket.utils.types import PyTree, Array
 
 from .base import SR
 
+from .sr_onthefly_logic import mat_vec as mat_vec_onthefly, tree_cast
+from .s_onthefly_mat import SROnTheFly, SMatrixOnTheFly
+
 
 @struct.dataclass
-class SRLazy(SR):
+class SROnTheFlyIterative(SROnTheFly):
     """
     Base class holding the parameters for the iterative solution of the
     SR system x = ⟨S⟩⁻¹⟨F⟩, where S is a lazy linear operator
@@ -56,18 +57,24 @@ class SRLazy(SR):
     that fewer iterations are needed to reach a given error tolerance.
     """
 
-    centered: bool = struct.field(pytree_node=False, default=True)
-    """Uses S=⟨ΔÔᶜΔÔ⟩ if True (default), S=⟨ÔᶜΔÔ⟩ otherwise. The two forms are 
-    mathematically equivalent, but might lead to different results due to numerical
-    precision. The non-centered variaant should bee approximately 33% faster.
-    """
+    def create(self, vstate, **kwargs) -> "LazySMatrixIterative":
+        """
+        Construct the Lazy representation of the S corresponding to this SR type.
 
-    def create(self, *args, **kwargs):
-        return LazySMatrix(*args, **kwargs)
+        Args:
+            vstate: The Variational State
+        """
+        return LazySMatrixIterative(
+            apply_fun=vstate._apply_fun,
+            params=vstate.parameters,
+            samples=vstate.samples,
+            model_state=vstate.model_state,
+            sr=self,
+        )
 
 
 @struct.dataclass
-class SRLazyCG(SRLazy):
+class SRLazyCG(SROnTheFlyIterative):
     """
     Computes x = ⟨S⟩⁻¹⟨F⟩ by using an iterative conjugate gradient method.
 
@@ -88,7 +95,7 @@ class SRLazyCG(SRLazy):
 
 
 @struct.dataclass
-class SRLazyGMRES(SRLazy):
+class SRLazyGMRES(SROnTheFlyIterative):
     """
     Computes x = ⟨S⟩⁻¹⟨F⟩ by using an iterative GMRES method.
 
@@ -129,7 +136,7 @@ class SRLazyGMRES(SRLazy):
 
 
 @struct.dataclass
-class LazySMatrix:
+class LazySMatrixIterative(SMatrixOnTheFly):
     """
     Lazy representation of an S Matrix behving like a linear operator.
 
@@ -139,33 +146,10 @@ class LazySMatrix:
     the field `sr`.
     """
 
-    apply_fun: Callable[[PyTree, jnp.ndarray], jnp.ndarray] = struct.field(
-        pytree_node=False
-    )
-    """The forward pass of the Ansatz."""
-
-    params: PyTree
-    """The first input to apply_fun (parameters of the ansatz)."""
-
-    samples: jnp.ndarray
-    """The second input to apply_fun (points where the ansatz is evaluated)."""
-
-    sr: SRLazy
-    """Parameters for the solution of the system."""
-
-    model_state: Optional[PyTree] = None
-    """Optional state of the ansataz."""
-
     x0: Optional[PyTree] = None
     """Optional initial guess for the iterative solution."""
 
-    def __matmul__(self, vec):
-        return lazysmatrix_mat_treevec(self, vec)
-
-    def __rtruediv__(self, y):
-        return self.solve(y)
-
-    def solve(self, y: PyTree, x0: Optional[PyTree] = None) -> PyTree:
+    def solve(self, y: PyTree, x0: Optional[PyTree] = None, **kwargs) -> PyTree:
         """
         Solve the linear system x=⟨S⟩⁻¹⟨y⟩ with the chosen iterataive solver.
 
@@ -189,21 +173,11 @@ class LazySMatrix:
 
         return out, info
 
-    @jax.jit
-    def to_dense(self) -> jnp.ndarray:
-        """
-        Convert the lazy matrix representation to a dense matrix representation.s
-
-        Returns:
-            A dense matrix representation of this S matrix.
-        """
-        Npars = nkjax.tree_size(self.params)
-        I = jax.numpy.eye(Npars)
-        return jax.vmap(lambda S, x: self @ x, in_axes=(None, 0))(self, I)
-
 
 @jax.jit
-def apply_onthefly(S: LazySMatrix, grad: PyTree, x0: Optional[PyTree]) -> PyTree:
+def apply_onthefly(
+    S: LazySMatrixIterative, grad: PyTree, x0: Optional[PyTree]
+) -> PyTree:
     # Preapply the model state so that when computing gradient we only
     # get gradient of parameeters
     def fun(W, σ):
@@ -214,71 +188,14 @@ def apply_onthefly(S: LazySMatrix, grad: PyTree, x0: Optional[PyTree]) -> PyTree
     if x0 is None:
         x0 = jax.tree_map(jnp.zeros_like, grad)
 
-    samples = S.samples
-    if jnp.ndim(samples) != 2:
-        samples = samples.reshape((-1, samples.shape[-1]))
-
     _mat_vec = partial(
         mat_vec_onthefly,
         forward_fn=fun,
         params=S.params,
-        samples=samples,
+        samples=S.samples,
         diag_shift=S.sr.diag_shift,
         centered=S.sr.centered,
     )
     solve_fun = S.sr.solve_fun()
     out, info = solve_fun(_mat_vec, grad, x0=x0)
     return out, info
-
-
-@jax.jit
-def lazysmatrix_mat_treevec(
-    S: LazySMatrix, vec: Union[PyTree, jnp.ndarray]
-) -> Union[PyTree, jnp.ndarray]:
-    """
-    Perform the lazy mat-vec product, where vec is either a tree with the same structure as
-    params or a ravelled vector
-    """
-
-    def fun(W, σ):
-        return S.apply_fun({"params": W, **S.model_state}, σ)
-
-    # if hasa ndim it's an array and not a pytree
-    if hasattr(vec, "ndim"):
-        if not vec.ndim == 1:
-            raise ValueError("Unsupported mat-vec for batches of vectors")
-        # If the input is a vector
-        if not nkjax.tree_size(S.params) == vec.size:
-            raise ValueError(
-                """Size mismatch between number of parameters ({nkjax.tree_size(S.params)}) 
-                                and vector size {vec.size}.
-                             """
-            )
-
-        _, unravel = nkjax.tree_ravel(S.params)
-        vec = unravel(vec)
-        ravel_result = True
-    else:
-        ravel_result = False
-
-    samples = S.samples
-    if jnp.ndim(samples) != 2:
-        samples = samples.reshape((-1, samples.shape[-1]))
-
-    vec = tree_cast(vec, S.params)
-
-    mat_vec = partial(
-        mat_vec_onthefly,
-        forward_fn=fun,
-        params=S.params,
-        samples=samples,
-        diag_shift=S.sr.diag_shift,
-        centered=S.sr.centered,
-    )
-
-    res = mat_vec(vec)
-
-    if ravel_result:
-        res, _ = nkjax.tree_ravel(res)
-
-    return res

--- a/netket/variational/mc_state.py
+++ b/netket/variational/mc_state.py
@@ -36,7 +36,7 @@ from netket.sampler import Sampler, SamplerState, ExactSampler
 from netket.stats import Stats, statistics, mean, sum_inplace
 from netket.utils import flax as flax_utils, n_nodes, maybe_wrap_module, deprecated
 from netket.utils.types import PyTree, PRNGKeyT, SeedT, Shape, NNInitFunc
-from netket.optimizer import SR
+from netket.optimizer.sr import SR, AbstractSMatrix
 from netket.operator import (
     AbstractOperator,
     AbstractSuperOperator,
@@ -493,7 +493,7 @@ class MCState(VariationalState):
 
         return Ō, Ō_grad
 
-    def quantum_geometric_tensor(self, sr: SR):
+    def quantum_geometric_tensor(self, sr: SR) -> AbstractSMatrix:
         r"""Computes an estimate of the quantum geometric tensor G_ij.
         This function returns a linear operator that can be used to apply G_ij to a given vector
         or can be converted to a full matrix.
@@ -501,15 +501,7 @@ class MCState(VariationalState):
         Returns:
             scipy.sparse.linalg.LinearOperator: A linear operator representing the quantum geometric tensor.
         """
-
-        return sr.create(
-            apply_fun=self._apply_fun,
-            params=self.parameters,
-            samples=self.samples,
-            model_state=self.model_state,
-            x0=None,
-            sr=sr,
-        )
+        return sr.create(self)
 
     def to_array(self, normalize: bool = True) -> jnp.ndarray:
         return netket.nn.to_array(


### PR DESCRIPTION
This PR makes no change to our public API or functional changes within netket.
It simply creates a class hierarchy for SMatrix types as follows:

```
AbstractSMatrix < -- AbstractLazySMatrix <-- OnTheFlySMatrix <--IterativeSMatrix
```

My idea is that #648 can be rebased on top of this one, and it's Matrix type can be a subclass of `AbstractLazySMatrix`. 
This will be handy also for discussions in #649.

The PR also clearly defines what is the api that those objects should define to conform to NetKet.