### PR TITLE
Fix Flakehell on tests + fix legacy removal on tests

### DIFF
--- a/Examples/Legacy/BoseHubbard1d/bosehubbard1d.py
+++ b/Examples/Legacy/BoseHubbard1d/bosehubbard1d.py
@@ -18,7 +18,7 @@ from netket import legacy as nk
 g = nk.graph.Hypercube(length=8, n_dim=1, pbc=True)
 
 # Boson Hilbert Space
-hi = nk.hilbert.Boson(N=g.n_nodes, n_max=3, n_bosons=8)
+hi = nk.hilbert.Fock(N=g.n_nodes, n_max=3, n_bosons=8)
 
 # Bose Hubbard Hamiltonian
 ha = nk.operator.BoseHubbard(hilbert=hi, graph=g, U=4.0)

--- a/Examples/Legacy/BoseHubbard1d/bosehubbard1d_jastrow.py
+++ b/Examples/Legacy/BoseHubbard1d/bosehubbard1d_jastrow.py
@@ -18,7 +18,7 @@ from netket import legacy as nk
 g = nk.graph.Hypercube(length=12, n_dim=1, pbc=True)
 
 # Boson Hilbert Space
-hi = nk.hilbert.Boson(N=g.n_nodes, n_max=3, n_bosons=12)
+hi = nk.hilbert.Fock(N=g.n_nodes, n_max=3, n_bosons=12)
 
 # Bose Hubbard Hamiltonian
 ha = nk.operator.BoseHubbard(U=4.0, hilbert=hi, graph=g)

--- a/netket/nn/utils.py
+++ b/netket/nn/utils.py
@@ -23,9 +23,9 @@ def to_array(hilbert, apply_fun, variables, normalize=True):
     # mpi4jax does not have (yet) allgatherv so we need to be creative
     # could be made easier if we update mpi4jax
     n_states = hilbert.n_states
-    n_states_fake = int(np.ceil(n_states / mpi.n_nodes)) * mpi.n_nodes
+    n_states_padded = int(np.ceil(n_states / mpi.n_nodes)) * mpi.n_nodes
     states_n = np.arange(n_states)
-    fake_states_n = np.arange(n_states_fake - n_states)
+    fake_states_n = np.arange(n_states_padded - n_states)
 
     # divide the hilbert space in chunks for each node
     states_per_rank = np.split(np.concatenate([states_n, fake_states_n]), mpi.n_nodes)
@@ -53,7 +53,7 @@ def _to_array_rank(apply_fun, variables, σ_rank, n_states, normalize):
     # last rank, get rid of fake elements
     if mpi.rank == mpi.n_nodes - 1 and n_fake_states > 0:
         log_psi_local = jax.ops.index_update(
-            log_psi_local, jax.ops.index[-n_fake_states:], 0.0
+            log_psi_local, jax.ops.index[-n_fake_states:], -jnp.inf
         )
 
     if normalize:

--- a/netket/operator/_hamiltonian.py
+++ b/netket/operator/_hamiltonian.py
@@ -473,8 +473,8 @@ class BoseHubbard(SpecialHamiltonian):
 
            >>> import netket as nk
            >>> g = nk.graph.Hypercube(length=3, n_dim=2, pbc=True)
-           >>> hi = nk.hilbert.Boson(n_max=3, n_bosons=6, N=g.n_nodes)
-           >>> op = nk.operator.BoseHubbard(U=4.0, hilbert=hi, graph=g)
+           >>> hi = nk.hilbert.Fock(n_max=3, n_particles=6, N=g.n_nodes)
+           >>> op = nk.operator.BoseHubbard(hi, U=4.0, graph=g)
            >>> print(op.hilbert.size)
            9
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ testpaths = [
 ]
 
 [tool.flakehell]
-exclude = ["netket/legacy"]
+exclude = ["netket/legacy", "test/legacy"]
 # make output nice
 format = "grouped"
 max-line-length = 88

--- a/test/driver/test_steadystate.py
+++ b/test/driver/test_steadystate.py
@@ -1,17 +1,8 @@
-from functools import partial
-from io import StringIO
-
 import pytest
-from pytest import approx, raises
+from pytest import raises
 
 import numpy as np
-import jax
-import jax.numpy as jnp
 import netket as nk
-
-from contextlib import redirect_stderr
-import tempfile
-import re
 
 from .. import common
 
@@ -65,12 +56,12 @@ def _setup_ss(dtype=np.float32, sr=True):
     return lind, vs, driver
 
 
-def _setup_obs():
+def _setup_obs(L):
     hi = nk.hilbert.Spin(s=0.5) ** L
 
     obs_sx = nk.operator.LocalOperator(hi)
     for i in range(L):
