### PR TITLE
SR with precomputed gradient pytrees

### DIFF
--- a/Test/Optimizer/test_sr_logic.py
+++ b/Test/Optimizer/test_sr_logic.py
@@ -314,9 +314,7 @@ def test_matvec_linear_transpose(e, centered, jit):
     assert tree_allclose(actual, expected)
 
 
-# TODO put this test in its own file or rename this one to test_sr_logic.py
 # TODO separate test for prepare_doks
-# TODO test non-holomorphic and inhomogeneous parameters once implemented
 @pytest.mark.parametrize("holomorphic", [True])
 @pytest.mark.parametrize("n_samp", [25, 1024])
 @pytest.mark.parametrize("jit", [True, False])

--- a/netket/optimizer/sr/sr_treemv_logic.py
+++ b/netket/optimizer/sr/sr_treemv_logic.py
@@ -76,12 +76,6 @@ def jvp(oks, v):
     return jax.tree_util.tree_reduce(jnp.add, jax.tree_multimap(td, oks, v))
 
 
-def _cast(x, target):
-    res = x if jnp.iscomplexobj(target) else x.real
-    res = res.astype(target.dtype)
-    return res
-
-
 def vjp(oks, w):
     res = jax.tree_map(partial(jnp.tensordot, w, axes=1), oks)
     return jax.tree_map(sum_inplace, res)  # MPI

--- a/netket/optimizer/sr/sr_treemv_logic.py
+++ b/netket/optimizer/sr/sr_treemv_logic.py
@@ -117,7 +117,7 @@ def vjp(oks: PyTree, w: Array) -> PyTree:
 
 def _mat_vec(v: PyTree, oks: PyTree) -> PyTree:
     """
-    compute S v = 1/n ⟨O†O⟩v = 1/n ∑ₗ ⟨OₖᴴOₗ⟩ vₗ
+    compute S v = 1/n ⟨ΔO† ΔO⟩v = 1/n ∑ₗ ⟨ΔOₖᴴ ΔOₗ⟩ vₗ
     """
     res = tree_conj(vjp(oks, jvp(oks, v).conjugate()))
     return tree_cast(res, v)
