### PR TITLE
[WIP] Overhaul statistics computation

### DIFF
--- a/netket/stats/__init__.py
+++ b/netket/stats/__init__.py
@@ -14,7 +14,8 @@
 
 from .mpi_stats import subtract_mean, mean, sum, var, total_size
 
-from .mc_stats import statistics, Stats
+from .stats_base import StatsBase as Stats
+from .mc_stats import statistics, BlockStats, ChainStats
 
 from netket.utils import _hide_submodules
 

--- a/netket/stats/mc_stats.py
+++ b/netket/stats/mc_stats.py
@@ -12,91 +12,128 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import math
-
-from typing import Union
-
 from functools import partial
 
-from flax import struct
 import jax
 from jax import numpy as jnp
 
 import numpy as np
 
-from netket import jax as nkjax
+from netket.utils import mpi
+from netket.utils import struct
 
-from . import mean as _mean
-from . import var as _var
-from . import total_size as _total_size
-
-
-def _format_decimal(value, std, var):
-    if math.isfinite(std) and std > 1e-7:
-        decimals = max(int(np.ceil(-np.log10(std))), 0)
-        return (
-            "{0:.{1}f}".format(value, decimals + 1),
-            "{0:.{1}f}".format(std, decimals + 1),
-            "{0:.{1}f}".format(var, decimals + 1),
-        )
-    else:
-        return (
-            "{0:.3e}".format(value),
-            "{0:.3e}".format(std),
-            "{0:.3e}".format(var),
-        )
-
-
-_NaN = float("NaN")
+from .mpi_stats import var as _var, sum as _sum
+from .stats_base import StatsBase
 
 
 @struct.dataclass
-class Stats:
-    """A dict-compatible class containing the result of the statistics function."""
+class ChainStats(StatsBase):
+    """A Statistics class that uses the variance of the chains to compute
+    correlation time and Rhat.
+    """
 
-    mean: Union[float, complex] = _NaN
-    """The mean value"""
-    error_of_mean: float = _NaN
-    variance: float = _NaN
-    tau_corr: float = _NaN
-    R_hat: float = _NaN
+    @struct.property_cached(pytree_node=True)
+    def error(self) -> float:
+        return jnp.sqrt(self.batch_variance / self.n_chains)
 
-    def to_dict(self):
-        jsd = {}
-        jsd["Mean"] = self.mean.item()
-        jsd["Variance"] = self.variance.item()
-        jsd["Sigma"] = self.error_of_mean.item()
-        jsd["R_hat"] = self.R_hat.item()
-        jsd["TauCorr"] = self.tau_corr.item()
-        return jsd
+    @struct.property_cached(pytree_node=True)
+    def r_hat(self) -> float:
+        if self.n_chains > 1:
+            return jnp.sqrt(
+                (self._n - 1) / self._n + self.batch_variance / self.variance
+            )
+        else:
+            return jnp.nan
 
-    def to_compound(self):
-        return "Mean", self.to_dict()
+    @struct.property_cached(pytree_node=True)
+    def tau_corr(self) -> float:
+        return jnp.clip(0.5 * (self._n * self.batch_variance / self.variance - 1), 0)
+
+    @struct.property_cached(pytree_node=True)
+    def batch_variance(self) -> float:
+        return _var(self._μ)
+
+    def merge(self, other):
+        """
+        Merge the two statistics.
+        """
+        return super().merge(other)
 
     def __repr__(self):
-        mean, err, var = _format_decimal(self.mean, self.error_of_mean, self.variance)
-        if not math.isnan(self.R_hat):
-            ext = ", R̂={:.4f}".format(self.R_hat)
-        else:
-            ext = ""
-        return "{} ± {} [σ²={}{}]".format(mean, err, var, ext)
+        return super().__repr__()
 
