### PR TITLE
update for jax 0.2.14, mpi4jax 0.3.1

### DIFF
--- a/netket/utils/mpi/mpi.py
+++ b/netket/utils/mpi/mpi.py
@@ -16,8 +16,6 @@ import os
 import warnings
 from textwrap import dedent
 
-from distutils.version import LooseVersion as _LooseVersion
-
 from netket.utils.config_flags import config
 
 _mpi4py_loaded = False
@@ -101,10 +99,26 @@ except ImportError:
 
 
 if mpi_available:
-    _min_mpi4jax_version = "0.2.11"
-    if not _LooseVersion(mpi4jax.__version__) >= _LooseVersion(_min_mpi4jax_version):
+    _MIN_MPI4JAX_VERSION = "0.3.1"
+
+    def _get_version_tuple(verstr):
+        # drop everything after the numeric part of the version
+        allowed_chars = "0123456789."
+        for i, char in enumerate(verstr):
+            if char not in allowed_chars:
+                break
+        else:
+            i = len(verstr) + 1
+
+        verstr = verstr[:i].rstrip(".")
+        return tuple(int(v) for v in verstr.split("."))[:3]
+
+    if _get_version_tuple(mpi4jax.__version__) < _get_version_tuple(
+        _MIN_MPI4JAX_VERSION
+    ):
         raise ImportError(
-            "Netket is only compatible with mpi4jax >= {}. Please update it (`pip install -U mpi4jax`).".format(
-                _min_mpi4jax_version
-            )
+            f"Netket is only compatible with mpi4jax >= {_MIN_MPI4JAX_VERSION} "
+            f"(you have mpi4jax == {mpi4jax.__version__}). "
+            "Please update it to a more recent version by running "
+            "(`pip install -U mpi4jax`)."
         )

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ DEV_DEPENDENCIES = [
     "pre-commit",
     "black==20.8b1",
 ]
-MPI_DEPENDENCIES = ["mpi4py>=3.0.1, <4", "mpi4jax~0.3.1"]
+MPI_DEPENDENCIES = ["mpi4py>=3.0.1, <4", "mpi4jax~=0.3.1"]
 TENSORBOARD_DEPENDENCIES = ["tensorboardx>=2.0.0"]
 BASE_DEPENDENCIES = [
     "numpy~=1.18",

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ DEV_DEPENDENCIES = [
     "pre-commit",
     "black==20.8b1",
 ]
-MPI_DEPENDENCIES = ["mpi4py>=3.0.1", "mpi4jax>=0.3.1"]
+MPI_DEPENDENCIES = ["mpi4py>=3.0.1, <4", "mpi4jax~0.3.1"]
 TENSORBOARD_DEPENDENCIES = ["tensorboardx>=2.0.0"]
 BASE_DEPENDENCIES = [
     "numpy~=1.18",

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ DEV_DEPENDENCIES = [
     "pre-commit",
     "black==20.8b1",
 ]
-MPI_DEPENDENCIES = ["mpi4py>=3.0.1", "mpi4jax>=0.2.11"]
+MPI_DEPENDENCIES = ["mpi4py>=3.0.1", "mpi4jax>=0.3.1"]
 TENSORBOARD_DEPENDENCIES = ["tensorboardx>=2.0.0"]
 BASE_DEPENDENCIES = [
     "numpy~=1.18",
@@ -19,7 +19,7 @@ BASE_DEPENDENCIES = [
     "plum-dispatch~=1.0",
     "numba>=0.52, <0.54",
     "python-igraph~=0.9",
-    "jax>=0.2.9, <0.2.14",
+    "jax>=0.2.9, <0.2.15",
     "jaxlib>=0.1.57",
     "flax>=0.3.0, <0.4",
     "orjson~=3.4",


### PR DESCRIPTION
I'll soon tag a new mpi4jax release (0.3.1) that works with the latest jax as well as the old ones.
Since there are a few features that require more recent versions of mpi4jax (like `vs.to_array()`) 
I bumped the minimum required `mpi4jax` version to the latest.

This PR also changes the code used to check the lowest compatible mpi4jax version to use a custom function instead of depending on setuptools, which will simplify the conda installation.