@@ -125,11 +125,11 @@ def _mat_vec(v: PyTree, oks: PyTree) -> PyTree:
 
 def mat_vec(v: PyTree, oks: PyTree, diag_shift: Scalar) -> PyTree:
     """
-    compute (S + δ) v = 1/n ⟨O†O⟩v + δ v = ∑ₗ 1/n ⟨OₖᴴOₗ⟩ vₗ + δ vₗ
+    compute (S + δ) v = 1/n ⟨ΔO† ΔO⟩v + δ v = ∑ₗ 1/n ⟨ΔOₖᴴΔOₗ⟩ vₗ + δ vₗ
 
     Args:
         v: pytree representing the vector v
-        oks: pytree of gradients 1/√n Oⱼₖ or 1/√n ΔOⱼₖ
+        oks: pytree of gradients 1/√n ΔOⱼₖ
         diag_shift: a scalar diagonal shift δ
     Returns:
         a pytree corresponding to the sr matrix-vector product (S + δ) v

--- a/netket/optimizer/sr/sr_treemv_logic.py
+++ b/netket/optimizer/sr/sr_treemv_logic.py
@@ -1,0 +1,80 @@
+# Copyright 2021 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import jax
+import jax.flatten_util
+import jax.numpy as jnp
+
+import numpy as np
+from functools import partial
+
+from netket.stats import sum_inplace, subtract_mean
+from netket.utils import n_nodes
+
+from .sr_onthefly_logic import tree_cast, tree_conj, tree_axpy
+
+
+# TODO cheapest way to calculate the gradients?
+
+
+@partial(jax.vmap, in_axes=(None, None, 0))
+def perex_grads(forward_fn, params, samples):
+    def f(p, x):
+        return forward_fn(p, jnp.expand_dims(x, 0))[0]
+
+    y, vjp_fun = jax.vjp(f, params, samples)
+    res, _ = vjp_fun(np.ones((), dtype=jnp.result_type(y)))
+    return res
+
+
+def sub_mean(oks):
+    return jax.tree_map(partial(subtract_mean, axis=0), oks)  # MPI
+
+
+def prepare_doks(forward_fn, params, samples):
+    oks = perex_grads(forward_fn, params, samples)
+    n_samp = samples.shape[0] * n_nodes  # MPI
+    # TODO where to divide by n_samp?
+    oks = jax.tree_map(lambda x: x / np.sqrt(n_samp), oks)
+    return sub_mean(oks)
+
+
+def jvp(oks, v):
+    td = lambda x, y: jnp.tensordot(x, y, axes=y.ndim)
+    return jax.tree_util.tree_reduce(jnp.add, jax.tree_multimap(td, oks, v))
+
+
+def _cast(x, target):
+    res = x if jnp.iscomplexobj(target) else x.real
+    res = res.astype(target.dtype)
+    return res
+
+
+def vjp(oks, w):
+    # TODO check that w is casted only once for each leaf dtype and reused
+    # otherwise cache them manually
+    def td(x):
+        return jnp.tensordot(_cast(w, x), x, axes=1)
+
+    res = jax.tree_map(td, oks)
+    return jax.tree_map(sum_inplace, res)  # MPI
+
+
+def _mat_vec(v, oks):
+    res = tree_conj(vjp(oks, jvp(oks, v).conjugate()))
+    return res
+
+
+def mat_vec(v, oks, diag_shift):
+    return tree_axpy(diag_shift, v, _mat_vec(v, oks))

--- a/netket/optimizer/sr/sr_treemv_logic.py
+++ b/netket/optimizer/sr/sr_treemv_logic.py
@@ -41,12 +41,12 @@ def perex_grads_rr_cc(forward_fn, params, samples):
 
 @partial(jax.vmap, in_axes=(None, None, 0))
 def perex_grads_rc(forward_fn, params, samples):
-    fr = lambda p, x: forward_fn(p, jnp.expand_dims(x, 0))[0].real
-    fi = lambda p, x: forward_fn(p, jnp.expand_dims(x, 0))[0].imag
-    yr, vjp_funr = jax.vjp(fr, params, samples)
-    yi, vjp_funi = jax.vjp(fi, params, samples)
-    gr, _ = vjp_funr(np.ones((), dtype=jnp.result_type(yr)))
-    gi, _ = vjp_funi(np.ones((), dtype=jnp.result_type(yi)))
+    def f(p, x):
+        return forward_fn(p, jnp.expand_dims(x, 0))[0]
+
+    y, vjp_fun = jax.vjp(f, params, samples)
+    gr, _ = vjp_fun(np.array(1.0, dtype=jnp.result_type(y)))
+    gi, _ = vjp_fun(np.array(-1.0j, dtype=jnp.result_type(y)))
     return jax.tree_multimap(jax.lax.complex, gr, gi)
 
 

--- a/netket/optimizer/sr/sr_treemv_logic.py
+++ b/netket/optimizer/sr/sr_treemv_logic.py
@@ -23,6 +23,8 @@ from netket.stats import sum_inplace, subtract_mean
 from netket.utils import n_nodes
 import netket.jax as nkjax
 
+from netket.utils.types import Array, Callable, PyTree, Scalar
+
 from .sr_onthefly_logic import tree_cast, tree_conj, tree_axpy
 
 
@@ -50,7 +52,11 @@ def vmap_grad_rc(forward_fn, params, samples):
     return jax.tree_multimap(jax.lax.complex, gr, gi)
 
 
-def vmap_grad(forward_fn, params, samples):
+def vmap_grad(forward_fn: Callable, params: PyTree, samples: Array) -> PyTree:
+    """
+    compute the jacobian of forward_fn(params, samples) w.r.t params
+    as a pytree using vmapped gradients for efficiency
+    """
     complex_output = nkjax.is_complex(jax.eval_shape(forward_fn, params, samples))
     real_params = not nkjax.tree_leaf_iscomplex(params)
     if real_params and complex_output:
@@ -59,11 +65,24 @@ def vmap_grad(forward_fn, params, samples):
         return vmap_grad_rr_cc(forward_fn, params, samples)
 
 
-def sub_mean(oks):
+def sub_mean(oks: PyTree) -> PyTree:
     return jax.tree_map(partial(subtract_mean, axis=0), oks)  # MPI
 
 
-def prepare_doks(forward_fn, params, samples):
+def prepare_doks(forward_fn: Callable, params: PyTree, samples: Array) -> PyTree:
+    """
+    compute ΔOⱼₖ = Oⱼₖ - ⟨Oₖ⟩ = ∂/∂pₖ ln Ψ(σⱼ) - ⟨∂/∂pₖ ln Ψ⟩
+    divided by √n
+
+    Args:
+        forward_fn: the vectorised log wavefunction  ln Ψ(p; σ)
+        params : a pytree of parameters p
+        samples : an array of n samples σ
+
+    Returns:
+        a pytree representing the centered jacobian of ln Ψ evaluated at the samples σ
+        divided by √n
+    """
     oks = vmap_grad(forward_fn, params, samples)
     n_samp = samples.shape[0] * n_nodes  # MPI
     oks = jax.tree_map(lambda x: x / np.sqrt(n_samp), oks)
@@ -74,26 +93,45 @@ def prepare_doks(forward_fn, params, samples):
     if real_params and complex_oks:
         # R->C
         # convert the complex oks to real ones with twice the number of rows
-        # Re[S] = Re[(Or + i Oi)^H (Or + i Oi)] = Or^T Or + Oi^T Oi = [Or Oi] [Or Oi]^T
+        # Re[S] = Re[(Oᵣ + i Oᵢ)ᴴ(Oᵣ + i Oᵢ)] = Oᵣᵀ Oᵣ + Oᵢᵀ Oᵢ = [Oᵣ Oᵢ] [Oᵣ Oᵢ]ᵀ
         doks = jax.tree_map(lambda x: jnp.concatenate([x.real, x.imag], axis=0), doks)
 
     return doks
 
 
-def jvp(oks, v):
+def jvp(oks: PyTree, v: PyTree) -> Array:
+    """
+    compute the matrix-vector product between the pytree jacobian oks and the pytree vector v
+    """
     td = lambda x, y: jnp.tensordot(x, y, axes=y.ndim)
     return jax.tree_util.tree_reduce(jnp.add, jax.tree_multimap(td, oks, v))
 
 
-def vjp(oks, w):
+def vjp(oks: PyTree, w: Array) -> PyTree:
+    """
+    compute the vector-matrix product between the vector w and the pytree jacobian oks
+    """
     res = jax.tree_map(partial(jnp.tensordot, w, axes=1), oks)
     return jax.tree_map(sum_inplace, res)  # MPI
 
 
-def _mat_vec(v, oks):
+def _mat_vec(v: PyTree, oks: PyTree) -> PyTree:
+    """
+    compute S v = 1/n ⟨O†O⟩v = 1/n ∑ₗ ⟨OₖᴴOₗ⟩ vₗ
+    """
     res = tree_conj(vjp(oks, jvp(oks, v).conjugate()))
     return tree_cast(res, v)
 
 
-def mat_vec(v, oks, diag_shift):
+def mat_vec(v: PyTree, oks: PyTree, diag_shift: Scalar) -> PyTree:
+    """
+    compute (S + δ) v = 1/n ⟨O†O⟩v + δ v = ∑ₗ 1/n ⟨OₖᴴOₗ⟩ vₗ + δ vₗ
+
+    Args:
+        v: pytree representing the vector v
+        oks: pytree of gradients 1/√n Oⱼₖ or 1/√n ΔOⱼₖ
+        diag_shift: a scalar diagonal shift δ
+    Returns:
+        a pytree corresponding to the sr matrix-vector product (S + δ) v
+    """
     return tree_axpy(diag_shift, v, _mat_vec(v, oks))


### PR DESCRIPTION
This so far only adds the necessary logic, adding the interfaces around it should be straightforward though.

- The gradients (oks) are stored as a pytree where the first dim of each leaf is k (of size n_samples)
- Reduces to the usual two matrix-vector multiplications if a flattened model and parameters  (and a flattened gradient matrix) are passed, all the tree maps should be optimized away by the jit complier
- ~Works with inhomogeneous parameters (e.g. a mix of complex and real) just like the onthefly code does~
- works with R->R, holomprphic C->C and R->C
-  non-homogenous parameters and non-holomorphic C->C requires converting to homogeneous real parameters
- is MPI enabled