### PR TITLE
SR onthefly: avoid converting to real

### DIFF
--- a/netket/jax/__init__.py
+++ b/netket/jax/__init__.py
@@ -18,6 +18,7 @@ from .utils import (
     is_complex_dtype,
     tree_size,
     eval_shape,
+    tree_leaf_isreal,
     tree_leaf_iscomplex,
     tree_ishomogeneous,
     dtype_complex,

--- a/netket/optimizer/qgt/qgt_onthefly.py
+++ b/netket/optimizer/qgt/qgt_onthefly.py
@@ -22,7 +22,7 @@ from flax import struct
 from netket.utils.types import PyTree
 import netket.jax as nkjax
 
-from .qgt_onthefly_logic import mat_vec as mat_vec_onthefly, tree_cast
+from .qgt_onthefly_logic import mat_vec as mat_vec_onthefly
 
 from ..linear_operator import LinearOperator, Uninitialized
 
@@ -139,7 +139,7 @@ def onthefly_mat_treevec(
     else:
         ravel_result = False
 
-    vec = tree_cast(vec, S.params)
+    vec = nkjax.tree_cast(vec, S.params)
 
     def fun(W, σ):
         return S.apply_fun({"params": W, **S.model_state}, σ)
@@ -166,7 +166,7 @@ def _solve(
     self: QGTOnTheFlyT, solve_fun, y: PyTree, *, x0: Optional[PyTree], **kwargs
 ) -> PyTree:
 
-    y = tree_cast(y, self.params)
+    y = nkjax.tree_cast(y, self.params)
 
     # we could cache this...
     if x0 is None:

--- a/netket/optimizer/qgt/qgt_onthefly_logic.py
+++ b/netket/optimizer/qgt/qgt_onthefly_logic.py
@@ -18,7 +18,7 @@ from functools import partial
 from netket.stats import subtract_mean
 from netket.utils import mpi
 import netket.jax as nkjax
-from netket.jax import tree_conj, tree_dot, tree_cast, tree_axpy
+from netket.jax import tree_conj, tree_dot, tree_axpy
 
 # Stochastic Reconfiguration with jvp and vjp
 
@@ -35,74 +35,56 @@ def O_jvp(forward_fn, params, samples, v):
 
 
 def O_vjp(forward_fn, params, samples, w):
-    _, vjp_fun = jax.vjp(forward_fn, params, samples)
-    res, _ = vjp_fun(w)
+    y, vjp_fun = jax.vjp(forward_fn, params, samples)
+    res = jax.tree_map(lambda x: vjp_fun(x)[0], w)
     return jax.tree_map(lambda x: mpi.mpi_sum_jax(x)[0], res)  # allreduce w/ MPI.SUM
 
 
-def O_vjp_rc(forward_fn, params, samples, w):
-    _, vjp_fun = jax.vjp(forward_fn, params, samples)
-    res_r, _ = vjp_fun(w)
-    res_i, _ = vjp_fun(-1.0j * w)
-    res = jax.tree_multimap(jax.lax.complex, res_r, res_i)
-    return jax.tree_map(lambda x: mpi.mpi_sum_jax(x)[0], res)  # allreduce w/ MPI.SUM
+def O_mean(forward_fn, params, samples):
 
-
-def O_mean(forward_fn, params, samples, holomorphic=True):
     r"""
-    compute \langle O \rangle
+    compute ⟨O⟩
     i.e. the mean of the rows of the jacobian of forward_fn
     """
+    y = jax.eval_shape(forward_fn, params, samples)
+    w = jnp.array(1.0 / (samples.shape[0] * mpi.n_nodes), dtype=y.dtype)
+    w = jax.lax.broadcast(w, y.shape)
+    return O_vjp(forward_fn, params, samples, w)
 
-    # determine the output type of the forward pass
-    dtype = jax.eval_shape(forward_fn, params, samples).dtype
-    w = jnp.ones(samples.shape[0], dtype=dtype) * (
-        1.0 / (samples.shape[0] * mpi.n_nodes)
-    )
 
-    homogeneous = nkjax.tree_ishomogeneous(params)
-    real_params = not nkjax.tree_leaf_iscomplex(params)
-    real_out = not nkjax.is_complex(jax.eval_shape(forward_fn, params, samples))
-
-    if homogeneous and (real_params or holomorphic):
-        if real_params and not real_out:
-            # R->C
-            return O_vjp_rc(forward_fn, params, samples, w)
-        else:
-            # R->R and holomorphic C->C
-            return O_vjp(forward_fn, params, samples, w)
-    else:
-        # R&C -> C
-        # non-holomorphic
-        # C->R
-        assert False
+def O_mean_complex(forward_fn, params, samples):
+    r"""
+    compute ⟨O⟩
+    for a ℂ→ℂ function f(x+iy) = u(x,y) + i v(x,y)
+    returns the mean along axis 0 of (∂x + i ∂y) u, (∂x + i ∂y) v
+    """
+    y = jax.eval_shape(forward_fn, params, samples)
+    w = jnp.array(1.0 / (samples.shape[0] * mpi.n_nodes), dtype=y.dtype)
+    w = jax.lax.broadcast(w, y.shape)
+    return O_vjp(forward_fn, params, samples, (w, -1.0j * w))
 
 
 def OH_w(forward_fn, params, samples, w):
     r"""
-    compute  O^H w
-    (where ^H is the hermitian transpose)
+    compute  Oᴴw
+    (where ᴴ denotes the hermitian transpose)
     """
 
-    # O^H w = (w^H O)^H
+    # Oᴴw = (wᴴO)ᴴ
     # The transposition of the 1D arrays is omitted in the implementation:
-    # (w^H O)^H -> (w* O)*
+    # (wᴴO)ᴴ -> (w* O)*
 
-    # TODO The allreduce in O_vjp could be deferred until after the tree_cast
-    # where the amount of data to be transferred would potentially be smaller
-    res = tree_conj(O_vjp(forward_fn, params, samples, w.conjugate()))
-
-    return tree_cast(res, params)
+    return tree_conj(O_vjp(forward_fn, params, samples, w.conjugate()))
 
 
 def Odagger_O_v(forward_fn, params, samples, v, *, center=False):
     r"""
     if center=False (default):
-        compute \langle O^\dagger O \rangle v
+        compute ⟨O†O⟩v
 
     else (center=True):
-        compute \langle O^\dagger \Delta O \rangle v
-        where \Delta O = O - \langle O \rangle
+        compute ⟨O†ΔO⟩v
+        where ΔO = O-⟨O⟩
     """
 
     # w is an array of size n_samples; each MPI rank has its own slice
@@ -122,34 +104,44 @@ Odagger_DeltaO_v = partial(Odagger_O_v, center=True)
 def DeltaOdagger_DeltaO_v(forward_fn, params, samples, v, holomorphic=True):
 
     r"""
-    compute \langle \Delta O^\dagger \Delta O \rangle v
+    compute ⟨ΔO†ΔO⟩ v
 
-    where \Delta O = O - \langle O \rangle
+    where ΔO = O-⟨O⟩
     """
 
-    homogeneous = nkjax.tree_ishomogeneous(params)
-    real_params = not nkjax.tree_leaf_iscomplex(params)
-    #  real_out = not nkjax.is_complex(jax.eval_shape(forward_fn, params, samples))
+    complex_params = not nkjax.tree_leaf_isreal(params)
+    complex_out = nkjax.is_complex(jax.eval_shape(forward_fn, params, samples))
 
-    if not (homogeneous and (real_params or holomorphic)):
-        # everything except R->R, holomorphic C->C and R->C
-        params, reassemble = nkjax.tree_to_real(params)
-        v, _ = nkjax.tree_to_real(v)
-        _forward_fn = forward_fn
+    if holomorphic and complex_params and complex_out:
+        # holomorphic ℂ→ℂ
+        omean = O_mean(forward_fn, params, samples)
 
-        def forward_fn(p, x):
-            return _forward_fn(reassemble(p), x)
+        def forward_fn_centered(p, x):
+            return forward_fn(p, x) - tree_dot(p, omean)
 
-    omean = O_mean(forward_fn, params, samples, holomorphic=holomorphic)
+    elif complex_out:
+        # non-holomorphic ℂ→ℂ
+        # ℝ&ℂ→ℂ
+        # ℝ→ℂ
 
-    def forward_fn_centered(p, x):
-        return forward_fn(p, x) - tree_dot(p, omean)
+        omean_r, omean_i = O_mean_complex(forward_fn, params, samples)
 
-    res = Odagger_O_v(forward_fn_centered, params, samples, v)
+        def forward_fn_centered(p, x):
+            return forward_fn(p, x) - jax.lax.complex(
+                tree_dot(p, omean_r).real, tree_dot(p, omean_i).real
+            )
 
-    if not (homogeneous and (real_params or holomorphic)):
-        res = reassemble(res)
-    return res
+    else:
+        # ℝ→ℝ
+        # ℂ→ℝ
+        # ℝ&ℂ→ℝ
+
+        omean = O_mean(forward_fn, params, samples)
+
+        def forward_fn_centered(p, x):
+            return forward_fn(p, x) - tree_dot(p, omean).real
+
+    return Odagger_O_v(forward_fn_centered, params, samples, v)
 
 
 # TODO block the computations (in the same way as done with MPI) if memory consumtion becomes an issue
@@ -161,11 +153,11 @@ def mat_vec(
 
     where the elements of S are given by one of the following equivalent formulations:
 
-    if centered=True (default): S_kl = \langle \Delta O_k^\dagger \Delta O_l \rangle
-    if centered=False : S_kl = \langle O_k^\dagger \Delta O_l \rangle
+    if centered=True (default): Sₖₗ = ⟨ΔOₖ†ΔOₗ⟩
+    if centered=False : Sₖₗ = ⟨Oₖ†ΔOₗ⟩
 
-    where \Delta O_k = O_k - \langle O_k \rangle
-    and O_k (operator) is derivative of the log wavefunction w.r.t parameter k
+    where ΔOₖ = Oₖ-⟨Oₖ⟩
+    and Oₖ (operator) is derivative of the log wavefunction w.r.t parameter k
     The expectation values are calculated as mean over the samples
 
     v: a pytree with the same structure as params

--- a/test/optimizer/test_qgt_logic.py
+++ b/test/optimizer/test_qgt_logic.py
@@ -63,7 +63,7 @@ def reassemble_complex(x, target, fun=tree_toreal_flat):
     (res,) = jax.linear_transpose(fun, target)(x)
     res = qgt_onthefly_logic.tree_conj(res)
     # fix the dtypes:
-    return qgt_onthefly_logic.tree_cast(res, target)
+    return nkjax.tree_cast(res, target)
 
 
 def tree_allclose(t1, t2):
@@ -184,8 +184,11 @@ r_r_test_types = list(itertools.product(rt, rt))
 c_c_test_types = list(itertools.product(ct, ct))
 r_c_test_types = list(itertools.product(ct, rt))
 rc_c_test_types = list(itertools.product(ct, [None]))
-# c_r_test_types = list(itertools.product(rt, ct))
+c_r_test_types = list(itertools.product(rt, ct))
+rc_r_test_types = list(itertools.product(rt, [None]))
+
 test_types = r_r_test_types + c_c_test_types + r_c_test_types + rc_c_test_types
+all_test_types = test_types + c_r_test_types + rc_r_test_types
 
 # tests
 
@@ -263,7 +266,7 @@ def test_Odagger_O_v(e):
 
 @pytest.mark.parametrize("holomorphic", [True, False])
 @pytest.mark.parametrize("n_samp", [25])
-@pytest.mark.parametrize("outdtype, pardtype", test_types)
+@pytest.mark.parametrize("outdtype, pardtype", all_test_types)
 def test_Odagger_DeltaO_v(e):
     actual = qgt_onthefly_logic.Odagger_DeltaO_v(e.f, e.params, e.samples, e.v)
     expected = reassemble_complex(e.S_real @ e.v_real_flat, target=e.target)
@@ -272,7 +275,7 @@ def test_Odagger_DeltaO_v(e):
 
 @pytest.mark.parametrize("holomorphic", [True, False])
 @pytest.mark.parametrize("n_samp", [25])
-@pytest.mark.parametrize("outdtype, pardtype", test_types)
+@pytest.mark.parametrize("outdtype, pardtype", all_test_types)
 def test_DeltaOdagger_DeltaO_v(e, holomorphic):
     actual = qgt_onthefly_logic.DeltaOdagger_DeltaO_v(
         e.f, e.params, e.samples, e.v, holomorphic
@@ -285,7 +288,7 @@ def test_DeltaOdagger_DeltaO_v(e, holomorphic):
 @pytest.mark.parametrize("n_samp", [25, 1024])
 @pytest.mark.parametrize("centered", [True, False])
 @pytest.mark.parametrize("jit", [True, False])
-@pytest.mark.parametrize("outdtype, pardtype", test_types)
+@pytest.mark.parametrize("outdtype, pardtype", all_test_types)
 def test_matvec(e, centered, jit, holomorphic):
     diag_shift = 0.01
     mv = qgt_onthefly_logic.mat_vec
@@ -302,7 +305,7 @@ def test_matvec(e, centered, jit, holomorphic):
 @pytest.mark.parametrize("n_samp", [25, 1024])
 @pytest.mark.parametrize("centered", [True, False])
 @pytest.mark.parametrize("jit", [True, False])
-@pytest.mark.parametrize("outdtype, pardtype", test_types)
+@pytest.mark.parametrize("outdtype, pardtype", all_test_types)
 def test_matvec_linear_transpose(e, centered, jit):
     def mvt(v, f, params, samples, centered, w):
         (res,) = jax.linear_transpose(


### PR DESCRIPTION
For `centered=True` the mean of the gradients ⟨Oₖ⟩ has to be precomputed in order to define the centered log-wavefunction (i.e. the function whose gradient is ΔOₖ). For non-homogeneous (and also non-holomorphic ℂ→ℂ) parameters this is currently done by converting all parameters to real ones.

This can be avoided by storing the gradients Oₖ ( more specifically the mean ⟨Oₖ⟩) or as two (pytrees of) complex numbers, representing the top and bottom row of the corresponding 2x2 real jacobian.

In the following I put together a short sketch for proving that the `centered=False` is correct for non-holomorphic ℂ→ℂ (actually it works universally), while deriving what this PR is doing (and what the next one for jacobianpytree will do).

___

## setup

Following the [Autodiff Cookbook](https://jax.readthedocs.io/en/latest/notebooks/autodiff_cookbook.html#complex-numbers-and-differentiation) one can consider a general complex function <img src=
"https://render.githubusercontent.com/render/math?math=%5Cdisplaystyle+f%3A+%5Cmathbb%7BC%7D+%5Cto+%5Cmathbb%7BC%7D" 
alt="f: \mathbb{C} \to \mathbb{C}">

<img src=
"https://render.githubusercontent.com/render/math?math=%5Cdisplaystyle+f%28x%2Bi+y%29+%3D+u%28x%2Cy%29+%2B+i+v%28x%2Cy%29" 
alt="f(x+i y) = u(x,y) + i v(x,y)">

The corresponding (vector-valued) real function <img src=
"https://render.githubusercontent.com/render/math?math=%5Cdisplaystyle+g%3A+%5Cmathbb%7BR%7D%5E2+%5Cto+%5Cmathbb%7BR%7D%5E2" 
alt="g: \mathbb{R}^2 \to \mathbb{R}^2"> is given by 

<img src=
"https://render.githubusercontent.com/render/math?math=%5Cdisplaystyle+g%28x%2Cy%29+%3D+%5Cbegin%7Bbmatrix%7D+u%28x%2Cy%29+%5C%5C+v%28x%2Cy%29+%5Cend%7Bbmatrix%7D" 
alt="g(x,y) = \begin{bmatrix} u(x,y) \\ v(x,y) \end{bmatrix}">

Its jacobian is a real 2x2 matrix

<img src=
"https://render.githubusercontent.com/render/math?math=%5Cdisplaystyle+J_g+%3D+%5Cbegin%7Bbmatrix%7D+%5Cpartial_x+u+%26+%5Cpartial_y+u+%5C%5C+%5Cpartial_x+v+%26+%5Cpartial_y+v+%5Cend%7Bbmatrix%7D" 
alt="J_g = \begin{bmatrix} \partial_x u & \partial_y u \\ \partial_x v & \partial_y v \end{bmatrix}">

One can represent this jacobian with two complex numbers by doing the transformation 


<img src=
"https://render.githubusercontent.com/render/math?math=%5Cdisplaystyle+%5Cbegin%7Bbmatrix%7D+%5Cpartial_x+u+%26+%5Cpartial_y+u+%5C%5C+%5Cpartial_x+v+%26+%5Cpartial_y+v+%5Cend%7Bbmatrix%7D%0A%5Cmapsto+%0A%5Cbegin%7Bbmatrix%7D+%5Cpartial_x+u+%2B+i+%5Cpartial_y+u+%5C%5C+%5Cpartial_x+v+%2Bi+%5Cpartial_y+v+%5Cend%7Bbmatrix%7D%0A%5Ceqqcolon%0A%5Cbegin%7Bbmatrix%7D+J_u+%5C%5C+J_v+%5Cend%7Bbmatrix%7D" 
alt="\begin{bmatrix} \partial_x u & \partial_y u \\ \partial_x v & \partial_y v \end{bmatrix}
\mapsto 
\begin{bmatrix} \partial_x u + i \partial_y u \\ \partial_x v +i \partial_y v \end{bmatrix}
\eqqcolon
\begin{bmatrix} J_u \\ J_v \end{bmatrix}">

which correspond to the jacobian of the real part u and immaginary part v of f.


## VJP


Jax' complex vjp of <img src=
"https://render.githubusercontent.com/render/math?math=%5Cdisplaystyle+f" 
alt="f"> with a complex number <img src=
"https://render.githubusercontent.com/render/math?math=%5Cdisplaystyle+z+%3D+c%2Bi+d" 
alt="z = c+i d">  is defined as

<img src=
"https://render.githubusercontent.com/render/math?math=%5Cdisplaystyle+%5Cbegin%7Bbmatrix%7D+c+%26+-d+%5Cend%7Bbmatrix%7D%0AJ_g%0A%5Cbegin%7Bbmatrix%7D+1++%5C%5C++%7B-i%7D++%5Cend%7Bbmatrix%7D%0A%3D+%5Ccdots%0A%3D++c+%28%5Cpartial_x++u-+i+%5Cpartial_y+u%29+-++d+%28%5Cpartial_x++v-+i+%5Cpartial_y+v%29%0A%3D+c+J_u%5E%2A+-+d+J_v%5E%2A" 
alt="\begin{bmatrix} c & -d \end{bmatrix}
J_g
\begin{bmatrix} 1  \\  {-i}  \end{bmatrix}
= \cdots
=  c (\partial_x  u- i \partial_y u) -  d (\partial_x  v- i \partial_y v)
= c J_u^* - d J_v^*">


and it is easy to see that one can calculate <img src=
"https://render.githubusercontent.com/render/math?math=%5Cdisplaystyle+J_u%5E%2A" 
alt="J_u^*"> and <img src=
"https://render.githubusercontent.com/render/math?math=%5Cdisplaystyle+J_v%5E%2A" 
alt="J_v^*"> by backpropagating <img src=
"https://render.githubusercontent.com/render/math?math=%5Cdisplaystyle+z+%3D+c+%2B+i+d+%3D+1" 
alt="z = c + i d = 1"> and <img src=
"https://render.githubusercontent.com/render/math?math=%5Cdisplaystyle+z+%3D+c+%2B+i+d+%3D+-i" 
alt="z = c + i d = -i"> respectively.

### real VJP

The corresponding real vjp is given by 

<img src=
"https://render.githubusercontent.com/render/math?math=%5Cdisplaystyle+%5Cbegin%7Bbmatrix%7D+c+%26+d+%5Cend%7Bbmatrix%7D%0AJ_g%0A%3D+%5Ccdots%0A+%3D+%0A%5Cbegin%7Bbmatrix%7D%0A+c+%5Cpartial_x+u+%2B+d+%5Cpartial_x+v%0A%26+%0A+c+%5Cpartial_y+u+%2B+d+%5Cpartial_y+v%0A%5Cend%7Bbmatrix%7D" 
alt="\begin{bmatrix} c & d \end{bmatrix} J_g = \cdots = \begin{bmatrix} c \partial_x u + d \partial_x v & c \partial_y u + d \partial_y v \end{bmatrix}">

and it's corresponding complex number is 
<img src=
"https://render.githubusercontent.com/render/math?math=%5Cdisplaystyle++%28c+%5Cpartial_x+u+%2B+d+%5Cpartial_x+v%29+%2B+i++%28c+%5Cpartial_y+u+%2B+d+%5Cpartial_y+v%29" 
alt=" (c \partial_x u + d \partial_x v) + i  (c \partial_y u + d \partial_y v)">.
Up to complex conjugations it is equivalent to the complex vjp above.

The _correct_ (in terms of the real 2x2 matrix) vjp can thus be implemented with a complex jax vjp by conjugating both z and the result, i.e. when denoting the complex jax-vjp as <img src=
"https://render.githubusercontent.com/render/math?math=%5Cdisplaystyle+z+%5Cstar+J" 
alt="z \star J"> one calculates the _correct_ one as <img src=
"https://render.githubusercontent.com/render/math?math=%5Cdisplaystyle+z+J+%3D+%28z%5E%2A+%5Cstar+J%29%5E%2A" 
alt="z J = (z^* \star J)^*">.
The inverse of this statement is that the complex jax-vjp can be defined as <img src=
"https://render.githubusercontent.com/render/math?math=%5Cdisplaystyle+z+%5Cstar+J+%5Ccoloneqq+%28z%5E%2A+J%29%5E%2A" 
alt="z \star J \coloneqq (z^* J)^*">, which is clear from fact that the transformation <img src=
"https://render.githubusercontent.com/render/math?math=%5Cdisplaystyle+%28z+J%29+%5Cmapsto+%28z%5E%2A+J%29%5E%2A" 
alt="(z J) \mapsto (z^* J)^*"> is trivially self-inverse. Effectively this transformation means that the _correct_ vjp corresponds to a complex vector product with the hermitian tanspose of the jacobian since <img src=
"https://render.githubusercontent.com/render/math?math=%5Cdisplaystyle+J%5EH+z+%3D+%28z%5EH+J%29%5EH%0A" 
alt="J^H z = (z^H J)^H
"> (up to transposition).


By doing some rearrangements the _correct_ vjp in terms of <img src=
"https://render.githubusercontent.com/render/math?math=%5Cdisplaystyle+J_u" 
alt="J_u"> and <img src=
"https://render.githubusercontent.com/render/math?math=%5Cdisplaystyle+J_v" 
alt="J_v"> can be expressed as 
<img src=
"https://render.githubusercontent.com/render/math?math=%5Cdisplaystyle+c+J_u+%2B+d+J_v+%3D+%5Ctext%7BRe%7D%5C%7Bz%5C%7D%5C+J_u+%2B+%5Ctext%7BIm%7D%5C%7Bz%5C%7D%5C+J_v" 
alt="c J_u + d J_v = \text{Re}\{z\}\ J_u + \text{Im}\{z\}\ J_v">

When implemented with the complex <img src=
"https://render.githubusercontent.com/render/math?math=%5Cdisplaystyle+z+%5Cstar+J" 
alt="z \star J">
vjp's from above this becomes <img src=
"https://render.githubusercontent.com/render/math?math=%5Cdisplaystyle+%5Ctext%7BRe%7D%5C%7Bz%5C%7D%5C+J_u+%2B+%5Ctext%7BIm%7D%5C%7Bz%5C%7D%5C+J_v+%3D+%28%5Ctext%7BRe%7D%5C%7Bz%5E%2A%5C%7D%5Cstar+J_u+%2B+%5Ctext%7BIm%7D%5C%7Bz%5E%2A%5C%7D%5Cstar+J_v%29%5E%2A+%3D+%5Ctext%7BRe%7D%5C%7Bz%5C%7D%5Cstar+J_u%5E%2A+-+%5Ctext%7BIm%7D%5C%7Bz%5C%7D%5Cstar+J_v%5E%2A" 
alt="\text{Re}\{z\}\ J_u + \text{Im}\{z\}\ J_v = (\text{Re}\{z^*\}\star J_u + \text{Im}\{z^*\}\star J_v)^* = \text{Re}\{z\}\star J_u^* - \text{Im}\{z\}\star J_v^*">


## JVP

Jax' complex jvp of <img src=
"https://render.githubusercontent.com/render/math?math=%5Cdisplaystyle+f" 
alt="f"> with a complex number <img src=
"https://render.githubusercontent.com/render/math?math=%5Cdisplaystyle+z+%3D+c%2Bi+d" 
alt="z = c+i d">  is defined as

<img src=
"https://render.githubusercontent.com/render/math?math=%5Cdisplaystyle+%5Cbegin%7Bbmatrix%7D+1+%26+i+%5Cend%7Bbmatrix%7D%0AJ_g%0A%5Cbegin%7Bbmatrix%7D+c++%5C%5C++d++%5Cend%7Bbmatrix%7D%0A%3D+%5Ccdots%0A%3D+%28c+%5Cpartial_x+%2B+d+%5Cpartial_y%29+%28u%2Biv%29%0A%3D+%28c+%5Cpartial_x+%2B+d+%5Cpartial_y%29+u+%2B+i+%28c+%5Cpartial_x+%2B+d+%5Cpartial_y%29+v%0A" 
alt="\begin{bmatrix} 1 & i \end{bmatrix}
J_g
\begin{bmatrix} c  \\  d  \end{bmatrix}
= \cdots
= (c \partial_x + d \partial_y) (u+iv)
= (c \partial_x + d \partial_y) u + i (c \partial_x + d \partial_y) v
">

by taking the real parts and expanding the terms inside it can be shown that this is equivalent to

<img src=
"https://render.githubusercontent.com/render/math?math=%5Cdisplaystyle+%5Ctext%7BRe%7D+%5C%7BJ_u%5E%2A+%5C+z+%5C%7D+%2B+i+%5Ctext%7BRe%7D%5C%7BJ_v%5E%2A+%5C++z+%5C%7D" 
alt="\text{Re} \{J_u^* \ z \} + i \text{Re}\{J_v^* \  z \}">

### real JVP
The equivalent real jvp is given as

<img src=
"https://render.githubusercontent.com/render/math?math=%5Cdisplaystyle+%5Cbegin%7Bbmatrix%7D+c+%26+d+%5Cend%7Bbmatrix%7D%0AJ_g%0A%3D+%5Ccdots%0A%3D+%28c+%5Cpartial_x%2B+d+%5Cpartial_y%29+%5Cbegin%7Bbmatrix%7D+u+%5C%5C+v+%5Cend%7Bbmatrix%7D" 
alt="\begin{bmatrix} c & d \end{bmatrix}
J_g
= \cdots
= (c \partial_x+ d \partial_y) \begin{bmatrix} u \\ v \end{bmatrix}">

which is exactly the same as the complex jax jvp above.
Thus the complex jax-jvp corresponds to the _correct_ (in terms of the real 2x2 matrix) real jvp.


## holomorphic

for a holomorphic wavefunction the Cauchy-Riemann equations  
<img src=
"https://render.githubusercontent.com/render/math?math=%5Cdisplaystyle+%5Cbegin%7Baligned%7D%0A%5Cpartial_x+u+%26%3D+%5Cpartial_y+v+%5C%5C%0A%5Cpartial_y+u+%26%3D+-%5Cpartial_x+v%0A%5Cend%7Baligned%7D" 
alt="\begin{aligned}
\partial_x u &= \partial_y v \\
\partial_y u &= -\partial_x v
\end{aligned}">  
are satisfied.

Adding i times the second equation to the first one it follows that  Jᵤ = -i Jᵥ.
This means it is enough to pre-compute Jᵤ.

### VJP
with Jᵥ* = - i Jᵤ*:

<img src=
"https://render.githubusercontent.com/render/math?math=%5Cdisplaystyle+%5Ctext%7BRe%7D%5C%7Bz%5C%7D%5Cstar+J_u%5E%2A+%2B+%5Ctext%7BIm%7D%5C%7Bz%5C%7D%5Cstar+J_v%5E%2A+%3D+%0A%5Ctext%7BRe%7D%5C%7Bz%5C%7D%5Cstar+J_u%5E%2A+%2B+i+%5Ctext%7BIm%7D%5C%7Bz%5C%7D%5Cstar+J_u%5E%2A+%3D+z+%5Cstar+J_u%5E%2A" 
alt="\text{Re}\{z\}\star J_u^* + \text{Im}\{z\}\star J_v^* = 
\text{Re}\{z\}\star J_u^* + i \text{Im}\{z\}\star J_u^* = z \star J_u^*">

### JVP
with Jᵥ* = - i Jᵤ*:

<img src=
"https://render.githubusercontent.com/render/math?math=%5Cdisplaystyle+%5Ctext%7BRe%7D+%5C%7BJ_u%5E%2A+%5C+z+%5C%7D+%2B+i+%5Ctext%7BRe%7D%5C%7BJ_v%5E%2A+%5C++z+%5C%7D+%3D+%0A%5Ctext%7BRe%7D+%5C%7BJ_u%5E%2A+%5C+z+%5C%7D+%2B+i+%5Ctext%7BIm%7D%5C%7BJ_u%5E%2A+%5C++z+%5C%7D+%3D+J_u%5E%2A+%5C++z" 
alt="\text{Re} \{J_u^* \ z \} + i \text{Re}\{J_v^* \  z \} = 
\text{Re} \{J_u^* \ z \} + i \text{Im}\{J_u^* \  z \} = J_u^* \  z">

___

- For ℝ→ℂ one can do the same as for ℂ→ℂ, in this case Jᵤ and Jᵥ as well as the input vector of the vjp and output of the vjp are real, so most of the conjugations simply won't have any effect.

- Same for the real parts of pytrees with mixed (non-homogeneous) ℝ&ℂ parameters 

- For ℂ→ℝ one can do the same as for ℂ→ℂ while dropping all terms with v/Jᵥ since v≡0.

___


This PR Implements the computation of the means <img src=
"https://render.githubusercontent.com/render/math?math=%5Cdisplaystyle+%5Clangle+J_R%5E%2A+%5Crangle%2C+%5Clangle+J_I%5E%2A+%5Crangle" 
alt="\langle J_R^* \rangle, \langle J_I^* \rangle"> by doing vjp's with 1 and -i,  
as well as the dot-product (similarly to a jvp)   
<img src=
"https://render.githubusercontent.com/render/math?math=%5Cdisplaystyle+%5Ctheta+%5Ccdot+%5Clangle+J+%5Crangle+%5Ccoloneqq+%5Ctext%7BRe%7D%5C%7B%5Ctheta%5C%7D%5Ccdot+%5Clangle+J_u%5E%2A+%5Crangle+-+%5Ctext%7BIm%7D%5C%7B%5Ctheta%5C%7D%5Ccdot+%5Clangle+J_v%5E%2A%5Crangle" 
alt="\theta \cdot \langle J \rangle \coloneqq \text{Re}\{\theta\}\cdot \langle J_u^* \rangle - \text{Im}\{\theta\}\cdot \langle J_v^*\rangle">   
which is needed for correctly defining the centered log-wavefunction.


___

The next PR will be doing the same for qgt-jacobian-pytree, i.e. using <img src=
"https://render.githubusercontent.com/render/math?math=%5Cdisplaystyle+%5Ctext%7BRe%7D+%5C%7BJ_u%5E%2A+%5C+z+%5C%7D+%2B+i+%5Ctext%7BRe%7D%5C%7BJ_v%5E%2A+%5C++z+%5C%7D" 
alt="\text{Re} \{J_u^* \ z \} + i \text{Re}\{J_v^* \  z \}"> and <img src=
"https://render.githubusercontent.com/render/math?math=%5Cdisplaystyle+%5Ctext%7BRe%7D%5C%7Bz%5C%7D%5Cstar+J_u%5E%2A+%2B+%5Ctext%7BIm%7D%5C%7Bz%5C%7D%5Cstar+J_v%5E%2A" 
alt="\text{Re}\{z\}\star J_u^* + \text{Im}\{z\}\star J_v^*">.

I have implemented it already [here](https://github.com/inailuig/netket/commits/e72b0e10d3259939bd8afb4b553bebc30b1486a2), however iirc the scale-invariant regularization still needs some work.

___

Also we should maybe re-discuss the need/meaning of having both mode and holomorphic parameters in jacobian-pytree, and analogously add a holomorphic parameter to qgt_onthefly.py (which is only needed when centered=True). 

Alternatively we should check wether centered=False really has numerical issues, which, if it hasn't would allow us to remove centered=True and make this (but not the next) PR obsolete.
 