### PR TITLE
support (old) jaxlib<=0.1.61

### DIFF
--- a/netket/utils/__init__.py
+++ b/netket/utils/__init__.py
@@ -14,6 +14,8 @@
 
 from .config_flags import config
 
+from . import types
+
 from .array import HashableArray
 from .jax import jit_if_singleproc, get_afun_if_module
 from .mpi import (

--- a/netket/utils/numbers.py
+++ b/netket/utils/numbers.py
@@ -7,17 +7,7 @@ import numpy as np
 import jax
 import jaxlib
 
-# compatibility with jaxlib<=0.1.61
-# we don't really support this old jaxlib, because previous
-# versions had bugs and dont work with mpi4jax, but some people
-# do use that because of old computer without AVX so...
-# eventually delete this.
-try:
-    _DeviceArray = jaxlib.xla_extension.DeviceArray
-except:
-    _DeviceArray = jax.interpreters.xla._DeviceArray
-
-ArrayT = Union[np.ndarray, _DeviceArray, jax.core.Tracer]
+from .types import Array
 
 
 @dispatch
@@ -26,7 +16,7 @@ def dtype(x: Number):
 
 
 @dispatch
-def dtype(x: ArrayT):
+def dtype(x: Array):
     return x.dtype
 
 
@@ -41,5 +31,5 @@ def is_scalar(x: Number):
 
 
 @dispatch
-def is_scalar(x: ArrayT):
+def is_scalar(x: Array):
     return x.ndim == 0

--- a/netket/utils/numbers.py
+++ b/netket/utils/numbers.py
@@ -7,7 +7,17 @@ import numpy as np
 import jax
 import jaxlib
 
-ArrayT = Union[np.ndarray, jaxlib.xla_extension.DeviceArray, jax.core.Tracer]
+# compatibility with jaxlib<=0.1.61
+# we don't really support this old jaxlib, because previous
+# versions had bugs and dont work with mpi4jax, but some people
+# do use that because of old computer without AVX so...
+# eventually delete this.
+try:
+    _DeviceArray = jaxlib.xla_extension.DeviceArray
+except:
+    _DeviceArray = jax.interpreters.xla._DeviceArray
+
+ArrayT = Union[np.ndarray, _DeviceArray, jax.core.Tracer]
 
 
 @dispatch

--- a/netket/utils/types.py
+++ b/netket/utils/types.py
@@ -14,12 +14,28 @@
 
 from typing import Any, Sequence, Callable, Union
 
+import jax as _jax
+import jaxlib as _jaxlib
+import numpy as _np
+
+# compatibility with jaxlib<=0.1.61
+# we don't really support this old jaxlib, because previous
+# versions had bugs and dont work with mpi4jax, but some people
+# do use that because of old computer without AVX so...
+# eventually delete this.
+try:
+    _DeviceArray = _jaxlib.xla_extension.DeviceArray
+except:
+    _DeviceArray = _jax.interpreters.xla._DeviceArray
+
+
 PRNGKeyT = Any
 SeedT = Union[int, PRNGKeyT]
 
 Shape = Sequence[int]
 DType = Any  # this could be a real type?
-Array = Any
+
+Array = Union[_np.ndarray, _DeviceArray, _jax.core.Tracer]
 
 NNInitFunc = Callable[[PRNGKeyT, Shape, DType], Array]
 


### PR DESCRIPTION
mpi4jax does not support it,
however it seems that later jaxlib versions require a cpu with AVX unless you build them yourself.
It came up recently. It's low effort supporting it for now so we do it.

I think eventually this will get deleted but... yeah.