### PR TITLE
Permutation group product table

### DIFF
--- a/netket/utils/group/_permutation_group.py
+++ b/netket/utils/group/_permutation_group.py
@@ -161,16 +161,15 @@ class PermutationGroup(FiniteGroup):
             perms = self.to_array()
             inverse = perms[self.inverse].squeeze()
             n_symm = len(perms)
-            product_table = []
-
             lookup = self._canonical_lookup()
 
-            for g_inv in inverse:
+            product_table = np.zeros([n_symm, n_symm], dtype=int)
+            for i, g_inv in enumerate(inverse):
                 row_perms = perms[:, g_inv]
-                row_pt = [lookup[HashableArray(perm)] for perm in row_perms]
-                product_table.append(row_pt)
+                for j, perm in enumerate(row_perms):
+                    product_table[i, j] = lookup[HashableArray(perm)]
 
-            return np.asarray(product_table, dtype=int)
+            return product_table
         except KeyError as err:
             raise RuntimeError(
                 "PermutationGroup is not closed under multiplication"

--- a/netket/utils/group/_permutation_group.py
+++ b/netket/utils/group/_permutation_group.py
@@ -166,7 +166,7 @@ class PermutationGroup(FiniteGroup):
             lookup = self._canonical_lookup()
 
             for g_inv in inverse:
-                row_perms = perms[:,g_inv]
+                row_perms = perms[:, g_inv]
                 row_pt = [lookup[HashableArray(perm)] for perm in row_perms]
                 product_table.append(row_pt)
 

--- a/netket/utils/group/_permutation_group.py
+++ b/netket/utils/group/_permutation_group.py
@@ -161,23 +161,16 @@ class PermutationGroup(FiniteGroup):
             perms = self.to_array()
             inverse = perms[self.inverse].squeeze()
             n_symm = len(perms)
-            product_table = np.zeros([n_symm, n_symm], dtype=int)
-
-            inv_t = inverse.transpose()
-            perms_t = perms.transpose()
-            inv_elements = perms_t[inv_t].reshape(-1, n_symm * n_symm).transpose()
-
-            inv_perms = [HashableArray(element) for element in inv_elements]
+            product_table = []
 
             lookup = self._canonical_lookup()
 
-            inds = [(index, lookup[element]) for index, element in enumerate(inv_perms)]
+            for g_inv in inverse:
+                row_perms = perms[:,g_inv]
+                row_pt = [lookup[HashableArray(perm)] for perm in row_perms]
+                product_table.append(row_pt)
 
-            inds = np.asarray(inds)
-
-            product_table[inds[:, 0] // n_symm, inds[:, 0] % n_symm] = inds[:, 1]
-
-            return product_table
+            return np.asarray(product_table, dtype=int)
         except KeyError as err:
             raise RuntimeError(
                 "PermutationGroup is not closed under multiplication"


### PR DESCRIPTION
This PR changes `PermutationGroup.product_table` to make it more memory-friendly.

The upstream version calculates the permutations corresponding to every g^-1 h in one numpy-array-indexing command. This generates a matrix of N_site * N_symm^2 integers, which quickly gets obscenely large, leading to memory errors. (As a modest example, a 16×16 square lattice has N_site=256 and N_symm=2048, leading to a size-1,073,741,824 array). It's even worse as the array is then recreated as a list of `HashableArray`s.

Instead, I split this calculation by rows of the product table. This makes the code quite transparent, memory-friendly, and I don't expect it to introduce a large time overhead. (There is a new loop over the rows, but we've already had loops that cycle through every entry of the product table, so I'm not too worried. In fact, one of those is gone now.) It has already been a very slow method, but there doesn't seem to be a way to make it significantly more performant.

The output of the function doesn't change.