### PR TITLE
bump plum dependency version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ BASE_DEPENDENCIES = [
     "numpy~=1.18",
     "scipy~=1.5",
     "tqdm~=4.56",
-    "plum-dispatch~=1.3.2",
+    "plum-dispatch~=1.5.1",
     "numba>=0.52, <0.54",
     "python-igraph~=0.9",
     "jax>0.2.16, <0.2.19",


### PR DESCRIPTION
version 1.5 is broken because of an error on my part. 
vversion 1.5.1 is fixed again.
It speeds up plum. Should be almost unnoticeable, but if we use it more it will start to play a small role.