### PR TITLE
Reduce connected elements in pauli strings

### DIFF
--- a/netket/operator/_pauli_strings.py
+++ b/netket/operator/_pauli_strings.py
@@ -93,7 +93,8 @@ class PauliStrings(AbstractOperator):
 
         def append(key, k):
             # convert list to tuple
-            key = tuple(key)
+            key = set(key)  # order of X and Y does not matter
+            key = tuple(key)  # make hashable
             if key in acting:
                 acting[key].append(k)
             else:


### PR DESCRIPTION
The order at which X and Y operators are detected in pauli strings should not matter to determine the independent connected elements. Making the list of spin sites where spin flips occur independent of this order can reduce the number of wave function evaluations in cases with large number of pauli strings (but typically not really case in most common hamiltonians).