### PR TITLE
fix jax 0.2.13

### DIFF
--- a/netket/jax/utils.py
+++ b/netket/jax/utils.py
@@ -28,7 +28,14 @@ from jax.tree_util import (
     tree_leaves,
 )
 from jax.util import as_hashable_function
-from jax.dtypes import dtype_real
+
+# Workaround https://github.com/google/jax/issues/6641
+# To be removed if we drop support for old jax versions
+# pre 0.2.14
+if hasattr(jax.dtypes, "dtype_real"):
+    from jax.dtypes import dtype_real
+else:
+    from jax._src.dtypes import dtype_real
 
 from netket.utils import MPI, n_nodes, rank, random_seed
 from netket.utils.types import PyTree, PRNGKeyT, SeedT, Scalar

--- a/netket/models/ndm.py
+++ b/netket/models/ndm.py
@@ -24,6 +24,7 @@ from netket.hilbert import AbstractHilbert
 from netket.graph import AbstractGraph
 from netket.utils.types import PRNGKeyT, Shape, DType, Array, NNInitFunc
 
+from netket import jax as nkjax
 from netket import nn as nknn
 from netket.nn.initializers import lecun_normal, variance_scaling, zeros, normal
 
@@ -138,7 +139,7 @@ class MixedRBM(nn.Module):
                 "bias",
                 self.bias_init,
                 (int(self.alpha * σr.shape[-1]),),
-                jax.dtypes.dtype_real(self.dtype),
+                nkjax.dtype_real(self.dtype),
             )
             y = y + bias
 

--- a/netket/sampler/metropolis_numpy.py
+++ b/netket/sampler/metropolis_numpy.py
@@ -28,6 +28,8 @@ from netket.utils import n_nodes
 from netket.stats import sum_inplace
 from netket.utils.types import PyTree, PRNGKeyT
 
+import netket.jax as nkjax
+
 from .metropolis import MetropolisSampler
 
 SeedType = Union[int, PRNGKeyT]
@@ -127,7 +129,7 @@ class MetropolisSamplerNumpy(MetropolisSampler):
             log_values=np.zeros(sampler.n_batches, dtype=ma_out.dtype),
             log_values_1=np.zeros(sampler.n_batches, dtype=ma_out.dtype),
             log_prob_corr=np.zeros(
-                sampler.n_batches, dtype=jax.dtypes.dtype_real(ma_out.dtype)
+                sampler.n_batches, dtype=nkjax.dtype_real(ma_out.dtype)
             ),
             rng=rgen,
             rule_state=sampler.rule.init_state(sampler, machine, parameters, rgen),

--- a/netket/stats/mc_stats.py
+++ b/netket/stats/mc_stats.py
@@ -24,6 +24,9 @@ from jax import numpy as jnp
 
 from numba import jit
 import numpy as np
+
+from netket import jax as nkjax
+
 from . import mean as _mean
 from . import var as _var
 from . import total_size as _total_size
@@ -185,7 +188,7 @@ def _statistics(data, batch_size):
     batch_good = (tau_batch < 6 * data.shape[1]) * (n_batches >= batch_size)
     block_good = (tau_block < 6 * l_block) * (n_blocks >= batch_size)
 
-    stat_dtype = jax.dtypes.dtype_real(data.dtype)
+    stat_dtype = nkjax.dtype_real(data.dtype)
     # if batch_good:
     #    error_of_mean = jnp.sqrt(batch_var / n_batches)
     #    tau_corr = jnp.max(0, tau_batch)


### PR DESCRIPTION
they stopped exporting stuff.
@femtobit we should start upper bounding our dependencies.
But they seem to break even in patch releases