### PR TITLE
add utility to convert operators to qutip qobj

### DIFF
--- a/netket/operator/_abstract_operator.py
+++ b/netket/operator/_abstract_operator.py
@@ -288,6 +288,18 @@ class AbstractOperator(abc.ABC):
         """
         return self.to_sparse().todense().A
 
+    def to_qobj(self) -> "qutip.Qobj":  # noqa: F821
+        r"""Convert the operator to a qutip's Qobj.
+
+        Returns:
+            A `qutip.Qobj` object.
+        """
+        from qutip import Qobj
+
+        return Qobj(
+            self.to_sparse(), dims=[list(self.hilbert.shape), list(self.hilbert.shape)]
+        )
+
     def apply(self, v: np.ndarray) -> np.ndarray:
         op = self.to_linear_operator()
         return op.dot(v)

--- a/netket/operator/_abstract_super_operator.py
+++ b/netket/operator/_abstract_super_operator.py
@@ -39,3 +39,6 @@ class AbstractSuperOperator(AbstractOperator):
     def hilbert_physical(self) -> AbstractHilbert:
         """The physical hilbert space on which this super-operator acts."""
         return self.hilbert.physical
+
+    def to_qobj(self) -> "qutip.Qobj":  # noqa: F821
+        raise NotImplementedError("Superoperator to Qobj not yet implemented")


### PR DESCRIPTION
It will be handy for tutorials showcasing time-evolution (And we can use it in tests in the future).

I am not adding tests for now because installing qutip has issues being installed inside GitHub Actions at the moment and I'd rather merge this quickly.