### PR TITLE
Dataclass: support pytree_node=True cached properties

### DIFF
--- a/netket/utils/struct/dataclass.py
+++ b/netket/utils/struct/dataclass.py
@@ -132,6 +132,10 @@ class CachedProperty:
 def property_cached(fun=None, pytree_node=False):
     """Decorator to make the method behave as a property but cache the resulting value and
     clears it upon replace.
+
+    Args:
+        pytree_node: a leaf node in the pytree representation of this dataclass.
+            If False this must be hashable
     """
     if fun is None:
         return partial(property_cached, pytree_node=pytree_node)

--- a/netket/utils/struct/dataclass.py
+++ b/netket/utils/struct/dataclass.py
@@ -129,14 +129,14 @@ class CachedProperty:
         )
 
 
-def property_cached(fun):
+def property_cached(fun=None, pytree_node=False):
     """Decorator to make the method behave as a property but cache the resulting value and
     clears it upon replace.
     """
-    # if fun is None:
-    #    return partial(property_cached, pytree_node=pytree_node)
+    if fun is None:
+        return partial(property_cached, pytree_node=pytree_node)
 
-    return CachedProperty(fun, pytree_node=False)
+    return CachedProperty(fun, pytree_node=pytree_node)
 
 
 def _set_annotation(clz, attr, typ):
@@ -243,7 +243,7 @@ def process_cached_properties(clz, globals=None):
         _precompute_body_method.append("pass")
 
     fun = _create_fn(
-        name,
+        PRECOMPUTE_CACHED_PROPERTY_NAME,
         [self_name],
         _precompute_body_method,
         globals=globals,
@@ -288,14 +288,18 @@ def attach_preprocess_init(data_clz, *, globals={}, init_doc=MISSING, cache_hash
     _set_new_attribute(data_clz, _DATACLASS_INIT_NAME, data_clz.__init__)
 
     # Create a new init function calling __pre_init__ and then __dataclass_init__
+    # If __precompute_cached_properties is True, then also precompute all cached
+    # properties after having initialised the dataclass
     self_name = "self"
     body_lines = [
         "if not __skip_preprocess:",
         f"\targs, kwargs = {self_name}.{_PRE_INIT_NAME}(*args, **kwargs)",
         f"{self_name}.{_DATACLASS_INIT_NAME}(*args, **kwargs)",
+        "if __precompute_cached_properties:",
+        f"\t{self_name}.{PRECOMPUTE_CACHED_PROPERTY_NAME}()",
     ]
 
-    # If r3equested, create the cache hash field
+    # If requested, create the cache hash field
     if cache_hash:
         body_lines.append(
             f"BUILTINS.object.__setattr__({self_name},{_hash_cache_name(data_clz.__name__)!r},Uninitialized)"
@@ -303,7 +307,13 @@ def attach_preprocess_init(data_clz, *, globals={}, init_doc=MISSING, cache_hash
 
     fun = _create_fn(
         "__init__",
-        [self_name, "*args", "__skip_preprocess=False", "**kwargs"],
+        [
+            self_name,
+            "*args",
+            "__precompute_cached_properties=False",
+            "__skip_preprocess=False",
+            "**kwargs",
+        ],
         body_lines,
         globals=globals,
     )
@@ -405,8 +415,12 @@ def dataclass(clz=None, *, init_doc=MISSING, cache_hash=False):
     cache_fields = []
     for _, cp in getattr(data_clz, _CACHES, {}).items():
         cache_fields.append(cp.cache_name)
+        # they count as struct fields
+        if cp.pytree_node:
+            data_fields.append(cp.cache_name)
         # they count as meta fields
-        meta_fields.append(cp.cache_name)
+        else:
+            meta_fields.append(cp.cache_name)
 
     def replace(self, **updates):
         """Returns a new object replacing the specified fields with new values."""

--- a/test/utils/test_struct.py
+++ b/test/utils/test_struct.py
@@ -182,11 +182,13 @@ class PointC:
 
 # test for pytree_node=True cached properties
 def test_cached_pytreenode_properties():
+    # check cache uninitialized then populated
     p = PointC(2.0, 3.0)
     assert p.__cached_node_cache is struct.Uninitialized
     assert p.cached_node == 2.0 * 3.0
     assert p.__cached_node_cache == 6.0
 
+    # check cache reset after call to replace
     p = p.replace(y=3.0)
     assert p.__cached_node_cache is struct.Uninitialized
     assert p.cached_node == 2.0 * 3.0
@@ -196,12 +198,14 @@ def test_cached_pytreenode_properties():
     def compute(x: PointC):
         return x.cached_node * 3, x
 
+    # check cache populated when returned from jitted function
     p = PointC(2.0, 3.0)
     res, p2 = compute(p)
     assert p.__cached_node_cache is struct.Uninitialized
     assert res == 6.0 * 3
     assert p2.__cached_node_cache == 6.0
 
+    # check cache not modified by jit
     res, p3 = compute(p2)
     assert res == 6.0 * 3
     assert p3.__cached_node_cache == 6.0

--- a/test/utils/test_struct.py
+++ b/test/utils/test_struct.py
@@ -168,3 +168,40 @@ def test_cache_hash():
     assert a.__Point0cache_hash_cache == 123
     object.__setattr__(a, "__Point0cache_hash_cache", 1234)
     hash(a) == 1234
+
+
+@struct.dataclass
+class PointC:
+    x: float
+    y: float
+
+    @struct.property_cached(pytree_node=True)
+    def cached_node(self) -> int:
+        return self.x * self.y
+
+
+# test for pytree_node=True cached properties
+def test_cached_pytreenode_properties():
+    p = PointC(2.0, 3.0)
+    assert p.__cached_node_cache is struct.Uninitialized
+    assert p.cached_node == 2.0 * 3.0
+    assert p.__cached_node_cache == 6.0
+
+    p = p.replace(y=3.0)
+    assert p.__cached_node_cache is struct.Uninitialized
+    assert p.cached_node == 2.0 * 3.0
+    assert p.__cached_node_cache == 6.0
+
+    @jax.jit
+    def compute(x: PointC):
+        return x.cached_node * 3, x
+
+    p = PointC(2.0, 3.0)
+    res, p2 = compute(p)
+    assert p.__cached_node_cache is struct.Uninitialized
+    assert res == 6.0 * 3
+    assert p2.__cached_node_cache == 6.0
+
+    res, p3 = compute(p2)
+    assert res == 6.0 * 3
+    assert p3.__cached_node_cache == 6.0


### PR DESCRIPTION
Also a spinoff from #824, so those PRs can be streamlined only on the relevant things...

This PR adds support for cached nodes that are `pytree_node`.
I will use it in #824 to cache the mean and avoid recomputing it several times.