### PR TITLE
Fixing typo in serialisation documentation

### DIFF
--- a/docs/docs/varstate.rst
+++ b/docs/docs/varstate.rst
@@ -257,7 +257,7 @@ A simple example to serialize data is provided below:
 
     import flax
 
-    with open("test.mpack", 'w') as file:
+    with open("test.mpack", 'wb') as file:
       file.write(flax.serialization.to_bytes(vstate))
 
 


### PR DESCRIPTION
I was checking the new way of saving and loading models (variational states), and found a typo in the documentation that throws an error when running because the correct writing mode is "wb" and not "w".