### PR TITLE
Speed up `QGTOnTheFly`

### DIFF
--- a/Benchmarks/qgt.py
+++ b/Benchmarks/qgt.py
@@ -67,17 +67,27 @@ def benchmark(n_nodes, n_samples, n_layers, width):
     vecp = vec * jax.random.normal(keys[3], shape=vec.shape, dtype=vec.dtype)
     pars = unravel(vecp)
 
-    time1 = timeit(lambda: jax.tree_map(lambda x: x.block_until_ready(), qgt_.solve(cg, rhs1)), number=1)
+    time1 = timeit(
+        lambda: jax.tree_map(lambda x: x.block_until_ready(), qgt_.solve(cg, rhs1)),
+        number=1,
+    )
 
     # See what jit hath wrought us
     vstate._samples = hilbert.random_state(key=keys[4], size=n_samples)
     vstate._parameters = pars
     qgt_ = qgt.QGTOnTheFly(vstate=vstate, diag_shift=0.01, centered=False)
 
-    time2 = timeit(lambda: jax.tree_map(lambda x: x.block_until_ready(), qgt_.solve(cg, rhs2)), number = 10)/10
-    print(f'{n_nodes}\t{width}\t{n_layers}\t{n_samples}\t{time1:.6f}\t{time2:.6f}')
+    time2 = (
+        timeit(
+            lambda: jax.tree_map(lambda x: x.block_until_ready(), qgt_.solve(cg, rhs2)),
+            number=10,
+        )
+        / 10
+    )
+    print(f"{n_nodes}\t{width}\t{n_layers}\t{n_samples}\t{time1:.6f}\t{time2:.6f}")
 
-print(f'# Nodes\tWidth\tLayers\tSamples\tJitting\tAfter jitting')
+
+print(f"# Nodes\tWidth\tLayers\tSamples\tJitting\tAfter jitting")
 
 # Different network widths/system sizes
 benchmark(256, 256, 4, 256)

--- a/Benchmarks/qgt.py
+++ b/Benchmarks/qgt.py
@@ -1,0 +1,100 @@
+import netket as nk
+from netket.optimizer import qgt
+from flax import linen as nn
+from flax.linen.initializers import normal, variance_scaling
+import jax
+from jax import numpy as jnp
+from jax.scipy.sparse.linalg import cg
+import numpy as np
+from typing import Any
+from netket.utils.types import NNInitFunc
+from timeit import timeit
+
+
+class FFNN(nn.Module):
+    n_layers: int
+    width: int
+    dtype: Any = np.float64
+    activation: Any = jax.nn.selu
+    kernel_init: NNInitFunc = variance_scaling(1.0, "fan_in", "normal")
+    bias_init: NNInitFunc = normal(0.01)
+
+    def setup(self):
+        self.layers = [
+            nk.nn.Dense(
+                features=self.width,
+                use_bias=True,
+                dtype=self.dtype,
+                kernel_init=self.kernel_init,
+                bias_init=self.bias_init,
+            )
+            for layer in range(self.n_layers)
+        ]
+
+    @nn.compact
+    def __call__(self, x_in):
+        x = x_in
+        for layer in self.layers:
+            x = layer(x)
+            x = self.activation(x)
+        return jnp.sum(x, axis=-1) / (x.shape[-1]) ** 0.5
+
+
+# Benchmark starts here
+def benchmark(n_nodes, n_samples, n_layers, width):
+    keys = jax.random.split(jax.random.PRNGKey(0), 5)
+
+    graph = nk.graph.Chain(n_nodes)
+    hilbert = nk.hilbert.Spin(s=0.5, N=n_nodes)
+    machine = FFNN(n_layers=n_layers, width=width)
+
+    # Create a variational state to run QGT on
+    sa = nk.sampler.MetropolisExchange(hilbert=hilbert, graph=graph, d_max=2)
+    vstate = nk.variational.MCState(sampler=sa, model=machine, n_samples=n_samples)
+    vstate.init(seed=0)
+    # We don't actually want to perform a rather slow sampling
+    vstate._samples = hilbert.random_state(key=keys[0], size=n_samples)
+
+    qgt_ = qgt.QGTOnTheFly(vstate=vstate, diag_shift=0.01, centered=False)
+
+    # Generate a random RHS of the same pytree shape as the parameters
+    vec, unravel = nk.jax.tree_ravel(vstate.parameters)
+    vec1 = jax.random.normal(keys[1], shape=vec.shape, dtype=vec.dtype)
+    rhs1 = unravel(vec1)
+    vec2 = jax.random.normal(keys[2], shape=vec.shape, dtype=vec.dtype)
+    rhs2 = unravel(vec2)
+    # Generate a new set of parameters for the second set of runs
+    vecp = vec * jax.random.normal(keys[3], shape=vec.shape, dtype=vec.dtype)
+    pars = unravel(vecp)
+
+    time1 = timeit(lambda: jax.tree_map(lambda x: x.block_until_ready(), qgt_.solve(cg, rhs1)), number=1)
+
+    # See what jit hath wrought us
+    vstate._samples = hilbert.random_state(key=keys[4], size=n_samples)
+    vstate._parameters = pars
+    qgt_ = qgt.QGTOnTheFly(vstate=vstate, diag_shift=0.01, centered=False)
+
+    time2 = timeit(lambda: jax.tree_map(lambda x: x.block_until_ready(), qgt_.solve(cg, rhs2)), number = 10)/10
+    print(f'{n_nodes}\t{width}\t{n_layers}\t{n_samples}\t{time1:.6f}\t{time2:.6f}')
+
+print(f'# Nodes\tWidth\tLayers\tSamples\tJitting\tAfter jitting')
+
+# Different network widths/system sizes
+benchmark(256, 256, 4, 256)
+benchmark(512, 256, 4, 512)
+benchmark(1024, 256, 4, 1024)
+benchmark(2048, 256, 4, 2048)
+benchmark(4096, 256, 4, 4096)
+
+# Different sample numbers
+benchmark(512, 256, 4, 512)
+benchmark(512, 512, 4, 512)
+benchmark(512, 1024, 4, 512)
+benchmark(512, 2048, 4, 512)
+benchmark(512, 4096, 4, 512)
+
+# Different number of layers
+benchmark(512, 256, 4, 512)
+benchmark(512, 256, 8, 512)
+benchmark(512, 256, 16, 512)
+benchmark(512, 256, 32, 512)

