### PR TITLE
Variance scaling initializers with complex dtype

### DIFF
--- a/netket/models/mps.py
+++ b/netket/models/mps.py
@@ -23,10 +23,7 @@ import numpy as np
 
 from netket.graph import AbstractGraph, Chain
 from netket.hilbert import AbstractHilbert
-from netket.nn.initializers import lecun_normal
 from netket.utils.types import NNInitFunc
-
-default_kernel_init = lecun_normal()
 
 
 class MPSPeriodic(nn.Module):

--- a/netket/nn/initializers.py
+++ b/netket/nn/initializers.py
@@ -17,9 +17,14 @@ from functools import partial
 import jax
 from flax.linen.initializers import *
 from jax import numpy as jnp
-from jax._src.nn.initializers import _compute_fans
-
 from netket.jax.utils import dtype_real
+
+
+def _compute_fans(shape, in_axis=-2, out_axis=-1):
+    receptive_field_size = shape.total / shape[in_axis] / shape[out_axis]
+    fan_in = shape[in_axis] * receptive_field_size
+    fan_out = shape[out_axis] * receptive_field_size
+    return fan_in, fan_out
 
 
 def _complex_uniform(key, shape, dtype):

--- a/netket/nn/initializers.py
+++ b/netket/nn/initializers.py
@@ -12,11 +12,94 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import jax
-from jax import numpy as jnp
-
 from functools import partial
 
+import jax
 from flax.linen.initializers import *
+from jax import numpy as jnp
+from jax._src.nn.initializers import _compute_fans
 
-lecun_complex = partial(variance_scaling, 1.0, "fan_in", "normal", dtype=jnp.complex64)
+from netket.jax.utils import dtype_real
+
+
+def _complex_uniform(key, shape, dtype):
+    """
+    Sample uniform random values within a circle on the complex plane,
+    with zero mean and unit variance.
+    """
+    key_r, key_theta = jax.random.split(key)
+    dtype = dtype_real(dtype)
+    r = jnp.sqrt(2 * jax.random.uniform(key_r, shape, dtype))
+    theta = 2 * jnp.pi * jax.random.uniform(key_theta, shape, dtype)
+    return r * jnp.exp(1j * theta)
+
+
+def _complex_truncated_normal(key, upper, shape, dtype):
+    """
+    Sample random values from a centered normal distribution on the complex plane,
+    whose modulus is truncated to `upper`, and the variance before the truncation is one.
+    """
+    key_r, key_theta = jax.random.split(key)
+    dtype = dtype_real(dtype)
+    t = (1 - jnp.exp(-(upper ** 2))) * jax.random.uniform(key_r, shape, dtype)
+    r = jnp.sqrt(-jnp.log(1 - t))
+    theta = 2 * jnp.pi * jax.random.uniform(key_theta, shape, dtype)
+    return r * jnp.exp(1j * theta)
+
+
+def variance_scaling(
+    scale, mode, distribution, in_axis=-2, out_axis=-1, dtype=jnp.float32
+):
+    """
+    `jax.nn.initializers.variance_scaling` with complex dtype supported.
+    """
+
+    def init(key, shape, dtype=dtype):
+        shape = jax.core.as_named_shape(shape)
+        fan_in, fan_out = _compute_fans(shape, in_axis, out_axis)
+        if mode == "fan_in":
+            denominator = fan_in
+        elif mode == "fan_out":
+            denominator = fan_out
+        elif mode == "fan_avg":
+            denominator = (fan_in + fan_out) / 2
+        else:
+            raise ValueError(
+                "invalid mode for variance scaling initializer: {}".format(mode)
+            )
+
+        variance = jnp.array(scale / denominator, dtype=dtype)
+
+        if distribution == "truncated_normal":
+            if jnp.issubdtype(dtype, jnp.floating):
+                # constant is stddev of standard normal truncated to (-2, 2)
+                stddev = jnp.sqrt(variance) / 0.87962566103423978
+                return jax.random.truncated_normal(key, -2, 2, shape, dtype) * stddev
+            else:
+                stddev = jnp.sqrt(variance) / 0.95311164380491208
+                return _complex_truncated_normal(key, 2, shape, dtype) * stddev
+        elif distribution == "normal":
+            return jax.random.normal(key, shape, dtype) * jnp.sqrt(variance)
+        elif distribution == "uniform":
+            if jnp.issubdtype(dtype, jnp.floating):
+                stddev = jnp.sqrt(3 * variance)
+                return jax.random.uniform(key, shape, dtype, -1) * stddev
+            else:
+                return _complex_uniform(key, shape, dtype) * jnp.sqrt(variance)
+        else:
+            raise ValueError("invalid distribution for variance scaling initializer")
+
+    return init
+
+
+glorot_uniform = partial(variance_scaling, 1, "fan_avg", "uniform")
+glorot_normal = partial(variance_scaling, 1, "fan_avg", "truncated_normal")
+lecun_uniform = partial(variance_scaling, 1, "fan_in", "uniform")
+lecun_normal = partial(variance_scaling, 1, "fan_in", "truncated_normal")
+he_uniform = partial(variance_scaling, 2, "fan_in", "uniform")
+he_normal = partial(variance_scaling, 2, "fan_in", "truncated_normal")
+
+xavier_uniform = glorot_uniform
+xavier_normal = glorot_normal
+kaiming_uniform = he_uniform
+kaiming_normal = he_normal

