### PR TITLE
Fix docs for σ^± and extend tests to higher spins

### DIFF
--- a/netket/operator/spin.py
+++ b/netket/operator/spin.py
@@ -88,7 +88,7 @@ def sigmaz(hilbert: AbstractHilbert, site: int, dtype: DType = float) -> _LocalO
 
 def sigmam(hilbert: AbstractHilbert, site: int, dtype: DType = float) -> _LocalOperator:
     """
-    Builds the :math:`\\sigma^{-} = \\sigma^x - i \\sigma^y` operator acting on the
+    Builds the :math:`\\sigma^{-} = \\frac{1}{2}(\\sigma^x - i \\sigma^y)` operator acting on the
     `site`-th of the Hilbert space `hilbert`.
 
     If `hilbert` is a non-Spin space of local dimension M, it is considered
@@ -111,7 +111,7 @@ def sigmam(hilbert: AbstractHilbert, site: int, dtype: DType = float) -> _LocalO
 
 def sigmap(hilbert: AbstractHilbert, site: int, dtype: DType = float) -> _LocalOperator:
     """
-    Builds the :math:`\\sigma^{+} = \\sigma^x + i \\sigma^y` operator acting on the
+    Builds the :math:`\\sigma^{+} = \\frac{1}{2}(\\sigma^x + i \\sigma^y)` operator acting on the
     `site`-th of the Hilbert space `hilbert`.
 
     If `hilbert` is a non-Spin space of local dimension M, it is considered

--- a/test/operator/test_spin.py
+++ b/test/operator/test_spin.py
@@ -1,7 +1,8 @@
+import pytest
+
 from netket.operator import spin
 import netket as nk
 import numpy as np
-
 from numpy.testing import assert_almost_equal
 
 herm_operators = {}
@@ -10,8 +11,9 @@ generic_operators = {}
 N = 4
 
 
-def test_pauli_algebra():
-    hi = nk.hilbert.Spin(1 / 2) ** N
+@pytest.mark.parametrize("S", [1 / 2, 1, 3 / 2])
+def test_pauli_algebra(S):
+    hi = nk.hilbert.Spin(S) ** N
 
     for i in range(N):
         sx = spin.sigmax(hi, i)
@@ -26,8 +28,11 @@ def test_pauli_algebra():
         assert_almost_equal(0.5 * (sx.to_dense() - 1j * sy.to_dense()), sm.to_dense())
         assert_almost_equal(0.5 * (sx.to_dense() + 1j * sy.to_dense()), sp.to_dense())
 
-        Imat = np.eye(hi.n_states)
+        if S == 1 / 2:
+            Imat = np.eye(hi.n_states)
 
-        # check that -i sx sy sz = I
-        assert_almost_equal((-1j * sx @ sy @ sz).to_dense(), Imat)
-        assert_almost_equal((-1j * sx.to_dense() @ sy.to_dense() @ sz.to_dense()), Imat)
+            # check that -i sx sy sz = I
+            assert_almost_equal((-1j * sx @ sy @ sz).to_dense(), Imat)
+            assert_almost_equal(
+                (-1j * sx.to_dense() @ sy.to_dense() @ sz.to_dense()), Imat
+            )


### PR DESCRIPTION
This resolves #845 and extends the tests to make sure that `σ^± = 1/2 (σ^x ± i σ^y)` is also true for higher spins.