### PR TITLE
Add `Sampler.is_exact`

### DIFF
--- a/Examples/Autoregressive/ising1d_autoreg_conv.py
+++ b/Examples/Autoregressive/ising1d_autoreg_conv.py
@@ -40,7 +40,7 @@ sr = nk.optimizer.SR(diag_shift=0.01)
 # Variational state
 # With direct sampling, we don't need many samples in each step to form a
 # Markov chain, and we don't need to discard samples
-vs = nk.vqs.MCState(sa, ma, n_samples=64, n_discard_per_chain=0)
+vs = nk.vqs.MCState(sa, ma, n_samples=64)
 
 # n_parameters also takes masked parameters into account
 # The number of non-masked parameters is about a half

--- a/Examples/Autoregressive/ising1d_autoreg_dense.py
+++ b/Examples/Autoregressive/ising1d_autoreg_dense.py
@@ -40,7 +40,7 @@ sr = nk.optimizer.SR(diag_shift=0.01)
 # Variational state
 # With direct sampling, we don't need many samples in each step to form a
 # Markov chain, and we don't need to discard samples
-vs = nk.vqs.MCState(sa, ma, n_samples=64, n_discard_per_chain=0)
+vs = nk.vqs.MCState(sa, ma, n_samples=64)
 
 # n_parameters also takes masked parameters into account
 # The number of non-masked parameters is about a half

--- a/Test/Sampler/test_sampler.py
+++ b/Test/Sampler/test_sampler.py
@@ -302,3 +302,11 @@ def test_throwing(model_and_weights):
         ma, w = model_and_weights(hi)
 
         sampler_state = sampler.init_state(ma, w, seed=SAMPLER_SEED)
+
+
+def test_exact_sampler(sampler):
+    known_exact_samplers = [nk.sampler.ExactSampler, nk.sampler.ARDirectSampler]
+    if any(isinstance(sampler, x) for x in known_exact_samplers):
+        assert sampler.is_exact == True
+    else:
+        assert sampler.is_exact == False

--- a/Test/Variational/test_autoreg.py
+++ b/Test/Variational/test_autoreg.py
@@ -26,7 +26,8 @@ def test_AR_VMC(s):
     model = nk.models.ARNNDense(hilbert=hilbert, layers=3, features=5)
     sampler = nk.sampler.ARDirectSampler(hilbert, n_chains=3)
 
-    vstate = nk.variational.MCState(sampler, model, n_samples=6, n_discard_per_chain=0)
+    vstate = nk.vqs.MCState(sampler, model, n_samples=6)
+    assert vstate.n_discard_per_chain == 0
     vstate.sample()
 
     H = nk.operator.Ising(hilbert=hilbert, graph=graph, h=1)

--- a/Test/Variational/test_experimental.py
+++ b/Test/Variational/test_experimental.py
@@ -35,7 +35,7 @@ def vstate(request):
         visible_bias_init=nk.nn.initializers.normal(),
     )
 
