### PR TITLE
Improve consistency of the lattice API

### DIFF
--- a/Test/Graph/test_graph.py
+++ b/Test/Graph/test_graph.py
@@ -24,29 +24,29 @@ graphs = [
     Grid(length=[4, 2], pbc=[True, False]),
     # lattice graphs
     Lattice(
-        basis_vectors=[[1.0, 0.0], [1.0 / 2.0, math.sqrt(3) / 2.0]],
+        primitives=[[1.0, 0.0], [1.0 / 2.0, math.sqrt(3) / 2.0]],
         extent=[3, 3],
         pbc=[False, False],
-        atoms_coord=[[0, 0]],
+        basis=[[0, 0]],
     ),
     Lattice(
-        basis_vectors=[[1.5, math.sqrt(3) / 2.0], [0, math.sqrt(3)]],
+        primitives=[[1.5, math.sqrt(3) / 2.0], [0, math.sqrt(3)]],
         extent=[3, 5],
-        atoms_coord=[[0, 0], [1, 1]],
+        basis=[[0, 0], [1, 1]],
     ),
     Lattice(
-        basis_vectors=[
+        primitives=[
             [1.0, 0.0, 0.0],
             [1.0 / 2.0, math.sqrt(3) / 2.0, 0.0],
             [0.0, 0.0, 1.0],
         ],
         extent=[2, 3, 4],
-        atoms_coord=[[0, 0, 0]],
+        basis=[[0, 0, 0]],
     ),
     Lattice(
-        basis_vectors=[[2.0, 0.0], [1.0, math.sqrt(3)]],
+        primitives=[[2.0, 0.0], [1.0, math.sqrt(3)]],
         extent=[4, 4],
-        atoms_coord=[[0, 0], [1.0 / 2.0, math.sqrt(3) / 2.0], [1.0, 0.0]],
+        basis=[[0, 0], [1.0 / 2.0, math.sqrt(3) / 2.0], [1.0, 0.0]],
     ),
     # edgeless graph
     Edgeless(10),
@@ -54,27 +54,27 @@ graphs = [
 
 symmetric_graphs = [
     # Square
-    nk.graph.Lattice(basis_vectors=[[0, 1], [1, 0]], extent=[3, 3]),
+    nk.graph.Lattice(primitives=[[0, 1], [1, 0]], extent=[3, 3]),
     # Triangular
-    nk.graph.Lattice(basis_vectors=[[0, 1], [np.sqrt(3) / 2, 1 / 2]], extent=[3, 3]),
+    nk.graph.Lattice(primitives=[[0, 1], [np.sqrt(3) / 2, 1 / 2]], extent=[3, 3]),
     # Honeycomb
     nk.graph.Lattice(
-        basis_vectors=[[0, 1], [np.sqrt(3) / 2, 1 / 2]],
-        atoms_coord=[[1 / (2 * np.sqrt(3)), 1 / 2], [1 / np.sqrt(3), 1]],
+        primitives=[[0, 1], [np.sqrt(3) / 2, 1 / 2]],
+        basis=[[1 / (2 * np.sqrt(3)), 1 / 2], [1 / np.sqrt(3), 1]],
         extent=[3, 3],
     ),
     # Kagome
     nk.graph.Lattice(
-        basis_vectors=[[0, 1], [np.sqrt(3) / 2, 1 / 2]],
-        atoms_coord=[[0, 1 / 2], [np.sqrt(3) / 4, 1 / 4], [np.sqrt(3) / 4, 3 / 4]],
+        primitives=[[0, 1], [np.sqrt(3) / 2, 1 / 2]],
+        basis=[[0, 1 / 2], [np.sqrt(3) / 4, 1 / 4], [np.sqrt(3) / 4, 3 / 4]],
         extent=[3, 3],
     ),
     # Cube
-    nk.graph.Lattice(basis_vectors=[[1, 0, 0], [0, 1, 0], [0, 0, 1]], extent=[2, 2, 2]),
+    nk.graph.Lattice(primitives=[[1, 0, 0], [0, 1, 0], [0, 0, 1]], extent=[2, 2, 2]),
     # Body Centered Cubic
     nk.graph.Lattice(
-        basis_vectors=[[1, 0, 0], [0, 1, 0], [0, 0, 1]],
-        atoms_coord=[[0, 0, 0], [1 / 2, 1 / 2, 1 / 2]],
+        primitives=[[1, 0, 0], [0, 1, 0], [0, 0, 1]],
+        basis=[[0, 0, 0], [1 / 2, 1 / 2, 1 / 2]],
         extent=[2, 2, 2],
     ),
 ]
@@ -195,7 +195,7 @@ def test_draw_lattices():
     # Just checking that lattices are drawn:
     lattices = [graph for graph in graphs if isinstance(graph, Lattice)]
     for lattice in lattices:
-        ndim = len(lattice._atoms[0]["r_coord"])
+        ndim = lattice.ndim
         if ndim not in [1, 2]:
             with pytest.raises(ValueError):
                 lattice.draw()
@@ -462,12 +462,12 @@ def test_symmgroup():
 
 def test_duplicate_atoms():
     lattice = Lattice(
-        basis_vectors=[[1.0, 0.0], [1.0 / 2.0, math.sqrt(3) / 2.0]],
+        primitives=[[1.0, 0.0], [1.0 / 2.0, math.sqrt(3) / 2.0]],
         extent=[10, 10],
         pbc=[False, False],
-        atoms_coord=[[0, 0], [0, 0]],
+        basis=[[0, 0], [0, 0]],
     )
-    assert np.all(lattice.atoms_coord == np.array([[0, 0]]))
+    assert np.all(lattice.basis == np.array([[0, 0]]))
 
 
 # def test_edge_color_accessor():

--- a/docs/docs/api.rst
+++ b/docs/docs/api.rst
@@ -22,6 +22,7 @@ Graph
    netket.graph.Edgeless
    netket.graph.Hypercube
    netket.graph.Lattice
+   netket.graph.lattice.LatticeSite
    netket.graph.Chain
    netket.graph.Grid
 


### PR DESCRIPTION
Since I've started to actively use `Lattice` in my own code recently, I have started a number of things in the interface that I think can be polished a bit.

In order to not burden you (specifically @chrisrothUT  and @attila-i-szabo) with a lot of change requests in subsequent PRs, I've implemented several of the API changes I would like to see myself and propose them here as PR so we can discuss this early (also picking up some of the things that were left open when merging PR #702) and have a solid base for finalizing the symmetries (which this PR just moves around).

While it may look like a lot of changes, this PR is mostly just rearrangement and renaming with the aim of making the lattice interface more intuitive and also making the `Lattice` implementation easier to follow.

### ID, position, and cell coords

Most importantly, I am trying to have the API use consistent terms for the different ways of referring to a lattice site or its location as mentions of position, coordinates, cell, label, etc. can easily get confusing otherwise.

Specifically, I propose the following naming convention which is described by the new `Lattice` docstring:
https://github.com/netket/netket/blob/eb2c496ac55d41436b1a43313821d7ddddd1373d/netket/graph/lattice.py#L200-L235

I think by using these terms consistently in the interface and having a symmetrical naming convention for look-up functions (`id_from_position`, `id_from_cell_coords`) the API becomes much easier to use.

### Use the usual names for primitive vectors and basis

I propose we use "primitive vectors" (`primitives`) for the unit cell translations and "basis" for the positions of the sites contained within one unit cell. This convention is quite standard in the solid state and crystallography literature, so I think its easiest if we stick to that here.

Also, I've replaced the mentions of "atom" with site as this is more general.

### Hashing / position-based lookup

As discussed in https://github.com/netket/netket/pull/702#discussion_r632435892, I've removed the references to "hashing" (as this is mostly an implementation detail of the `dict` lookup) and also extracted the `id_from_position` function (which is generally useful and thus should not be hidden in the internal API).



I hope these changes are not causing too many merge conflicts in anyone's code at the moment, otherwise I apologize, but I'd be very happy to get the `Lattice` interface polished before we finalize our work on the symmetries.

Let me know what you think.
