### PR TITLE
Add netket.tools.info to help debug issues with NetKet 

### DIFF
--- a/docs/docs/sharp-bits.rst
+++ b/docs/docs/sharp-bits.rst
@@ -20,7 +20,18 @@ To disable this behaviour, refer to `Jax#743 <https://github.com/google/jax/issu
 
 Usually we have noticed that the best performance is achieved by combining both BLAS parallelism and MPI, for example by guaranteeing between 2-4 (depending on your problem size) cpus to every MPI thread.
 
+Note that when using :code:`netket` it is crucial to run Python with the same implementation and version of MPI that the :code:`mpi4py` module is compiled against.
+If you encounter issues, you can check whether your MPI environment is set up properly by running::
 
+   $ mpirun -np 2 python3 -m netket.tools.check_mpi
+   mpi_available                : True
+   mpi4jax_available            : True
+   n_nodes                      : 2
+   mpi4py | MPI version         : (3, 1)
+   mpi4py | MPI library_version : Open MPI v4.1.0 <...>
+
+This should print some basic information about the MPI installation and, in particular, pick up the correct `n_nodes`.
+If you get the same output multiple times, each with :code:`n_nodes : 1`, this is a clear sign that your MPI setup is broken.
 
 .. _running_on_cpu:
 
@@ -79,6 +90,5 @@ If you find NaNs while training, especially if you are using your own model, the
   if you use general flax layers they might use different initializers.
   different initialisation distributions have particoularly strong effects when working with complex-valued models. 
   A good way to enforce the same distribution across all your weights, similar to NetKet 2 behaviour, is to use :py:meth:`~netket.variational.VariationalState.init_parameters`.
-
 
 

--- a/netket/tools/_common.py
+++ b/netket/tools/_common.py
@@ -1,0 +1,51 @@
+from subprocess import check_output
+import sys
+import os
+import platform
+import importlib
+
+
+def exec_in_terminal(command):
+    """Run a command in the terminal and get the
+    output stripping the last newline.
+
+    Args:
+        command: a string or list of strings
+    """
+    return check_output(command).strip().decode("utf8")
+
+
+def is_available(lib_name: str) -> bool:
+    """
+    Checks if a library can be imported
+    """
+    try:
+        importlib.import_module(lib_name)
+        available = True
+    except ImportError:
+        available = False
+
+    return available
+
+
+def version(lib_name) -> str:
+    """
+    Returns the version of a library as a string or
+    unavailable if it cannot be imported
+    """
+    if is_available(lib_name):
+        return _version(lib_name)
+    else:
+        return "unavailable"
+
+
+def _version(lib_name):
+    """
+    Returns the version of a package.
+    If version cannot be determined returns "available"
+    """
+    lib = importlib.import_module(lib_name)
+    if hasattr(lib, "__version__"):
+        return lib.__version__
+    else:
+        return "available"

--- a/netket/tools/_cpu_info.py
+++ b/netket/tools/_cpu_info.py
@@ -1,0 +1,32 @@
+import sys
+import os
+import platform
+import importlib
+
+PLATFORM = sys.platform
+
+
+def available_cpus():
+    """
+    Detects the number of logical CPUs subscriptable by this process.
+    On Linux, this checks /proc/self/status for limits set by
+    taskset, on other platforms taskset do not exist so simply uses
+    multiprocessing.
+
+    This should be a good estimate of how many cpu cores Jax/XLA sees.
+    """
+    if PLATFORM.startswith("linux"):
+        try:
+            m = re.search(
+                r"(?m)^Cpus_allowed:\s*(.*)$", open("/proc/self/status").read()
+            )
+            if m:
+                res = bin(int(m.group(1).replace(",", ""), 16)).count("1")
+                if res > 0:
+                    return res
+        except IOError:
+            pass
+    else:
+        import multiprocessing
+
+        return multiprocessing.cpu_count()

--- a/netket/tools/_cpu_info.py
+++ b/netket/tools/_cpu_info.py
@@ -3,6 +3,8 @@ import os
 import platform
 import importlib
 
+from ._common import exec_in_terminal
+
 PLATFORM = sys.platform
 
 
@@ -15,6 +17,107 @@ def available_cpus():
 
     This should be a good estimate of how many cpu cores Jax/XLA sees.
     """
+    if PLATFORM.startswith("linux"):
+        try:
+            m = re.search(
+                r"(?m)^Cpus_allowed:\s*(.*)$", open("/proc/self/status").read()
+            )
+            if m:
+                res = bin(int(m.group(1).replace(",", ""), 16)).count("1")
+                if res > 0:
+                    return res
+        except IOError:
+            pass
+    else:
+        import multiprocessing
+
+        return multiprocessing.cpu_count()
+
+
+## Taken from https://github.com/matthew-brett/x86cpu/blob/530f89f678aba501381e94be5325b9c91b878a32/x86cpu/tests/info_getters.py#L24
+##
+
+SYSCTL_KEY_TRANSLATIONS = dict(
+    model="model_display",
+    family="family_display",
+    extmodel="extended_model",
+    extfamily="extended_family",
+)
+
+
+SYSCTL_FLAG_TRANSLATIONS = {
+    "sse4.1": "sse4_1",
+    "sse4.2": "sse4_2",
+}
+
+
+def cpu_info():
+    if PLATFORM.startswith("darwin"):
+        return get_sysctl_cpu()
+    elif PLATFORM.startswith("linux"):
+        return get_proc_cpuinfo()
+    else:
+        raise ValueError(f"Unsupported platform {PLATFORM}")
+
+
+def get_sysctl_cpu():
+    sysctl_text = exec_in_terminal(["sysctl", "-a"])
+    info = {}
+    for line in sysctl_text.splitlines():
+        if not line.startswith("machdep.cpu."):
+            continue
+        line = line.strip()[len("machdep.cpu.") :]
+        key, value = line.split(": ", 1)
+        key = SYSCTL_KEY_TRANSLATIONS.get(key, key)
+        try:
+            value = int(value)
+        except ValueError:
+            pass
+        info[key] = value
+    flags = [flag.lower() for flag in info["features"].split()]
+    info["flags"] = [SYSCTL_FLAG_TRANSLATIONS.get(flag, flag) for flag in flags]
+    info["unknown_flags"] = ["3dnow"]
+    info["supports_avx"] = "hw.optional.avx1_0: 1\n" in sysctl_text
+    info["supports_avx2"] = "hw.optionxwal.avx2_0: 1\n" in sysctl_text
+    return info
+
+
+PCPUINFO_KEY_TRANSLATIONS = {
+    "vendor_id": "vendor",
+    "model": "model_display",
+    "family": "family_display",
+    "model name": "brand",
+}
+
+
+def get_proc_cpuinfo():
+    with open("/proc/cpuinfo", "rt") as fobj:
+        pci_lines = fobj.readlines()
+    info = {}
+    for line in pci_lines:
+        line = line.strip()
+        if line == "":  # End of first processor
+            break
+        key, value = line.split(":", 1)
+        key, value = key.strip(), value.strip()
+        key = PCPUINFO_KEY_TRANSLATIONS.get(key, key)
+        try:
+            value = int(value)
+        except ValueError:
+            pass
+        info[key] = value
+    info["flags"] = info["flags"].split()
+    # cpuinfo records presence of Prescott New Instructions, Intel's code name
+    # for SSE3.
+    if "pni" in info["flags"]:
+        info["flags"].append("sse3")
+    info["unknown_flags"] = ["3dnow"]
+    info["supports_avx"] = "avx" in info["flags"]
+    info["supports_avx2"] = "avx2" in info["flags"]
+    return info
+
+
+def available_cpus():
     if PLATFORM.startswith("linux"):
         try:
             m = re.search(

--- a/netket/tools/_mpi_info.py
+++ b/netket/tools/_mpi_info.py
@@ -1,0 +1,37 @@
+from subprocess import CalledProcessError
+
+from ._common import exec_in_terminal
+
+
+def get_global_mpi_info():
+    info = {}
+    try:
+        info["mpicc"] = exec_in_terminal(["which", "mpicc"])
+    except CalledProcessError:
+        info["mpicc"] = ""
+
+    try:
+        info["mpirun"] = exec_in_terminal(["which", "mpirun"])
+    except CalledProcessError:
+        info["mpirun"] = ""
+
+    try:
+        info["mpiexec"] = exec_in_terminal(["which", "mpiexec"])
+    except CalledProcessError:
+        info["mpiexec"] = ""
+
+    if info["mpicc"]:
+        info["link_flags"] = get_link_flags(exec_in_terminal([info["mpicc"], "-show"]))
+    else:
+        info["link_flags"] = ""
+    return info
+
+
+def get_link_flags(flags):
+    flags = flags.replace(",", " ").split()
+    res = []
+    for flag in flags:
+        if flag.startswith("-L"):
+            res.append(flag)
+
+    return res

--- a/netket/tools/check_mpi.py
+++ b/netket/tools/check_mpi.py
@@ -14,6 +14,8 @@
 
 from netket.utils import mpi_available, mpi4jax_available, rank, n_nodes
 
+from ._cpu_info import available_cpus
+
 
 def check_mpi():
     """
@@ -33,6 +35,7 @@ def check_mpi():
     info = {
         "mpi_available": mpi_available,
         "mpi4jax_available": mpi4jax_available,
+        "avalable_cpus (rank 0)": available_cpus(),
     }
     if mpi_available:
         from mpi4py import MPI

--- a/netket/tools/check_mpi/__main__.py
+++ b/netket/tools/check_mpi/__main__.py
@@ -1,0 +1,54 @@
+# Copyright 2021 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from netket.utils import mpi_available, mpi4jax_available, rank, n_nodes
+
+
+def check_mpi():
+    """
+    When called via::
+
+        # python3 -m netket.tools.check_mpi
+        mpi_available     : True
+        mpi4jax_available : True
+        n_nodes           : 1
+
+    this will print out basic MPI information to make allow users to check whether
+    the environment has been set up correctly.
+    """
+    if rank > 0:
+        return
+
+    info = {
+        "mpi_available": mpi_available,
+        "mpi4jax_available": mpi4jax_available,
+    }
+    if mpi_available:
+        from mpi4py import MPI
+
+        info.update(
+            {
+                "n_nodes": n_nodes,
+                "mpi4py | MPI version": MPI.Get_version(),
+                "mpi4py | MPI library_version": MPI.Get_library_version(),
+            }
+        )
+
+    maxkeylen = max(len(k) for k in info.keys())
+
+    for k, v in info.items():
+        print(f"{k:{maxkeylen}} : {v}")
+
+
+check_mpi()

--- a/netket/tools/info.py
+++ b/netket/tools/info.py
@@ -1,0 +1,157 @@
+# Copyright 2021 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import platform
+import importlib
+
+PLATFORM = sys.platform
+
+from ._common import exec_in_terminal, version, is_available
+from ._cpu_info import cpu_info
+from ._mpi_info import get_global_mpi_info, get_link_flags
+
+STD_SPACE = 20
+
+
+def printfmt(key, value=None, *, indent=0, pre="", alignment=STD_SPACE):
+    INDENT_STR = "- "
+
+    if indent > 0:
+        indent_spaces = indent * 2
+        alignment -= indent_spaces + len(INDENT_STR)
+
+        pre = f"{pre}{'' : <{indent_spaces}}{INDENT_STR}"
+
+    if value is not None:
+        print(f"{pre}{key : <{alignment}} : {value}", flush=True)
+    else:
+        print(f"{pre}{key : <{alignment}}", flush=True)
+
+
+def info():
+    """
+    When called via::
+
+        # python3 -m netket.tools.check_mpi
+        mpi_available     : True
+        mpi4jax_available : True
+        n_nodes           : 1
+
+    this will print out basic MPI information to make allow users to check whether
+    the environment has been set up correctly.
+    """
+    print("====================================================")
+    print("==         NetKet Diagnostic Informations         ==")
+    print("====================================================")
+
+    # try to import version without import netket itself
+    from .. import _version
+
+    printfmt(f"NetKet version", _version.version)
+    print()
+
+    print("# Python")
+    printfmt("implementation", platform.python_implementation(), indent=1)
+    printfmt("version", platform.python_version(), indent=1)
+    printfmt("distribution", platform.python_compiler(), indent=1)
+    printfmt("path", sys.executable, indent=1)
+    print()
+
+    # Try to detect platform
+    print("# Host informations")
+    printfmt("System      ", platform.platform(), indent=1)
+    printfmt("Architecture", platform.machine(), indent=1)
+
+    # Try to query cpu info
+    platform_info = cpu_info()
+
+    printfmt("AVX", platform_info["supports_avx"], indent=1)
+    printfmt("AVX2", platform_info["supports_avx2"], indent=1)
+    if "cpu cores" in platform_info:
+        printfmt("Cores", platform_info["cpu cores"], indent=1)
+    elif "cpu_cores" in platform_info:
+        printfmt("Cores", platform_info["cpu_cores"], indent=1)
+    elif "core_count" in platform_info:
+        printfmt("Cores", platform_info["core_count"], indent=1)
+    print()
+
+    # try to load jax
+    print(f"# NetKet dependencies")
+    printfmt("numpy", version("numpy"), indent=1)
+    printfmt("jaxlib", version("jaxlib"), indent=1)
+    printfmt("jax", version("jax"), indent=1)
+    printfmt("flax", version("flax"), indent=1)
+    printfmt("optax", version("optax"), indent=1)
+    printfmt("numba", version("numba"), indent=1)
+    printfmt("mpi4py", version("mpi4py"), indent=1)
+    printfmt("mpi4jax", version("mpi4jax"), indent=1)
+    printfmt("netket", version("netket"), indent=1)
+    print()
+
+    if is_available("jax"):
+        print(f"# Jax ")
+        import jax
+
+        backends = _jax_backends()
+        printfmt("backends", backends, indent=1)
+        for backend in backends:
+            printfmt(f"{backend}", jax.devices(backend), indent=2)
+        print()
+
+    if is_available("mpi4jax"):
+        print(f"# MPI4JAX")
+        import mpi4jax
+
+        if hasattr(mpi4jax._src.xla_bridge, "HAS_GPU_EXT"):
+            printfmt(f"HAS_GPU_EXT", mpi4jax._src.xla_bridge.HAS_GPU_EXT, indent=1)
+        print()
+
+    if is_available("mpi4py"):
+        print(f"# MPI ")
+        import mpi4py
+        from mpi4py import MPI
+
+        printfmt("mpi4py", indent=1)
+        printfmt("MPICC", mpi4py.get_config()["mpicc"], indent=1)
+        printfmt(
+            "MPI link flags",
+            get_link_flags(exec_in_terminal([mpi4py.get_config()["mpicc"], "-show"])),
+            indent=1,
+        )
+        printfmt("MPI version", MPI.Get_version(), indent=2)
+        printfmt("MPI library_version", MPI.Get_library_version(), indent=2)
+
+        global_info = get_global_mpi_info()
+        printfmt("global", indent=1)
+        printfmt("MPICC", global_info["mpicc"], indent=2)
+        printfmt("MPI link flags", global_info["link_flags"], indent=2)
+        print()
+
+
+def _jax_backends():
+    import jax
+
+    backends = []
+    for backend in ["cpu", "gpu", "tpu"]:
+        try:
+            jax.devices(backend)
+        except RuntimeError:
+            pass
+        else:
+            backends.append(backend)
+    return backends
+
+
+info()


### PR DESCRIPTION
PR on top of #671 and #672 

In the spirit of #671, adds a tool that can be run like `python -m netket.tools.info` to provide a lot of information about the stack below netket.

In particular it tries to collect some informations about the system and prints them before importing any netket/jax-related library to help debug issues like #667:

 - It prints NetKet version without importing netket itself
 - It prints the python version/interpreter being used
 - It prints some informations about the host, such as operating system, architecture (#666 issues)  and, mainly, if AVX is supported or not by the CPU. Only at this point it will try to load most netket dependencies in order and print their versions
 - Print all jax backends in case someone wants to use gpus but ain't detected. Prints whever Mpi4jax supports gpus, the same mpi4py informations as @femtobit tool, but a bit more verbose 
 - also tries to detect the global mpi environment (Very rudimentary) by running `which mpicc` and `which mpirun` to diagnose mpi mismatches.

My idea is to add a GitHub issue template asking people to post the output of this tool when opening an issue, if they think it's relevant.

```python
➜ python -m netket.tools.info
====================================================
==         NetKet Diagnostic Informations         ==
====================================================
NetKet version       : 3.0b1.post9.dev4+g753a7f2a.d20210501