-    return nk.variational.MCState(
+    return nk.vqs.MCState(
         nk.sampler.MetropolisLocal(hi),
         ma,
     )
@@ -48,11 +48,11 @@ def test_variables_from_file(vstate, tmp_path):
         f.write(serialization.to_bytes(vstate.variables))
 
     for name in [fname, fname[:-6]]:
-        vstate2 = nk.variational.MCState(
+        vstate2 = nk.vqs.MCState(
             vstate.sampler, vstate.model, n_samples=10, seed=SEED + 100
         )
 
-        vstate2.variables = nk.variational.experimental.variables_from_file(
+        vstate2.variables = nk.vqs.experimental.variables_from_file(
             name, vstate2.variables
         )
 
@@ -72,12 +72,12 @@ def test_variables_from_tar(vstate, tmp_path):
             )
 
     for name in [fname, fname[:-4]]:
-        vstate2 = nk.variational.MCState(
+        vstate2 = nk.vqs.MCState(
             vstate.sampler, vstate.model, n_samples=10, seed=SEED + 100
         )
 
         for j in [0, 3, 8]:
-            vstate2.variables = nk.variational.experimental.variables_from_tar(
+            vstate2.variables = nk.vqs.experimental.variables_from_tar(
                 name, vstate2.variables, j
             )
 
@@ -87,7 +87,7 @@ def test_variables_from_tar(vstate, tmp_path):
             )
 
         with pytest.raises(KeyError):
-            nk.variational.experimental.variables_from_tar(name, vstate2.variables, 15)
+            nk.vqs.experimental.variables_from_tar(name, vstate2.variables, 15)
 
 
 def save_binary_to_tar(tar_file, byte_data, name):

--- a/Test/Variational/test_variational.py
+++ b/Test/Variational/test_variational.py
@@ -84,7 +84,7 @@ def vstate(request):
 
     sa = nk.sampler.ExactSampler(hilbert=hi, n_chains=16)
 
-    vs = nk.variational.MCState(sa, ma, n_samples=1000, seed=SEED)
+    vs = nk.vqs.MCState(sa, ma, n_samples=1000, seed=SEED)
 
     return vs
 
@@ -146,9 +146,7 @@ def test_serialization(vstate):
     old_nsamples = vstate.n_samples
     old_ndiscard = vstate.n_discard_per_chain
 
-    vstate = nk.variational.MCState(
-        vstate.sampler, vstate.model, n_samples=10, seed=SEED + 100
-    )
+    vstate = nk.vqs.MCState(vstate.sampler, vstate.model, n_samples=10, seed=SEED + 100)
 
     vstate = serialization.from_bytes(vstate, bdata)
 

--- a/Test/Variational/test_variational_mixed.py
+++ b/Test/Variational/test_variational_mixed.py
@@ -64,7 +64,7 @@ def vstate(request):
 
     sa = nk.sampler.ExactSampler(hilbert=nk.hilbert.DoubledHilbert(hi), n_chains=16)
 
-    vs = nk.variational.MCMixedState(sa, ma, n_samples=1000, seed=SEED)
+    vs = nk.vqs.MCMixedState(sa, ma, n_samples=1000, seed=SEED)
 
     return vs
 
@@ -167,7 +167,7 @@ def test_serialization(vstate):
 
     bdata = serialization.to_bytes(vstate)
 
-    vstate_new = nk.variational.MCMixedState(
+    vstate_new = nk.vqs.MCMixedState(
         vstate.sampler, vstate.model, n_samples=10, seed=SEED + 313
     )
 

--- a/netket/sampler/autoreg.py
+++ b/netket/sampler/autoreg.py
@@ -63,6 +63,10 @@ class ARDirectSamplerState(SamplerState):
 class ARDirectSampler(Sampler):
     """Direct sampler for autoregressive neural networks."""
 
+    @property
+    def is_exact(sampler):
+        return True
+
     def _init_cache(sampler, model, σ, key):
         variables = model.init(key, σ)
         if "cache" in variables:

--- a/netket/sampler/base.py
+++ b/netket/sampler/base.py
@@ -151,6 +151,13 @@ class Sampler(abc.ABC):
         """
         return self.n_chains_per_rank
 
+    @property
+    def is_exact(self) -> bool:
+        """
+        Whether the sampler is exact.
+        """
+        return False
+
     def log_pdf(self, model: Union[Callable, nn.Module]) -> Callable:
         """
         Returns a closure with the log_pdf function encoded by this sampler.

--- a/netket/sampler/base.py
+++ b/netket/sampler/base.py
@@ -154,7 +154,10 @@ class Sampler(abc.ABC):
     @property
     def is_exact(self) -> bool:
         """
-        Whether the sampler is exact.
+        Returns `True` if the sampler is exact.
+        
+        The sampler is exact if the samples are always distributed according to the
+        chosen power of the variational state.
         """
         return False
 

--- a/netket/sampler/base.py
+++ b/netket/sampler/base.py
@@ -155,7 +155,7 @@ class Sampler(abc.ABC):
     def is_exact(self) -> bool:
         """
         Returns `True` if the sampler is exact.
-        
+
         The sampler is exact if the samples are always distributed according to the
         chosen power of the variational state.
         """

--- a/netket/sampler/exact.py
+++ b/netket/sampler/exact.py
@@ -53,6 +53,10 @@ class ExactSampler(Sampler):
     option.
     """
 
+    @property
+    def is_exact(sampler):
+        return True
+
     def _init_state(sampler, machine, params, key):
         pdf = jnp.zeros(sampler.hilbert.n_states, dtype=jnp.float32)
         return ExactSamplerState(pdf=pdf, rng=key)

--- a/netket/vqs/mc_state.py
+++ b/netket/vqs/mc_state.py
@@ -333,7 +333,7 @@ class MCState(VariationalState):
         if self.sampler.is_exact:
             if n_discard_per_chain is not None and n_discard_per_chain > 0:
                 warnings.warn(
-                    "Exact sampler does not need to discard samples. Setting n_discard_per_chain to 0."
+                    "An exact sampler does not need to discard samples. Setting n_discard_per_chain to 0."
                 )
             n_discard_per_chain = 0
 

--- a/netket/vqs/mc_state.py
+++ b/netket/vqs/mc_state.py
@@ -132,7 +132,8 @@ class MCState(VariationalState):
             n_samples: the total number of samples across chains and processes when sampling (default=1000).
             n_samples_per_rank: the total number of samples across chains on one process when sampling. Cannot be
                 specified together with n_samples (default=None).
-            n_discard_per_chain: number of discarded samples at the beginning of each monte-carlo chain (default=n_samples/10).
+            n_discard_per_chain: number of discarded samples at the beginning of each monte-carlo chain (default=0 for exact sampler,
+                and n_samples/10 for approximate sampler).
             parameters: Optional PyTree of weights from which to start.
             seed: rng seed used to generate a set of parameters (only if parameters is not passed). Defaults to a random one.
             sampler_seed: rng seed used to initialise the sampler. Defaults to a random one.
@@ -146,7 +147,6 @@ class MCState(VariationalState):
                 `model.apply(variables, σ)`. specify only if your network has a non-standard apply method.
             training_kwargs: a dict containing the optionaal keyword arguments to be passed to the apply_fun during training.
                 Useful for example when you have a batchnorm layer that constructs the average/mean only during training.
-
         """
         super().__init__(sampler.hilbert)
 
@@ -329,11 +329,11 @@ class MCState(VariationalState):
                 )
             )
 
-        # don't discard if ExactSampler
-        if isinstance(self.sampler, ExactSampler):
+        # don't discard if the sampler is exact
+        if self.sampler.is_exact:
             if n_discard_per_chain is not None and n_discard_per_chain > 0:
                 warnings.warn(
-                    "Exact Sampler does not need to discard samples. Setting n_discard_per_chain to 0."
+                    "Exact sampler does not need to discard samples. Setting n_discard_per_chain to 0."
                 )
             n_discard_per_chain = 0
 


### PR DESCRIPTION
When an exact sampler is used in `MCState`, `MCState.n_discard_per_chain` defaults to 0.