### PR TITLE
Rename MCState `n_discard` to `n_discard_per_chain` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ### Breaking Changes
 
+* `MCState.n_discard` has been renamed `MCState.n_discard_per_chain` and the old binding has been deprecated [#739](https://github.com/netket/netket/pull/739).
+
 
 ### Bug Fixes
 

--- a/Examples/Autoregressive/ising1d_autoreg_conv.py
+++ b/Examples/Autoregressive/ising1d_autoreg_conv.py
@@ -40,7 +40,7 @@ sr = nk.optimizer.SR(diag_shift=0.01)
 # Variational state
 # With direct sampling, we don't need many samples in each step to form a
 # Markov chain, and we don't need to discard samples
-vs = nk.vqs.MCState(sa, ma, n_samples=64, n_discard=0)
+vs = nk.vqs.MCState(sa, ma, n_samples=64, n_discard_per_chain=0)
 
 # n_parameters also takes masked parameters into account
 # The number of non-masked parameters is about a half

--- a/Examples/Autoregressive/ising1d_autoreg_dense.py
+++ b/Examples/Autoregressive/ising1d_autoreg_dense.py
@@ -40,7 +40,7 @@ sr = nk.optimizer.SR(diag_shift=0.01)
 # Variational state
 # With direct sampling, we don't need many samples in each step to form a
 # Markov chain, and we don't need to discard samples
-vs = nk.vqs.MCState(sa, ma, n_samples=64, n_discard=0)
+vs = nk.vqs.MCState(sa, ma, n_samples=64, n_discard_per_chain=0)
 
 # n_parameters also takes masked parameters into account
 # The number of non-masked parameters is about a half

--- a/Examples/Heisenberg1d/heisenberg1d.py
+++ b/Examples/Heisenberg1d/heisenberg1d.py
@@ -45,7 +45,7 @@ op = nk.optim.Sgd(learning_rate=0.01)
 sr = nk.optim.SR(diag_shift=0.1)
 
 # Variational monte carlo driver
-gs = nk.VMC(ha, op, sa, ma, n_samples=1000, n_discard=100, preconditioner=sr)
+gs = nk.VMC(ha, op, sa, ma, n_samples=1000, n_discard_per_chain=100, preconditioner=sr)
 
 # Print parameter structure
 print(f"# variational parameters: {gs.state.n_parameters}")

--- a/Examples/Ising1d/ising1d_hk.py
+++ b/Examples/Ising1d/ising1d_hk.py
@@ -56,7 +56,7 @@ sa = nk.sampler.MetropolisLocal(hi, n_chains=16)
 op = nk.optimizer.Sgd(learning_rate=0.1)
 
 # Variational monte carlo driver
-gs = nk.VMC(ha, op, sa, ma, n_samples=1000, n_discard=50)
+gs = nk.VMC(ha, op, sa, ma, n_samples=1000, n_discard_per_chain=50)
 
 # Run the optimization for 300 iterations
 gs.run(n_iter=300, out="test")

--- a/Examples/Ising1d/ising1d_sr.py
+++ b/Examples/Ising1d/ising1d_sr.py
@@ -37,7 +37,7 @@ op = nk.optimizer.Sgd(learning_rate=0.1)
 sr = nk.optimizer.SR(diag_shift=0.01)
 
 # Variational state
-vs = nk.variational.MCState(sa, ma, n_samples=1000, n_discard=100)
+vs = nk.variational.MCState(sa, ma, n_samples=1000, n_discard_per_chain=100)
 
 # Variational monte carlo driver with a variational state
 gs = nk.VMC(ha, op, variational_state=vs, preconditioner=sr)

--- a/Examples/Ising1d/ising1d_sr_chol.py
+++ b/Examples/Ising1d/ising1d_sr_chol.py
@@ -37,7 +37,7 @@ op = nk.optimizer.Sgd(learning_rate=0.1)
 sr = nk.optimizer.SR(solver=nk.optimizer.solver.cholesky, diag_shift=0.01)
 
 # Variational state
-vs = nk.variational.MCState(sa, ma, n_samples=1000, n_discard=100)
+vs = nk.variational.MCState(sa, ma, n_samples=1000, n_discard_per_chain=100)
 
 # Variational monte carlo driver with a variational state
 gs = nk.VMC(ha, op, variational_state=vs, preconditioner=sr)

--- a/Examples/Ising2d/ising2d.py
+++ b/Examples/Ising2d/ising2d.py
@@ -30,7 +30,7 @@ ma = nk.models.RBM(alpha=1, use_visible_bias=True, dtype=float)
 sa = nk.sampler.MetropolisLocal(hi, n_chains=16)
 
 # The variational state
-vs = nk.variational.MCState(sa, ma, n_samples=1000, n_discard=100)
+vs = nk.variational.MCState(sa, ma, n_samples=1000, n_discard_per_chain=100)
 vs.init_parameters(nk.nn.initializers.normal(stddev=0.01), seed=1234)
 
 # Optimizer

--- a/Test/GroundState/test_vmc.py
+++ b/Test/GroundState/test_vmc.py
@@ -125,7 +125,7 @@ def test_vmc_functions():
 
     n_samples = 16000
     ma.n_samples = n_samples
-    ma.n_discard = 100
+    ma.n_discard_per_chain = 100
 
     ## Check zero gradieent
     _, grads = ma.expect_and_grad(ha)
@@ -239,7 +239,7 @@ def test_vmc_gradient(dtype):
     grad_exact = central_diff_grad(energy_fun, pars, 1.0e-5, ma, ha.to_sparse())
 
     driver.state.n_samples = 1e5
-    driver.state.n_discard = 1e3
+    driver.state.n_discard_per_chain = 1e3
     driver.state.parameters = pars_0
     _, _grad_approx = ma.expect_and_grad(ha)  # driver._forward_and_backward()
     grad_approx, _ = nk.jax.tree_ravel(_grad_approx)

--- a/Test/Variational/test_autoreg.py
+++ b/Test/Variational/test_autoreg.py
@@ -26,7 +26,7 @@ def test_AR_VMC(s):
     model = nk.models.ARNNDense(hilbert=hilbert, layers=3, features=5)
     sampler = nk.sampler.ARDirectSampler(hilbert, n_chains=3)
 
-    vstate = nk.variational.MCState(sampler, model, n_samples=6, n_discard=0)
+    vstate = nk.variational.MCState(sampler, model, n_samples=6, n_discard_per_chain=0)
     vstate.sample()
 
     H = nk.operator.Ising(hilbert=hilbert, graph=graph, h=1)

--- a/Test/Variational/test_variational.py
+++ b/Test/Variational/test_variational.py
@@ -103,7 +103,7 @@ def test_n_samples_api(vstate):
     with raises(
         ValueError,
     ):
-        vstate.n_discard = -1
+        vstate.n_discard_per_chain = -1
 
     vstate.n_samples = 2
     assert vstate.samples.shape[0:2] == (1, vstate.sampler.n_chains)
@@ -113,12 +113,27 @@ def test_n_samples_api(vstate):
     assert vstate.samples.shape[0:2] == (2, vstate.sampler.n_chains)
 
     vstate.n_samples = 1000
-    vstate.n_discard = None
-    assert vstate.n_discard == 0
+    vstate.n_discard_per_chain = None
+    assert vstate.n_discard_per_chain == 0
 
     vstate.sampler = nk.sampler.MetropolisLocal(hilbert=hi, n_chains=16)
-    vstate.n_discard = None
-    assert vstate.n_discard == vstate.n_samples // 10
+    vstate.n_discard_per_chain = None
+    assert vstate.n_discard_per_chain == vstate.n_samples // 10
+
+
+def test_deprecations(vstate):
+    vstate.sampler = nk.sampler.MetropolisLocal(hilbert=hi, n_chains=16)
+
+    # deprecation
+    with pytest.warns(FutureWarning):
+        vstate.n_discard = 10
+
+    with pytest.warns(FutureWarning):
+        vstate.n_discard
+
+    vstate.n_discard = 10
+    assert vstate.n_discard == 10
+    assert vstate.n_discard_per_chain == 10
 
 
 def test_serialization(vstate):
@@ -129,7 +144,7 @@ def test_serialization(vstate):
     old_params = vstate.parameters
     old_samples = vstate.samples
     old_nsamples = vstate.n_samples
-    old_ndiscard = vstate.n_discard
+    old_ndiscard = vstate.n_discard_per_chain
 
     vstate = nk.variational.MCState(
         vstate.sampler, vstate.model, n_samples=10, seed=SEED + 100
@@ -140,7 +155,7 @@ def test_serialization(vstate):
     jax.tree_multimap(np.testing.assert_allclose, vstate.parameters, old_params)
     np.testing.assert_allclose(vstate.samples, old_samples)
     assert vstate.n_samples == old_nsamples
-    assert vstate.n_discard == old_ndiscard
+    assert vstate.n_discard_per_chain == old_ndiscard
 
 
 def test_init_parameters(vstate):
@@ -190,7 +205,7 @@ def test_expect_numpysampler_works(vstate, operator):
 def test_expect(vstate, operator):
     #  Use lots of samples
     vstate.n_samples = 5 * 1e5
-    vstate.n_discard = 1e3
+    vstate.n_discard_per_chain = 1e3
 
     # sample the expectation value and gradient with tons of samples
     O_stat1 = vstate.expect(operator)

--- a/Test/Variational/test_variational_mixed.py
+++ b/Test/Variational/test_variational_mixed.py
@@ -83,7 +83,7 @@ def test_n_samples_api(vstate):
     with raises(
         ValueError,
     ):
-        vstate.n_discard = -1
+        vstate.n_discard_per_chain = -1
 
     vstate.n_samples = 2
     assert vstate.samples.shape[0:2] == (1, vstate.sampler.n_chains)
@@ -93,14 +93,14 @@ def test_n_samples_api(vstate):
     assert vstate.samples.shape[0:2] == (2, vstate.sampler.n_chains)
 
     vstate.n_samples = 1000
-    vstate.n_discard = None
-    assert vstate.n_discard == 0
+    vstate.n_discard_per_chain = None
+    assert vstate.n_discard_per_chain == 0
 
     vstate.sampler = nk.sampler.MetropolisLocal(
         hilbert=nk.hilbert.DoubledHilbert(hi), n_chains=16
     )
-    vstate.n_discard = None
-    assert vstate.n_discard == vstate.n_samples // 10
+    vstate.n_discard_per_chain = None
+    assert vstate.n_discard_per_chain == vstate.n_samples // 10
 
 
 def test_n_samples_diag_api(vstate):
@@ -117,7 +117,7 @@ def test_n_samples_diag_api(vstate):
     with raises(
         ValueError,
     ):
-        vstate.n_discard = -1
+        vstate.n_discard_per_chain = -1
 
     vstate.n_samples_diag = 2
     assert (
@@ -139,12 +139,27 @@ def test_n_samples_diag_api(vstate):
     )
 
     vstate.n_samples = 1000
-    vstate.n_discard = None
-    assert vstate.n_discard_diag == 0
+    vstate.n_discard_per_chain = None
+    assert vstate.n_discard_per_chain_diag == 0
 
     vstate.sampler_diag = nk.sampler.MetropolisLocal(hilbert=hi, n_chains=16)
-    vstate.n_discard_diag = None
-    assert vstate.n_discard_diag == vstate.n_samples_diag // 10
+    vstate.n_discard_per_chain_diag = None
+    assert vstate.n_discard_per_chain_diag == vstate.n_samples_diag // 10
+
+
+def test_deprecations(vstate):
+    vstate.sampler_diag = nk.sampler.MetropolisLocal(hilbert=hi, n_chains=16)
+
+    # deprecation
+    with pytest.warns(FutureWarning):
+        vstate.n_discard_diag = 10
+
+    with pytest.warns(FutureWarning):
+        vstate.n_discard_diag
+
+    vstate.n_discard_diag = 10
+    assert vstate.n_discard_diag == 10
+    assert vstate.n_discard_per_chain_diag == 10
 
 
 def test_serialization(vstate):
@@ -164,9 +179,9 @@ def test_serialization(vstate):
     np.testing.assert_allclose(vstate.samples, vstate_new.samples)
     np.testing.assert_allclose(vstate.diagonal.samples, vstate_new.diagonal.samples)
     assert vstate.n_samples == vstate_new.n_samples
-    assert vstate.n_discard == vstate_new.n_discard
+    assert vstate.n_discard_per_chain == vstate_new.n_discard_per_chain
     assert vstate.n_samples_diag == vstate_new.n_samples_diag
-    assert vstate.n_discard_diag == vstate_new.n_discard_diag
+    assert vstate.n_discard_per_chain_diag == vstate_new.n_discard_per_chain_diag
 
 
 @pytest.mark.parametrize(

--- a/Tutorials/G-CNN_Honeycomb.ipynb
+++ b/Tutorials/G-CNN_Honeycomb.ipynb
@@ -589,7 +589,7 @@
         "#Redefine everything on bigger graph\n",
         "ma = nk.models.GCNN(symmetries = symmetries, layers = num_layers, features = feature_dims)\n",
         "sa = nk.sampler.MetropolisExchange(hilbert = hi, graph=graph, d_max=2)\n",
-        "vstate = nk.variational.MCState(sampler=sa, model=ma, n_samples=100, n_discard=100)\n",
+        "vstate = nk.variational.MCState(sampler=sa, model=ma, n_samples=100, n_discard_per_chain=100)\n",
         "gs = nk.driver.VMC(ha, op, sr=sr, variational_state=vstate)"
       ],
       "id": "466e14c7",

--- a/docs/docs/getting_started.rst
+++ b/docs/docs/getting_started.rst
@@ -196,7 +196,7 @@ use an arbitrary flax optimiser, or define your own.
 .. code-block:: python
 
     # Variational monte carlo driver
-    gs = nk.VMC(ha, op, sa, ma, n_samples=1000, n_discard=100)
+    gs = nk.VMC(ha, op, sa, ma, n_samples=1000, n_discard_per_chain=100)
 
     gs.run(n_iter=300, out=None)
 

--- a/docs/docs/varstate.rst
+++ b/docs/docs/varstate.rst
@@ -159,9 +159,9 @@ You can also change the number of samples to extract (note: this will
 trigger recompilation of the sample function, so you should not this
 in a hot loop) by changing :py:attr:`~netket.vqs.MCState.n_samples`, and
 the number of discarded samples at the beginning of every markov chain by
-changing :py:attr:`~netket.vqs.MCState.n_discard`.
+changing :py:attr:`~netket.vqs.MCState.n_discard_per_chain`.
 
-By default, :py:attr:`~netket.vqs.MCState.n_discard` is 10% of
+By default, :py:attr:`~netket.vqs.MCState.n_discard_per_chain` is 10% of
 :py:attr:`~netket.vqs.MCState.n_samples`.
 
 The number of samples is then split among the number of chains/batches of the sampler.
@@ -180,14 +180,14 @@ The number of samples is then split among the number of chains/batches of the sa
     print(vstate.chain_length)
     63
 
-    print(vstate.n_discard)
+    print(vstate.n_discard_per_chain)
     50
 
 You can see that 500 samples are split among 8 chains, giving :math:`500/8=62.5` (rounded to
 the next largest integer, 63). Therefore 8 chains of length 63 will be run.
-n_discard gives the number of discarded steps taken in the markov chain before actually storing
-them, so the Markov Chains are actually :code:`chain_length + n_discard` long. The default
-n_discard is 10% of the total samples, but you can change that to any number.
+n_discard_per_chain gives the number of discarded steps taken in the markov chain before actually storing
+them, so the Markov Chains are actually :code:`chain_length + n_discard_per_chain` long. The default
+n_discard_per_chain is 10% of the total samples, but you can change that to any number.
 
 .. _warn-mpi-sampling:
 


### PR DESCRIPTION
I should have done this as part of #706 but I did not think about it.

`n_discard` Is going to raise deprecation warnings for now, and will be removed at a later date.

This is a simple renaming and does not change the default value (which is still 10% of total samples).