--- a/Benchmarks/qgt_gcnn.py
+++ b/Benchmarks/qgt_gcnn.py
@@ -11,11 +11,13 @@ from typing import Any
 from netket.utils.types import NNInitFunc
 import timeit
 
-def timeit_gc(x, number = 1):
-    return timeit.Timer(x, 'gc.enable()').timeit(number=number)
+
+def timeit_gc(x, number=1):
+    return timeit.Timer(x, "gc.enable()").timeit(number=number)
+
 
 # Benchmark starts here
-def benchmark(side, n_samples, layers, features, pure_jax = True):
+def benchmark(side, n_samples, layers, features, pure_jax=True):
     n_nodes = side * side
     keys = jax.random.split(jax.random.PRNGKey(0), 5)
 
@@ -57,31 +59,42 @@ def benchmark(side, n_samples, layers, features, pure_jax = True):
     vecp = vec * jax.random.normal(keys[3], shape=vec.shape, dtype=vec.dtype)
     pars = unravel(vecp)
 
-    time1 = timeit_gc(lambda: jax.tree_map(lambda x: x.block_until_ready(), qgt_.solve(cg, rhs1)), number = 1)
-    
+    time1 = timeit_gc(
+        lambda: jax.tree_map(lambda x: x.block_until_ready(), qgt_.solve(cg, rhs1)),
+        number=1,
+    )
+
     # See what jit hath wrought us
     vstate._samples = hilbert.random_state(key=keys[4], size=n_samples)
     vstate._parameters = pars
     qgt_ = qgt.QGTOnTheFly(vstate=vstate, diag_shift=0.01)
 
-    time2 = timeit_gc(lambda: jax.tree_map(lambda x: x.block_until_ready(), qgt_.solve(cg, rhs2)), number=5)/5
-    print(f'{side}\t{features}\t{layers}\t{n_samples}\t{pure_jax}\t{time1:.6f}\t{time2:.6f}')
+    time2 = (
+        timeit_gc(
+            lambda: jax.tree_map(lambda x: x.block_until_ready(), qgt_.solve(cg, rhs2)),
+            number=5,
+        )
+        / 5
+    )
+    print(
+        f"{side}\t{features}\t{layers}\t{n_samples}\t{pure_jax}\t{time1:.6f}\t{time2:.6f}"
+    )
 
 
-print(f'# Side length\tFeatures\tLayers\tSamples\tPure JAX\tJitting\tAfter jitting')
+print(f"# Side length\tFeatures\tLayers\tSamples\tPure JAX\tJitting\tAfter jitting")
 
 # Different system sizes
 benchmark(6, 256, 4, 4)
 benchmark(8, 256, 4, 4)
 benchmark(12, 256, 4, 4)
-#benchmark(16, 256, 4, 4)
+# benchmark(16, 256, 4, 4)
 
 # Different feature count
 benchmark(8, 256, 4, 2)
 benchmark(8, 256, 4, 4)
 benchmark(8, 256, 4, 6)
