### PR TITLE
Use igraph as underlying graph library

### DIFF
--- a/Test/Graph/test_graph.py
+++ b/Test/Graph/test_graph.py
@@ -7,7 +7,16 @@ from math import pi
 import numpy as np
 import igraph as ig
 
-from netket.graph import *
+from netket.graph import (
+    Graph,
+    Hypercube,
+    Grid,
+    Lattice,
+    Edgeless,
+    Triangular,
+    Honeycomb,
+    Kagome,
+)
 from netket.graph import _lattice
 from netket.utils import group
 
@@ -15,10 +24,10 @@ from .. import common
 
 pytestmark = common.skipif_mpi
 
-nxg = nx.star_graph(10)
 graphs = [
-    # star graph
-    Graph(edges=list(nxg.edges())),
+    # star and tree
+    Graph.from_igraph(ig.Graph.Star(5)),
+    Graph.from_igraph(ig.Graph.Tree(n=3, children=2)),
     # Grid graphs
     Hypercube(length=10, n_dim=1, pbc=True),
     Hypercube(length=4, n_dim=2, pbc=True),
@@ -256,20 +265,11 @@ def coord2index(xs, length):
     return i
 
 
-def check_edges(length, n_dim, pbc):
-    x = nx.grid_graph(dim=[length] * n_dim, periodic=pbc)
-    x_edges = [[coord2index(i, length) for i in edge] for edge in x.edges()]
-    x_edges = sorted([sorted(ed) for ed in x_edges])
-    y = nk.graph.Hypercube(length=length, n_dim=n_dim, pbc=pbc)
-    y_edges = sorted([sorted(ed) for ed in y.edges()])
-    assert x_edges == y_edges
-
-
 def test_graph_wrong():
     with pytest.raises(TypeError):
         nk.graph.Graph(5)
 
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         nk.graph.Graph([1, 2, 3], True)
 
     with pytest.raises(ValueError):
@@ -277,14 +277,24 @@ def test_graph_wrong():
 
 
 def test_edges_are_correct():
-    # check_edges(1, 1, False)
-    # check_edges(1, 2, False) # KDTree removes the single site
-    for length in [3, 4, 5]:
-        for dim in [1, 2, 3]:
+    def check_edges(length, n_dim, pbc):
+        x = nx.grid_graph(dim=[length] * n_dim, periodic=pbc)
+        x_edges = [[coord2index(i, length) for i in edge] for edge in x.edges()]
+        x_edges = sorted([sorted(ed) for ed in x_edges])
+        y = nk.graph.Hypercube(length=length, n_dim=n_dim, pbc=pbc)
+        y_edges = sorted([sorted(ed) for ed in y.edges()])
+        assert x_edges == y_edges
+
+    with pytest.raises(ValueError):
+        check_edges(1, 1, False)
+        check_edges(1, 2, False)
+
+    for length in [3, 4]:
+        for dim in [1, 2]:
             for pbc in [True, False]:
                 check_edges(length, dim, pbc)
     for pbc in [True, False]:
-        check_edges(3, 7, pbc)
+        check_edges(3, 5, pbc)
 
 
 def test_nodes():
@@ -341,7 +351,7 @@ def test_is_connected():
     for i in range(5, 10):
         for j in range(i + 1, i * i):
             x = nx.dense_gnm_random_graph(i, j)
-            y = nk.graph.Graph(nodes=list(x.nodes()), edges=list(x.edges()))
+            y = Graph.from_networkx(x)
 
             if len(x) == len(
                 set((i for (i, j) in x.edges)) | set((j for (i, j) in x.edges))
@@ -355,7 +365,7 @@ def test_is_bipartite():
     for i in range(1, 10):
         for j in range(1, i * i):
             x = nx.dense_gnm_random_graph(i, j)
-            y = nk.graph.Graph(nodes=list(x.nodes()), edges=list(x.edges()))
+            y = Graph.from_networkx(x)
             if len(x) == len(
                 set((i for (i, j) in x.edges())) | set((j for (i, j) in x.edges()))
             ):
@@ -439,18 +449,23 @@ def test_adjacency_list():
 #    assert sorted(g1.edges()) == sorted(g2.edges())
 
 
-# skip star graph because it has 10! (≈ 3 million) isomorphisms
-@pytest.mark.parametrize("graph", graphs[1:])
+@pytest.mark.parametrize("graph", graphs)
 def test_automorphisms(graph):
     if not graph.is_connected():
         return
 
-    g = ig.Graph(edges=graph.edges())
-    autom = g.get_isomorphisms_vf2()
-    autom_g = graph.automorphisms()
-    dim = len(autom_g)
-    for i in range(dim):
-        assert np.asarray(autom_g[i]).tolist() in autom
+    def is_automorphism(f, graph):
+        edges = graph.edges()
+        for v, w in edges:
+            fv, fw = f[v], f[w]
+            if (fv, fw) not in edges and (fw, fv) not in edges:
+                print(f"E  ({(v, w)} -> {(fv, fw)})")
+                return False
+        return True
+
+    autom = np.asarray(graph.automorphisms())
+    for f in autom:
+        assert is_automorphism(f, graph)
 
 
 def _check_symmgroup(autom, symmgroup):
@@ -624,7 +639,7 @@ def test_edge_color_accessor():
 
     g = Hypercube(4, 1)
 
-    assert [(i, j, None) for (i, j, _) in edges] == sorted(g.edges(color=True))
+    assert [(i, j, 0) for (i, j, _) in edges] == sorted(g.edges(color=True))
 
 
 def test_union():
@@ -635,3 +650,40 @@ def test_union():
 
         assert ug.n_nodes == graph1.n_nodes + graph.n_nodes
         assert ug.n_edges == graph1.n_edges + graph.n_edges
+
+
+def test_graph_conversions():
+    igraph = ig.Graph.Star(6)
+    g = Graph.from_igraph(igraph)
+    assert g.n_nodes == igraph.vcount()
+    assert g.edges() == igraph.get_edgelist()
+    assert all(c == 0 for c in g._edge_colors)
+
+    nxg = nx.star_graph(5)
+    g = Graph.from_networkx(nxg)
+    assert g.n_nodes == igraph.vcount()
+    assert g.edges() == igraph.get_edgelist()
+    assert all(c == 0 for c in g._edge_colors)
+
+    igraph = ig.Graph()
+    igraph.add_vertices(3)
+    igraph.add_edges(
+        [(0, 1), (1, 2)],
+        attributes={
+            "color": ["red", "blue"],
+        },
+    )
+    with pytest.raises(ValueError, match="not all colors are integers"):
+        _ = Graph.from_igraph(igraph)
+
+    igraph = ig.Graph()
+    igraph.add_vertices(3)
+    igraph.add_edges(
+        [(0, 1), (1, 2)],
+        attributes={
+            "color": [0, 1],
+        },
+    )
+    g = Graph.from_igraph(igraph)
+    assert g.edges(color=0) == [(0, 1)]
+    assert g.edges(color=1) == [(1, 2)]

--- a/Test/Models/test_mps.py
+++ b/Test/Models/test_mps.py
@@ -25,7 +25,7 @@ def test_mps(diag):
     ma = nk.models.MPSPeriodic(hilbert=hi, graph=g, bond_dim=2, diag=diag)
     sa = nk.sampler.MetropolisLocal(hilbert=hi, n_chains=16)
 
-    vs = nk.variational.MCState(sa, ma, n_samples=1000)
+    vs = nk.vqs.MCState(sa, ma, n_samples=1000)
 
     ha = nk.operator.Ising(hi, graph=g, h=1.0)
     op = nk.optimizer.Sgd(learning_rate=0.05)
@@ -33,3 +33,15 @@ def test_mps(diag):
     driver = nk.Vmc(ha, op, variational_state=vs)
 
     driver.run(3)
+
+
+def test_mps_nonchain():
+    g = nk.graph.Hypercube(3, 2)
+    hi = nk.hilbert.Spin(1 / 2, g.n_nodes)
+    with pytest.warns(
+        UserWarning,
+        match="graph is not isomorphic to chain with periodic boundary conditions",
+    ):
+        ma = nk.models.MPSPeriodic(hi, g, bond_dim=2)
+        sa = nk.sampler.MetropolisLocal(hilbert=hi, n_chains=16)
+        vs = nk.vqs.MCState(sa, ma, n_samples=1000)

--- a/netket/graph/__init__.py
+++ b/netket/graph/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from .abstract_graph import AbstractGraph
-from .graph import NetworkX, Graph, Edgeless, DoubledGraph, disjoint_union
+from .graph import Graph, Edgeless, DoubledGraph, disjoint_union
 from .lattice import Lattice
 from .common_lattices import (
     Grid,

--- a/netket/graph/abstract_graph.py
+++ b/netket/graph/abstract_graph.py
@@ -13,7 +13,12 @@
 # limitations under the License.
 
 import abc
-from typing import List, Generator, Iterator, Tuple
+from typing import List, Iterator, Sequence, Tuple, Union
+
+
+Edge = Tuple[int, int]
+ColoredEdge = Tuple[int, int, int]
+EdgeSequence = Union[Sequence[Edge], Sequence[ColoredEdge]]
 
 
 class AbstractGraph(abc.ABC):
@@ -30,8 +35,8 @@ class AbstractGraph(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def edges(self) -> Iterator[Tuple[int, int]]:
-        r"""Iterator over the edges of the graph"""
+    def edges(self, color: Union[bool, int] = False) -> EdgeSequence:
+        r"""Iterator over the edges of the graph. Optionally filter by edge color."""
         raise NotImplementedError
 
     @abc.abstractmethod

--- a/netket/graph/graph.py
+++ b/netket/graph/graph.py
@@ -12,180 +12,171 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Generator, Union
+from typing import List, Optional, Sequence, Union
 
 import numpy as np
-import networkx as _nx
+import igraph
 
 from netket.utils.group import Permutation, PermutationGroup
-from .abstract_graph import AbstractGraph
+from .abstract_graph import AbstractGraph, Edge, ColoredEdge, EdgeSequence
 
 
-class NetworkX(AbstractGraph):
-    """Wrapper for a networkx graph"""
+class Graph(AbstractGraph):
+    # Initialization
+    # ------------------------------------------------------------------------
+    def __init__(
+        self,
+        edges: Union[Sequence[Edge], Sequence[ColoredEdge]],
+        n_nodes: Optional[int] = None,
+    ) -> None:
+        edges, colors = self._clean_edges(edges)
+        if n_nodes is None:
+            if len(edges) > 0:
+                n_nodes = max(max(e) for e in edges) + 1
+            else:
+                n_nodes = 0
+        graph = igraph.Graph(directed=False)
+        graph.add_vertices(n_nodes)
+        graph.add_edges(edges, attributes={"color": colors})
 
-    def __init__(self, graph: _nx.Graph):
-        """
-        Constructs a netket graph from a networkx graph.
-
-        Args:
-            graph: A networkx graph (might be a :class:`networkx.Graph` or a :class:`networkx.MultiGraph`)
-
-        Examples:
-
-            A graph of nodes [0,1,2] with edges [(0,1), (0,2), (1,2)]
-
-            >>> import netket
-            >>> import networkx
-            >>> nx_g = networkx.Graph([(0,1), (0,2), (1,2)])
-            >>> nk_g = netket.graph.NetworkX(nx_g)
-            >>> print(nk_g.n_nodes)
-            3
-
-        """
-        if not (
-            isinstance(graph, _nx.classes.graph.Graph)
-            or isinstance(graph, _nx.classes.multigraph.MultiGraph)
-        ):
-            raise TypeError("graph must be a networx Graph or MultiGraph", type(graph))
-
-        if isinstance(graph, _nx.classes.graph.Graph):
-            self.graph = _nx.MultiGraph(graph)
-        else:
-            self.graph = graph
-
+        self._igraph = graph
         self._automorphisms = None
 
-        super().__init__()
+    @staticmethod
+    def _clean_edges(edges):
+        """Validate and normalize edges argument."""
+        if not isinstance(edges, Sequence):
+            raise TypeError("edges must be a sequence.")
+        if len(edges) == 0:
+            return edges, []
 
+        e0 = edges[0]
+        if not isinstance(e0, Sequence) or len(e0) not in (2, 3):
+            raise ValueError(
+                "Edges must be tuple of length 2 (or 3 for colored edges)."
+            )
+        if not all(len(e) == len(e0) for e in edges):
+            raise ValueError("Either all or none of the edges need to specify a color.")
+
+        if len(e0) == 2:
+            return edges, [0] * len(edges)
+        else:
+            return [(v, w) for (v, w, _) in edges], [c for (*_, c) in edges]
+
+    # Conversion
+    # ------------------------------------------------------------------------
+    @classmethod
+    def from_igraph(cls, graph: igraph.Graph):
+        """
+        Creates a new Graph instance from an igraph.Graph instance.
+        """
+        if graph.is_directed():
+            raise ValueError("Directed graphs are not currently supported.")
+        self = cls.__new__(cls)
+        self._igraph = graph.copy()
+        self._automorphisms = None
+
+        if "color" not in self._igraph.edge_attributes():
+            self._igraph.es.set_attribute_values("color", [0] * self._igraph.ecount())
+        else:
+            if not all(isinstance(c, int) for (_, _, c) in self.edges(color=True)):
+                raise ValueError(
+                    "graph has 'color' edge attributes, but not all colors are integers."
+                )
+
+        return self
+
+    @classmethod
+    def from_networkx(cls, graph):
+        """
+        Creates a new Graph instance from a networkx graph.
+        """
+        ig = igraph.Graph.from_networkx(graph)
+        return cls.from_igraph(ig)
+
+    def to_igraph(self):
+        """
+        Returns a copy of this graph as an igraph.Graph instance.
+        """
+        return self._igraph.copy()
+
+    def to_networkx(self):
+        """
+        Returns a copy of this graph as an igraph.Graph instance.
+        This method requires networkx to be installed.
+        """
+        return self._igraph.to_networkx()
+
+    # Graph properties
+    # ------------------------------------------------------------------------
     def adjacency_list(self) -> List[List]:
-        return [list(self.graph.neighbors(node)) for node in self.graph.nodes]
+        return self._igraph.get_adjlist()
 
     def is_connected(self) -> bool:
-        return _nx.is_connected(self.graph)
-
-    def nodes(self) -> Generator:
-        return self.graph.nodes()
-
-    def edges(self, color: Union[bool, int] = False) -> Generator:
-        if color is True:
-            return self.graph.edges(data="color")
-        elif color is not False:
-            return ((u, v) for u, v, k in self.graph.edges(data="color") if k == color)
-        else:  # color is False
-            return self.graph.edges()
-
-    def distances(self) -> List[List]:
-        return _nx.floyd_warshall_numpy(self.graph).tolist()
+        return self._igraph.is_connected()
 
     def is_bipartite(self) -> bool:
-        return _nx.is_bipartite(self.graph)
+        return self._igraph.is_bipartite()
 
     @property
     def n_nodes(self) -> int:
-        r"""The number of nodes (or vertices) in the graph"""
-        return self.graph.number_of_nodes()
+        return self._igraph.vcount()
 
     @property
     def n_edges(self) -> int:
-        r"""The number of edges in the graph."""
-        return self.graph.size()
+        return self._igraph.ecount()
+
+    def nodes(self) -> Sequence[int]:
+        return range(self._igraph.vcount())
+
+    def edges(self, color: Union[bool, int] = False) -> EdgeSequence:
+        edges = self._igraph.get_edgelist()
+        if color is False:
+            return edges
+        colors = self._edge_colors
+        if color is True:
+            return [(*e, c) for e, c in zip(edges, colors)]
+        else:
+            return [e for e, c in zip(edges, colors) if c == color]
+
+    @property
+    def _edge_colors(self):
+        return self._igraph.es.get_attribute_values("color")
+
+    # Graph algorithms
+    # ------------------------------------------------------------------------
+    def distances(self) -> List[List]:
+        return np.array(self._igraph.shortest_paths())
 
     def _compute_automorphisms(self):
         """
-        Compute the graph autmorphisms of this graph using igraph.
+        Compute the graph autmorphisms of this graph.
         """
-        import igraph
-
-        colored_edges = self.edges(color=True)
-        edges = [(v, w) for (v, w, _) in colored_edges]
-        colors = [(c if c is not None else -1) for (_, _, c) in colored_edges]
-
-        ig = igraph.Graph(edges=edges)
-        result = ig.get_isomorphisms_vf2(edge_color1=colors, edge_color2=colors)
+        colors = self._edge_colors
+        result = self._igraph.get_isomorphisms_vf2(
+            edge_color1=colors, edge_color2=colors
+        )
 
         # sort them s.t. the identity comes first
         result = np.unique(result, axis=0).tolist()
-        result = PermutationGroup(
-            [Permutation(i) for i in result], self.n_nodes
-        )
+        result = PermutationGroup([Permutation(i) for i in result], self.n_nodes)
         return result
 
     # TODO turn into a struct.property_cached?
     def automorphisms(self) -> PermutationGroup:
-        if self._automorphisms is  None:
+        if self._automorphisms is None:
             self._automorphisms = self._compute_automorphisms()
         return self._automorphisms
 
+    # Output and drawing
+    # ------------------------------------------------------------------------
     def __repr__(self):
-        return "{}(n_nodes={})".format(
-            str(type(self)).split(".")[-1][:-2], self.n_nodes
+        return "{}(n_nodes={}, n_edges={})".format(
+            str(type(self)).split(".")[-1][:-2], self.n_nodes, self.n_edges
         )
 
 
-def Graph(nodes: List = [], edges: List = []) -> NetworkX:
-    r"""
-    Constructs a Graph given a list of nodes and edges.
-    Args:
-        nodes: A list of ints that index nodes of a graph
-        edges: A list of 2- or 3-tuples that denote an edge with an optional color
-
-    The Graph can be constructed specifying only the edges and the nodes will be deduced from the edges.
-
-    Examples:
-        A 10-site one-dimensional lattice with periodic boundary conditions can be
-        constructed specifying the edges as follows:
-
-        >>> import netket
-        >>> g=netket.graph.Graph(edges=[[i, (i + 1) % 10] for i in range(10)])
-        >>> print(g.n_nodes)
-        10
-
-    """
-    if not isinstance(nodes, list):
-        raise TypeError("nodes must be a list")
-
-    if not isinstance(edges, list):
-        raise TypeError("edges must be a list")
-
-    if edges:
-        type_condition = [
-            isinstance(edge, list) or isinstance(edge, tuple) for edge in edges
-        ]
-        if False in type_condition:
-            raise ValueError("edges must be a list of lists or tuples")
-
-        edges_array = np.array(edges, dtype=np.int32)
-        if edges_array.ndim != 2:
-            raise ValueError(
-                "edges must be a list of lists or tuples of the same length (2 or 3)"
-            )
-
-        if not (edges_array.shape[1] == 2 or edges_array.shape[1] == 3):
-            raise ValueError(
-                "edges must be a list of lists or tuples of the same length (2 or 3), where the third column indicates the color"
-            )
-
-        # Sort node names for ordering reasons:
-    if nodes:
-        node_names = sorted(nodes)
-    elif edges:
-        node_names = sorted(set((node for edge in edges_array for node in edge)))
-
-    graph = _nx.MultiGraph()
-    graph.add_nodes_from(node_names)
-    if edges:
-        graph.add_edges_from(edges_array)
-        if edges_array.shape[1] == 3:  # edges with color
-            colors = {tuple(e): e[-1] for e in edges}
-            _nx.set_edge_attributes(graph, colors, name="color")
-        else:  # only one color
-            _nx.set_edge_attributes(graph, 0, name="color")
-
-    return NetworkX(graph)
-
-
-def Edgeless(nodes: Union[list, int]) -> NetworkX:
+def Edgeless(n_nodes: int) -> Graph:
     """
     Construct a set graph (collection of unconnected vertices).
 
@@ -200,18 +191,10 @@ def Edgeless(nodes: Union[list, int]) -> NetworkX:
         >>> print(g.n_edges)
         0
     """
-    if not isinstance(nodes, list):
-        if not isinstance(nodes, int):
-            raise TypeError("nodes must be either an integer or a list")
-        nodes = range(nodes)
-
-    edgelessgraph = _nx.MultiGraph()
-    edgelessgraph.add_nodes_from(nodes)
-
-    return NetworkX(edgelessgraph)
+    return Graph([], n_nodes)
 
 
-def DoubledGraph(graph: AbstractGraph) -> NetworkX:
+def DoubledGraph(graph: AbstractGraph) -> Graph:
     """
     DoubledGraph(graph)
 
@@ -225,23 +208,14 @@ def DoubledGraph(graph: AbstractGraph) -> NetworkX:
     dedges = list(graph.edges())
     n_v = graph.n_nodes
 
-    dnodes = [i for i in range(n_v)] + [i + n_v for i in range(n_v)]
-
+    dnodes = 2 * n_v
     dedges += [(edge[0] + n_v, edge[1] + n_v) for edge in graph.edges()]
 
-    return Graph(nodes=dnodes, edges=dedges)
+    return Graph(n_nodes=dnodes, edges=dedges)
 
 
-def disjoint_union(graph_1: NetworkX, graph_2: NetworkX) -> NetworkX:
+def disjoint_union(graph_1: Graph, graph_2: Graph) -> Graph:
     """
-    disjoint_union(graph_1, graph_2)
-
-    Args:
-        graph_1: a NetworkX graph
-        graph_2: a NetworkX graph
-
-    Returns:
-        The Disjoint union of the two graphs. See NetworkX documentation for more informations.
+    Returns the disjoint union of two graphs.
     """
-    union_graph = _nx.disjoint_union(graph_1.graph, graph_2.graph)
-    return NetworkX(union_graph)
+    return Graph.from_igraph(igraph.disjoint_union([graph_1._igraph, graph_2._igraph]))

--- a/netket/graph/lattice.py
+++ b/netket/graph/lattice.py
@@ -29,7 +29,7 @@ from netket.utils import HashableArray
 from netket.utils.float import comparable, comparable_periodic, is_approx_int
 from netket.utils.group import PointGroup, PermutationGroup, trivial_point_group
 
-from .graph import NetworkX
+from .graph import Graph
 
 PositionT = _np.ndarray
 CoordT = _np.ndarray
@@ -164,7 +164,7 @@ REPR_TEMPLATE = """Lattice(
 """
 
 
-class Lattice(NetworkX):
+class Lattice(Graph):
     r"""
     A lattice built by periodic arrangement of a given unit cell.
 
@@ -326,7 +326,7 @@ class Lattice(NetworkX):
             HashableArray(pos): index for index, pos in enumerate(int_positions)
         }
 
-        super().__init__(graph)
+        super().__init__(list(graph.edges()), graph.number_of_nodes())
 
     @staticmethod
     def _clean_basis(basis_vectors):
@@ -681,8 +681,9 @@ class Lattice(NetworkX):
 
         # FIXME (future) as of 11Apr2021, networkx can draw curved
         # edges only for directed graphs.
+        nxgraph = self.to_networkx().to_directed()
         _nx.draw_networkx_edges(
-            self.graph.to_directed(),
+            nxgraph,
             pos=positions,
             edgelist=self.edges(),
             connectionstyle=f"arc3,rad={curvature}",
@@ -692,10 +693,10 @@ class Lattice(NetworkX):
             node_size=node_size,
         )
         _nx.draw_networkx_nodes(
-            self.graph, pos=positions, ax=ax, node_color=node_color, node_size=node_size
+            nxgraph, pos=positions, ax=ax, node_color=node_color, node_size=node_size
         )
         _nx.draw_networkx_labels(
-            self.graph, pos=positions, ax=ax, font_size=font_size, font_color=font_color
+            nxgraph, pos=positions, ax=ax, font_size=font_size, font_color=font_color
         )
         ax.axis("equal")
         return ax

--- a/netket/graph/lattice.py
+++ b/netket/graph/lattice.py
@@ -19,7 +19,7 @@ from netket.utils.types import Array
 from typing import Callable, Dict, Sequence, Tuple, Union, Optional
 import warnings
 
-import networkx as _nx
+import igraph
 import numpy as _np
 from scipy.spatial import cKDTree
 from scipy.sparse import find, triu
@@ -298,27 +298,22 @@ class Lattice(Graph):
             self._extent,
             distance_atol,
         )
-        graph = _nx.MultiGraph(edges)
 
-        # Rename sites
         old_nodes = sorted(set(node for edge in edges for node in edge))
+        new_nodes = {old_node: new_node for new_node, old_node in enumerate(old_nodes)}
+
+        graph = igraph.Graph()
+        graph.add_vertices(len(old_nodes))
+        graph.add_edges([(new_nodes[edge[0]], new_nodes[edge[1]]) for edge in edges])
         self._sites = []
         for i, site in enumerate(sites[old_node] for old_node in old_nodes):
             site.id = i
             self._sites.append(site)
-        new_nodes = {old_node: new_node for new_node, old_node in enumerate(old_nodes)}
-        graph = _nx.relabel_nodes(graph, new_nodes)
         self._basis_coord_to_site = {
             HashableArray(p.basis_coord): p.id for p in self._sites
         }
         self._positions = _np.array([p.position for p in self._sites])
         self._basis_coords = _np.array([p.basis_coord for p in self._sites])
-
-        # Order node names
-        edges = list(graph.edges())
-        graph = _nx.MultiGraph()
-        graph.add_nodes_from([p.id for p in self._sites])
-        graph.add_edges_from(edges)
         self._lattice_dims = _np.expand_dims(self._extent, 1) * self.basis_vectors
         self._inv_dims = _np.linalg.inv(self._lattice_dims)
         int_positions = self._to_integer_position(self._positions)
@@ -326,7 +321,7 @@ class Lattice(Graph):
             HashableArray(pos): index for index, pos in enumerate(int_positions)
         }
 
-        super().__init__(list(graph.edges()), graph.number_of_nodes())
+        super().__init__(list(graph.get_edgelist()), graph.vcount())
 
     @staticmethod
     def _clean_basis(basis_vectors):
@@ -679,25 +674,44 @@ class Lattice(Graph):
         if ax is None:
             _, ax = plt.subplots(figsize=figsize)
 
-        # FIXME (future) as of 11Apr2021, networkx can draw curved
-        # edges only for directed graphs.
-        nxgraph = self.to_networkx().to_directed()
-        _nx.draw_networkx_edges(
-            nxgraph,
-            pos=positions,
-            edgelist=self.edges(),
-            connectionstyle=f"arc3,rad={curvature}",
-            ax=ax,
-            arrowsize=0.1,
-            edge_color=edge_color,
-            node_size=node_size,
+        for edge in self.edges():
+            x1, y1 = positions[edge[0]]
+            x2, y2 = positions[edge[1]]
+            annotation = ax.annotate(
+                "",
+                xy=(x1, y1),
+                xycoords="data",
+                xytext=(x2, y2),
+                textcoords="data",
+                arrowprops=dict(
+                    arrowstyle="-",
+                    color=edge_color,
+                    shrinkA=0,
+                    shrinkB=0,
+                    patchA=None,
+                    patchB=None,
+                    connectionstyle=f"arc3,rad={curvature}",
+                ),
+            )
+        ax.scatter(
+            *positions.T,
+            s=node_size,
+            c=node_color,
+            marker="o",
+            zorder=annotation.get_zorder() + 1,
         )
-        _nx.draw_networkx_nodes(
-            nxgraph, pos=positions, ax=ax, node_color=node_color, node_size=node_size
-        )
-        _nx.draw_networkx_labels(
-            nxgraph, pos=positions, ax=ax, font_size=font_size, font_color=font_color
-        )
+        for node in self.nodes():
+            x1, y1 = positions[node]
+            ax.text(
+                x1,
+                y1,
+                str(node),
+                horizontalalignment="center",
+                verticalalignment="center",
+                fontsize=font_size,
+                color=font_color,
+                zorder=annotation.get_zorder() + 1,
+            )
         ax.axis("equal")
         return ax
 

--- a/netket/operator/_graph_operator.py
+++ b/netket/operator/_graph_operator.py
@@ -76,7 +76,7 @@ class GraphOperator(LocalOperator):
          >>> op = nk.operator.GraphOperator(
          ... hi, site_ops=[sigmax], bond_ops=[mszsz], graph=g)
          >>> print(op)
-         GraphOperator(dim=20, #acting_on=40 locations, constant=0, dtype=float64, graph=NetworkX(n_nodes=20))
+         GraphOperator(dim=20, #acting_on=40 locations, constant=0, dtype=float64, graph=Graph(n_nodes=20, n_edges=20))
         """
 
         if graph.n_nodes != hilbert.size:

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,8 @@ DEV_DEPENDENCIES = [
     "pytest-xdist>=2",
     "coverage>=5",
     "pytest-cov>=2.10.1",
+    "networkx~=2.4",
     "flaky>=3.7",
-    "python-igraph",
     "pre-commit",
     "black==20.8b1",
 ]
@@ -18,7 +18,7 @@ BASE_DEPENDENCIES = [
     "tqdm~=4.56",
     "plum-dispatch~=1.0",
     "numba>=0.52, <0.54",
-    "networkx~=2.4",
+    "python-igraph~=0.9",
     "jax>=0.2.9, <0.2.14",
     "jaxlib>=0.1.57",
     "flax>=0.3.0, <0.4",


### PR DESCRIPTION
This is a draft PR which partially addresses #727. (Note that this is currently a PR on a separate working branch in this repo which is based on the current state of #724. This is just so the changes show up correctly here so we can already discuss them. This PR should re-targeted and merged only after the lattice PR went through.)

Main changes:

- [x] Rename `NetworkX` to `Graph` and merge the old `Graph` function with its constructor.
- [x] Use `igraph.Graph` internally in `Graph`, which speeds up some computations. Incidentally, this also means `Graph.automorphisms` now works with colored edges which was unsupported by the `networkx` implementation previously.
- [x] Makes `igraph` a base dependency of NetKet, obviously.

While the internal graph is not exposed, `Graph` now does provide two method pairs `from_igraph`/`to_igraph` and `from_networkx`/`to_networkx` (they are easy to implement, regardless of our underlying implementation). Once `networkx` is not a hard dependency anymore, we can still leave `to_networkx` which will only work if the user optionally installs `networkx`. which seems pretty natural to me (we also have this with `matplotlib` in `Lattice.draw`).

~What is not (yet) done here:~

- [x] Remove the dependency on `networkx` outside of the tests.

There is one other change to discuss:

- Vertices are now always labeled by `range(0, n_nodes)` in `Graph`, without support for custom indices. I think this is a good change, because this is what we supported in v2 (as far as I remember) and random parts of our code still assume this and will break if the nodes are represented by something else. Note that if users want to associate names or any other objects with vertices, they can just put those in list of length `n_nodes` easily anyways.