--- a/netket/nn/initializers.py
+++ b/netket/nn/initializers.py
@@ -29,7 +29,7 @@ def _compute_fans(shape, in_axis=-2, out_axis=-1):
 
 def _complex_uniform(key, shape, dtype):
     """
-    Sample uniform random values within a circle on the complex plane,
+    Sample uniform random values within a disk on the complex plane,
     with zero mean and unit variance.
     """
     key_r, key_theta = jax.random.split(key)
@@ -56,7 +56,32 @@ def variance_scaling(
     scale, mode, distribution, in_axis=-2, out_axis=-1, dtype=jnp.float32
 ):
     """
-    `jax.nn.initializers.variance_scaling` with complex dtype supported.
+    Initializer capable of adapting its scale to the shape of the weights tensor.
+
+    With `distribution="truncated_normal" or "normal"`, samples are
+    drawn from a truncated/untruncated normal distribution with a mean of zero and
+    a standard deviation (after truncation, if used) `stddev = sqrt(scale / n)`,
+    where `n` is:
+    - number of input units in the weights tensor, if `mode="fan_in"`
+    - number of output units, if `mode="fan_out"`
+    - average of the numbers of input and output units, if `mode="fan_avg"`
+
+    With `distribution="truncated_normal"`, the absolute values of the samples are
+    truncated below 2 standard deviations before truncation.
+
+    With `distribution="uniform"`, samples are drawn from:
+    - a uniform interval, if `dtype` is real
+    - a uniform disk, if `dtype` is complex
+    with a mean of zero and a standard deviation of `stddev`.
+
+    Args:
+      scale: scaling factor (positive float).
+      mode: one of "fan_in", "fan_out", and "fan_avg".
+      distribution: random distribution to use. One of "truncated_normal",
+        "normal" and "uniform".
+      in_axis: axis of the input dimension in the weights tensor (default: -2).
+      out_axis: axis of the output dimension in the weights tensor (default: -1).
+      dtype: the dtype of the weights (default: float32).
     """
 
     def init(key, shape, dtype=dtype):