# Python
  - implementation   : CPython
  - version          : 3.8.2
  - distribution     : Clang 12.0.0 (clang-1200.0.32.29)
  - path             : /Users/filippovicentini/Documents/pythonenvs/netket_env/bin/python

# Host informations
  - System           : macOS-11.2.3-x86_64-i386-64bit
  - Architecture     : x86_64
  - AVX              : True
  - AVX2             : False
  - Cores            : 6

# NetKet dependencies
  - numpy            : 1.20.2
  - jaxlib           : 0.1.65
  - jax              : 0.2.12
  - flax             : 0.3.3
  - optax            : 0.0.6
  - numba            : 0.53.1
  - mpi4py           : 3.0.3
  - mpi4jax          : 0.2.18
  - netket           : 3.0b1.post9.dev4+g753a7f2a.d20210501

# Jax
  - backends         : ['cpu']
    - cpu            : [CpuDevice(id=0)]

# MPI4JAX
  - HAS_GPU_EXT      : False

# MPI
  - mpi4py
  - MPICC            : /usr/local/bin/mpicc
  - MPI link flags   : ['-L/usr/local/opt/libevent/lib', '-L/usr/local/Cellar/open-mpi/4.1.0/lib']
    - MPI version    : (3, 1)
    - MPI library_version : Open MPI v4.1.0, package: Open MPI brew@BigSur Distribution, ident: 4.1.0, repo rev: v4.1.0, Dec 18, 2020
  - global
    - MPICC          : /usr/local/bin/mpicc
    - MPI link flags : ['-L/usr/local/opt/libevent/lib', '-L/usr/local/Cellar/open-mpi/4.1.0/lib']
```