-    # Alias accessors
-    def __getattr__(self, name):
-        if name in ("mean", "Mean"):
-            return self.mean
-        elif name in ("variance", "Variance"):
-            return self.variance
-        elif name in ("error_of_mean", "Sigma"):
-            return self.error_of_mean
-        elif name in ("R_hat", "R"):
-            return self.R_hat
-        elif name in ("tau_corr", "TauCorr"):
-            return self.tau_corr
-        else:
-            raise AttributeError(
-                "'Stats' object object has no attribute '{}'".format(name)
+
+# TODO: Find a better algorithm.
+# This blocked versions does not perform very well and has a high error
+@struct.dataclass
+class BlockStats(StatsBase):
+    """A Statistics class that uses re-blocking to compute correlation time.
+    Rhat is 0.
+    """
+
+    _M2_block: float = 0.0
+    """Sum of the squared residuals of the blocks."""
+    _n_blocks: int = 0
+    """The number of blocks in the reduced data."""
+    _block_size: int = struct.field(pytree_node=False, default=0)
+    """The size of different blocks."""
+
+    @property
+    def n_blocks(self):
+        return self._n_blocks * mpi.n_nodes
+
+    @struct.property_cached(pytree_node=True)
+    def error(self) -> float:
+        return jnp.sqrt(self.block_variance / self.n_blocks)
+
+    @struct.property_cached(pytree_node=True)
+    def r_hat(self) -> float:
+        return jnp.nan
+
+    @struct.property_cached(pytree_node=True)
+    def tau_corr(self) -> float:
+        return jnp.clip(
+            0.5 * (self._block_size * self.block_variance / self.variance - 1), 0
+        )
+
+    @struct.property_cached(pytree_node=True)
+    def block_variance(self) -> float:
+        n = self._n_blocks
+        B = mpi.n_nodes
+
+        if B > 1:
+            μ_block = self._μ.mean()
+            # This is derived from the Weldford's formula for merging two M2, assuming
+            # they all have the same number of observations n
+            M2 = _sum(
+                self._M2_block + n * (μ_block * (μ_block - self.mean).conj()).real
             )
+        else:
+            M2 = self._M2_block
+        return M2 / (B * n)
+
+    def merge(self, other):
+        """
+        Merge the two statistics.
+        """
+        if self._block_size != other._block_size:
+            raise ValueError("Block sizes must match.")
+
+        self = super().merge(other)
+
+        n_blocks = self._n_blocks + other._n_blocks
+
+        δ = other._μ.mean() - self._μ.mean()
+        M2_block = (
+            self._M2_block
+            + other._M2_block
+            + (jnp.abs(δ) ** 2) * (self._n_blocks * other._n_blocks) / n_blocks
+        )
+
+        return self.replace(_M2_block=M2_block, _n_blocks=n_blocks)
+
+    def __repr__(self):
+        return super().__repr__()
 
 
 def _get_blocks(data, block_size):
@@ -104,26 +141,15 @@ def _get_blocks(data, block_size):
 
     n_blocks = int(np.floor(chain_length / float(block_size)))
 
-    return data[:, 0 : n_blocks * block_size].reshape((-1, block_size)).mean(axis=1)
-
-
-def _block_variance(data, l):
-    blocks = _get_blocks(data, l)
-    ts = _total_size(blocks)
-    if ts > 0:
-        return _var(blocks), ts
-    else:
-        return jnp.nan, 0
-
-
-def _batch_variance(data):
-    b_means = data.mean(axis=1)
-    ts = _total_size(b_means)
-    return _var(b_means), ts
+    return (
+        data[:, 0 : n_blocks * block_size]
+        .reshape((-1, n_blocks, block_size))
+        .mean(axis=-1)
+    )
 
 
 # this is not batch_size maybe?
-def statistics(data, batch_size=32):
+def statistics(data, block_size=32, precompute=True) -> StatsBase:
     r"""
     Returns statistics of a given array (or matrix, see below) containing a stream of data.
     This is particularly useful to analyze Markov Chain data, but it can be used
@@ -145,11 +171,11 @@ def statistics(data, batch_size=32):
              dict sintax (e.g. res['mean']), one can also access them directly with the dot operator
              (e.g. res.mean).
     """
-    return _statistics(data, batch_size)
+    return _statistics(data, block_size, precompute)
 
 
-@partial(jax.jit, static_argnums=1)
-def _statistics(data, batch_size):
+@partial(jax.jit, static_argnums=(1, 2))
+def _statistics(data, block_size, precompute):
     data = jnp.atleast_1d(data)
     if data.ndim == 1:
         data = data.reshape((1, -1))
@@ -157,89 +183,44 @@ def _statistics(data, batch_size):
     if data.ndim > 2:
         raise NotImplementedError("Statistics are implemented only for ndim<=2")
 
-    mean = _mean(data)
-    variance = _var(data)
+    μ = data.mean(axis=-1)
+    n = data.shape[-1]
+    M2 = data.var(axis=-1) * n
 
-    ts = _total_size(data)
-
-    bare_var = variance
-
-    batch_var, n_batches = _batch_variance(data)
-
-    l_block = max(1, data.shape[1] // batch_size)
-
-    block_var, n_blocks = _block_variance(data, l_block)
-
-    tau_batch = ((ts / n_batches) * batch_var / bare_var - 1) * 0.5
-    tau_block = ((ts / n_blocks) * block_var / bare_var - 1) * 0.5
-
-    batch_good = (tau_batch < 6 * data.shape[1]) * (n_batches >= batch_size)
-    block_good = (tau_block < 6 * l_block) * (n_blocks >= batch_size)
-
-    stat_dtype = nkjax.dtype_real(data.dtype)
-
-    # if batch_good:
-    #    error_of_mean = jnp.sqrt(batch_var / n_batches)
-    #    tau_corr = jnp.max(0, tau_batch)
-    # elif block_good:
-    #    error_of_mean = jnp.sqrt(block_var / n_blocks)
-    #    tau_corr = jnp.max(0, tau_block)
-    # else:
-    #    error_of_mean = jnp.nan
-    #    tau_corr = jnp.nan
-    # jax style
-
-    def batch_good_err(args):
-        batch_var, tau_batch, *_ = args
-        error_of_mean = jnp.sqrt(batch_var / n_batches)
-        tau_corr = jnp.clip(tau_batch, 0)
-        return jnp.asarray(error_of_mean, dtype=stat_dtype), jnp.asarray(
-            tau_corr, dtype=stat_dtype
+    # use blocking algorithm instead of batches if less than 8 chains
+    use_blocks = mpi.n_nodes * μ.shape[0] < 8
+    if not use_blocks:
+        res = ChainStats(
+            _μ=μ,
+            _M2=M2,
+            _n=n,
+            __precompute_cached_properties=precompute,
         )
 
-    def block_good_err(args):
-        _, _, block_var, tau_block = args
-        error_of_mean = jnp.sqrt(block_var / n_blocks)
-        tau_corr = jnp.clip(tau_block, 0)
-        return jnp.asarray(error_of_mean, dtype=stat_dtype), jnp.asarray(
-            tau_corr, dtype=stat_dtype
-        )
-
-    def nan_err(args):
-        return jnp.asarray(jnp.nan, dtype=stat_dtype), jnp.asarray(
-            jnp.nan, dtype=stat_dtype
-        )
-
-    def batch_not_good(args):
-        batch_var, tau_batch, block_var, tau_block, block_good = args
-        return jax.lax.cond(
-            block_good,
-            block_good_err,
-            nan_err,
-            (batch_var, tau_batch, block_var, tau_block),
-        )
-
-    error_of_mean, tau_corr = jax.lax.cond(
-        batch_good,
-        batch_good_err,
-        batch_not_good,
-        (batch_var, tau_batch, block_var, tau_block, block_good),
-    )
-
-    if n_batches > 1:
-        N = data.shape[-1]
-
-        # V_loc = _np.var(data, axis=-1, ddof=0)
-        # W_loc = _np.mean(V_loc)
-        # W = _mean(W_loc)
-        # # This approximation seems to hold well enough for larger n_samples
-        W = variance
-
-        R_hat = jnp.sqrt((N - 1) / N + batch_var / W)
     else:
-        R_hat = jnp.nan
+        chain_length = data.shape[-1]
 
-    res = Stats(mean, error_of_mean, variance, tau_corr, R_hat)
+        # compute the total number of blocks, making sure that there are at least 32 blocks
+        # and special case the condition where the chain is shorter than 32 elements
+        n_blocks_min = min(32, chain_length)
+        n_blocks = max(n_blocks_min, int(np.floor(chain_length / float(block_size))))
+
+        # Compute the actual block size starting from the total number of blocks
+        block_size = max(1, chain_length // n_blocks)
+        data = _get_blocks(data, block_size)
+
+        n_blocks = data.size
+        M2_block = data.var() * n_blocks
+
+        res = BlockStats(
+            _μ=μ,
+            _M2=M2,
+            _n=n,
+            _n_blocks=n_blocks,
+            _M2_block=M2_block,
+            _block_size=block_size,
+            __precompute_cached_properties=precompute,
+        )
 
     return res
     ##

--- a/netket/stats/mpi_stats.py
+++ b/netket/stats/mpi_stats.py
@@ -89,7 +89,11 @@ def sum(a, axis=None, keepdims: bool = False):
     return out
 
 
-def var(a, axis=None, ddof: int = 0):
+# needed othewise it is shadowed...
+_mean = mean
+
+
+def var(a, axis=None, ddof: int = 0, mean=None):
     """
     Compute the variance mean along the specified axis and over MPI processes.
     Assumes same shape on all MPI processes.
@@ -106,12 +110,13 @@ def var(a, axis=None, ddof: int = 0):
         The array with reduced dimensions defined by axis. If out is not none, returns out.
 
     """
-    m = mean(a, axis=axis)
+    if mean is None:
+        mean = _mean(a, axis=axis)
 
     if axis is None:
-        ssq = jnp.abs(a - m) ** 2.0
+        ssq = jnp.abs(a - mean) ** 2.0
     else:
-        ssq = jnp.abs(a - jnp.expand_dims(m, axis)) ** 2.0
+        ssq = jnp.abs(a - jnp.expand_dims(mean, axis)) ** 2.0
 
     out = sum(ssq, axis=axis)
 

--- a/netket/stats/stats_base.py
+++ b/netket/stats/stats_base.py
@@ -1,0 +1,134 @@
+# Copyright 2021 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Union
+import math
+
+import numpy as np
+
+import jax.numpy as jnp
+
+from netket.utils import mpi
+from netket.utils import struct
+
+from .mpi_stats import mean as _mean, sum as _sum
+
+
+def _format_decimal(value, std, var):
+    if math.isfinite(std) and std > 1e-7:
+        decimals = max(int(np.ceil(-np.log10(std))), 0)
+        return (
+            "{0:.{1}f}".format(value, decimals + 1),
+            "{0:.{1}f}".format(std, decimals + 1),
+            "{0:.{1}f}".format(var, decimals + 1),
+        )
+    else:
+        return (
+            "{0:.3e}".format(value),
+            "{0:.3e}".format(std),
+            "{0:.3e}".format(var),
+        )
+
+
+@struct.dataclass
+class StatsBase:
+    """A dict-compatible class containing the result of the statistics function.
+
+    This class should be derived to implement rhat and tau_corr."""
+
+    _μ: Union[float, complex] = 0
+    """The mean value per-chain."""
+    _M2: float = 0
+    """The sum of the residuals squared, per chain."""
+    _n: int = 0
+    """The number of datapoints per chain."""
+
+    @property
+    def n_chains(self):
+        """The total number of independent streams in the data."""
+        return self._μ.size * mpi.n_nodes
+
+    @struct.property_cached(pytree_node=True)
+    def mean(self) -> float:
+        """The sample mean of the reduced data."""
+        return _mean(self._μ)
+
+    @struct.property_cached(pytree_node=True)
+    def variance(self) -> float:
+        """The sample variance of the reduced data."""
+        n = self._n
+        B = self.n_chains
+
+        # This is derived from the Weldford's formula for merging two M2, assuming
+        # they all have the same number of observations n
+        M2 = _sum(self._M2 + n * (self._μ * (self._μ - self.mean).conj()).real)
+        return M2 / (B * n)
+
+    def merge(self, other):
+        """
+        Merge two statistics objects.
+        """
+        if self.n_chains != other.n_chains:
+            raise ValueError(
+                "Cannot sum two Stats objects for a different number of chains."
+            )
+
+        n = self._n + other._n
+
+        a1 = self._n / n
+        a2 = other._n / n
+
+        μ = a1 * self._μ + a2 * other._μ
+
+        δ = other._μ - self._μ
+        M2 = self._M2 + other._M2 + (jnp.abs(δ) ** 2) * (self._n * other._n) / n
+
+        return self.replace(_μ=μ, _M2=M2, _n=n)
+
+    def __repr__(self):
+        mean, err, var = _format_decimal(self.mean, self.error, self.variance)
+        if not math.isnan(self.r_hat):
+            ext = ", R̂={:.4f}".format(self.r_hat)
+        else:
+            ext = ""
+        return "{} ± {} [σ²={}{}]".format(mean, err, var, ext)
+
+    def to_dict(self):
+        jsd = {}
+        jsd["Mean"] = self.mean.item()
+        jsd["Variance"] = self.variance.item()
+        jsd["Sigma"] = self.error.item()
+        jsd["Rhat"] = self.r_hat.item()
+        jsd["TauCorr"] = self.tau_corr.item()
+        return jsd
+
+    def to_compound(self):
+        return "Mean", self.to_dict()
+
+    # Alias accessors
+    def __getattr__(self, name):
+        if name in ("mean", "Mean"):
+            return self.mean
+        elif name in ("variance", "Variance"):
+            return self.variance
+        elif name in ("error_of_mean", "Sigma"):
+            return self.error
+        elif name in ("R_hat", "R"):
+            return self.r_hat
+        elif name in ("tau_corr", "TauCorr"):
+            return self.tau_corr
+        else:
+            raise AttributeError(
+                "'Stats' object object has no attribute '{}'".format(name)
+            )


### PR DESCRIPTION
This PR rewrites the logic computing the statistics of our `Stats` class in order to use  _single-pass_ algorithms that need traverse the data only once. 

With this PR, once a `Stats` object is created, it can be `Stats.merge(other_stats)` with another object in order to combine the indicators.

This is a requirement for properly computing such statistical diagnostics when working with minibatches  while keeping memory requirements contained.

My idea is to compute the tau_corr and error of the mean by using the variance among the chains if there is a sufficient number of chains, otherwise switch to the variance among blocks. 

Interestingly, this implementation requires 1 less MPI call then before, so it might be marginally faster in MPI contexts when computing many observables because it reduces the number of sync points.