### PR TITLE
Test docstring examples as part of CI runs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,15 +21,23 @@ jobs:
 
           - os: ubuntu-latest
             python-version: 3.8
-            mpi: "mpich"
-
-          - os: macos-latest
-            python-version: 3.8
-            mpi: "mpich"
-
-          - os: macos-latest
-            python-version: 3.8
             mpi: ""
+            doctest: true
+
+          - os: ubuntu-latest
+            python-version: 3.8
+            mpi: "mpich"
+            main_tests: true
+
+          - os: macos-latest
+            python-version: 3.8
+            mpi: "mpich"
+            main_tests: true
+
+          - os: ubuntu-latest
+            python-version: 3.7
+            mpi: ""
+            main_tests: true
 
         #python-version: [3.6, 3.7, 3.8]
         #os: [ubuntu-latest, macos-latest]
@@ -67,15 +75,15 @@ jobs:
           fi
 
       - name: Netket tests
-        if: ${{ !matrix.legacy }}
+        if: ${{ matrix.main_tests }}
         run : |
           export NETKET_EXPERIMENTAL=1
           pytest --cov=netket --cov-append Test
 
       - name: NetKet docstring tests
-        if: ${{ !matrix.legacy }}
+        if: ${{ matrix.doctest }}
         run: |
-          pytest --doctest-modules netket/ --ignore-glob="netket/legacy/**"
+          pytest --doctest-continue-on-failure --doctest-modules netket/ --ignore-glob="netket/legacy/**"
 
       - name: Netket Legacy tests
         if: ${{ matrix.legacy }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -72,6 +72,11 @@ jobs:
           export NETKET_EXPERIMENTAL=1
           pytest --cov=netket --cov-append Test
 
+      - name: NetKet docstring tests
+        if: ${{ !matrix.legacy }}
+        run: |
+          pytest --doctest-modules netket/ --ignore-glob="netket/legacy/**"
+
       - name: Netket Legacy tests
         if: ${{ matrix.legacy }}
         run : |

--- a/netket/_exact_dynamics.py
+++ b/netket/_exact_dynamics.py
@@ -112,21 +112,21 @@ class PyExactTimePropagation:
            Examples:
                Solving 1D Ising model with imaginary time propagation:
 
-               ```python
                >>> import netket as nk
                >>> import numpy as np
                >>> L = 8
                >>> graph = nk.graph.Hypercube(L, n_dim=1, pbc=True)
-               >>> hilbert = nk.hilbert.Spin(graph, 1/2)
-               >>> n_states = hilbert.n_states
-               >>> hamiltonian = nk.operator.Ising(hilbert, h=1.0)
-               >>> psi0 = np.random.rand(n_states)
-               >>> driver = nk.exact.PyExactTimePropagation(hamiltonian, stepper, t0=0,
+               >>> hi = nk.hilbert.Spin(1/2, N=graph.n_nodes)
+               >>> hamiltonian = nk.operator.Ising(hi, h=1.0, graph=graph)
+               >>> psi0 = np.ones(hi.n_states)
+               >>> driver = nk.exact.PyExactTimePropagation(hamiltonian, t0=0, dt=0.1,
                ...                                          initial_state=psi0,
                ...                                          propagation_type="imaginary")
-               >>> for step in driver.iter(dt=0.05, n_iter=20):
+               >>> for step in driver.iter(n_iter=3):
                ...     print(driver.estimate(hamiltonian))
-               ```
+               -2.048e+03 ± 0.000e+00 [σ²=-4.176e+06]
+               -1.107e+01 ± 0.000e+00 [σ²=-1.756e+01]
+               -9.860e+00 ± 0.000e+00 [σ²=-9.977e-01]
         """
         if isinstance(hamiltonian, _nk.operator.AbstractOperator):
             self._h_op = _make_op(hamiltonian, matrix_type)

--- a/netket/exact.py
+++ b/netket/exact.py
@@ -56,7 +56,7 @@ def lanczos_ed(
         s
         >>> import netket as nk
         >>> hi = nk.hilbert.Spin(s=1/2)**8
-        >>> hamiltonian = nk.operator.Ising(hi, h=1.0)
+        >>> hamiltonian = nk.operator.Ising(hi, h=1.0, graph=nk.graph.Chain(8))
         >>> w = nk.exact.lanczos_ed(hamiltonian, k=3)
         >>> w
         array([-10.25166179, -10.05467898,  -8.69093921])
@@ -100,8 +100,8 @@ def full_ed(operator: AbstractOperator, *, compute_eigenvectors: bool = False):
         Test for 1D Ising chain with 8 sites.
 
         >>> import netket as nk
-        >>> hi = nk.hilbert.Spin(nk.graph.Chain(8), s=1/2)
-        >>> hamiltonian = nk.operator.Ising(hi, h=1.0)
+        >>> hi = nk.hilbert.Spin(s=1/2)**8
+        >>> hamiltonian = nk.operator.Ising(hi, h=1.0, graph=nk.graph.Chain(8))
         >>> w = nk.exact.full_ed(hamiltonian)
         >>> w.shape
         (256,)

--- a/netket/graph/lattice.py
+++ b/netket/graph/lattice.py
@@ -300,7 +300,21 @@ class Lattice(NetworkX):
             ... ])
             >>> g = Lattice(basis_vectors=basis, site_offsets=cell, extent=[3, 3])
             >>> print(g.n_nodes)
-            192
+            27
+            >>> print(g.basis_coords[:6])
+            [[0 0 0]
+             [0 0 1]
+             [0 0 2]
+             [0 1 0]
+             [0 1 1]
+             [0 1 2]]
+             >>> print(g.positions[:6])
+             [[0.5        0.        ]
+              [0.25       0.4330127 ]
+              [0.75       0.4330127 ]
+              [1.         0.8660254 ]
+              [0.75       1.29903811]
+              [1.25       1.29903811]]
         """
 
         self._basis_vectors = self._clean_basis(basis_vectors)
@@ -432,16 +446,12 @@ class Lattice(NetworkX):
     # ------------------------------------------------------------------------
     @property
     def basis_vectors(self):
-        """
-        Basis vectors of the lattice
-        """
+        """Basis vectors of the lattice"""
         return self._basis_vectors
 
     @property
     def site_offsets(self):
-        """
-        Position offsets of sites in the unit cell
-        """
+        """Position offsets of sites in the unit cell"""
         return self._site_offsets
 
     @property
@@ -451,28 +461,32 @@ class Lattice(NetworkX):
 
     @property
     def pbc(self):
+        """
+        Array of bools such that `pbc[d]` indicates whether dimension d has
+        periodic boundaries.
+        """
         return self._pbc
 
     @property
     def extent(self):
+        """
+        Extent of the lattice
+        """
         return self._extent
 
     @property
     def sites(self) -> Sequence[LatticeSite]:
+        """Sequence of lattice site objects"""
         return self._sites
 
     @property
     def positions(self) -> PositionT:
-        """
-        Real-space positions of all lattice sites
-        """
+        """Real-space positions of all lattice sites"""
         return self._positions
 
     @property
     def basis_coords(self) -> CoordT:
-        """
-        basis coordinates of all lattice sites
-        """
+        """basis coordinates of all lattice sites"""
         return self._basis_coords
 
     # Site lookup

--- a/netket/hilbert/abstract_hilbert.py
+++ b/netket/hilbert/abstract_hilbert.py
@@ -193,11 +193,14 @@ class AbstractHilbert(abc.ABC):
 
         Example:
 
+            >>> import netket, jax
             >>> hi = netket.hilbert.Qubit(N=2)
-            >>> hi.random_state(jax.random.PRNGKey(0))
-            array([0., 1.])
-            >>> hi.random_state(size=2)
-            array([[0., 0.], [1., 0.]])
+            >>> k1, k2 = jax.random.split(jax.random.PRNGKey(1))
+            >>> print(hi.random_state(key=k1))
+            [1. 0.]
+            >>> print(hi.random_state(key=k2, size=2))
+            [[0. 0.]
+             [0. 1.]]
         """
         # legacy support
         # TODO: Remove in 3.1

--- a/netket/hilbert/custom_hilbert.py
+++ b/netket/hilbert/custom_hilbert.py
@@ -72,9 +72,9 @@ class CustomHilbert(AbstractHilbert):
         Examples:
            Simple custom hilbert space.
 
-           >>> from netket.hilbert import CustomHilbert
-           >>> g = Hypercube(length=10,n_dim=2,pbc=True)
-           >>> hi = CustomHilbert(local_states=[-1232, 132, 0], N=100)
+           >>> import netket
+           >>> g = netket.graph.Hypercube(length=10,n_dim=2,pbc=True)
+           >>> hi = netket.hilbert.CustomHilbert(local_states=[-1232, 132, 0], N=100)
            >>> print(hi.size)
            100
         """

--- a/netket/hilbert/doubled_hilbert.py
+++ b/netket/hilbert/doubled_hilbert.py
@@ -35,12 +35,12 @@ class DoubledHilbert(AbstractHilbert):
         Examples:
             Simple superoperatorial hilbert space for few spins.
 
-           >>> from netket.hilbert import Spin, DoubledHilbert
-           >>> g = Hypercube(length=5,n_dim=2,pbc=True)
-           >>> hi = Spin(N=3, s=0.5)
-           >>> hi2 = DoubledHilbert(hi)
+           >>> import netket as nk
+           >>> g = nk.graph.Hypercube(length=5,n_dim=2,pbc=True)
+           >>> hi = nk.hilbert.Spin(N=3, s=0.5)
+           >>> hi2 = nk.hilbert.DoubledHilbert(hi)
            >>> print(hi2.size)
-           50
+           6
         """
         self.physical = hilb
         self._size = 2 * hilb.size

--- a/netket/hilbert/fock.py
+++ b/netket/hilbert/fock.py
@@ -55,10 +55,12 @@ class Fock(CustomHilbert):
         Examples:
            Simple boson hilbert space.
 
-           >>> from netket.hilbert import Boson
-           >>> hi = Boson(n_max=5, n_particles=11, N=3)
+           >>> from netket.hilbert import Fock
+           >>> hi = Fock(n_max=5, n_particles=11, N=3)
            >>> print(hi.size)
            3
+           >>> print(hi.n_states)
+           15
         """
         N = graph_to_N_depwarn(N=N, graph=graph)
 

--- a/netket/hilbert/homogeneous.py
+++ b/netket/hilbert/homogeneous.py
@@ -73,9 +73,9 @@ class HomogeneousHilbert(AbstractHilbert):
         Examples:
            Simple custom hilbert space.
 
-           >>> from netket.hilbert import CustomHilbert
-           >>> g = Hypercube(length=10,n_dim=2,pbc=True)
-           >>> hi = CustomHilbert(local_states=[-1232, 132, 0], N=100)
+           >>> import netket as nk
+           >>> g = nk.graph.Hypercube(length=10,n_dim=2,pbc=True)
+           >>> hi = nk.hilbert.homogeneous.HomogeneousHilbert(local_states=[-1232, 132, 0], N=100)
            >>> print(hi.size)
            100
         """

--- a/netket/hilbert/qubit.py
+++ b/netket/hilbert/qubit.py
@@ -36,10 +36,8 @@ class Qubit(CustomHilbert):
         Examples:
             Simple spin hilbert space.
 
-            >>> from netket.graph import Hypercube
             >>> from netket.hilbert import Qubit
-            >>> g = Hypercube(length=10,n_dim=2,pbc=True)
-            >>> hi = Qubit(graph=g)
+            >>> hi = Qubit(N=100)
             >>> print(hi.size)
             100
         """

--- a/netket/hilbert/random/base.py
+++ b/netket/hilbert/random/base.py
@@ -31,11 +31,14 @@ def random_state(hilb, key, size=None, dtype=np.float32):
             number generator is used.
 
     Example:
+
+        >>> import netket, jax
         >>> hi = netket.hilbert.Qubit(N=2)
-        >>> hi.random_state()
-        array([0., 1.])
-        >>> hi.random_state(size=2)
-        array([[0., 0.], [1., 0.]])
+        >>> print(hi.random_state(key=jax.random.PRNGKey(0)))
+        [1. 0.]
+        >>> print(hi.random_state(size=2, key=jax.random.PRNGKey(1)))
+        [[0. 1.]
+         [0. 0.]]
     """
     if size is None:
         return random_state_scalar(hilb, key, dtype)

--- a/netket/hilbert/spin.py
+++ b/netket/hilbert/spin.py
@@ -79,9 +79,8 @@ class Spin(CustomHilbert):
         Examples:
            Simple spin hilbert space.
 
-           >>> from netket.hilbert import Spin
-           >>> g = Hypercube(length=10,n_dim=2,pbc=True)
-           >>> hi = Spin(s=0.5, N=4)
+           >>> import netket as nk
+           >>> hi = nk.hilbert.Spin(s=1/2, N=4)
            >>> print(hi.size)
            4
         """

--- a/netket/jax/_grad.py
+++ b/netket/jax/_grad.py
@@ -83,7 +83,7 @@ def grad(
     >>>
     >>> grad_tanh = jax.grad(jax.numpy.tanh)
     >>> print(grad_tanh(0.2))
-    0.961043
+    0.9610429829661166
     """
     value_and_grad_f = value_and_grad(
         fun, argnums, has_aux=has_aux, allow_int=allow_int

--- a/netket/logging/tensorboard.py
+++ b/netket/logging/tensorboard.py
@@ -85,6 +85,8 @@ class TBLog:
     Examples:
         Logging optimisation to tensorboard.
 
+        >>> import pytest; pytest.skip("skip automated test of this docstring")
+        >>>
         >>> import netket as nk
         >>> # create a summary writer with automatically generated folder name.
         >>> writer = nk.logging.TBLog()

--- a/netket/operator/_graph_operator.py
+++ b/netket/operator/_graph_operator.py
@@ -60,7 +60,7 @@ class GraphOperator(LocalOperator):
              The default is None. Note that if no bond_ops are
              specified, the user must give a list of site operators.
          bond_ops_colors: A list of edge colors, specifying the color each
-             bond operator acts on. The defualt is an empty list.
+             bond operator acts on. The default is an empty list.
 
         Examples:
          Constructs a ``GraphOperator`` operator for a 2D system.
@@ -71,12 +71,12 @@ class GraphOperator(LocalOperator):
          >>> edges = [[0, 1], [1, 2], [2, 3], [3, 4], [4, 5], [5, 6], [6, 7], [7, 8],
          ... [8, 9], [9, 10], [10, 11], [11, 12], [12, 13], [13, 14], [14, 15],
          ... [15, 16], [16, 17], [17, 18], [18, 19], [19, 0]]
-         >>> g = nk.graph.CustomGraph(edges=edges)
-         >>> hi = nk.hilbert.CustomHilbert(local_states=[-1, 1], graph=g)
+         >>> g = nk.graph.Graph(edges=edges)
+         >>> hi = nk.hilbert.CustomHilbert(local_states=[-1, 1], N=g.n_nodes)
          >>> op = nk.operator.GraphOperator(
-         ... hi, site_ops=[sigmax], bond_ops=[mszsz])
-         >>> print(op.hilbert.size)
-         20
+         ... hi, site_ops=[sigmax], bond_ops=[mszsz], graph=g)
+         >>> print(op)
+         GraphOperator(dim=20, #acting_on=40 locations, constant=0, dtype=float64, graph=NetworkX(n_nodes=20))
         """
 
         if graph.n_nodes != hilbert.size:
@@ -87,7 +87,7 @@ class GraphOperator(LocalOperator):
 
         # Ensure that at least one of SiteOps and BondOps was initialized
         if len(bond_ops) == 0 and len(site_ops) == 0:
-            raise InvalidInputError("Must input at least site_ops or bond_ops.")
+            raise ValueError("Must input at least site_ops or bond_ops.")
 
         # Create the local operator as the sum of all site and bond operators
         operators = []
@@ -103,7 +103,7 @@ class GraphOperator(LocalOperator):
         # Bond operators
         if len(bond_ops_colors) > 0:
             if len(bond_ops) != len(bond_ops_colors):
-                raise InvalidInputError(
+                raise ValueError(
                     """The GraphHamiltonian definition is inconsistent.
                     The sizes of bond_ops and bond_ops_colors do not match."""
                 )

--- a/netket/operator/_hamiltonian.py
+++ b/netket/operator/_hamiltonian.py
@@ -132,10 +132,10 @@ class Ising(SpecialHamiltonian):
 
             >>> import netket as nk
             >>> g = nk.graph.Hypercube(length=20, n_dim=1, pbc=True)
-            >>> hi = nk.hilbert.Spin(s=0.5, graph=g)
-            >>> op = nk.operator.Ising(h=1.321, hilbert=hi, J=0.5)
-            >>> print(op.hilbert.size)
-            20
+            >>> hi = nk.hilbert.Spin(s=0.5, N=g.n_nodes)
+            >>> op = nk.operator.Ising(h=1.321, hilbert=hi, J=0.5, graph=g)
+            >>> print(op)
+            Ising(J=0.5, h=1.321; dim=20)
         """
         assert (
             graph.n_nodes == hilbert.size
@@ -385,10 +385,10 @@ class Heisenberg(GraphOperator):
 
             >>> import netket as nk
             >>> g = nk.graph.Hypercube(length=20, n_dim=1, pbc=True)
-            >>> hi = nk.hilbert.Spin(s=0.5, total_sz=0, graph=g)
-            >>> op = nk.operator.Heisenberg(hilbert=hi)
-            >>> print(op.hilbert.size)
-            20
+            >>> hi = nk.hilbert.Spin(s=0.5, total_sz=0, N=g.n_nodes)
+            >>> op = nk.operator.Heisenberg(hilbert=hi, graph=g)
+            >>> print(op)
+            Heisenberg(J=1, sign_rule=True; dim=20)
         """
         if sign_rule is None:
             sign_rule = graph.is_bipartite()

--- a/netket/operator/_local_operator.py
+++ b/netket/operator/_local_operator.py
@@ -223,7 +223,7 @@ class LocalOperator(AbstractOperator):
 
            >>> from netket.hilbert import CustomHilbert
            >>> from netket.operator import LocalOperator
-           >>> hi = CustomHilbert(local_states=[1, -1])**20
+           >>> hi = CustomHilbert(local_states=[-1, 1])**20
            >>> empty_hat = LocalOperator(hi)
            >>> print(len(empty_hat.acting_on))
            0

--- a/netket/sampler/metropolis.py
+++ b/netket/sampler/metropolis.py
@@ -452,20 +452,17 @@ def MetropolisExchange(
 
     Examples:
           Sampling from a RBM machine in a 1D lattice of spin 1/2, using
-          nearest-neighbours exchanges.
+          nearest-neighbor exchanges.
 
           >>> import netket as nk
           >>>
           >>> g=nk.graph.Hypercube(length=10,n_dim=2,pbc=True)
-          >>> hi=nk.hilbert.Spin(s=0.5,graph=g)
-          >>>
-          >>> # RBM Spin Machine
-          >>> ma = nk.machine.RbmSpin(alpha=1, hilbert=hi)
+          >>> hi=nk.hilbert.Spin(s=0.5, N=g.n_nodes)
           >>>
           >>> # Construct a MetropolisExchange Sampler
-          >>> sa = nk.sampler.MetropolisExchange(machine=ma)
-          >>> print(sa.machine.hilbert.size)
-          100
+          >>> sa = nk.sampler.MetropolisExchange(hi, graph=g)
+          >>> print(sa)
+          MetropolisSampler(rule = ExchangeRule(# of clusters: 200), n_chains = 16, machine_power = 2, n_sweeps = 100, dtype = <class 'numpy.float64'>)
     """
     rule = ExchangeRule(clusters=clusters, graph=graph, d_max=d_max)
     return MetropolisSampler(hilbert, rule, *args, **kwargs)
@@ -512,16 +509,15 @@ def MetropolisHamiltonian(hilbert, hamiltonian, *args, **kwargs) -> MetropolisSa
        >>> import netket as nk
        >>>
        >>> g=nk.graph.Hypercube(length=10,n_dim=2,pbc=True)
-       >>> hi=nk.hilbert.Spin(s=0.5,graph=g)
-       >>>
-       >>> # RBM Spin Machine
-       >>> ma = nk.machine.RbmSpin(alpha=1, hilbert=hi)
+       >>> hi=nk.hilbert.Spin(s=0.5, N=g.n_nodes)
        >>>
        >>> # Transverse-field Ising Hamiltonian
-       >>> ha = nk.operator.Ising(hilbert=hi, h=1.0)
+       >>> ha = nk.operator.Ising(hilbert=hi, h=1.0, graph=g)
        >>>
-       >>> # Construct a MetropolisHamiltonian Sampler
-       >>> sa = nk.sampler.MetropolisHamiltonian(machine=ma,hamiltonian=ha)
+       >>> # Construct a MetropolisExchange Sampler
+       >>> sa = nk.sampler.MetropolisHamiltonian(hi, hamiltonian=ha)
+       >>> print(sa)
+       MetropolisSampler(rule = HamiltonianRule(Ising(J=1.0, h=1.0; dim=100)), n_chains = 16, machine_power = 2, n_sweeps = 100, dtype = <class 'numpy.float64'>)
     """
     rule = HamiltonianRule(hamiltonian)
     return MetropolisSampler(hilbert, rule, *args, **kwargs)

--- a/netket/sampler/metropolis_pt.py
+++ b/netket/sampler/metropolis_pt.py
@@ -518,18 +518,17 @@ def MetropolisExchangePt(hilbert, *args, clusters=None, graph=None, d_max=1, **k
           Sampling from a RBM machine in a 1D lattice of spin 1/2, using
           nearest-neighbours exchanges.
 
+          >>> import pytest; pytest.skip("EXPERIMENTAL")
           >>> import netket as nk
+          >>> import netket.sampler.metropolis_pt as mpt
           >>>
           >>> g=nk.graph.Hypercube(length=10,n_dim=2,pbc=True)
-          >>> hi=nk.hilbert.Spin(s=0.5,graph=g)
-          >>>
-          >>> # RBM Spin Machine
-          >>> ma = nk.machine.RbmSpin(alpha=1, hilbert=hi)
+          >>> hi=nk.hilbert.Spin(s=0.5, N=g.n_nodes)
           >>>
           >>> # Construct a MetropolisExchange Sampler
-          >>> sa = nk.sampler.MetropolisExchange(machine=ma)
-          >>> print(sa.machine.hilbert.size)
-          100
+          >>> sa = mpt.MetropolisExchangePt(hi, graph=g)
+          >>> print(sa)
+          MetropolisSampler(rule = ExchangeRule(# of clusters: 200), n_chains = 16, machine_power = 2, n_sweeps = 100, dtype = <class 'numpy.float64'>)
     """
     rule = ExchangeRule(clusters=clusters, graph=graph, d_max=d_max)
     return MetropolisPtSampler(hilbert, rule, *args, **kwargs)
@@ -572,19 +571,20 @@ def MetropolisHamiltonianPt(hilbert, hamiltonian, *args, **kwargs):
     Examples:
        Sampling from a RBM machine in a 1D lattice of spin 1/2
 
+       >>> import pytest; pytest.skip("EXPERIMENTAL")
        >>> import netket as nk
+       >>> import netket.sampler.metropolis_pt as mpt
        >>>
        >>> g=nk.graph.Hypercube(length=10,n_dim=2,pbc=True)
-       >>> hi=nk.hilbert.Spin(s=0.5,graph=g)
-       >>>
-       >>> # RBM Spin Machine
-       >>> ma = nk.machine.RbmSpin(alpha=1, hilbert=hi)
+       >>> hi=nk.hilbert.Spin(s=0.5, N=g.n_nodes)
        >>>
        >>> # Transverse-field Ising Hamiltonian
-       >>> ha = nk.operator.Ising(hilbert=hi, h=1.0)
+       >>> ha = nk.operator.Ising(hilbert=hi, h=1.0, graph=g)
        >>>
-       >>> # Construct a MetropolisHamiltonian Sampler
-       >>> sa = nk.sampler.MetropolisHamiltonian(machine=ma,hamiltonian=ha)
+       >>> # Construct a MetropolisExchange Sampler
+       >>> sa = mpt.MetropolisHamiltonianPt(hi, hamiltonian=ha)
+       >>> print(sa)
+       MetropolisSampler(rule = HamiltonianRule(Ising(J=1.0, h=1.0; dim=100)), n_chains = 16, machine_power = 2, n_sweeps = 100, dtype = <class 'numpy.float64'>)
     """
     rule = HamiltonianRule(hamiltonian)
     return MetropolisPtSampler(hilbert, rule, *args, **kwargs)

--- a/netket/variational/experimental.py
+++ b/netket/variational/experimental.py
@@ -25,25 +25,25 @@ def variables_from_file(filename: str, variables: _PyTree):
        >>> import flax
        >>> # construct an RBM model on 10 spins
        >>> vstate = nk.variational.MCState(
-                nk.sampler.MetropolisLocal(nk.hilbert.Spin(0.5)**10),
-                nk.models.RBM())
-       >>> with open("test.mpack", 'w') as file:
-       >>>     file.write(flax.serialization.to_bytes(vstate))
-
-       Deserializing the data:
-
-       >>> import netket as nk
-       >>> import flax
+       ...      nk.sampler.MetropolisLocal(nk.hilbert.Spin(0.5)**10),
+       ...      nk.models.RBM())
+       >>> with open("test.mpack", 'wb') as file:
+       ...     bytes_written = file.write(flax.serialization.to_bytes(vstate.variables))
+       >>> print(bytes_written)
+       1052
+       >>>
+       >>> # Deserialize the data
+       >>>
+       >>> del vstate
        >>> # construct an RBM model on 10 spins
-       >>> vstate = nk.variational.MCState(
-                nk.sampler.MetropolisLocal(nk.hilbert.Spin(0.5)**10),
-                nk.models.RBM())
+       >>> vstate2 = nk.variational.MCState(
+       ...      nk.sampler.MetropolisLocal(nk.hilbert.Spin(0.5)**10),
+       ...      nk.models.RBM())
        >>> # Load the data by passing the model
        >>> vars = nk.variational.experimental.variables_from_file("test.mpack",
-                                                                  vstate.variables)
+       ...                                                        vstate2.variables)
        >>> # update the variables of vstate with the loaded data.
-       >>> vstate.variables = vars
-
+       >>> vstate2.variables = vars
     """
     if not _path.isfile(filename):
         if filename[-6:] != ".mpack":
@@ -64,7 +64,6 @@ def variables_from_tar(filename: str, variables: _PyTree, i: int):
         variables: An object variables with the same structure and shape
             of the object to be deserialized.
         i: the index of the variables to load
-
     """
     if not _path.isfile(filename):
         if filename[-4:] != ".tar":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ write_to = "netket/_version.py"
 
 [tool.pytest.ini_options]
 addopts = "--color=yes --verbose --durations=0 -n auto"
+doctest_optionflags = "NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL NUMBER"
 filterwarnings = [
     "ignore::UserWarning",
     "ignore:No GPU/TPU found, falling back to CPU.:UserWarning",


### PR DESCRIPTION
This PR adds a step to out GitHub Actions CI runs which executes all example sections in our docstring comments in order to make sure they are up-to-date and working as expected (f221a30).

Unsurprisingly, this has unearthed a lot of failing examples (mostly because of using old API or incomplete imports) which are fixed here as well (10b1baa).

Note that if a docstring example really should not be tested, it can be skipped by adding
```
>>> import pytest; pytest.skip("reason")
```
as I've done here (only) for some `NETKET_EXPERIMENTAL` code.