-        obs_sx += nk.operator.LocalOperator(hi, sx, [i])
+        obs_sx += nk.operator.spin.sigmax(hi, i)
 
     obs = {"SigmaX": obs_sx}
     return obs

--- a/test/graph/test_graph.py
+++ b/test/graph/test_graph.py
@@ -1,3 +1,17 @@
+# Copyright 2021 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import pytest
 
 import netket as nk
@@ -180,9 +194,9 @@ def test_lattice_site_lookup():
     np.testing.assert_almost_equal(ids, [0, 1])
 
     with pytest.raises(_lattice.InvalidSiteError):
-        idx = g.id_from_position([[0.5]])
+        g.id_from_position([[0.5]])
     with pytest.raises(_lattice.InvalidSiteError):
-        idx = g.id_from_position([0.5])
+        g.id_from_position([0.5])
 
     with pytest.raises(_lattice.InvalidSiteError):
         pos = g.position_from_basis_coords([2])
@@ -226,9 +240,9 @@ def test_lattice_symmetry(i, name):
     # Try an invalid symmetry group and fail
     with pytest.raises(_lattice.InvalidSiteError):
         if dimension[i] == 2:
-            sg = graph.space_group(group.planar.C(5))
+            _ = graph.space_group(group.planar.C(5))
         else:
-            sg = graph.space_group(group.axial.C(5))
+            _ = graph.space_group(group.axial.C(5))
     # Generate space group using the preloaded point group
     sgb = graph.space_group_builder()
 
@@ -257,7 +271,7 @@ def test_lattice_symmetry(i, name):
 
     # Try an invalid wave vector and fail
     with pytest.raises(_lattice.InvalidWaveVectorError):
-        lg = sgb.little_group([1] * dimension[i])
+        _ = sgb.little_group([1] * dimension[i])
 
     # The little group of Γ is the full point group
     assert sgb.little_group(np.zeros(dimension[i])) == sgb.point_group_
@@ -346,7 +360,7 @@ def test_draw_lattices():
             with pytest.raises(ValueError):
                 lattice.draw()
         else:
