### PR TITLE
Flakehell: fix remaining two issues and add it as a pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,3 +4,8 @@ repos:
     hooks:
       - id: black
         language_version: python3
+
+  - repo: https://github.com/life4/flakehell
+    rev: v.0.8.0
+    hooks:
+    -   id: flakehell

--- a/netket/__init__.py
+++ b/netket/__init__.py
@@ -38,23 +38,27 @@ __all__ = [
     "nn",
 ]
 
+from . import jax
+from . import stats
+
+from . import graph
+from . import hilbert
+
+from . import nn
+
 from . import legacy
 
 from . import (
-    hilbert,
     exact,
     callbacks,
-    graph,
     logging,
     operator,
     models,
     sampler,
-    jax,
-    nn,
-    stats,
     vqs,
     optimizer,
 )
+
 
 # Main applications
 from .driver import VMC

--- a/netket/graph/lattice.py
+++ b/netket/graph/lattice.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass
 from math import pi
 
 from netket.utils.types import Array
-from typing import Callable, Dict, Sequence, Tuple, Union, Optional
+from typing import Callable, Dict, Sequence, Tuple, Union, Optional, TYPE_CHECKING
 import warnings
 
 import igraph
@@ -30,6 +30,9 @@ from netket.utils.float import comparable, comparable_periodic, is_approx_int
 from netket.utils.group import PointGroup, PermutationGroup, trivial_point_group
 
 from .graph import Graph
+
+if TYPE_CHECKING:
+    from .space_group import SpaceGroupBuilder
 
 PositionT = _np.ndarray
 CoordT = _np.ndarray

--- a/netket/logging/json_log.py
+++ b/netket/logging/json_log.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
 import orjson
 import time
 
@@ -91,7 +90,6 @@ class JsonLog(RuntimeLog):
             mode: Specify the behaviour in case the file already exists at this
                 output_prefix. Options are
                 - `[w]rite`: (default) overwrites file if it already exists;
-                - `[a]ppend`: appends to the file if it exists, overwise creates it;
                 - `[x]` or `fail`: fails if file already exists;
             save_params: bool flag indicating whever variables of the variational state
                 should be serialized at some interval. The output file is overwritten
@@ -115,21 +113,12 @@ class JsonLog(RuntimeLog):
                 "`[x]`(fail)."
             )
 
+        if mode == "append":
+            raise ValueError("Append mode is no longer supported.")
+
         file_exists = _exists_json(output_prefix)
 
-        starting_json_content = {"Output": []}
-
-        if file_exists and mode == "append":
-            # if there is only the .mpacck file but not the json one, raise an error
-            if not _path.exists(output_prefix + ".log"):
-                raise ValueError(
-                    "History file does not exists, but wavefunction file does."
-                    "Please change `output_prefix or set mode=`write`."
-                )
-
-            starting_json_content = json.load(open(output_prefix + ".log"))
-
-        elif file_exists and mode == "fail":
+        if file_exists and mode == "fail":
             raise ValueError(
                 "Output file already exists. Either delete it manually or"
                 "change `output_prefix`."


### PR DESCRIPTION
One issue was a circular import in the new lattice code (of which we were aware)

The other was due to the fact that the new output format can no longer be appended to an existing file (in principle it can, but it would require some work).

While i had not thought about this when i proposed the new format, I still think that appending to an existing file is not a so-much-usedf feature, and it's still possible to concatenate the output of two runs by using the same logger object, which mitigates the issue.

The PR also makes it so flakehell is run when running pre-commit hook (I know @femtobit really wants this!)
It's still not hooked up to CI yet. 