### PR TITLE
Increase atol in test_qgt_itersolve.py::test_qgt_dense

### DIFF
--- a/test/optimizer/test_qgt_itersolve.py
+++ b/test/optimizer/test_qgt_itersolve.py
@@ -189,4 +189,4 @@ def test_qgt_dense(qgt, vstate, _mpi_size, _mpi_rank):
             S = qgt(vstate)
             Sd_all = S.to_dense()
 
-            np.testing.assert_allclose(Sd_all, Sd, rtol=1e-5, atol=1e-17)
+            np.testing.assert_allclose(Sd_all, Sd, rtol=1e-5, atol=1e-15)


### PR DESCRIPTION
As discussed [here](https://github.com/netket/netket/pull/840#issuecomment-896994242)

I think `atol=1e-17` is too small for float64, while `atol=1e-15` is already used [here](https://github.com/netket/netket/blob/761953a39d5fc16c9de93848ff83dad3757eaec5/test/utils/test_group.py#L90).