-#benchmark(8, 256, 4, 8)
-#benchmark(8, 256, 4, 12)
+# benchmark(8, 256, 4, 8)
+# benchmark(8, 256, 4, 12)
 
 # Different sample numbers
 benchmark(8, 256, 4, 4)
@@ -93,7 +106,7 @@ benchmark(8, 2048, 4, 4)
 benchmark(8, 256, 4, 4)
 benchmark(8, 256, 8, 4)
 benchmark(8, 256, 12, 4)
-#benchmark(8, 256, 32, 4)
+# benchmark(8, 256, 32, 4)
 
 # Pure JAX?
 benchmark(8, 256, 4, 4, False)

--- a/Benchmarks/qgt_gcnn.py
+++ b/Benchmarks/qgt_gcnn.py
@@ -1,0 +1,99 @@
+import netket as nk
+from netket.optimizer import qgt
+from flax.core import unfreeze
+from flax import linen as nn
+from flax.linen.initializers import normal, variance_scaling
+import jax
+from jax import numpy as jnp
+from jax.scipy.sparse.linalg import cg
+import numpy as np
+from typing import Any
+from netket.utils.types import NNInitFunc
+import timeit
+
+def timeit_gc(x, number = 1):
+    return timeit.Timer(x, 'gc.enable()').timeit(number=number)
+
+# Benchmark starts here
+def benchmark(side, n_samples, layers, features, pure_jax = True):
+    n_nodes = side * side
+    keys = jax.random.split(jax.random.PRNGKey(0), 5)
+
+    graph = nk.graph.Square(side)
+    hilbert = nk.hilbert.Spin(s=0.5, N=n_nodes)
+    symm_group = graph.automorphisms()
+
+    if pure_jax:
+        symm = nk.utils.HashableArray(np.asarray(symm_group))
+        pt = nk.utils.HashableArray(np.asarray(symm_group.product_table.ravel()))
+        machine = nk.models.GCNN(
+            symmetries=symm,
+            flattened_product_table=pt,
+            layers=layers,
+            features=features,
+        )
+    else:
+        machine = nk.models.GCNN(
+            symmetries=symm_group, layers=layers, features=features
+        )
+    pure_jax = 1 if pure_jax else 0
+
+    # Create a variational state to run QGT on
+    sa = nk.sampler.MetropolisExchange(hilbert=hilbert, graph=graph, d_max=2)
+    vstate = nk.variational.MCState(sampler=sa, model=machine, n_samples=n_samples)
+    vstate.init(seed=0)
+    # We don't actually want to perform a rather slow sampling
+    vstate._samples = hilbert.random_state(key=keys[0], size=n_samples)
+
+    qgt_ = qgt.QGTOnTheFly(vstate=vstate, diag_shift=0.01)
+
+    # Generate a random RHS of the same pytree shape as the parameters
+    vec, unravel = nk.jax.tree_ravel(vstate.parameters)
+    vec1 = jax.random.normal(keys[1], shape=vec.shape, dtype=vec.dtype)
+    rhs1 = unravel(vec1)
+    vec2 = jax.random.normal(keys[2], shape=vec.shape, dtype=vec.dtype)
+    rhs2 = unravel(vec2)
+    # Generate a new set of parameters for the second set of runs
+    vecp = vec * jax.random.normal(keys[3], shape=vec.shape, dtype=vec.dtype)
+    pars = unravel(vecp)
+
+    time1 = timeit_gc(lambda: jax.tree_map(lambda x: x.block_until_ready(), qgt_.solve(cg, rhs1)), number = 1)
+    
+    # See what jit hath wrought us
+    vstate._samples = hilbert.random_state(key=keys[4], size=n_samples)
+    vstate._parameters = pars
+    qgt_ = qgt.QGTOnTheFly(vstate=vstate, diag_shift=0.01)
+
+    time2 = timeit_gc(lambda: jax.tree_map(lambda x: x.block_until_ready(), qgt_.solve(cg, rhs2)), number=5)/5
+    print(f'{side}\t{features}\t{layers}\t{n_samples}\t{pure_jax}\t{time1:.6f}\t{time2:.6f}')
+
+
+print(f'# Side length\tFeatures\tLayers\tSamples\tPure JAX\tJitting\tAfter jitting')
+
+# Different system sizes
+benchmark(6, 256, 4, 4)
+benchmark(8, 256, 4, 4)
+benchmark(12, 256, 4, 4)
+#benchmark(16, 256, 4, 4)
+
+# Different feature count
+benchmark(8, 256, 4, 2)
+benchmark(8, 256, 4, 4)
+benchmark(8, 256, 4, 6)
+#benchmark(8, 256, 4, 8)
+#benchmark(8, 256, 4, 12)
+
+# Different sample numbers
+benchmark(8, 256, 4, 4)
+benchmark(8, 512, 4, 4)
+benchmark(8, 1024, 4, 4)
+benchmark(8, 2048, 4, 4)
+
+# Different number of layers
+benchmark(8, 256, 4, 4)
+benchmark(8, 256, 8, 4)
+benchmark(8, 256, 12, 4)
+#benchmark(8, 256, 32, 4)
+
+# Pure JAX?
+benchmark(8, 256, 4, 4, False)

