### PR TITLE
Fix publish-to-pypi

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,7 @@ name: Publish to PyPi
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   deploy:


### PR DESCRIPTION
According to https://github.com/actions/starter-workflows/issues/554 if you first draft then publish our old action was not beeing triggered