### PR TITLE
Change default initializer for Dense

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,25 @@
 
 # Change Log
 
-## NetKet 3.0b4 (unreleased)
+## NetKet 3.0b5 (unreleased)
 
-[GitHub commits](https://github.com/netket/netket/compare/v3.0b3...master).
+[GitHub commits](https://github.com/netket/netket/compare/v3.0b4...master).
+
+### New features
+
+
+### Breaking Changes
+* The default initializer for `netket.nn.Dense` layers now matches the same default as `flax.linen`, and it is `lecun_normal` instead of `normal(0.01)` [#869](https://github.com/netket/netket/pull/869)
+
+### Internal Changes
+
+
+### Bug Fixes
+
+
+## NetKet 3.0b4 (17 august 2021)
+
+[GitHub commits](https://github.com/netket/netket/compare/v3.0b3...v3.0b4).
 
 ### New features
 * DenseSymm now accepts a mode argument to specify whever the symmetries should be computed with a full dense matrix or FFT. The latter method is much faster for sufficiently large systems. Other kwargs have been added to satisfy the interface. The api changes are also reflected in RBMSymm and GCNN. [#792](https://github.com/netket/netket/pull/792)

--- a/netket/nn/linear.py
+++ b/netket/nn/linear.py
@@ -22,7 +22,7 @@ from jax import lax
 import jax.numpy as jnp
 import numpy as np
 
-from netket.nn.initializers import lecun_normal, normal, zeros
+from netket.nn.initializers import lecun_normal, zeros
 
 PRNGKey = Any
 Shape = Iterable[int]

--- a/netket/nn/linear.py
+++ b/netket/nn/linear.py
@@ -22,14 +22,14 @@ from jax import lax
 import jax.numpy as jnp
 import numpy as np
 
-from netket.nn.initializers import normal, zeros
+from netket.nn.initializers import lecun_normal, normal, zeros
 
 PRNGKey = Any
 Shape = Iterable[int]
 Dtype = Any  # this could be a real type?
 Array = Any
 
-default_kernel_init = normal(stddev=0.01)
+default_kernel_init = lecun_normal()
 
 
 def _normalize_axes(axes, ndim):


### PR DESCRIPTION
using lecun_normal is the default for linear layers in flax.
However, lecun_normal was broken for complex numbers so i had to change the default behaviour.

We now have fixed it upstream (a few versions ago) so there is no reason to depart from flax default behaviour anymore.