### PR TITLE
MPI distribute to_array (Aka: Improve exact sampling)

### DIFF
--- a/Test/nn/utils.py
+++ b/Test/nn/utils.py
@@ -1,0 +1,92 @@
+import pytest
+
+import jax
+import jax.numpy as jnp
+import jax.flatten_util
+import numpy as np
+from functools import partial
+import itertools
+
+import tarfile
+import glob
+from io import BytesIO
+
+from flax import serialization
+
+import netket as nk
+
+from .. import common
+
+SEED = 111
+
+
+@pytest.fixture(params=[pytest.param(M, id=f"Fock(M={M})") for M in [0, 3, 5, 7, 9]])
+def vstate(request):
+    M = request.param
+    # keep this a prime number so we get different sizes on every rank...
+    hi = nk.hilbert.Fock(7, 1)
+
+    ma = nk.models.RBM(
+        alpha=1,
+        dtype=float,
+        hidden_bias_init=nk.nn.initializers.normal(),
+        visible_bias_init=nk.nn.initializers.normal(),
+    )
+
+    return nk.variational.MCState(
+        nk.sampler.MetropolisLocal(hi),
+        ma,
+    )
+
+
+@pytest.mark.parametrize("normalize", [True, False])
+def test_to_array(vstate, normalize):
+    psi = vstate.to_array(normalize=normalize)
+
+    if normalize:
+        np.testing.assert_allclose(jnp.linalg.norm(psi), 1.0)
+
+    psi_norm = psi / jnp.linalg.norm(psi)
+
+    assert psi.shape == (vstate.hilbert.n_states,)
+
+    x = vstate.hilbert.all_states()
+    psi_exact = jnp.exp(vstate.log_value(x))
+    psi_exact = psi_exact / jnp.linalg.norm(psi_exact)
+
+    np.testing.assert_allclose(psi_norm, psi_exact)
+
+
+@pytest.fixture(params=[pytest.param(M, id=f"Fock(M={M})") for M in [0, 5, 9]])
+def vstate_rho(request):
+    M = request.param
+    # keep this a prime number so we get different sizes on every rank...
+    hi = nk.hilbert.Fock(7, 1)
+
+    ma = nk.models.NDM()
+
+    return nk.variational.MCMixedState(
+        nk.sampler.MetropolisLocal(nk.hilbert.DoubledHilbert(hi)),
+        ma,
+    )
+
+
+@pytest.mark.parametrize("normalize", [True, False])
+def test_to_matrix(vstate_rho, normalize):
+    rho = vstate_rho.to_matrix(normalize=normalize)
+
+    if normalize:
+        np.testing.assert_allclose(jnp.trace(rho), 1.0)
+
+    rho_norm = rho / jnp.trace(rho)
+
+    assert rho.shape == (
+        vstate_rho.hilbert.physical.n_states,
+        vstate_rho.hilbert.physical.n_states,
+    )
+
+    x = vstate_rho.hilbert.all_states()
+    rho_exact = jnp.exp(vstate_rho.log_value(x)).reshape(rho.shape)
+    rho_exact = rho_exact / jnp.trace(rho_exact)
+
+    np.testing.assert_allclose(rho_norm, rho_exact)

--- a/netket/nn/__init__.py
+++ b/netket/nn/__init__.py
@@ -63,48 +63,4 @@ from flax.linen import Embed
 
 from flax.linen import compact
 
-
-def to_array(hilbert, machine, params, normalize=True):
-    import numpy as np
-    from jax import numpy as jnp
-    from netket.utils import get_afun_if_module
-
-    machine = get_afun_if_module(machine)
-
-    if hilbert.is_indexable:
-        xs = hilbert.all_states()
-        psi = machine(params, xs)
-        logmax = psi.real.max()
-        psi = jnp.exp(psi - logmax)
-
-        if normalize:
-            norm = jnp.linalg.norm(psi)
-            psi /= norm
-
-        return psi
-    else:
-        raise RuntimeError("The hilbert space is not indexable")
-
-
-def to_matrix(hilbert, machine, params, normalize=True):
-    import numpy as np
-    from jax import numpy as jnp
-    from netket.utils import get_afun_if_module
-
-    machine = get_afun_if_module(machine)
-
-    if hilbert.is_indexable:
-        xs = hilbert.all_states()
-        psi = machine(params, xs)
-        logmax = psi.real.max()
-        psi = jnp.exp(psi - logmax)
-
-        L = hilbert.physical.n_states
-        rho = psi.reshape((L, L))
-        if normalize:
-            trace = jnp.trace(rho)
-            rho /= trace
-
-        return rho
-    else:
-        raise RuntimeError("The hilbert space is not indexable")
+from .utils import to_array, to_matrix