--- a/netket/optimizer/qgt/qgt_onthefly_logic.py
+++ b/netket/optimizer/qgt/qgt_onthefly_logic.py
@@ -47,14 +47,13 @@ def O_mean(forward_fn, params, holomorphic=True):
     """
 
     # determine the output type of the forward pass
-    shape = jax.eval_shape(forward_fn, params)
-    dtype = shape.dtype
-    n_samples = math.prod(shape.shape)
-    w = jnp.ones(n_samples, dtype=dtype) * (1.0 / (n_samples * mpi.n_nodes))
+    out_type = jax.eval_shape(forward_fn, params)
+    (n_samples,) = out_type.shape
+    w = jnp.ones(n_samples, dtype=out_type.dtype) * (1.0 / (n_samples * mpi.n_nodes))
 
     homogeneous = nkjax.tree_ishomogeneous(params)
     real_params = not nkjax.tree_leaf_iscomplex(params)
-    real_out = not nkjax.is_complex_dtype(dtype)
+    real_out = not nkjax.is_complex(out_type)
 
     # only support R->C, R->R, holomorphic C->C
     assert homogeneous and (real_params or holomorphic)


### PR DESCRIPTION
This PR introduces a more effective way to handle JVPs and VJPs in `QGTOnTheFly`. 

## Current changes

* `mat_vec` in the logic file is replaced with `mat_vec_fun` that takes care of the logic included in `DeltaO...` and `mat_vec` and returns a matrix-vector product function that won't perform any differentation
* `solve` is augmented with a function `_fast_solve` that calls this `mat_vec_fun` only once and runs the solver with the output. We need to figure out how to switch between this and `_solve`: the current approach won't work as the VMC object won't adjust the `fast` parameter. We might want to add it as a boolean parameter to `QGTOnTheFLyT`?

The observation is that `QGTOnTheFlyT::__matmul__` calls `jax.jvp` and `jax.vjp` every time a matrix-vector product is needed, sometimes more than once. These are  heavy functions because they have to linearise the network. By contrast, the function produced by `vjp` (and `jax.linearize` in place of `jvp`) is a bunch of linear transformations, which is faster to evaluate than `jvp` or VJPing from scratch. This means that if we can cache the matrix-vector product function in terms of these linear functions, `solve` with an iterative solver (which needs a bunch of matrix-vector products) should speed up.

Rewriting `QGTOnTheFlyT` in terms of such a cached function doesn't work well, however, because we can't `jit` over the cached function (see [this branch](https://github.com/attila-i-szabo/netket/tree/fly-fast2) and [this question](https://github.com/google/jax/discussions/7053) for more details, the code in that branch is way slower than the upstream one). This mean that I leave the broad structure unchanged: `mat_vec` and `solve` takes PyTrees with parameters of the `vstate` etc. and returns a PyTree, so they can be jitted as a whole. 

## Benchmarks

See [here](https://gist.github.com/attila-i-szabo/f3865c41c3952be1375e016205ab3b73). The bottom line is that the code in this PR speeds up `solve` by about 20% for dense networks and by a factor of 2 for GCNNs. This suggests that `jit` does a pretty good job at eliminating the overhead I'm worrying about, but we can improve on it, especially if the computational graph is complicated.

## Further ideas

1. We still perform the same linearisation twice, once in `linearize`, once in `vjp`. We could save on this by writing one as the `jax.linear_transpose` of the other. Would this be an actual improvement?
2. The same idea could remove `O_mean` and the associated complications in calculating the centred S matrix. If `jvp_fun` is a linear function, so is `lambda v: subtract_mean(jvp_fun(v))`, so in principle we can `linear_transpose` that too. This linear transpose be the VJP with the _centred_ Jacobian, without having to worry about the dtypes of the network arguments, meaning we can get the centred S matrix with a single linearisation step. The only place where this can go wrong is `subtract_mean` which calls MPI. @PhilipVinc would you expect this to work?

## Tests

I'll fix the tests as soon as any changes due to the ideas above are done. (It's not clear which of the logic functions survive and in what form.)