### PR TITLE
Breaking: `reset_chain`->`reset_chains`, `acceptance_ratio`->`acceptance`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,22 +9,16 @@ New features
 ------------
 
 * Group Equivariant Neural Networks have been added to `models` [#620](https://github.com/netket/netket/pull/620)
-
 * Permutation invariant RBM and Permutation invariant dense layer have been added to `models` 
   and `nn.linear` [#573](https://github.com/netket/netket/pull/573)
-
 * Add the property `acceptance` to `MetropolisSampler`'s `SamplerState`, computing the
   MPI-enabled acceptance ratio. [#592](https://github.com/netket/netket/pull/592). 
-
 * Add `StateLog`, a new logger that stores the parameters of the model during the 
   optimization in a folder or in a tar file. [#645](https://github.com/netket/netket/pull/645)
-
 * A warning is now issued if netket detects to be running under `mpirun` but MPI dependencies
   are not installed [#631](https://github.com/netket/netket/pull/631)
-
 * `operator.LocalOperator`s now do not return a zero matrix element on the diagonal if the whole
   diagonal is zero. [#623](https://github.com/netket/netket/pull/623).
-
 * `logger.JSONLog` now automatically flushes at every iteration if it does not consume significant
   CPU cycles. [#599](https://github.com/netket/netket/pull/599)
 
@@ -33,13 +27,10 @@ Breaking Changes
 
 * `MetropolisSampler.reset_chain` has been renamed to `MetropolisSampler.reset_chains`. 
   Likewise in the constructor of all samplers.
-
 * Briefly during development releases `MetropolisSamplerState.acceptance_ratio` returned
   the percentage (not ratio) of acceptance. `acceptance_ratio` is now deprecated in 
   favour of the correct `acceptance`.
-
 * `models.Jastrow` now internally simmetrizes the matrix before computing its value [#644](https://github.com/netket/netket/pull/644)
-
 * `MCState.evaluate` has been renamed to `MCState.log_value` [#632](https://github.com/netket/netket/pull/632)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,60 @@
+NetKet release notes for all versions
+=====================================
+
+## NetKet 3.0b2 (unreleased)
+* [GitHub commits](https://github.com/netket/netket/compare/v3.0b1...master).
+
+
+New features
+------------
+
+* Group Equivariant Neural Networks have been added to `models` [#620](https://github.com/netket/netket/pull/620)
+
+* Permutation invariant RBM and Permutation invariant dense layer have been added to `models` 
+  and `nn.linear` [#573](https://github.com/netket/netket/pull/573)
+
+* Add the property `acceptance` to `MetropolisSampler`'s `SamplerState`, computing the
+  MPI-enabled acceptance ratio. [#592](https://github.com/netket/netket/pull/592). 
+
+* Add `StateLog`, a new logger that stores the parameters of the model during the 
+  optimization in a folder or in a tar file. [#645](https://github.com/netket/netket/pull/645)
+
+* A warning is now issued if netket detects to be running under `mpirun` but MPI dependencies
+  are not installed [#631](https://github.com/netket/netket/pull/631)
+
+* `operator.LocalOperator`s now do not return a zero matrix element on the diagonal if the whole
+  diagonal is zero. [#623](https://github.com/netket/netket/pull/623).
+
+* `logger.JSONLog` now automatically flushes at every iteration if it does not consume significant
+  CPU cycles. [#599](https://github.com/netket/netket/pull/599)
+
+Breaking Changes
+----------------
+
+* `MetropolisSampler.reset_chain` has been renamed to `MetropolisSampler.reset_chains`. 
+  Likewise in the constructor of all samplers.
+
+* Briefly during development releases `MetropolisSamplerState.acceptance_ratio` returned
+  the percentage (not ratio) of acceptance. `acceptance_ratio` is now deprecated in 
+  favour of the correct `acceptance`.
+
+* `models.Jastrow` now internally simmetrizes the matrix before computing its value [#644](https://github.com/netket/netket/pull/644)
+
+* `MCState.evaluate` has been renamed to `MCState.log_value` [#632](https://github.com/netket/netket/pull/632)
+
+
+Bug Fixes
+---------
+
+* Fix `BoseHubbard` usage under jax Hamiltonian Sampling [#662](https://github.com/netket/netket/pull/662)
+* Fix `SROnTheFly` for `R->C` models with non homogeneous parameters [#661](https://github.com/netket/netket/pull/661)
+* Fix MPI Compilation deadlock when computing expectation values [#655](https://github.com/netket/netket/pull/655)
+* Fix bug preventing the creation of a `hilbert.Spin` hilbert space with odd sites and even `S`. [#641](https://github.com/netket/netket/pull/641)
+* Fix bug [#635](https://github.com/netket/netket/pull/635) preventing the usage of `NumpyMetropolisSampler` with `MCState.expect` [#635](https://github.com/netket/netket/pull/635)
+* Fix bug [#635](https://github.com/netket/netket/pull/635) where the `graph.Lattice` was not correctly computing neighbours because of floating point issues. [#633](https://github.com/netket/netket/pull/633)
+* Fix bug the Y pauli matrix, which was stored as its conjugate. [#618](https://github.com/netket/netket/pull/618) [#617](https://github.com/netket/netket/pull/617) [#615](https://github.com/netket/netket/pull/615)
+
+
+## NetKet 3.0b1 (published beta release)
+
+Too many to count

--- a/Examples/Ising1d/ising1d.py
+++ b/Examples/Ising1d/ising1d.py
@@ -29,7 +29,7 @@ ha = nk.operator.Ising(hilbert=hi, graph=g, h=1.0)
 ma = nk.models.RBM(alpha=1, use_visible_bias=True, dtype=float)
 
 # Metropolis Local Sampling
-sa = nk.sampler.MetropolisLocal(hi, n_chains=16)
+sa = nk.sampler.MetropolisLocal(hi, n_chains=16, reset_chains=False)
 
 # Optimizer
 op = nk.optimizer.Sgd(learning_rate=0.1)

--- a/Test/Sampler/test_sampler.py
+++ b/Test/Sampler/test_sampler.py
@@ -65,13 +65,13 @@ samplers["Metropolis(Exchange): Fock-1particle)"] = nk.sampler.MetropolisExchang
 samplers["Metropolis(Hamiltonian,Jax): Spin"] = nk.sampler.MetropolisHamiltonian(
     hi,
     hamiltonian=ha,
-    reset_chain=True,
+    reset_chains=True,
 )
 
 samplers["Metropolis(Hamiltonian,Numpy): Spin"] = nk.sampler.MetropolisHamiltonianNumpy(
     hi,
     hamiltonian=ha,
-    reset_chain=True,
+    reset_chains=True,
 )
 
 samplers["Metropolis(Custom: Sx): Spin"] = nk.sampler.MetropolisCustom(
@@ -258,14 +258,14 @@ def test_throwing(rbm_and_weights):
         nk.sampler.MetropolisHamiltonian(
             hi,
             hamiltonian=10,
-            reset_chain=True,
+            reset_chains=True,
         )
 
     with pytest.raises(ValueError):
         sampler = nk.sampler.MetropolisHamiltonian(
             nk.hilbert.DoubledHilbert(hi),
             hamiltonian=ha,
-            reset_chain=True,
+            reset_chains=True,
         )
 
         ma, w = rbm_and_weights(hi)
@@ -276,7 +276,7 @@ def test_throwing(rbm_and_weights):
         sampler = nk.sampler.MetropolisHamiltonianNumpy(
             nk.hilbert.Fock(3) ** hi.size,
             hamiltonian=ha,
-            reset_chain=True,
+            reset_chains=True,
         )
 
         ma, w = rbm_and_weights(hi)
@@ -287,7 +287,7 @@ def test_throwing(rbm_and_weights):
         sampler = nk.sampler.MetropolisHamiltonianNumpy(
             nk.hilbert.DoubledHilbert(hi),
             hamiltonian=ha,
-            reset_chain=True,
+            reset_chains=True,
         )
 
         ma, w = rbm_and_weights(hi)

--- a/netket/sampler/metropolis.py
+++ b/netket/sampler/metropolis.py
@@ -25,6 +25,8 @@ from netket.utils import n_nodes
 from netket.stats import sum_inplace
 from netket.utils.types import PyTree, PRNGKeyT
 
+from netket.utils import deprecated
+
 from .base import Sampler, SamplerState
 
 
@@ -139,8 +141,8 @@ class MetropolisSamplerState(SamplerState):
     """Number of accepted transitions among the chains in this process since the last reset."""
 
     @property
-    def acceptance_ratio(self) -> float:
-        """The percentage of accepted moves across all chains and MPI processes.
+    def acceptance(self) -> float:
+        """The fraction of accepted moves across all chains and MPI processes.
 
         The rate is computed since the last reset of the sampler.
         Will return None if no sampling has been performed since then.
@@ -148,7 +150,27 @@ class MetropolisSamplerState(SamplerState):
         if self.n_steps == 0:
             return None
 
-        return self.n_accepted / self.n_steps * 100
+        return self.n_accepted / self.n_steps
+
+    @property
+    @deprecated(
+        """Please use the attribute `.acceptance` instead of 
+        `.acceptance_ratio`. The new attribute `.acceptance` returns the 
+        acceptance ratio ∈ [0,1], instead of the current `acceptance_ratio`
+        returning a percentage, which is a bug."""
+    )
+    def acceptance_ratio(self):
+        """DEPRECATED: Please use the attribute `.acceptance` instead of
+        `.acceptance_ratio`. The new attribute `.acceptance` returns the
+        acceptance ratio ∈ [0,1], instead of the current `acceptance_ratio`
+        returning a percentage, which is a bug.
+
+        The percentage of accepted moves across all chains and MPI processes.
+
+        The rate is computed since the last reset of the sampler.
+        Will return None if no sampling has been performed since then.
+        """
+        return self.acceptance * 100
 
     @property
     def n_steps(self) -> int:
@@ -163,7 +185,7 @@ class MetropolisSamplerState(SamplerState):
     def __repr__(self):
         if self.n_steps > 0:
             acc_string = "# accepted = {}/{} ({}%), ".format(
-                self.n_accepted, self.n_steps, self.acceptance_ratio
+                self.n_accepted, self.n_steps, self.acceptance * 100
             )
         else:
             acc_string = ""

--- a/netket/sampler/metropolis_numpy.py
+++ b/netket/sampler/metropolis_numpy.py
@@ -27,6 +27,7 @@ from netket.hilbert import AbstractHilbert
 from netket.utils import n_nodes
 from netket.stats import sum_inplace
 from netket.utils.types import PyTree, PRNGKeyT
+from netket.utils.deprecation import deprecated, warn_deprecation
 
 import netket.jax as nkjax
 
@@ -155,7 +156,7 @@ class MetropolisSamplerNumpy(MetropolisSampler):
             rule_state=sampler.rule.init_state(sampler, machine, parameters, rgen),
         )
 
-        if not sampler.reset_chain:
+        if not sampler.reset_chains:
             key = jnp.asarray(
                 state.rng.integers(0, 1 << 32, size=2, dtype=np.uint32), dtype=np.uint32
             )
@@ -167,7 +168,7 @@ class MetropolisSamplerNumpy(MetropolisSampler):
         return state
 
     def _reset(sampler, machine, parameters, state):
-        if sampler.reset_chain:
+        if sampler.reset_chains:
             # directly generate a PRNGKey which is a [2xuint32] array
             key = jnp.asarray(
                 state.rng.integers(0, 1 << 32, size=2, dtype=np.uint32), dtype=np.uint32
@@ -246,7 +247,7 @@ class MetropolisSamplerNumpy(MetropolisSampler):
             + "\n  rule = {},".format(sampler.rule)
             + "\n  n_chains = {},".format(sampler.n_chains)
             + "\n  machine_power = {},".format(sampler.machine_pow)
-            + "\n  reset_chain = {},".format(sampler.reset_chain)
+            + "\n  reset_chains = {},".format(sampler.reset_chains)
             + "\n  n_sweeps = {},".format(sampler.n_sweeps)
             + "\n  dtype = {},".format(sampler.dtype)
             + ")"

--- a/netket/sampler/metropolis_numpy.py
+++ b/netket/sampler/metropolis_numpy.py
@@ -60,8 +60,8 @@ class MetropolisNumpySamplerState:
     """Number of accepted transitions among the chains in this process since the last reset."""
 
     @property
-    def acceptance_ratio(self) -> float:
-        """The percentage of accepted moves across all chains and MPI processes.
+    def acceptance(self) -> float:
+        """The fraction of accepted moves across all chains and MPI processes.
 
         The rate is computed since the last reset of the sampler.
         Will return None if no sampling has been performed since then.
@@ -69,7 +69,27 @@ class MetropolisNumpySamplerState:
         if self.n_steps == 0:
             return None
 
-        return self.n_accepted / self.n_steps * 100
+        return self.n_accepted / self.n_steps
+
+    @property
+    @deprecated(
+        """Please use the attribute `.acceptance` instead of 
+        `.acceptance_ratio`. The new attribute `.acceptance` returns the 
+        acceptance ratio ∈ [0,1], instead of the current `acceptance_ratio`
+        returning a percentage, which is a bug."""
+    )
+    def acceptance_ratio(self) -> float:
+        """DEPRECATED: Please use the attribute `.acceptance` instead of
+        `.acceptance_ratio`. The new attribute `.acceptance` returns the
+        acceptance ratio ∈ [0,1], instead of the current `acceptance_ratio`
+        returning a percentage, which is a bug.
+
+        The percentage of accepted moves across all chains and MPI processes.
+
+        The rate is computed since the last reset of the sampler.
+        Will return None if no sampling has been performed since then.
+        """
+        return self.acceptance * 100
 
     @property
     def n_steps(self) -> int:
@@ -84,7 +104,7 @@ class MetropolisNumpySamplerState:
     def __repr__(self):
         if self.n_steps > 0:
             acc_string = "# accepted = {}/{} ({}%), ".format(
-                self.n_accepted, self.n_steps, self.acceptance_ratio
+                self.n_accepted, self.n_steps, self.acceptance * 100
             )
         else:
             acc_string = ""

--- a/netket/sampler/metropolis_pt.py
+++ b/netket/sampler/metropolis_pt.py
@@ -47,7 +47,7 @@ class MetropolisPtSamplerState(MetropolisSamplerState):
     def __repr__(self):
         if self.n_steps > 0:
             acc_string = "# accepted = {}/{} ({}%), ".format(
-                self.n_accepted, self.n_steps, self.acceptance_ratio
+                self.n_accepted, self.n_steps, self.acceptance * 100
             )
         else:
             acc_string = ""


### PR DESCRIPTION
From feedback from a few users:
 - reset_chain was singular, while everything else was plural, so let's be consistent. 
 - `SampelrState.acceptance_ratio` returned the percentage (not a ratio). Also in much code that automatically adjust number of samples you need a ratio not a percentage. So fixes the bug and rename the variable to `acceptance`.

There are deprecation warnings in case anybody was using this stuff.