--- a/netket/nn/utils.py
+++ b/netket/nn/utils.py
@@ -1,0 +1,81 @@
+from functools import partial
+
+import numpy as np
+from jax import numpy as jnp
+from netket.utils import get_afun_if_module
+from netket.utils import mpi
+import jax
+
+
+def to_array(hilbert, apply_fun, variables, normalize=True):
+
+    if not hilbert.is_indexable:
+        raise RuntimeError("The hilbert space is not indexable")
+
+    apply_fun = get_afun_if_module(apply_fun)
+
+    # mpi4jax does not have (yet) allgatherv so we need to be creative
+    # could be made easier if we update mpi4jax
+    n_states = hilbert.n_states
+    n_states_fake = int(np.ceil(n_states / mpi.n_nodes)) * mpi.n_nodes
+    n_fake_states = n_states_fake - n_states
+    states_n = np.arange(n_states)
+    fake_states_n = np.arange(n_states_fake - n_states)
+
+    # divide the hilbert space in chunks for each node
+    states_per_rank = np.split(np.concatenate([states_n, fake_states_n]), mpi.n_nodes)
+
+    xs = hilbert.numbers_to_states(states_per_rank[mpi.rank])
+    return _to_array_rank(apply_fun, variables, xs, n_states, normalize)
+
+
+@partial(jax.jit, static_argnums=(0, 3, 4))
+def _to_array_rank(apply_fun, variables, σ_rank, n_states, normalize):
+    """
+    Computes apply_fun(variables, σ_rank) and gathers all results across all ranks.
+    The input σ_rank should be a slice of all states in the hilbert space of equal
+    length across all ranks because mpi4jax does not support allgatherv (yet).
+
+    n_states: total number of elements in the hilbert space
+    """
+    # number of 'fake' states, in the last rank.
+    n_fake_states = σ_rank.shape[0] * mpi.n_nodes - n_states
+
+    psi_local = apply_fun(variables, σ_rank)
+
+    # last rank, get rid of fake elements
+    if mpi.rank == mpi.n_nodes - 1 and n_fake_states > 0:
+        psi_local = jax.ops.index_update(psi_local, jax.ops.index[-n_fake_states:], 0.0)
+
+    logmax, _ = mpi.mpi_max_jax(psi_local.real.max())
+    psi_local = jnp.exp(psi_local - logmax)
+
+    # compute normalization
+    if normalize:
+        norm2 = jnp.linalg.norm(psi_local) ** 2
+        norm2, _ = mpi.mpi_sum_jax(norm2)
+
+        psi_local /= jnp.sqrt(norm2)
+
+    psi, _ = mpi.mpi_allgather_jax(psi_local)
+    psi = psi.reshape(-1)
+
+    # remove fake states
+    psi = psi[0:n_states]
+    return psi
+
+
+def to_matrix(hilbert, machine, params, normalize=True):
+
+    if not hilbert.is_indexable:
+        raise RuntimeError("The hilbert space is not indexable")
+
+    psi = to_array(hilbert, machine, params, normalize=False)
+
+    L = hilbert.physical.n_states
+    rho = psi.reshape((L, L))
+    if normalize:
+        trace = jnp.trace(rho)
+        rho /= trace
+
+    return rho


### PR DESCRIPTION
This is another patch i am bored of carrying in my branches. It's been field tested for a while now.

It distributes to_array() across several MPI ranks by splitting the hilbert space in chunks.
mpi4jax does not support `MPI.Allgatherv` and won't in the near future so the implemnetation is a bit more complicated than what could be.

This speeds up enourmously `ExactSampler` under MPI