### PR TITLE
Also report number of subscriptable cpus in check_mpi

### DIFF
--- a/docs/docs/sharp-bits.rst
+++ b/docs/docs/sharp-bits.rst
@@ -26,12 +26,18 @@ If you encounter issues, you can check whether your MPI environment is set up pr
    $ mpirun -np 2 python3 -m netket.tools.check_mpi
    mpi_available                : True
    mpi4jax_available            : True
-   n_nodes                      : 2
+   avalable_cpus (rank 0)       : 12
+   n_nodes                      : 1
    mpi4py | MPI version         : (3, 1)
-   mpi4py | MPI library_version : Open MPI v4.1.0 <...>
+   mpi4py | MPI library_version : Open MPI v4.1.0, package: Open MPI brew@BigSur Distribution, ident: 4.1.0,  repo rev: v4.1.0, Dec 18, 2020
 
 This should print some basic information about the MPI installation and, in particular, pick up the correct `n_nodes`.
 If you get the same output multiple times, each with :code:`n_nodes : 1`, this is a clear sign that your MPI setup is broken.
+The tool above also reports the number of (logical) CPUs that might be subscribed by Jax on every independent MPI rank during linear algebra operations. 
+Be mindfull that Jax, in general, is like an invasive plant and tends to use all resources that he can access, and 
+the environment variables above might not prevent it from making use of the `available_cpus`. 
+On Mac it is not possible to control this number. 
+On Linux it can be controlled using `taskset` or `--bind-to core` when using `mpirun`. 
 
 .. _running_on_cpu:
 

--- a/netket/tools/_cpu_info.py
+++ b/netket/tools/_cpu_info.py
@@ -1,0 +1,32 @@
+import sys
+import os
+import platform
+import importlib
+
+PLATFORM = sys.platform
+
+
+def available_cpus():
+    """
+    Detects the number of logical CPUs subscriptable by this process.
+    On Linux, this checks /proc/self/status for limits set by
+    taskset, on other platforms taskset do not exist so simply uses
+    multiprocessing.
+
+    This should be a good estimate of how many cpu cores Jax/XLA sees.
+    """
+    if PLATFORM.startswith("linux"):
+        try:
+            m = re.search(
+                r"(?m)^Cpus_allowed:\s*(.*)$", open("/proc/self/status").read()
+            )
+            if m:
+                res = bin(int(m.group(1).replace(",", ""), 16)).count("1")
+                if res > 0:
+                    return res
+        except IOError:
+            pass
+    else:
+        import multiprocessing
+
+        return multiprocessing.cpu_count()

--- a/netket/tools/check_mpi.py
+++ b/netket/tools/check_mpi.py
@@ -22,11 +22,14 @@ def check_mpi():
     When called via::
 
         # python3 -m netket.tools.check_mpi
-        mpi_available     : True
-        mpi4jax_available : True
-        n_nodes           : 1
+        mpi_available                : True
+        mpi4jax_available            : True
+        avalable_cpus (rank 0)       : 12
+        n_nodes                      : 1
+        mpi4py | MPI version         : (3, 1)
+        mpi4py | MPI library_version : Open MPI v4.1.0, ...
 
-    this will print out basic MPI information to make allow users to check whether
+    this will print out basic MPI information to allow users to check whether
     the environment has been set up correctly.
     """
     if rank > 0:

--- a/netket/tools/check_mpi.py
+++ b/netket/tools/check_mpi.py
@@ -14,6 +14,8 @@
 
 from netket.utils import mpi_available, mpi4jax_available, rank, n_nodes
 
+from ._cpu_info import available_cpus
+
 
 def check_mpi():
     """
@@ -33,6 +35,7 @@ def check_mpi():
     info = {
         "mpi_available": mpi_available,
         "mpi4jax_available": mpi4jax_available,
+        "avalable_cpus (rank 0)": available_cpus(),
     }
     if mpi_available:
         from mpi4py import MPI


### PR DESCRIPTION
This detects the basically only method to control jax multithreading in linear algebra operations.
That is, using `taskset` or `mpirun --bind-to core`