-            ax = lattice.draw(
+            _ = lattice.draw(
                 figsize=(1.2, 3),
                 node_color="blue",
                 node_size=600,
@@ -605,19 +619,19 @@ def test_triangular_space_group(lattice):
 
     g = lattice([3, 3], pbc=False)
     with pytest.raises(RuntimeError):
-        grp = g.rotation_group()
+        _ = g.rotation_group()
     with pytest.raises(RuntimeError):
-        grp = g.point_group()
+        _ = g.point_group()
     with pytest.raises(RuntimeError):
-        grp = g.space_group()
+        _ = g.space_group()
 
     g = lattice([2, 4])
     with pytest.raises(RuntimeError):
-        grp = g.rotation_group()
+        _ = g.rotation_group()
     with pytest.raises(RuntimeError):
-        grp = g.point_group()
+        _ = g.point_group()
     with pytest.raises(RuntimeError):
-        grp = g.space_group()
+        _ = g.space_group()
     # 2x4 unit cells of the triangle lattice make a rectangular grid
     assert len(g.point_group(group.planar.rectangle())) == 4
 

--- a/test/groundstate/test_vmc.py
+++ b/test/groundstate/test_vmc.py
@@ -128,7 +128,7 @@ def test_vmc_functions():
     ma.n_samples = n_samples
     ma.n_discard_per_chain = 100
 
-    # Check zero gradieent
+    # Check zero gradient
     _, grads = ma.expect_and_grad(ha)
 
     def check_shape(a, b):

--- a/test/groundstate/test_vmc.py
+++ b/test/groundstate/test_vmc.py
@@ -123,13 +123,12 @@ def test_vmc_functions():
     assert driver.energy.mean == approx(ma.expect(ha).mean, abs=1e-5)
 
     state = ma.to_array()
-    exact_dist = np.abs(state) ** 2
 
     n_samples = 16000
     ma.n_samples = n_samples
     ma.n_discard_per_chain = 100
 
-    ## Check zero gradieent
+    # Check zero gradieent
     _, grads = ma.expect_and_grad(ha)
 
     def check_shape(a, b):
@@ -139,9 +138,7 @@ def test_vmc_functions():
     grads, _ = nk.jax.tree_ravel(grads)
 
     assert np.mean(np.abs(grads) ** 2) == approx(0.0, abs=1e-8)
-    ## end
-
-    states = np.array(list(ma.hilbert.states()))
+    # end
 
     for op, name in (ha, "ha"), (sx, "sx"):
         print("Testing expectation of op={}".format(name))

--- a/test/hilbert/test_hilbert.py
+++ b/test/hilbert/test_hilbert.py
@@ -14,13 +14,11 @@
 
 import itertools
 import netket as nk
-import networkx as nx
 import numpy as np
 import pytest
-from netket.hilbert import *
+from netket.hilbert import Spin, Fock, CustomHilbert, Qubit, DoubledHilbert
 
 import jax
-from jax import numpy as jnp
 
 from .. import common
 
@@ -75,17 +73,18 @@ hilberts["Spin 1/2 with total Sz Small"] = Spin(s=3, total_sz=1.0, N=4)
 hilberts["Fock Small"] = Fock(n_max=3, N=5)
 
 # Qubit
-hilberts["Qubit Small"] = nk.hilbert.Qubit(N=1)
+hilberts["Qubit Small"] = Qubit(N=1)
 
 # Custom Hilbert
 hilberts["Custom Hilbert Small"] = CustomHilbert(local_states=[-1232, 132, 0], N=5)
 
 # Custom Hilbert
-hilberts["Doubled Hilbert"] = nk.hilbert.DoubledHilbert(
+hilberts["Doubled Hilbert"] = DoubledHilbert(
     CustomHilbert(local_states=[-1232, 132, 0], N=5)
 )
 
 # hilberts["Tensor: Spin x Fock"] = Spin(s=0.5, N=4) * Fock(4, N=2)
+
 
 #
 # Tests
@@ -189,9 +188,9 @@ def test_hilbert_index(hi):
     op = nk.operator.Heisenberg(hilbert=Spin(s=0.5, N=g.n_nodes), graph=g)
 
     with pytest.raises(RuntimeError):
-        m1 = op.to_dense()
+        op.to_dense()
     with pytest.raises(RuntimeError):
-        m2 = op.to_sparse()
+        op.to_sparse()
 
 
 def test_state_iteration():
@@ -207,8 +206,8 @@ def test_deprecations():
     g = nk.graph.Edgeless(3)
 
     with pytest.warns(FutureWarning):
-        hilbert = Spin(s=0.5, graph=g)
+        Spin(s=0.5, graph=g)
 
     with pytest.warns(FutureWarning):
         with pytest.raises(ValueError):
-            hilbert = Spin(s=0.5, graph=g, N=3)
+            Spin(s=0.5, graph=g, N=3)

--- a/test/logging/test_state_log.py
+++ b/test/logging/test_state_log.py
@@ -1,12 +1,5 @@
 import pytest
 
-import jax
-import jax.numpy as jnp
-import jax.flatten_util
-import numpy as np
-from functools import partial
-import itertools
-
 import tarfile
 import glob
 
@@ -21,7 +14,6 @@ pytestmark = common.skipif_mpi
 def vstate(request):
     N = 8
     hi = nk.hilbert.Spin(1 / 2, N)
-    g = nk.graph.Chain(N)
 
     ma = nk.models.RBM(
         alpha=1,

--- a/test/models/test_jastrow.py
+++ b/test/models/test_jastrow.py
@@ -25,7 +25,7 @@ def test_Jastrow(dtype):
     g = nk.graph.Chain(N)
 
     ma = nk.models.Jastrow(dtype=dtype)
-    pars = ma.init(nk.jax.PRNGKey(), hi.random_state(nk.jax.PRNGKey()))
+    _ = ma.init(nk.jax.PRNGKey(), hi.random_state(nk.jax.PRNGKey()))
 
     vmc = nk.VMC(
         nk.operator.Ising(hi, g, h=1.0),

--- a/test/models/test_mps.py
+++ b/test/models/test_mps.py
@@ -1,19 +1,6 @@
-from functools import partial
-from io import StringIO
-
 import pytest
-from pytest import approx, raises
 
-import numpy as np
-import jax
-import jax.numpy as jnp
 import netket as nk
-from netket import nn as nknn
-import flax
-
-from contextlib import redirect_stderr
-import tempfile
-import re
 
 
 @pytest.mark.parametrize("diag", [False, True])
@@ -44,4 +31,4 @@ def test_mps_nonchain():
     ):
         ma = nk.models.MPSPeriodic(hi, g, bond_dim=2)
         sa = nk.sampler.MetropolisLocal(hilbert=hi, n_chains=16)
-        vs = nk.vqs.MCState(sa, ma, n_samples=1000)
+        _ = nk.vqs.MCState(sa, ma, n_samples=1000)

--- a/test/models/test_rbm.py
+++ b/test/models/test_rbm.py
@@ -91,7 +91,7 @@ def test_RBMSymm_creation():
 
     def check_init(creator):
         ma = creator()
-        p = ma.init(nk.jax.PRNGKey(0), hi.numbers_to_states(0))
+        _ = ma.init(nk.jax.PRNGKey(0), hi.numbers_to_states(0))
 
     perms = [[0, 1, 2, 3, 4, 5, 6, 7]]
 
@@ -124,7 +124,7 @@ def test_GCNN_creation():
 
     def check_init(creator):
         ma = creator()
-        p = ma.init(nk.jax.PRNGKey(0), hi.numbers_to_states(0))
+        _ = ma.init(nk.jax.PRNGKey(0), hi.numbers_to_states(0))
 
     perms = [[0, 1, 2, 3, 4, 5, 6, 7], [7, 6, 5, 4, 3, 2, 1, 0]]
 
@@ -190,7 +190,7 @@ def test_RBMMultiVal(use_hidden_bias, use_visible_bias):
         hidden_bias_init=nk.nn.initializers.uniform(),
         visible_bias_init=nk.nn.initializers.uniform(),
     )
-    pars = ma.init(nk.jax.PRNGKey(), hi.random_state(nk.jax.PRNGKey(), 1))
+    _ = ma.init(nk.jax.PRNGKey(), hi.random_state(nk.jax.PRNGKey(), 1))
 
     vmc = nk.VMC(
         nk.operator.BoseHubbard(hi, g, U=1.0),

--- a/test/mpi/test_mpi_setup.py
+++ b/test/mpi/test_mpi_setup.py
@@ -1,4 +1,16 @@
-import pytest
+# Copyright 2021 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from .. import common
 

--- a/test/mpi/test_mpi_utils.py
+++ b/test/mpi/test_mpi_utils.py
@@ -34,3 +34,4 @@ def test_key_split(_mpi_size, _mpi_comm):
     key, _ = nk.jax.mpi_split(key)
     keys = MPI.COMM_WORLD.allgather(key)
     assert all([not jnp.all(k == keys) for k in keys])
+    assert len(keys) == size

--- a/test/nn/test_utils.py
+++ b/test/nn/test_utils.py
@@ -1,21 +1,25 @@
+# Copyright 2021 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import pytest
 
-import jax
 import jax.numpy as jnp
-import jax.flatten_util
 import numpy as np
-from functools import partial
-import itertools
-
-import tarfile
-import glob
-from io import BytesIO
-
-from flax import serialization
 
 import netket as nk
 
-from .. import common
+from .. import common  # noqa: F401
 
 SEED = 111
 
@@ -24,7 +28,7 @@ SEED = 111
 def vstate(request):
     M = request.param
     # keep this a prime number so we get different sizes on every rank...
-    hi = nk.hilbert.Fock(7, 1)
+    hi = nk.hilbert.Fock(M, 1)
 
     ma = nk.models.RBM(
         alpha=1,
@@ -61,7 +65,7 @@ def test_to_array(vstate, normalize):
 def vstate_rho(request):
     M = request.param
     # keep this a prime number so we get different sizes on every rank...
-    hi = nk.hilbert.Fock(7, 1)
+    hi = nk.hilbert.Fock(M, 1)
 
     ma = nk.models.NDM()
 

--- a/test/nn/test_utils.py
+++ b/test/nn/test_utils.py
@@ -24,7 +24,9 @@ from .. import common  # noqa: F401
 SEED = 111
 
 
-@pytest.fixture(params=[pytest.param(M, id=f"Fock(M={M})") for M in [0, 3, 5, 7, 9]])
+@pytest.fixture(
+    params=[pytest.param(M, id=f"Fock(M={M})") for M in [0, 2, 3, 4, 5, 6, 8]]
+)
 def vstate(request):
     M = request.param
     # keep this a prime number so we get different sizes on every rank...
@@ -61,7 +63,9 @@ def test_to_array(vstate, normalize):
     np.testing.assert_allclose(psi_norm, psi_exact)
 
 
-@pytest.fixture(params=[pytest.param(M, id=f"Fock(M={M})") for M in [0, 5, 9]])
+@pytest.fixture(
+    params=[pytest.param(M, id=f"Fock(M={M})") for M in [0, 2, 3, 4, 5, 6, 8]]
+)
 def vstate_rho(request):
     M = request.param
     # keep this a prime number so we get different sizes on every rank...

--- a/test/operator/test_liouvillian.py
+++ b/test/operator/test_liouvillian.py
@@ -14,13 +14,10 @@
 
 import netket as nk
 import numpy as np
-import networkx as nx
 from scipy import sparse
 from scipy.sparse import linalg
-from numpy import linalg as lalg
-import pytest
+
 from pytest import approx
-import os
 
 from netket.operator import spin
 

--- a/test/operator/test_local_operator.py
+++ b/test/operator/test_local_operator.py
@@ -6,11 +6,9 @@ from netket.operator.boson import (
 from netket.operator.spin import sigmax, sigmay, sigmaz, sigmam, sigmap
 from netket.operator import LocalOperator
 import netket as nk
-import networkx as nx
 import numpy as np
 import pytest
 from pytest import approx, raises
-import os
 
 herm_operators = {}
 generic_operators = {}
@@ -109,8 +107,6 @@ def test_local_operator_transpose_conjugation():
 
 def test_local_operator_add():
     sz0 = nk.operator.spin.sigmaz(hi, 0)
-    sz1 = nk.operator.spin.sigmaz(hi, 1)
-    sz2 = nk.operator.spin.sigmaz(hi, 2)
 
     ham = 0.5 * sz0.to_dense()
     ha = 0.5 * sz0
@@ -206,7 +202,7 @@ def test_simple_operators():
         assert (sigmap(hi, i).to_dense() == sigmap_hat.to_dense()).all()
 
     print("Testing create/destroy composition...")
-    hi = nk.hilbert.Boson(3, N=L)
+    hi = nk.hilbert.Fock(3, N=L)
     for i in range(L):
         print("i=", i)
         a = bdestroy(hi, i)
@@ -219,7 +215,7 @@ def test_simple_operators():
     print("Testing mixed spaces...")
     L = 3
     his = nk.hilbert.Spin(0.5, N=L)
-    hib = nk.hilbert.Boson(3, N=L - 1)
+    hib = nk.hilbert.Fock(3, N=L - 1)
     hi = his * hib
     for i in range(hi.size):
         print("i=", i)
@@ -273,7 +269,7 @@ def test_mul_matmul():
     assert np.allclose(op.to_dense(), 2.0 * sx0sy1_hat.to_dense())
 
     with pytest.raises(TypeError):
-        doesnotwork = sx0_hat @ 2.0
+        sx0_hat @ 2.0
     with pytest.raises(TypeError):
         op = nk.operator.LocalOperator(hi, sx, [0])
         op @= 2.0
@@ -305,9 +301,9 @@ def test_truediv():
     assert np.allclose((sx0sy1_hat / 2).to_dense(), 0.5 * sx0sy1_hat.to_dense())
 
     with pytest.raises(TypeError):
-        doesnotwork = sx0_hat / sy1_hat
+        sx0_hat / sy1_hat
     with pytest.raises(TypeError):
-        doesnotwork = 1.0 / sx0_hat
+        1.0 / sx0_hat
 
     sx0sy1 = sx0sy1_hat.to_dense()
     sx0sy1_hat /= 3.0

--- a/test/operator/test_operator.py
+++ b/test/operator/test_operator.py
@@ -1,5 +1,4 @@
 import netket as nk
-import networkx as nx
 import numpy as np
 
 import pytest
@@ -19,7 +18,7 @@ operators["Heisenberg 1D"] = nk.operator.Heisenberg(hilbert=hi, graph=g)
 
 # Bose Hubbard
 g = nk.graph.Hypercube(length=3, n_dim=2, pbc=True)
-hi = nk.hilbert.Boson(n_max=3, n_bosons=6, N=g.n_nodes)
+hi = nk.hilbert.Fock(n_max=3, n_particles=6, N=g.n_nodes)
 operators["Bose Hubbard"] = nk.operator.BoseHubbard(U=4.0, hilbert=hi, graph=g)
 
 # Graph Hamiltonian
@@ -111,8 +110,6 @@ def test_is_hermitean(op):
 
     rstate = np.zeros(hi.size)
 
-    local_states = hi.local_states
-
     for i in range(100):
         hi.random_state(out=rstate)
         rstatet, mels = op.get_conn(rstate)
@@ -146,7 +143,6 @@ def test_get_conn_numpy_closure(op):
     closure = op._get_conn_flattened_closure()
     v = hi.random_state(jax.random.PRNGKey(0), 120)
     conn = np.empty(v.shape[0], dtype=np.intp)
-    conn2 = np.empty(v.shape[0], dtype=np.intp)
 
     vp, mels = closure(np.asarray(v), conn)
     vp2, mels2 = op.get_conn_flattened(v, conn, pad=False)
@@ -159,7 +155,7 @@ def test_get_conn_numpy_closure(op):
     "op", [pytest.param(op, id=name) for name, op in op_special.items()]
 )
 def test_to_local_operator(op):
-    op_local = op.to_local_operator()
+    op.to_local_operator()
     # TODO check dense representaiton.
 
 
@@ -209,7 +205,7 @@ def test_Heisenberg():
 
         assert not g.is_bipartite()
 
-        ha = nk.operator.Heisenberg(hi, graph=g, sign_rule=True)
+        nk.operator.Heisenberg(hi, graph=g, sign_rule=True)
 
 
 def test_pauli():

--- a/test/operator/test_operator.py
+++ b/test/operator/test_operator.py
@@ -83,17 +83,17 @@ for name, op in operators.items():
     "op", [pytest.param(op, id=name) for name, op in operators.items()]
 )
 def test_produce_elements_in_hilbert(op):
+    rng = nk.jax.PRNGSeq(0)
     hi = op.hilbert
     assert len(hi.local_states) == hi.local_size
     assert hi.size > 0
-    rstate = np.zeros(hi.size)
 
     local_states = hi.local_states
 
     max_conn_size = op.max_conn_size
 
     for i in range(1000):
-        hi.random_state(out=rstate)
+        rstate = hi.random_state(rng.next())
 
         rstatet, mels = op.get_conn(rstate)
 
@@ -105,13 +105,15 @@ def test_produce_elements_in_hilbert(op):
     "op", [pytest.param(op, id=name) for name, op in operators.items()]
 )
 def test_is_hermitean(op):
+    rng = nk.jax.PRNGSeq(0)
+
     hi = op.hilbert
     assert len(hi.local_states) == hi.local_size
 
     rstate = np.zeros(hi.size)
 
     for i in range(100):
-        hi.random_state(out=rstate)
+        rstate = hi.random_state(rng.next())
         rstatet, mels = op.get_conn(rstate)
 
         for k, state in enumerate(rstatet):

--- a/test/operator/test_spin.py
+++ b/test/operator/test_spin.py
@@ -1,17 +1,7 @@
-from netket.operator.boson import (
-    create as bcreate,
-    destroy as bdestroy,
-    number as bnumber,
-)
-from netket.operator import spin, boson
-from netket.operator import LocalOperator
+from netket.operator import spin
 import netket as nk
 import numpy as np
-import pytest
-from pytest import approx, raises
-import os
 
-from numpy import testing
 from numpy.testing import assert_almost_equal
 
 herm_operators = {}

--- a/test/optimizer/test_qgt_itersolve.py
+++ b/test/optimizer/test_qgt_itersolve.py
@@ -1,22 +1,30 @@
+# Copyright 2021 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import pytest
 
-import itertools
 from functools import partial
 
-
-import flax
 import jax
 
 import numpy as np
 from numpy import testing
 
-import jax.numpy as jnp
 import jax.flatten_util
-from jax.scipy.sparse.linalg import cg
 
 import netket as nk
 from netket.optimizer import qgt
-from netket.optimizer.qgt import qgt_onthefly_logic as _sr_onthefly_logic
 
 from .. import common
 
@@ -56,7 +64,6 @@ dtypes = {"float": float, "complex": complex}
 def vstate(request):
     N = 5
     hi = nk.hilbert.Spin(1 / 2, N)
-    g = nk.graph.Chain(N)
 
     dtype = request.param
 

--- a/test/optimizer/test_qgt_logic.py
+++ b/test/optimizer/test_qgt_logic.py
@@ -1,3 +1,17 @@
+# Copyright 2021 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # test qgt_onthefly_logic with inhomogeneous parameters
 
 import pytest
@@ -5,16 +19,12 @@ import pytest
 import jax
 import jax.numpy as jnp
 import jax.flatten_util
-import numpy as np
-from jax.scipy.sparse.linalg import cg
 from netket.optimizer.qgt import qgt_onthefly_logic, qgt_jacobian_pytree_logic
 
 from functools import partial
 import itertools
 
 from netket import jax as nkjax
-
-import pytest
 
 from .. import common
 
@@ -329,7 +339,6 @@ def test_matvec_linear_transpose(e, centered, jit):
     "outdtype, pardtype", r_r_test_types + c_c_test_types + r_c_test_types
 )
 def test_matvec_treemv(e, jit, holomorphic, pardtype, outdtype):
-    diag_shift = 0.01
     mv = qgt_jacobian_pytree_logic._mat_vec
 
     if not nkjax.is_complex_dtype(pardtype) and nkjax.is_complex_dtype(outdtype):

--- a/test/optimizer/test_qgt_solvers.py
+++ b/test/optimizer/test_qgt_solvers.py
@@ -1,24 +1,30 @@
+# Copyright 2021 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import pytest
 
-import itertools
 from functools import partial
 
 
-import flax
 import jax
 
-import numpy as np
-from numpy import testing
-
-import jax.numpy as jnp
 import jax.flatten_util
-from jax.scipy.sparse.linalg import cg
 
 import netket as nk
 from netket.optimizer import qgt
-from netket.optimizer.qgt import qgt_onthefly_logic as _sr_onthefly_logic
 
-from .. import common
+from .. import common  # noqa: F401
 
 QGT_objects = {}
 
@@ -37,7 +43,6 @@ dtypes = {"float": float, "complex": complex}
 def vstate(request):
     N = 5
     hi = nk.hilbert.Spin(1 / 2, N)
-    g = nk.graph.Chain(N)
 
     dtype = request.param
 

--- a/test/optimizer/test_sr_api.py
+++ b/test/optimizer/test_sr_api.py
@@ -1,22 +1,6 @@
 import pytest
 
-import itertools
-from functools import partial
-
-
-import flax
-import jax
-
-import numpy as np
-from numpy import testing
-
-import jax.numpy as jnp
-import jax.flatten_util
-from jax.scipy.sparse.linalg import cg
-
 import netket as nk
-from netket.optimizer import qgt
-from netket.optimizer.qgt import qgt_onthefly_logic as _sr_onthefly_logic
 
 from .. import common
 
@@ -25,7 +9,7 @@ pytestmark = common.skipif_mpi
 
 def test_deprecated_sr():
     with pytest.warns(FutureWarning):
-        sr = nk.optimizer.sr.SRLazyCG()
+        nk.optimizer.sr.SRLazyCG()
 
     with pytest.warns(FutureWarning):
-        sr = nk.optimizer.sr.SRLazyGMRES()
+        nk.optimizer.sr.SRLazyGMRES()

--- a/test/sampler/conftest.py
+++ b/test/sampler/conftest.py
@@ -1,4 +1,18 @@
-import pytest
+# Copyright 2021 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest  # noqa: F401
 
 
 def pytest_addoption(parser):

--- a/test/sampler/test_sampler.py
+++ b/test/sampler/test_sampler.py
@@ -1,9 +1,21 @@
+# Copyright 2021 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import netket as nk
-import networkx as nx
 import numpy as np
 import pytest
-from pytest import approx
-from scipy.stats import power_divergence, combine_pvalues, chisquare
+from scipy.stats import combine_pvalues, chisquare
 
 import jax
 import flax
@@ -145,7 +157,7 @@ def set_pdf_power(request):
             pytest.skip(f"Running only --mpow={cmdline_mpow}.")
 
         if isinstance(sampler, nk.sampler.ARDirectSampler) and request.param != 2:
-            pytest.skip(f"ARDirectSampler only supports machine_pow = 2.")
+            pytest.skip("ARDirectSampler only supports machine_pow = 2.")
 
         return sampler.replace(machine_pow=request.param)
 
@@ -212,7 +224,6 @@ def test_correct_sampling(sampler_c, model_and_weights, set_pdf_power):
     sampler = set_pdf_power(sampler_c)
 
     hi = sampler.hilbert
-    all_states = hi.all_states()
     n_states = hi.n_states
 
     ma, w = model_and_weights(hi, sampler)
@@ -279,7 +290,8 @@ def test_throwing(model_and_weights):
 
         ma, w = model_and_weights(hi)
 
-        sampler_state = sampler.init_state(ma, w, seed=SAMPLER_SEED)
+        # test raising of init state
+        sampler.init_state(ma, w, seed=SAMPLER_SEED)
 
     with pytest.raises(ValueError):
         sampler = nk.sampler.MetropolisHamiltonianNumpy(
@@ -290,7 +302,8 @@ def test_throwing(model_and_weights):
 
         ma, w = model_and_weights(hi)
 
-        sampler_state = sampler.init_state(ma, w, seed=SAMPLER_SEED)
+        # test raising of init state
+        sampler.init_state(ma, w, seed=SAMPLER_SEED)
 
     with pytest.raises(flax.errors.ScopeParamShapeError):
         sampler = nk.sampler.MetropolisHamiltonianNumpy(
@@ -301,12 +314,13 @@ def test_throwing(model_and_weights):
 
         ma, w = model_and_weights(hi)
 
-        sampler_state = sampler.init_state(ma, w, seed=SAMPLER_SEED)
+        # test raising of init state
+        sampler.init_state(ma, w, seed=SAMPLER_SEED)
 
 
 def test_exact_sampler(sampler):
     known_exact_samplers = [nk.sampler.ExactSampler, nk.sampler.ARDirectSampler]
     if any(isinstance(sampler, x) for x in known_exact_samplers):
-        assert sampler.is_exact == True
+        assert sampler.is_exact is True
     else:
-        assert sampler.is_exact == False
+        assert sampler.is_exact is False

--- a/test/stats/test_mpi_stats.py
+++ b/test/stats/test_mpi_stats.py
@@ -1,18 +1,26 @@
+# Copyright 2021 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import numpy as np
 import pytest
 
 import jax
 import jax.numpy as jnp
 
-from functools import partial
-
-from netket.stats import statistics
-from scipy.optimize import curve_fit
-from numba import jit
-
 import netket as nk
 
-from .. import common
+from .. import common  # noqa: F401
 
 WEIGHT_SEED = 3
 

--- a/test/stats/test_stats.py
+++ b/test/stats/test_stats.py
@@ -1,3 +1,17 @@
+# Copyright 2021 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import numpy as np
 import pytest
 
@@ -7,7 +21,6 @@ import jax.numpy as jnp
 from functools import partial
 
 import netket as nk
-import netket.vqs as vmc
 from netket.stats import statistics
 from scipy.optimize import curve_fit
 from numba import jit

--- a/test/utils/test_group.py
+++ b/test/utils/test_group.py
@@ -333,7 +333,7 @@ def test_pyrochlore():
     )
     # closure fails without specifying a unit cell
     with pytest.raises(RuntimeError):
-        pt = Fd3m.product_table
+        _ = Fd3m.product_table
     Fd3m = Fd3m.replace(
         unit_cell=np.asarray([[0.5, 0.5, 0], [0.5, 0, 0.5], [0, 0.5, 0.5]])
     )

--- a/test/utils/test_history.py
+++ b/test/utils/test_history.py
@@ -1,3 +1,17 @@
+# Copyright 2021 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import netket as nk
 
 import numpy as np

--- a/test/utils/test_struct.py
+++ b/test/utils/test_struct.py
@@ -14,11 +14,6 @@
 
 """Tests for flax.struct."""
 
-
-from .. import common
-
-pytestmark = common.skipif_mpi
-
 from typing import Any
 import pytest
 from functools import partial
@@ -28,6 +23,10 @@ import dataclasses
 from netket.utils import struct
 
 import jax
+
+from .. import common
+
+pytestmark = common.skipif_mpi
 
 
 @struct.dataclass
@@ -107,7 +106,7 @@ def test_pytree_nodes(PointT):
 
 def test_pytree_nodes_inheritance():
     p = Point1Child(x=1, y=2, z=3, meta={"abc": True})
-    p2 = Point1Child(1, 2, {"abc": True}, 3)
+    _ = Point1Child(1, 2, {"abc": True}, 3)
     leaves = jax.tree_leaves(p)
     assert leaves == [1, 2, 3]
     new_p = jax.tree_map(lambda x: x + x, p)
@@ -166,6 +165,6 @@ def test_cache_hash():
     a = Point0cache(1)
     assert a.__Point0cache_hash_cache is struct.Uninitialized
     hash(a) == 123
-    assert a.__Point0cache_hash_cache is 123
+    assert a.__Point0cache_hash_cache == 123
     object.__setattr__(a, "__Point0cache_hash_cache", 1234)
     hash(a) == 1234

--- a/test/utils/test_utils.py
+++ b/test/utils/test_utils.py
@@ -18,7 +18,6 @@ import jax.numpy as jnp
 
 from numpy.testing import assert_equal
 
-import netket as nk
 from netket.jax import PRNGKey, PRNGSeq
 from netket.utils import HashableArray
 

--- a/test/variational/test_experimental.py
+++ b/test/variational/test_experimental.py
@@ -1,14 +1,24 @@
+# Copyright 2021 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import pytest
 
 import jax
-import jax.numpy as jnp
 import jax.flatten_util
 import numpy as np
-from functools import partial
-import itertools
 
 import tarfile
-import glob
 from io import BytesIO
 
 from flax import serialization
@@ -26,7 +36,6 @@ SEED = 111
 def vstate(request):
     N = 8
     hi = nk.hilbert.Spin(1 / 2, N)
-    g = nk.graph.Chain(N)
 
     ma = nk.models.RBM(
         alpha=1,

--- a/test/variational/test_variational.py
+++ b/test/variational/test_variational.py
@@ -1,20 +1,26 @@
+# Copyright 2021 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from functools import partial
-from io import StringIO
 
 import pytest
 from pytest import approx, raises
 
 import numpy as np
-from numpy import testing
 import jax
-import jax.numpy as jnp
 import netket as nk
-from netket import nn as nknn
 import flax
-
-from contextlib import redirect_stderr
-import tempfile
-import re
 
 from .. import common
 

--- a/test/variational/test_variational_mixed.py
+++ b/test/variational/test_variational_mixed.py
@@ -1,20 +1,26 @@
+# Copyright 2021 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from functools import partial
-from io import StringIO
 
 import pytest
-from pytest import approx, raises
+from pytest import raises
 
 import numpy as np
-from numpy import testing
 import jax
-import jax.numpy as jnp
 import netket as nk
-from netket import nn as nknn
 import flax
-
-from contextlib import redirect_stderr
-import tempfile
-import re
 
 from .. import common
 


### PR DESCRIPTION
This PR fixes (mostly auto+ some manual work) all issues raised by flakehell on the tests.

This PR also fixes a few more tests that would fail once we remove legacy (mainly because we were doing `hi.random_state(3)` to generate 3 states, but now that will fail as we will require the first argument to be a PRNGKey.