--- a/netket/nn/initializers.py
+++ b/netket/nn/initializers.py
@@ -74,6 +74,11 @@ def variance_scaling(
     - a uniform disk, if `dtype` is complex
     with a mean of zero and a standard deviation of `stddev`.
 
+    The generalization of variance scaling initializers to complex numbers is discussed in,
+    e.g., `Trabelsi et. {\\it al} <https://arxiv.org/abs/1705.09792>`_.
+    They proposed an axisymmetric distribution implemented by first sampling the modulus
+    from the radial CDF, then uniformly sampling the phase.
+
     Args:
       scale: scaling factor (positive float).
       mode: one of "fan_in", "fan_out", and "fan_avg".

--- a/netket/nn/linear.py
+++ b/netket/nn/linear.py
@@ -22,16 +22,14 @@ from jax import lax
 import jax.numpy as jnp
 import numpy as np
 
-from netket.nn.initializers import lecun_normal, normal, zeros
+from netket.nn.initializers import normal, zeros
 
 PRNGKey = Any
 Shape = Iterable[int]
 Dtype = Any  # this could be a real type?
 Array = Any
 
-
 default_kernel_init = normal(stddev=0.01)
-# complex_kernel_init = lecun_normal()
 
 
 def _normalize_axes(axes, ndim):

--- a/netket/nn/masked_linear.py
+++ b/netket/nn/masked_linear.py
@@ -18,10 +18,10 @@ import flax
 from flax import linen as nn
 from jax import lax
 from jax import numpy as jnp
-from netket.nn.initializers import lecun_complex, zeros
+from netket.nn.initializers import lecun_normal, zeros
 from netket.utils.types import Array, DType, NNInitFunc
 
-default_kernel_init = lecun_complex()
+default_kernel_init = lecun_normal()
 
 
 def wrap_kernel_init(kernel_init, mask):

--- a/test/nn/test_initializers.py
+++ b/test/nn/test_initializers.py
@@ -23,6 +23,9 @@ from netket.jax.utils import dtype_real
 from netket.nn.initializers import lecun_normal, lecun_uniform
 from scipy.stats import kstest
 
+seed = 12345
+np.random.seed(seed)
+
 
 @pytest.mark.parametrize("dtype", [jnp.float64, jnp.complex128])
 @pytest.mark.parametrize("ndim", [2, 3, 4])
@@ -33,7 +36,7 @@ def test_initializer(init, ndim, dtype):
     elif init == "truncated_normal":
         init_fun = lecun_normal()
 
-    key = nk.jax.PRNGKey(12)
+    key, rand_key = jax.random.split(nk.jax.PRNGKey(seed))
     # The lengths of the weight dimensions and the input dimension are random
     shape = tuple(np.random.randint(1, 10) for _ in range(ndim))
     shape_prod = np.prod(shape)
@@ -63,7 +66,6 @@ def test_initializer(init, ndim, dtype):
 
     # Draw random samples using rejection sampling, and test if `param` and
     # `samples` are from the same distribution
-    rand_key = nk.jax.PRNGKey(13)
     rand_shape = (10 ** 4,)
     rand_dtype = dtype_real(dtype)
     if init == "uniform":

--- a/test/nn/test_initializers.py
+++ b/test/nn/test_initializers.py
@@ -38,7 +38,7 @@ def test_initializer(init, ndim, dtype):
     shape = tuple(np.random.randint(1, 10) for _ in range(ndim))
     shape_prod = np.prod(shape)
     # The length of the output dimension is a statistically large number, but not too large that OOM
-    len_out = int(10 ** 7 / shape_prod)
+    len_out = int(10 ** 6 / shape_prod)
     shape += (len_out,)
     param = init_fun(key, shape, dtype)
 
@@ -63,16 +63,16 @@ def test_initializer(init, ndim, dtype):
 
     # Draw random samples using rejection sampling, and test if `param` and
     # `samples` are from the same distribution
-    rand_shape = (10 ** 3,)
+    rand_key = nk.jax.PRNGKey()
+    rand_shape = (10 ** 4,)
     rand_dtype = dtype_real(dtype)
     if init == "uniform":
         if jnp.issubdtype(dtype, jnp.floating):
-            key = nk.jax.PRNGKey()
             samples = jax.random.uniform(
-                key, rand_shape, rand_dtype, -max_norm, max_norm
+                rand_key, rand_shape, rand_dtype, -max_norm, max_norm
             )
         else:
-            key_real, key_imag = jax.random.split(nk.jax.PRNGKey())
+            key_real, key_imag = jax.random.split(rand_key)
             samples = (
                 jax.random.uniform(
                     key_real, rand_shape, rand_dtype, -max_norm, max_norm
@@ -87,7 +87,7 @@ def test_initializer(init, ndim, dtype):
             rand_stddev = max_norm / 2
         else:
             rand_stddev = max_norm / (2 * sqrt(2))
-        samples = jax.random.normal(key, rand_shape, rand_dtype) * rand_stddev
+        samples = jax.random.normal(rand_key, rand_shape, rand_dtype) * rand_stddev
     samples = samples[jnp.abs(samples) < max_norm]
 
     _, pvalue = kstest(param.flatten(), samples)

--- a/test/nn/test_initializers.py
+++ b/test/nn/test_initializers.py
@@ -55,6 +55,8 @@ def test_initializer(init, dtype):
 
     assert jnp.abs(param).max() == pytest.approx(max_norm, abs=1e-3)
 
+    # Draw random samples using rejection sampling, and test if `param` and
+    # `samples` are from the same distribution
     rand_shape = (10 ** 3,)
     rand_dtype = dtype_real(dtype)
     if init == "uniform":

--- a/test/nn/test_initializers.py
+++ b/test/nn/test_initializers.py
@@ -1,0 +1,28 @@
+# Copyright 2021 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import netket as nk
+import pytest
+from jax import numpy as jnp
+from netket.nn.initializers import lecun_normal, lecun_uniform
+
+
+@pytest.mark.parametrize("dtype", [jnp.float64, jnp.complex128])
+@pytest.mark.parametrize("init", [lecun_uniform(), lecun_normal()])
+def test_initializer(init, dtype):
+    key = nk.jax.PRNGKey()
+    shape = (2, 2, 2, 10 ** 6)
+    param = init(key, shape, dtype)
+    assert param.mean() == pytest.approx(0, abs=1e-3)
+    assert param.var() == pytest.approx(1 / 8, abs=1e-2)

--- a/test/nn/test_initializers.py
+++ b/test/nn/test_initializers.py
@@ -33,7 +33,7 @@ def test_initializer(init, ndim, dtype):
     elif init == "truncated_normal":
         init_fun = lecun_normal()
 
-    key = nk.jax.PRNGKey()
+    key = nk.jax.PRNGKey(12)
     # The lengths of the weight dimensions and the input dimension are random
     shape = tuple(np.random.randint(1, 10) for _ in range(ndim))
     shape_prod = np.prod(shape)

--- a/test/nn/test_initializers.py
+++ b/test/nn/test_initializers.py
@@ -24,13 +24,14 @@ from netket.nn.initializers import lecun_normal, lecun_uniform
 from scipy.stats import kstest
 
 seed = 12345
-np.random.seed(seed)
 
 
 @pytest.mark.parametrize("dtype", [jnp.float64, jnp.complex128])
 @pytest.mark.parametrize("ndim", [2, 3, 4])
 @pytest.mark.parametrize("init", ["uniform", "truncated_normal"])
 def test_initializer(init, ndim, dtype):
+    np.random.seed(seed)
+
     if init == "uniform":
         init_fun = lecun_uniform()
     elif init == "truncated_normal":

--- a/test/nn/test_initializers.py
+++ b/test/nn/test_initializers.py
@@ -63,7 +63,7 @@ def test_initializer(init, ndim, dtype):
 
     # Draw random samples using rejection sampling, and test if `param` and
     # `samples` are from the same distribution
-    rand_key = nk.jax.PRNGKey()
+    rand_key = nk.jax.PRNGKey(13)
     rand_shape = (10 ** 4,)
     rand_dtype = dtype_real(dtype)
     if init == "uniform":

--- a/test/nn/test_initializers.py
+++ b/test/nn/test_initializers.py
@@ -12,17 +12,75 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from math import sqrt
+
+import jax
 import netket as nk
 import pytest
 from jax import numpy as jnp
+from netket.jax.utils import dtype_real
 from netket.nn.initializers import lecun_normal, lecun_uniform
+from numpy import prod
+from scipy.stats import kstest
 
 
 @pytest.mark.parametrize("dtype", [jnp.float64, jnp.complex128])
-@pytest.mark.parametrize("init", [lecun_uniform(), lecun_normal()])
+@pytest.mark.parametrize("init", ["uniform", "truncated_normal"])
 def test_initializer(init, dtype):
+    if init == "uniform":
+        init_fun = lecun_uniform()
+    elif init == "truncated_normal":
+        init_fun = lecun_normal()
+
     key = nk.jax.PRNGKey()
     shape = (2, 2, 2, 10 ** 6)
-    param = init(key, shape, dtype)
+    param = init_fun(key, shape, dtype)
+
+    variance = 1 / prod(shape[:-1])
+    stddev = sqrt(variance)
+
     assert param.mean() == pytest.approx(0, abs=1e-3)
-    assert param.var() == pytest.approx(1 / 8, abs=1e-2)
+    assert param.var() == pytest.approx(variance, abs=1e-2)
+
+    if init == "uniform":
+        if jnp.issubdtype(dtype, jnp.floating):
+            max_norm = sqrt(3) * stddev
+        else:
+            max_norm = sqrt(2) * stddev
+    elif init == "truncated_normal":
+        if jnp.issubdtype(dtype, jnp.floating):
+            max_norm = 2 / 0.87962566103423978 * stddev
+        else:
+            max_norm = 2 / 0.95311164380491208 * stddev
+
+    assert jnp.abs(param).max() == pytest.approx(max_norm, abs=1e-3)
+
+    rand_shape = (10 ** 3,)
+    rand_dtype = dtype_real(dtype)
+    if init == "uniform":
+        if jnp.issubdtype(dtype, jnp.floating):
+            key = nk.jax.PRNGKey()
+            samples = jax.random.uniform(
+                key, rand_shape, rand_dtype, -max_norm, max_norm
+            )
+        else:
+            key_real, key_imag = jax.random.split(nk.jax.PRNGKey())
+            samples = (
+                jax.random.uniform(
+                    key_real, rand_shape, rand_dtype, -max_norm, max_norm
+                )
+                + jax.random.uniform(
+                    key_imag, rand_shape, rand_dtype, -max_norm, max_norm
+                )
+                * 1j
+            )
+    elif init == "truncated_normal":
+        if jnp.issubdtype(dtype, jnp.floating):
+            rand_stddev = max_norm / 2
+        else:
+            rand_stddev = max_norm / (2 * sqrt(2))
+        samples = jax.random.normal(key, rand_shape, rand_dtype) * rand_stddev
+    samples = samples[jnp.abs(samples) < max_norm]
+
+    _, pvalue = kstest(param.flatten(), samples)
+    assert pvalue > 0.01


### PR DESCRIPTION
Implements the complex truncated normal distribution mentioned [here](https://github.com/netket/netket/pull/705#discussion_r642466919), and the complex uniform distribution within a circle on the complex plane.

(It seems that only my ARNNs are using LeCun normal as the default initializer. All other models in NetKet are using normal distributions with small constant variances.)