### PR TITLE
Add netket.tools.check_mpi to help debug MPI issues

### DIFF
--- a/docs/docs/sharp-bits.rst
+++ b/docs/docs/sharp-bits.rst
@@ -26,12 +26,18 @@ If you encounter issues, you can check whether your MPI environment is set up pr
    $ mpirun -np 2 python3 -m netket.tools.check_mpi
    mpi_available                : True
    mpi4jax_available            : True
-   n_nodes                      : 2
+   avalable_cpus (rank 0)       : 12
+   n_nodes                      : 1
    mpi4py | MPI version         : (3, 1)
-   mpi4py | MPI library_version : Open MPI v4.1.0 <...>
+   mpi4py | MPI library_version : Open MPI v4.1.0, package: Open MPI brew@BigSur Distribution, ident: 4.1.0,  repo rev: v4.1.0, Dec 18, 2020
 
 This should print some basic information about the MPI installation and, in particular, pick up the correct `n_nodes`.
 If you get the same output multiple times, each with :code:`n_nodes : 1`, this is a clear sign that your MPI setup is broken.
+The tool above also reports the number of (logical) CPUs that might be subscribed by Jax on every independent MPI rank during linear algebra operations. 
+Be mindfull that Jax, in general, is like an invasive plant and tends to use all resources that he can access, and 
+the environment variables above might not prevent it from making use of the `available_cpus`. 
+On Mac it is not possible to control this number. 
+On Linux it can be controlled using `taskset` or `--bind-to core` when using `mpirun`. 
 
 .. _running_on_cpu:
 

--- a/docs/docs/sharp-bits.rst
+++ b/docs/docs/sharp-bits.rst
@@ -20,7 +20,18 @@ To disable this behaviour, refer to `Jax#743 <https://github.com/google/jax/issu
 
 Usually we have noticed that the best performance is achieved by combining both BLAS parallelism and MPI, for example by guaranteeing between 2-4 (depending on your problem size) cpus to every MPI thread.
 
+Note that when using :code:`netket` it is crucial to run Python with the same implementation and version of MPI that the :code:`mpi4py` module is compiled against.
+If you encounter issues, you can check whether your MPI environment is set up properly by running::
 
+   $ mpirun -np 2 python3 -m netket.tools.check_mpi
+   mpi_available                : True
+   mpi4jax_available            : True
+   n_nodes                      : 2
+   mpi4py | MPI version         : (3, 1)
+   mpi4py | MPI library_version : Open MPI v4.1.0 <...>
+
+This should print some basic information about the MPI installation and, in particular, pick up the correct `n_nodes`.
+If you get the same output multiple times, each with :code:`n_nodes : 1`, this is a clear sign that your MPI setup is broken.
 
 .. _running_on_cpu:
 
@@ -79,6 +90,5 @@ If you find NaNs while training, especially if you are using your own model, the
   if you use general flax layers they might use different initializers.
   different initialisation distributions have particoularly strong effects when working with complex-valued models. 
   A good way to enforce the same distribution across all your weights, similar to NetKet 2 behaviour, is to use :py:meth:`~netket.variational.VariationalState.init_parameters`.
-
 
 

--- a/netket/tools/_cpu_info.py
+++ b/netket/tools/_cpu_info.py
@@ -1,0 +1,32 @@
+import sys
+import os
+import platform
+import importlib
+
+PLATFORM = sys.platform
+
+
+def available_cpus():
+    """
+    Detects the number of logical CPUs subscriptable by this process.
+    On Linux, this checks /proc/self/status for limits set by
+    taskset, on other platforms taskset do not exist so simply uses
+    multiprocessing.
+
+    This should be a good estimate of how many cpu cores Jax/XLA sees.
+    """
+    if PLATFORM.startswith("linux"):
+        try:
+            m = re.search(
+                r"(?m)^Cpus_allowed:\s*(.*)$", open("/proc/self/status").read()
+            )
+            if m:
+                res = bin(int(m.group(1).replace(",", ""), 16)).count("1")
+                if res > 0:
+                    return res
+        except IOError:
+            pass
+    else:
+        import multiprocessing
+
+        return multiprocessing.cpu_count()

--- a/netket/tools/check_mpi.py
+++ b/netket/tools/check_mpi.py
@@ -14,17 +14,22 @@
 
 from netket.utils import mpi_available, mpi4jax_available, rank, n_nodes
 
+from ._cpu_info import available_cpus
+
 
 def check_mpi():
     """
     When called via::
 
         # python3 -m netket.tools.check_mpi
-        mpi_available     : True
-        mpi4jax_available : True
-        n_nodes           : 1
+        mpi_available                : True
+        mpi4jax_available            : True
+        avalable_cpus (rank 0)       : 12
+        n_nodes                      : 1
+        mpi4py | MPI version         : (3, 1)
+        mpi4py | MPI library_version : Open MPI v4.1.0, ...
 
-    this will print out basic MPI information to make allow users to check whether
+    this will print out basic MPI information to allow users to check whether
     the environment has been set up correctly.
     """
     if rank > 0:
@@ -33,6 +38,7 @@ def check_mpi():
     info = {
         "mpi_available": mpi_available,
         "mpi4jax_available": mpi4jax_available,
+        "avalable_cpus (rank 0)": available_cpus(),
     }
     if mpi_available:
         from mpi4py import MPI

--- a/netket/tools/check_mpi/__main__.py
+++ b/netket/tools/check_mpi/__main__.py
@@ -1,0 +1,54 @@
+# Copyright 2021 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from netket.utils import mpi_available, mpi4jax_available, rank, n_nodes
+
+
+def check_mpi():
+    """
+    When called via::
+
+        # python3 -m netket.tools.check_mpi
+        mpi_available     : True
+        mpi4jax_available : True
+        n_nodes           : 1
+
+    this will print out basic MPI information to make allow users to check whether
+    the environment has been set up correctly.
+    """
+    if rank > 0:
+        return
+
+    info = {
+        "mpi_available": mpi_available,
+        "mpi4jax_available": mpi4jax_available,
+    }
+    if mpi_available:
+        from mpi4py import MPI
+
+        info.update(
+            {
+                "n_nodes": n_nodes,
+                "mpi4py | MPI version": MPI.Get_version(),
+                "mpi4py | MPI library_version": MPI.Get_library_version(),
+            }
+        )
+
+    maxkeylen = max(len(k) for k in info.keys())
+
+    for k, v in info.items():
+        print(f"{k:{maxkeylen}} : {v}")
+
+
+check_mpi()


### PR DESCRIPTION
Since we regularly see problems with MPI environments, in particular due to a mismatch between the MPI version used to compile `mpi4py` and the one used to actually run scripts usign NetKet, I propose we add a small utility to help users to check this in an easy way:
```bash
$ mpirun -np 2 python3 -m netket.tools.check_mpi
mpi_available                : True
mpi4jax_available            : True
n_nodes                      : 2
mpi4py | MPI version         : (3, 1)
mpi4py | MPI library_version : Open MPI v4.1.0,  <...>
```

If this breaks, say because I call it using `mpirun` from MPICH even though NetKet is set up to work with OpenMPI, I get this instead:
```bash
$ mpirun.mpich -np 2 python3 -m netket.tools.check_mpi
mpi_available                : True
mpi4jax_available            : True
n_nodes                      : 1
mpi4py | MPI_version         : (3, 1)
mpi4py | MPI_library_version : Open MPI v4.1.0, <...>
mpi_available                : True
mpi4jax_available            : True
n_nodes                      : 1
mpi4py | MPI_version         : (3, 1)
mpi4py | MPI_library_version : Open MPI v4.1.0,  <...>
```