### PR TITLE
Changes to RBMSymm

### DIFF
--- a/netket/models/equivariant.py
+++ b/netket/models/equivariant.py
@@ -612,7 +612,9 @@ def GCNN(
             mode = "irreps"
         sg = symmetries
     else:
-        if irreps is not None and (mode == "irreps" or mode == "auto"):
+        if layers == 1:
+            sg = symmetries
+        elif irreps is not None and (mode == "irreps" or mode == "auto"):
             mode = "irreps"
             sg = symmetries
             irreps = tuple(HashableArray(irrep) for irrep in irreps)
@@ -645,7 +647,7 @@ def GCNN(
 
     if mode == "fft":
         sym = HashableArray(np.asarray(sg))
-        if product_table is None:
+        if product_table is None and layers > 1:
             product_table = HashableArray(sg.product_table)
         if parity:
             return GCNN_Parity_FFT(
@@ -671,7 +673,7 @@ def GCNN(
     elif mode in ["irreps", "auto"]:
         sym = HashableArray(np.asarray(sg))
 
-        if irreps is None:
+        if irreps is None and layers > 1:
             irreps = tuple(HashableArray(irrep) for irrep in sg.irrep_matrices())
 
         if parity:

--- a/netket/models/equivariant.py
+++ b/netket/models/equivariant.py
@@ -568,9 +568,9 @@ def GCNN(
             Only needs to be specified if mode='irreps' and symmetries is specified as an array.
         point_group: The point group, from which the space group is built.
             If symmetries is a graph the default point group is overwritten.
-        mode: string "fft, irreps, matrix, auto" specifying whether to use a fast
-            fourier transform over the translation group, a fourier transform using
-            the irreducible representations or by constructing the full kernel matrix.
+        mode: string "fft, irreps, auto" specifying whether to use a fast
+            fourier transform over the translation group, or a fourier transform using
+            the irreducible representations.
         shape: A tuple specifying the dimensions of the translation group.
         layers: Number of layers (not including sum layer over output).
         features: Number of features in each layer starting from the input. If a single

--- a/test/models/test_rbm.py
+++ b/test/models/test_rbm.py
@@ -24,22 +24,19 @@ import pytest
 
 
 @pytest.mark.parametrize("use_hidden_bias", [True, False])
-@pytest.mark.parametrize("use_visible_bias", [True, False])
+@pytest.mark.parametrize("parity", [True, False])
 @pytest.mark.parametrize("symmetries", ["trans", "autom"])
-def test_RBMSymm(use_hidden_bias, use_visible_bias, symmetries):
+def test_RBMSymm(use_hidden_bias, parity, symmetries):
     g, hi, perms = _setup_symm(symmetries, N=8)
 
     ma = nk.models.RBMSymm(
         symmetries=perms,
         alpha=4,
-        use_visible_bias=use_visible_bias,
+        parity=parity,
         use_hidden_bias=use_hidden_bias,
         hidden_bias_init=nk.nn.initializers.uniform(),
-        visible_bias_init=nk.nn.initializers.uniform(),
     )
     pars = ma.init(nk.jax.PRNGKey(), hi.random_state(nk.jax.PRNGKey()))
-
-    print(pars)
 
     v = hi.random_state(jax.random.PRNGKey(1), 3)
     vals = [ma.apply(pars, v[..., p]) for p in np.asarray(perms)]


### PR DESCRIPTION
This PR integrates RBMSymm into the GCNN infrastructure, as a symmetrized  RBM is just a GCNN with one hidden layer and a cosh non-linearity.

This accomplishes a few things 1) RBMSymm is now initialized with variance scaling 2) RBMSymm can enforce parity symmetry 3) RBMSymm works with a character table 

As a side note I got rid of the visible bias as it doesn't really do anything besides add a constant. I can add it back if necessary

