### PR TITLE
Make nk more extensible, pt 1: use dispatch in netket.hilbert.random

### DIFF
--- a/netket/graph/space_group.py
+++ b/netket/graph/space_group.py
@@ -15,7 +15,6 @@
 # Ignore false-positives for redefined `product` functions:
 # pylint: disable=function-redefined
 
-from plum import dispatch
 import numpy as np
 from functools import reduce
 from math import pi
@@ -23,9 +22,11 @@ from typing import Optional, Sequence
 
 from .lattice import Lattice
 
-from netket.utils.types import Array, Union
 from netket.utils import struct
+from netket.utils.types import Array, Union
 from netket.utils.float import prune_zeros
+from netket.utils.dispatch import dispatch
+
 from netket.utils.group import (
     Identity,
     PointGroup,

--- a/netket/hilbert/doubled_hilbert.py
+++ b/netket/hilbert/doubled_hilbert.py
@@ -18,9 +18,12 @@ import jax
 from jax import numpy as jnp
 import numpy as np
 
+from netket.utils.dispatch import parametric
+
 from .abstract_hilbert import AbstractHilbert
 
 
+# TODO: Create parametric class
 class DoubledHilbert(AbstractHilbert):
     r"""Superoperatorial hilbert space for states living in the
     tensorised state H\otimes H, encoded according to Choi's isomorphism."""

--- a/netket/hilbert/random/__init__.py
+++ b/netket/hilbert/random/__init__.py
@@ -45,30 +45,29 @@ you should define a function taking 4 inputs, the hilbert space, a jax PRNG key 
 the dtype of the derised result. For random operations you should use the key 
 provided.
 
-def random_state_myhilbert_scalar_impl(hilb: MyHilbert, key, dtype):    
+@netket.utils.dispatch.dispatch
+def random_state(hilb: MyHilbert, key, dtype):    
     return mystate
 
-The batched version takes an extra argument, that is the number of batches to generate, 
-an int.
-
-def random_state_myhilbert_batch_impl(hilb: MyHilbert, key, batches, dtype):    
+@netket.utils.dispatch.dispatch
+def random_state(hilb: MyHilbert, key, batches: int, dtype):    
     return mystate
 
-Then register the implementation with the following function:
-batch can be None or your implementation. 
+flip_state is implemented in the same way, through
 
-nk.hilbert.random.register_random_state_impl(MyHilbert, scalar=random_state_myhilbert_scalar_impl, batch=None)
+@netket.utils.dispatch.dispatch
+def flip_state_scalar(hilb: Fock, key, σ, idx):
+    return new_state, oldval
 
-flip_state is implemented in the same way, through the function register_flip_state_impl
+There is a vmapped default fallback for the batched version.
 
+@netket.utils.dispatch.dispatch
+def flip_state_batch(hilb: Fock, key, σ, idx):
+    return new_states, oldvals
+    
 """
 
-from .base import (
-    random_state,
-    flip_state,
-    register_flip_state_impl,
-    register_random_state_impl,
-)
+from .base import random_state, flip_state
 
 from . import custom
 from . import qubit

--- a/netket/hilbert/random/__init__.py
+++ b/netket/hilbert/random/__init__.py
@@ -19,13 +19,13 @@ for sampling.
 If you define custom hilbert spaces, and want to sample from it, you
 should read carefully.
 
-This module *exports* two functions: 
+This module *exports* two functions:
  - `random_state(hilbert, key, batch_size, dtype)` which generates a batch of random
- states in the given hilbert space, in an array with the specified dtype. 
- - `flip_state(hilb, key, states, indices)` which, for every state σ in the batch of states,
- considers σᵢ and returns a new state where that entry is different from the previous.
- The new configuration is selected with uniform probability among the local possible
- configurations.
+ states in the given hilbert space, in an array with the specified dtype.
+ - `flip_state(hilb, key, states, indices)` which, for every state σ in the batch of
+ states, considers σᵢ and returns a new state where that entry is different from the
+ previous. The new configuration is selected with uniform probability among the local
+ possible configurations.
 
 Hilbert spaces must at least implement a `random_state` to support sampling.
 `flip_state` is only necessary in order to use LocalRule samplers.
@@ -35,22 +35,22 @@ How to implement the two functions above
 ----------------------------------------
 
 While the *exported* function acts on batches, sometimes it is hard to implement
-the function on batches. Therefore they can be implemented either as a scalar 
+the function on batches. Therefore they can be implemented either as a scalar
 function, that gets jax.vmap-ed automatically, or directly as a batched rule.
-Of course, if you implement the batched rule you will most likely see better 
+Of course, if you implement the batched rule you will most likely see better
 performance.
 
 In order to implement the scalar rule for your custom hilbert object `MyHilbert`
 you should define a function taking 4 inputs, the hilbert space, a jax PRNG key and
-the dtype of the derised result. For random operations you should use the key 
+the dtype of the derised result. For random operations you should use the key
 provided.
 
 @netket.utils.dispatch.dispatch
-def random_state(hilb: MyHilbert, key, dtype):    
+def random_state(hilb: MyHilbert, key, dtype):
     return mystate
 
 @netket.utils.dispatch.dispatch
-def random_state(hilb: MyHilbert, key, batches: int, dtype):    
+def random_state(hilb: MyHilbert, key, batches: int, dtype):
     return mystate
 
 flip_state is implemented in the same way, through
@@ -64,18 +64,12 @@ There is a vmapped default fallback for the batched version.
 @netket.utils.dispatch.dispatch
 def flip_state_batch(hilb: Fock, key, σ, idx):
     return new_states, oldvals
-    
+
 """
 
-from .base import random_state, flip_state
-
-from . import custom
-from . import qubit
-from . import spin
-from . import fock
-from . import doubled
-from . import tensor_hilbert
-
 from netket.utils import _hide_submodules
+
+from . import custom, doubled, fock, qubit, spin, tensor_hilbert
+from .base import flip_state, random_state
 
 _hide_submodules(__name__)

--- a/netket/hilbert/random/base.py
+++ b/netket/hilbert/random/base.py
@@ -14,11 +14,20 @@
 
 from functools import partial, singledispatch
 
+from textwrap import dedent
+
 import numpy as np
 import jax
 
+from typing import Tuple, Union
+from netket.utils.dispatch import dispatch
 
-def random_state(hilb, key, size=None, dtype=np.float32):
+NoneType = type(None)
+Dim = Union[Tuple[int], Tuple[int, int], Tuple[int, int, int]]
+
+
+@dispatch
+def random_state(hilb, key, *, size=None, dtype=np.float32):
     r"""Generates either a single or a batch of uniformly distributed random states.
 
     Args:
@@ -40,10 +49,54 @@ def random_state(hilb, key, size=None, dtype=np.float32):
         [[0. 1.]
          [0. 0.]]
     """
-    if size is None:
-        return random_state_scalar(hilb, key, dtype)
-    else:
-        return random_state_batch(hilb, key, size, dtype)
+    return random_state(hilb, key, size, dtype=dtype)
+
+
+@dispatch
+def random_state(hilb, key, size, dtype):
+    return random_state(hilb, key, size, dtype=dtype)
+
+
+@dispatch
+def random_state(hilb, key, size: NoneType, *, dtype):
+    return random_state(hilb, key, 1, dtype=dtype)[0]
+
+
+@dispatch
+def random_state(hilb, key, size: Dim, *, dtype):
+    n = int(np.prod(size))
+    return random_state(hilb, key, n, dtype=dtype).reshape(*size, -1)
+
+
+@dispatch
+def random_state(hilb, key, size: int, *, dtype):
+    raise NotImplementedError(
+        dedent(
+            f"""
+            random_state(hilb, key, size : int, *, dtype) is not implemented for the 
+            hilbert space {type(hilb)}.
+
+            Define the above function as follows:
+
+            >>>from netket.utils.dispatch import dispatch
+            >>>@dispatch
+            >>>def random_state(hilb : {type(hilb)}, key, size : int, *, dtype):
+            >>>  ...
+            >>>  return batch_of_size_states
+        """
+        )
+    )
+
+
+@dispatch
+def random_state(hilb, key, size: NoneType, *, dtype):
+    return random_state(hilb, key, 1, dtype=dtype)[0]
+
+
+@dispatch
+def random_state(hilb, key, size: Dim, *, dtype):
+    n = int(np.prod(size))
+    return random_state(hilb, key, n, dtype=dtype).reshape(*size, -1)
 
 
 def flip_state(hilb, key, state, indices):
@@ -64,186 +117,18 @@ def flip_state(hilb, key, state, indices):
         return flip_state_batch(hilb, key, state, indices)
 
 
-##############################
-### Random_state functions ###
-##############################
-
-
-@singledispatch
-def random_state_scalar(hilb, key, dtype):
-    """
-    Generates a single random state-vector given an hilbert space and a rng key.
-    """
-    # Attempt to use the scalar method
-    raise NotImplementedError(
-        f"""
-                              random_state_scalar(hilb, key, dtype) is not implemented
-                              for hilbert space of type {type(hilb)}. 
-
-                              See the documentation of 
-                              nk.hilbert.random.register_random_state_impl.
-                              """
-    )
-
-
-@singledispatch
-def random_state_batch(hilb, key, size, dtype):
-    """
-    Generates a batch of random state-vectors given an hilbert space and a rng key.
-    """
-    # Attempt to use the batch method
-    raise NotImplementedError(
-        f"""
-                              random_state_batch(hilb, key, size, dtype) is not implemented
-                              for hilbert space of type {type(hilb)}. 
-
-                              See the documentation of 
-                              nk.hilbert.random.register_random_state_impl.
-                              """
-    )
-
-
-def _random_state_scalar_default_impl(hilb, key, dtype, batch_rule):
-    return batch_rule(hilb, key, 1, dtype).reshape(-1)
-
-
-def _random_state_batch_default_impl(hilb, key, size, dtype, scalar_rule):
-    keys = jax.random.split(key, size)
-    res = jax.vmap(scalar_rule, in_axes=(None, 0, None), out_axes=0)(hilb, key, dtype)
-    return res
-
-
-def register_random_state_impl(clz=None, *, scalar=None, batch=None):
-    """
-    Register an implementation for the function generating random
-    state for the given Hilbert space class.
-
-    The rule can be implemented both as a scalar rule and as a batched
-    rule, but the best performance will be obtained by implementing
-    the batched version.
-
-    The missing rule will be auto-implemented from the over.
-
-    scalar must have signature
-        (hilb, key, dtype) -> vector
-    batch must have signature
-        (hilb, key, size, dtype) -> matrix of states
-
-    The function will be jit compiled, so make sure to use jax.numpy.
-    Hilbert is passed as a static object.
-
-    Arguments:
-        clz: The class of the hilbert space
-        scalar: The function computing a single random state
-        batch: the function computing batches of random states
-    """
-    if scalar is None and batch is None:
-        raise ValueError("You must at least provide a scalar or batch rule.")
-
-    scalar_rule = scalar
-    batch_rule = batch
-
-    if scalar is None:
-        if clz is None:
-            clz = list(batch.__annotations__.items())[0]
-        scalar_rule = partial(_random_state_scalar_default_impl, batch_rule=batch_rule)
-
-    if batch is None:
-        if clz is None:
-            clz = list(scalar.__annotations__.items())[0]
-
-        batch_rule = partial(_random_state_batch_default_impl, scalar_rule=scalar_rule)
-
-    random_state_scalar.register(clz, scalar_rule)
-    random_state_batch.register(clz, batch_rule)
-
-
-##############################
-### flip_state functions ###
-##############################
-
-
-@singledispatch
+@dispatch
 def flip_state_scalar(hilb, key, state, indx):
-    raise NotImplementedError(
-        f"""
-                              flip_state_scalar(hilb, key, state, indx) is not implemented
-                              for hilbert space of type {type(hilb)}. 
-
-                              See the documentation of 
-                              nk.hilbert.random.register_flip_state_impl
-                              """
+    new_state, old_val = flip_state_batch(
+        hilb, key, state.reshape(1, -1), indx.reshape(1, -1)
     )
+    return new_state.reshape(-1), old_val.reshape()
 
 
-@singledispatch
+@dispatch
 def flip_state_batch(hilb, key, states, indxs):
-    raise NotImplementedError(
-        f"""
-                              flip_state_batch(hilb, key, states, indx) is not implemented
-                              for hilbert space of type {type(hilb)}. 
-
-                              See the documentation of 
-                              nk.hilbert.random.register_flip_state_impl
-                              """
-    )
-
-
-def _flip_state_scalar_default_impl(hilb, key, state, indx, batch_rule):
-    new_state, old_val = batch_rule(
-        hilb, key, state.reshape((1, -1)), indx.reshape(1, -1)
-    )
-    return new_state.reshape(-1), old_val.reshape(())
-
-
-def _flip_state_batch_default_impl(hilb, key, states, indxs, scalar_rule):
     keys = jax.random.split(key, states.shape[0])
-    res = jax.vmap(scalar_rule, in_axes=(None, 0, 0, 0), out_axes=0)(
+    res = jax.vmap(flip_state_scalar, in_axes=(None, 0, 0, 0), out_axes=0)(
         hilb, keys, states, indxs
     )
     return res
-
-
-def register_flip_state_impl(clz=None, *, scalar=None, batch=None):
-    """
-    Register an implementation for the function generating and
-    applying random local states for the given Hilbert space class.
-
-    The rule can be implemented both as a scalar rule and as a batched
-    rule, but the best performance will be obtained by implementing
-    the batched version.
-
-    The missing rule will be auto-implemented from the over.
-
-    scalar must have signature
-        (hilb, key, state, indx) -> (new state, state[indx])
-    batch must have signature
-        (hilb, key, states, indxs) -> batch of scalar results
-
-    The function will be jit compiled, so make sure to use jax.numpy.
-    Hilbert is passed as a static object.
-
-    Arguments:
-        clz: The class of the hilbert space
-        scalar: The function computing a single entry
-        batch: the function computing batches
-    """
-    if scalar is None and batch is None:
-        raise ValueError("You must at least provide a scalar or batch rule.")
-
-    scalar_rule = scalar
-    batch_rule = batch
-
-    if scalar is None:
-        if clz is None:
-            clz = list(batch.__annotations__.items())[0]
-        scalar_rule = partial(_flip_state_scalar_default_impl, batch_rule=batch_rule)
-
-    if batch is None:
-        if clz is None:
-            clz = list(scalar.__annotations__.items())[0]
-
-        batch_rule = partial(_flip_state_batch_default_impl, scalar_rule=scalar_rule)
-
-    flip_state_scalar.register(clz, scalar_rule)
-    flip_state_batch.register(clz, batch_rule)

--- a/netket/hilbert/random/base.py
+++ b/netket/hilbert/random/base.py
@@ -12,14 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from functools import partial, singledispatch
-
 from textwrap import dedent
-
-import numpy as np
-import jax
-
 from typing import Tuple, Union
+
+import jax
+import numpy as np
+
 from netket.utils.dispatch import dispatch
 
 NoneType = type(None)
@@ -31,9 +29,10 @@ def random_state(hilb, key, *, size=None, dtype=np.float32):
     r"""Generates either a single or a batch of uniformly distributed random states.
 
     Args:
-        size: If provided, returns a batch of configurations of the form (size, #) if size
-            is an integer or (*size, #) if it is a tuple and where # is the Hilbert space size.
-            By default, a single random configuration with shape (#,) is returned.
+        size: If provided, returns a batch of configurations of the form (size, #) if
+            size is an integer or (*size, #) if it is a tuple and where # is the Hilbert
+            space size. By default, a single random configuration with shape (#,) is
+            returned.
         out: If provided, the random quantum numbers will be inserted into this array,
              which should be of the appropriate shape (see `size`) and data type.
         rgen: The random number generator. If None, the global NetKet random
@@ -53,27 +52,27 @@ def random_state(hilb, key, *, size=None, dtype=np.float32):
 
 
 @dispatch
-def random_state(hilb, key, size, dtype):
+def random_state(hilb, key, size, dtype):  # noqa: F811
     return random_state(hilb, key, size, dtype=dtype)
 
 
 @dispatch
-def random_state(hilb, key, size: NoneType, *, dtype):
+def random_state(hilb, key, size: NoneType, *, dtype):  # noqa: F811
     return random_state(hilb, key, 1, dtype=dtype)[0]
 
 
 @dispatch
-def random_state(hilb, key, size: Dim, *, dtype):
+def random_state(hilb, key, size: Dim, *, dtype):  # noqa: F811
     n = int(np.prod(size))
     return random_state(hilb, key, n, dtype=dtype).reshape(*size, -1)
 
 
 @dispatch
-def random_state(hilb, key, size: int, *, dtype):
+def random_state(hilb, key, size: int, *, dtype):  # noqa: F811
     raise NotImplementedError(
         dedent(
             f"""
-            random_state(hilb, key, size : int, *, dtype) is not implemented for the 
+            random_state(hilb, key, size : int, *, dtype) is not implemented for the
             hilbert space {type(hilb)}.
 
             Define the above function as follows:
@@ -89,12 +88,12 @@ def random_state(hilb, key, size: int, *, dtype):
 
 
 @dispatch
-def random_state(hilb, key, size: NoneType, *, dtype):
+def random_state(hilb, key, size: NoneType, *, dtype):  # noqa: F811
     return random_state(hilb, key, 1, dtype=dtype)[0]
 
 
 @dispatch
-def random_state(hilb, key, size: Dim, *, dtype):
+def random_state(hilb, key, size: Dim, *, dtype):  # noqa: F811
     n = int(np.prod(size))
     return random_state(hilb, key, n, dtype=dtype).reshape(*size, -1)
 

--- a/netket/hilbert/random/base.py
+++ b/netket/hilbert/random/base.py
@@ -29,14 +29,13 @@ def random_state(hilb, key, *, size=None, dtype=np.float32):
     r"""Generates either a single or a batch of uniformly distributed random states.
 
     Args:
+        hilb: The hilbert space
+        key: The Jax PRNGKey
         size: If provided, returns a batch of configurations of the form (size, #) if
             size is an integer or (*size, #) if it is a tuple and where # is the Hilbert
             space size. By default, a single random configuration with shape (#,) is
             returned.
-        out: If provided, the random quantum numbers will be inserted into this array,
-             which should be of the appropriate shape (see `size`) and data type.
-        rgen: The random number generator. If None, the global NetKet random
-            number generator is used.
+        dtype: The dtype of the resulting states.
 
     Example:
 

--- a/netket/hilbert/random/custom.py
+++ b/netket/hilbert/random/custom.py
@@ -15,17 +15,14 @@
 from typing import Optional, List
 
 import jax
-import numpy as np
 from jax import numpy as jnp
 
-# from numba import jit
-
-from ..custom_hilbert import CustomHilbert
-
-from .base import register_flip_state_impl, register_random_state_impl
+from netket.utils.dispatch import dispatch
+from netket.hilbert.custom_hilbert import CustomHilbert
 
 
-def random_state_batch_spin_impl(hilb: CustomHilbert, key, batches, dtype):
+@dispatch
+def random_state(hilb: CustomHilbert, key, batches: int, *, dtype):
     if not hilb.is_discrete or not hilb.is_finite or hilb._has_constraint:
         raise NotImplementedError()
 
@@ -41,8 +38,8 @@ def random_state_batch_spin_impl(hilb: CustomHilbert, key, batches, dtype):
     return jnp.asarray(σ, dtype=dtype)
 
 
-## flips
-def flip_state_scalar_spin_impl(hilb: CustomHilbert, key, σ, indx):
+@dispatch
+def flip_state_scalar(hilb: CustomHilbert, key, σ, indx):
     local_states = jnp.asarray(hilb.local_states)
 
     rs = jax.random.randint(key, shape=(), minval=0, maxval=len(hilb.local_states) - 1)
@@ -51,7 +48,8 @@ def flip_state_scalar_spin_impl(hilb: CustomHilbert, key, σ, indx):
     return jax.ops.index_update(σ, indx, new_val), σ[indx]
 
 
-def flip_state_batch_spin_impl(hilb: CustomHilbert, key, σ, indxs):
+@dispatch
+def flip_state_batch(hilb: CustomHilbert, key, σ, indxs):
     n_batches = σ.shape[0]
 
     local_states = jnp.asarray(hilb.local_states)
@@ -65,9 +63,3 @@ def flip_state_batch_spin_impl(hilb: CustomHilbert, key, σ, indxs):
         return jax.ops.index_update(σ, indx, new_val), σ[indx]
 
     return jax.vmap(scalar_update_fun, in_axes=(0, 0, 0), out_axes=0)(σ, indxs, rs)
-
-
-register_random_state_impl(CustomHilbert, batch=random_state_batch_spin_impl)
-register_flip_state_impl(
-    CustomHilbert, scalar=flip_state_scalar_spin_impl, batch=flip_state_batch_spin_impl
-)

--- a/netket/hilbert/random/custom.py
+++ b/netket/hilbert/random/custom.py
@@ -12,13 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, List
-
 import jax
 from jax import numpy as jnp
 
-from netket.utils.dispatch import dispatch
 from netket.hilbert.custom_hilbert import CustomHilbert
+from netket.utils.dispatch import dispatch
 
 
 @dispatch

--- a/netket/hilbert/random/doubled.py
+++ b/netket/hilbert/random/doubled.py
@@ -12,22 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, List, Union, Any
-
 import jax
-import numpy as np
 from jax import numpy as jnp
 
-from netket.utils.dispatch import dispatch
 from netket.hilbert import DoubledHilbert
+from netket.utils.dispatch import dispatch
 
-from .base import random_state, flip_state_scalar
+from .base import flip_state_scalar, random_state
 
 
 @dispatch
-def random_state(hilb: DoubledHilbert, key, batches: int, *, dtype):
-    shape = (batches, hilb.size)
-
+def random_state(hilb: DoubledHilbert, key, batches: int, *, dtype):  # noqa: F811
     key1, key2 = jax.random.split(key)
 
     v1 = random_state(hilb.physical, key1, batches, dtype)
@@ -37,7 +32,7 @@ def random_state(hilb: DoubledHilbert, key, batches: int, *, dtype):
 
 
 @dispatch
-def flip_state_scalar(hilb: DoubledHilbert, key, state, index):
+def flip_state_scalar(hilb: DoubledHilbert, key, state, index):  # noqa: F811
     def flip_lower_state_scalar(args):
         key, state, index = args
         return flip_state_scalar(hilb.physical, key, state, index)

--- a/netket/hilbert/random/doubled.py
+++ b/netket/hilbert/random/doubled.py
@@ -12,37 +12,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, List
+from typing import Optional, List, Union, Any
 
 import jax
 import numpy as np
 from jax import numpy as jnp
 
-# from numba import jit
-
+from netket.utils.dispatch import dispatch
 from netket.hilbert import DoubledHilbert
 
-from .base import (
-    random_state_batch,
-    register_random_state_impl,
-    flip_state_scalar,
-    register_flip_state_impl,
-)
+from .base import random_state, flip_state_scalar
 
 
-def random_state_batch_doubled_impl(hilb: DoubledHilbert, key, batches, dtype):
+@dispatch
+def random_state(hilb: DoubledHilbert, key, batches: int, *, dtype):
     shape = (batches, hilb.size)
 
     key1, key2 = jax.random.split(key)
 
-    v1 = random_state_batch(hilb.physical, key1, batches, dtype)
-    v2 = random_state_batch(hilb.physical, key2, batches, dtype)
+    v1 = random_state(hilb.physical, key1, batches, dtype)
+    v2 = random_state(hilb.physical, key2, batches, dtype)
 
-    return jnp.concatenate([v1, v2], axis=1)
+    return jnp.concatenate([v1, v2], axis=-1)
 
 
-## flips
-def flip_state_scalar_doubled(hilb: DoubledHilbert, key, state, index):
+@dispatch
+def flip_state_scalar(hilb: DoubledHilbert, key, state, index):
     def flip_lower_state_scalar(args):
         key, state, index = args
         return flip_state_scalar(hilb.physical, key, state, index)
@@ -57,7 +52,3 @@ def flip_state_scalar_doubled(hilb: DoubledHilbert, key, state, index):
         flip_upper_state_scalar,
         (key, state, index),
     )
-
-
-register_random_state_impl(DoubledHilbert, batch=random_state_batch_doubled_impl)
-register_flip_state_impl(DoubledHilbert, scalar=flip_state_scalar_doubled)

--- a/netket/hilbert/random/fock.py
+++ b/netket/hilbert/random/fock.py
@@ -12,14 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, List, Union, Tuple
-
 import jax
 import numpy as np
 from jax import numpy as jnp
 
-from netket.utils.dispatch import dispatch
 from netket.hilbert import Fock
+from netket.utils.dispatch import dispatch
 
 
 @dispatch
@@ -34,10 +32,8 @@ def random_state(hilb: Fock, key, batches: int, *, dtype=np.float32):
     else:
         from jax.experimental import host_callback as hcb
 
-        cb = lambda rng: _random_states_with_constraint(hilb, rng, batches, dtype)
-
         state = hcb.call(
-            cb,
+            lambda rng: _random_states_with_constraint(hilb, rng, batches, dtype),
             key,
             result_shape=jax.ShapeDtypeStruct(shape, dtype),
         )

--- a/netket/hilbert/random/fock.py
+++ b/netket/hilbert/random/fock.py
@@ -12,20 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, List
+from typing import Optional, List, Union, Tuple
 
 import jax
 import numpy as np
 from jax import numpy as jnp
 
-# from numba import jit
-
+from netket.utils.dispatch import dispatch
 from netket.hilbert import Fock
 
-from .base import register_flip_state_impl, register_random_state_impl
 
-
-def random_state_batch_fock_impl(hilb: Fock, key, batches, dtype):
+@dispatch
+def random_state(hilb: Fock, key, batches: int, *, dtype=np.float32):
     shape = (batches, hilb.size)
 
     # If unconstrained space, use fast sampling
@@ -68,7 +66,8 @@ def _random_states_with_constraint(hilb, rngkey, n_batches, dtype):
 
 
 ## flips
-def flip_state_scalar_fock(hilb: Fock, key, σ, idx):
+@dispatch
+def flip_state_scalar(hilb: Fock, key, σ, idx):
     if hilb._n_max == 0:
         return σ, σ[idx]
 
@@ -80,7 +79,3 @@ def flip_state_scalar_fock(hilb: Fock, key, σ, idx):
     σi_new = σi_new + (σi_new >= σi_old)
 
     return jax.ops.index_update(σ, idx, σi_new), σi_old
-
-
-register_random_state_impl(Fock, batch=random_state_batch_fock_impl)
-register_flip_state_impl(Fock, scalar=flip_state_scalar_fock)

--- a/netket/hilbert/random/qubit.py
+++ b/netket/hilbert/random/qubit.py
@@ -15,8 +15,8 @@
 import jax
 from jax import numpy as jnp
 
-from netket.utils.dispatch import dispatch
 from netket.hilbert import Qubit
+from netket.utils.dispatch import dispatch
 
 
 @dispatch

--- a/netket/hilbert/random/qubit.py
+++ b/netket/hilbert/random/qubit.py
@@ -15,20 +15,17 @@
 import jax
 from jax import numpy as jnp
 
+from netket.utils.dispatch import dispatch
 from netket.hilbert import Qubit
 
-from .base import register_flip_state_impl, register_random_state_impl
 
-
-def random_state_qubit_batch_impl(hilb: Qubit, key, batches, dtype):
+@dispatch
+def random_state(hilb: Qubit, key, batches: int, *, dtype):
     rs = jax.random.randint(key, shape=(batches, hilb.size), minval=0, maxval=2)
     return jnp.asarray(rs, dtype=dtype)
 
 
 ## flips
-def flip_state_scalar_spin(hilb: Qubit, key, x, i):
+@dispatch
+def flip_state_scalar(hilb: Qubit, key, x, i):
     return jax.ops.index_update(x, i, -x[i] + 1), x[i]
-
-
-register_random_state_impl(Qubit, batch=random_state_qubit_batch_impl)
-register_flip_state_impl(Qubit, scalar=flip_state_scalar_spin)

--- a/netket/hilbert/random/spin.py
+++ b/netket/hilbert/random/spin.py
@@ -12,13 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, List, Union, Tuple
-
 import jax
 import numpy as np
 from jax import numpy as jnp
-
-# from numba import jit
 
 from netket.hilbert import Spin
 from netket.utils.dispatch import dispatch
@@ -69,10 +65,8 @@ def random_state(hilb: Spin, key, batches: int, *, dtype=np.float32):
         else:
             from jax.experimental import host_callback as hcb
 
-            cb = lambda rng: _random_states_with_constraint(hilb, rng, batches, dtype)
-
             state = hcb.call(
-                cb,
+                lambda rng: _random_states_with_constraint(hilb, rng, batches, dtype),
                 key,
                 result_shape=jax.ShapeDtypeStruct(shape, dtype),
             )

--- a/netket/hilbert/random/tensor_hilbert.py
+++ b/netket/hilbert/random/tensor_hilbert.py
@@ -12,13 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, List
-
 import jax
-import numpy as np
 from jax import numpy as jnp
-
-# from numba import jit
 
 from netket.hilbert import TensorHilbert
 from netket.utils.dispatch import dispatch
@@ -26,12 +21,7 @@ from netket.utils.dispatch import dispatch
 
 @dispatch
 def random_state(hilb: TensorHilbert, key, batches: int, *, dtype):
-    shape = (batches, hilb.size)
-
     keys = jax.random.split(key, hilb._n_hilbert_spaces)
-
-    print(keys)
-    print(type(keys))
 
     vs = [
         random_state(hilb._hilbert_spaces[i], keys[i], batches, dtype=dtype)
@@ -56,11 +46,6 @@ def _make_subfun(hilb, i, sub_hi):
         return new_state, old_val
 
     return subfun
-
-
-## flips
-from jax import experimental
-from jax.experimental import host_callback
 
 
 @dispatch

--- a/netket/hilbert/tensor_hilbert.py
+++ b/netket/hilbert/tensor_hilbert.py
@@ -28,6 +28,7 @@ import numpy as _np
 import netket as nk
 
 
+# TODO: Make parametric class
 class TensorHilbert(AbstractHilbert):
     r"""Tensor product of several sub-spaces.
 

--- a/netket/utils/__init__.py
+++ b/netket/utils/__init__.py
@@ -38,4 +38,6 @@ jax_available = True
 flax_available = True
 mpi4jax_available = mpi.mpi_available
 
-_hide_submodules(__name__, remove_self=False, ignore=["numbers", "types", "float", "dispatch"])
+_hide_submodules(
+    __name__, remove_self=False, ignore=["numbers", "types", "float", "dispatch"]
+)

--- a/netket/utils/__init__.py
+++ b/netket/utils/__init__.py
@@ -14,6 +14,7 @@
 
 from .config_flags import config
 
+from . import dispatch
 from . import numbers
 from . import types
 from . import float
@@ -37,4 +38,4 @@ jax_available = True
 flax_available = True
 mpi4jax_available = mpi.mpi_available
 
-_hide_submodules(__name__, remove_self=False, ignore=["numbers", "types", "float"])
+_hide_submodules(__name__, remove_self=False, ignore=["numbers", "types", "float", "dispatch"])

--- a/netket/utils/dispatch.py
+++ b/netket/utils/dispatch.py
@@ -1,0 +1,15 @@
+# Copyright 2021 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from plum import dispatch, parametric, convert

--- a/netket/utils/group/_group.py
+++ b/netket/utils/group/_group.py
@@ -19,11 +19,11 @@ import itertools
 from typing import List, Tuple
 
 import numpy as np
-from plum import dispatch
 
 from netket.utils import HashableArray, struct
 from netket.utils.float import comparable, prune_zeros
 from netket.utils.types import Array, PyTree
+from netket.utils.dispatch import dispatch
 
 from ._semigroup import Element, FiniteSemiGroup, Identity
 

--- a/netket/utils/group/_permutation_group.py
+++ b/netket/utils/group/_permutation_group.py
@@ -19,10 +19,10 @@ import itertools
 from typing import Optional
 
 import numpy as np
-from plum import dispatch
 
 from netket.utils import HashableArray, struct
 from netket.utils.types import Array, DType, Shape
+from netket.utils.dispatch import dispatch
 
 from ._group import FiniteGroup
 from ._semigroup import Element

--- a/netket/utils/group/_point_group.py
+++ b/netket/utils/group/_point_group.py
@@ -21,12 +21,12 @@ from math import pi
 from typing import Dict, Optional, Tuple
 
 import numpy as np
-from plum import dispatch
 from scipy.linalg import schur
 
 from netket.utils import HashableArray, struct
 from netket.utils.float import comparable, comparable_periodic, is_approx_int
 from netket.utils.types import Array, Shape
+from netket.utils.dispatch import dispatch
 
 from ._group import FiniteGroup
 from ._semigroup import Element, Identity

--- a/netket/utils/group/_semigroup.py
+++ b/netket/utils/group/_semigroup.py
@@ -22,9 +22,9 @@ from dataclasses import dataclass
 from typing import List
 
 import numpy as np
-from plum import dispatch
 
 from netket.utils.types import Array
+from netket.utils.dispatch import dispatch
 
 
 class Element(ABC):

--- a/netket/utils/history.py
+++ b/netket/utils/history.py
@@ -18,8 +18,8 @@ import numpy as np
 from numbers import Number
 import jax.numpy as jnp
 
-from plum import dispatch
 
+from .dispatch import dispatch
 from .numbers import dtype, is_scalar
 from .types import Array, DType
 

--- a/netket/utils/numbers.py
+++ b/netket/utils/numbers.py
@@ -1,12 +1,12 @@
 from numbers import Number
 
 from typing import Any, Union
-from plum import dispatch
 
 import numpy as np
 import jax
 import jaxlib
 
+from .dispatch import dispatch
 from .types import Array
 
 


### PR DESCRIPTION
This is part 1 in making netket more easy to extend by moving to use dispatch in functions that might be extended and overridden by an user.

This PR does 2 things: 

- [x] Use `netket.utils.dispatch` instead of `from plum import dispatch` (even if they are identical) just for the sake that if, at some point, we need to change something in the dispatch, we just need to change it in one place.
- [x] Use dispatch throughout `netket.hilbert.random`.

The next step of this PR would be to make `DoubledHilbert` and `TensorHilbert` parametric classes in order to create special dispatches (for example, if `DoubledHilbert[<:HomogeneousHilbert]`, there is no need to split the rows and columns because they all are identical). 
But I think this can be done in a second moment.

The next step would be to do the same for `MCState.expect` and `.expect_and_grad` so an user could use his own, custom operators or anything with those two functions. 