### PR TITLE
Split `color` option for edges and add `edge_colors`

### DIFF
--- a/netket/graph/abstract_graph.py
+++ b/netket/graph/abstract_graph.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import abc
-from typing import List, Iterator, Sequence, Tuple, Union
+from typing import List, Iterator, Sequence, Tuple, Union, Optional
 
 
 Edge = Tuple[int, int]
@@ -35,8 +35,27 @@ class AbstractGraph(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def edges(self, color: Union[bool, int] = False) -> EdgeSequence:
-        r"""Iterator over the edges of the graph. Optionally filter by edge color."""
+    def edges(
+        self, return_color: bool = False, filter_color: Optional[int] = None
+    ) -> EdgeSequence:
+        r"""Returns the sequence of edges of the graph.
+
+        Arguments:
+            return_color: If :code:`True`, return edges with added color information.
+            filter_color: If set, return only edges of the given color.
+
+        Returns:
+            A sequence of edges as tuples :code:`(i, j)` or, if `return_color` is
+            passed, a sequence of tuples :code:`(i, j, c)` with :code:`c` indicating
+            the color of the respective edge.
+        """
+        raise NotImplementedError
+
+    @property
+    @abc.abstractmethod
+    def edge_colors(self) -> Sequence[int]:
+        r"""Sequence of edge colors, in the order of the edges returned by
+        :code:`self.edges`."""
         raise NotImplementedError
 
     @abc.abstractmethod

--- a/netket/graph/graph.py
+++ b/netket/graph/graph.py
@@ -137,14 +137,15 @@ class Graph(AbstractGraph):
         return_color: bool = False,
         filter_color: Optional[int] = None,
     ) -> EdgeSequence:
-        if color:
+        if color is not None:
             warn_deprecation(
                 "The color option has been split into return_color and filter_color."
             )
-            if isinstance(color, int):
-                filter_color = color
-            elif isinstance(color, bool):
+            # need to check for bool first, because bool is a subclass of int
+            if isinstance(color, bool):
                 return_color = color
+            elif isinstance(color, int):
+                filter_color = color
             else:
                 raise TypeError("Incorrect type for 'color'")
 

--- a/netket/operator/_graph_operator.py
+++ b/netket/operator/_graph_operator.py
@@ -106,7 +106,7 @@ class GraphOperator(LocalOperator):
 
             if len(bond_ops) > 0:
                 #  Use edge_colors to populate operators
-                for (u, v, color) in graph.edges(color=True):
+                for (u, v, color) in graph.edges(return_color=True):
                     edge = u, v
                     for c, bond_color in enumerate(bond_ops_colors):
                         if bond_color == color:

--- a/test/graph/test_graph.py
+++ b/test/graph/test_graph.py
@@ -401,6 +401,7 @@ def test_computes_distances():
 
 def test_lattice_is_bipartite():
     for graph in graphs:
+        print(graph)
         g = nx.Graph()
         for edge in graph.edges():
             g.add_edge(edge[0], edge[1])
@@ -441,17 +442,17 @@ def test_adjacency_list():
 #    count = lambda it: sum(1 for _ in it)
 #
 #    g = Grid([4, 4], pbc=True, color_edges=True)
-#    assert count(g.edges(color=0)) == 16
-#    assert count(g.edges(color=1)) == 16
+#    assert count(g.edges(filter_color=0)) == 16
+#    assert count(g.edges(filter_color=1)) == 16
 #    assert g.n_edges == 32
 #
 #    g = Grid([4, 2], pbc=True, color_edges=True)
-#    assert count(g.edges(color=0)) == 8
-#    assert count(g.edges(color=1)) == 4
+#    assert count(g.edges(filter_color=0)) == 8
+#    assert count(g.edges(filter_color=1)) == 4
 #
 #    g = Grid([4, 2], pbc=False, color_edges=True)
-#    assert count(g.edges(color=0)) == 6
-#    assert count(g.edges(color=1)) == 4
+#    assert count(g.edges(filter_color=0)) == 6
+#    assert count(g.edges(filter_color=1)) == 4
 #
 #    with pytest.raises(ValueError, match="Directions with length <= 2 cannot have PBC"):
 #        g = Grid([2, 4], pbc=[True, True])
@@ -651,11 +652,11 @@ def test_edge_color_accessor():
     edges = [(0, 1, 0), (0, 3, 1), (1, 2, 1), (2, 3, 0)]
     g = Graph(edges=edges)
 
-    assert edges == sorted(g.edges(color=True))
+    assert edges == sorted(g.edges(return_color=True))
 
     g = Hypercube(4, 1)
 
-    assert [(i, j, 0) for (i, j, _) in edges] == sorted(g.edges(color=True))
+    assert [(i, j, 0) for (i, j, _) in edges] == sorted(g.edges(return_color=True))
 
 
 def test_union():
@@ -673,13 +674,13 @@ def test_graph_conversions():
     g = Graph.from_igraph(igraph)
     assert g.n_nodes == igraph.vcount()
     assert g.edges() == igraph.get_edgelist()
-    assert all(c == 0 for c in g._edge_colors)
+    assert all(c == 0 for c in g.edge_colors)
 
     nxg = nx.star_graph(5)
     g = Graph.from_networkx(nxg)
     assert g.n_nodes == igraph.vcount()
     assert g.edges() == igraph.get_edgelist()
-    assert all(c == 0 for c in g._edge_colors)
+    assert all(c == 0 for c in g.edge_colors)
 
     igraph = ig.Graph()
     igraph.add_vertices(3)
@@ -701,5 +702,17 @@ def test_graph_conversions():
         },
     )
     g = Graph.from_igraph(igraph)
-    assert g.edges(color=0) == [(0, 1)]
-    assert g.edges(color=1) == [(1, 2)]
+    assert g.edges(filter_color=0) == [(0, 1)]
+    assert g.edges(filter_color=1) == [(1, 2)]
+    assert g.edges(filter_color=0, return_color=True) == [(0, 1, 0)]
+    assert g.edges(filter_color=1, return_color=True) == [(1, 2, 1)]
+
+    with pytest.warns(FutureWarning):
+        assert g.edges(color=0) == g.edges(filter_color=0)
+    with pytest.warns(FutureWarning):
+        assert g.edges(color=True) == g.edges(return_color=True)
+
+
+def test_edge_colors():
+    for g in graphs:
+        assert all(isinstance(c, int) for c in g.edge_colors)


### PR DESCRIPTION
This PR supersedes #756 based on the discussion there, where we have deemed compatibility with the v3.0 betas to be more important than making `edges` a property. Therefore, this PR keeps that interface while splitting the somewhat overloaded `color` option into two separate option (with deprecation warning).

Just as #756, this PR also adds an `edge_colors` attribute returning just the list of colors.

Closes #750.