### PR TITLE
Cleanup hilbert and operator namespaces

### DIFF
--- a/netket/hilbert/__init__.py
+++ b/netket/hilbert/__init__.py
@@ -21,7 +21,6 @@ from .doubled_hilbert import DoubledHilbert
 from .spin import Spin
 from .fock import Fock
 from .qubit import Qubit
-from .hilbert_index import HilbertIndex
 from .continuous_space_boson import ContinuousBoson
 from .continuous_space_fermion import ContinuousFermion
 

--- a/netket/operator/boson.py
+++ b/netket/operator/boson.py
@@ -12,15 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from netket.utils.types import DType
+from netket.utils.types import DType as _DType
 
-from netket.hilbert import AbstractHilbert
+from netket.hilbert import AbstractHilbert as _AbstractHilbert
 
 from ._local_operator import LocalOperator as _LocalOperator
 
 
 def destroy(
-    hilbert: AbstractHilbert, site: int, dtype: DType = float
+    hilbert: _AbstractHilbert, site: int, dtype: _DType = float
 ) -> _LocalOperator:
     """
     Builds the boson destruction operator :math:`\\hat{a}` acting on the `site`-th of
@@ -45,7 +45,9 @@ def destroy(
     return _LocalOperator(hilbert, mat, [site], dtype=dtype)
 
 
-def create(hilbert: AbstractHilbert, site: int, dtype: DType = float) -> _LocalOperator:
+def create(
+    hilbert: _AbstractHilbert, site: int, dtype: _DType = float
+) -> _LocalOperator:
     """
     Builds the boson creation operator :math:`\\hat{a}^\\dagger` acting on the `site`-th
     of the Hilbert space `hilbert`.
@@ -69,7 +71,9 @@ def create(hilbert: AbstractHilbert, site: int, dtype: DType = float) -> _LocalO
     return _LocalOperator(hilbert, mat, [site], dtype=dtype)
 
 
-def number(hilbert: AbstractHilbert, site: int, dtype: DType = float) -> _LocalOperator:
+def number(
+    hilbert: _AbstractHilbert, site: int, dtype: _DType = float
+) -> _LocalOperator:
     """
     Builds the number operator :math:`\\hat{a}^\\dagger\\hat{a}`  acting on the
     `site`-th of the Hilbert space `hilbert`.
@@ -94,7 +98,7 @@ def number(hilbert: AbstractHilbert, site: int, dtype: DType = float) -> _LocalO
 
 
 def proj(
-    hilbert: AbstractHilbert, site: int, n: int, dtype: DType = float
+    hilbert: _AbstractHilbert, site: int, n: int, dtype: _DType = float
 ) -> _LocalOperator:
     """
     Builds the projector operator :math:`|n\\rangle\\langle n |` acting on the
@@ -123,7 +127,3 @@ def proj(
     D[n] = 1
     mat = np.diag(D, 0)
     return _LocalOperator(hilbert, mat, [site], dtype=dtype)
-
-
-# clean up the module
-del AbstractHilbert, DType

--- a/netket/operator/spin.py
+++ b/netket/operator/spin.py
@@ -12,13 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from netket.hilbert import AbstractHilbert
-from netket.utils.types import DType
+from netket.utils.types import DType as _DType
+
+from netket.hilbert import AbstractHilbert as _AbstractHilbert
 
 from ._local_operator import LocalOperator as _LocalOperator
 
 
-def sigmax(hilbert: AbstractHilbert, site: int, dtype: DType = float) -> _LocalOperator:
+def sigmax(
+    hilbert: _AbstractHilbert, site: int, dtype: _DType = float
+) -> _LocalOperator:
     """
     Builds the :math:`\\sigma^x` operator acting on the `site`-th of the Hilbert
     space `hilbert`.
@@ -41,7 +44,7 @@ def sigmax(hilbert: AbstractHilbert, site: int, dtype: DType = float) -> _LocalO
 
 
 def sigmay(
-    hilbert: AbstractHilbert, site: int, dtype: DType = complex
+    hilbert: _AbstractHilbert, site: int, dtype: _DType = complex
 ) -> _LocalOperator:
     """
     Builds the :math:`\\sigma^y` operator acting on the `site`-th of the Hilbert
@@ -64,7 +67,9 @@ def sigmay(
     return _LocalOperator(hilbert, mat, [site], dtype=dtype)
 
 
-def sigmaz(hilbert: AbstractHilbert, site: int, dtype: DType = float) -> _LocalOperator:
+def sigmaz(
+    hilbert: _AbstractHilbert, site: int, dtype: _DType = float
+) -> _LocalOperator:
     """
     Builds the :math:`\\sigma^z` operator acting on the `site`-th of the Hilbert
     space `hilbert`.
@@ -86,7 +91,9 @@ def sigmaz(hilbert: AbstractHilbert, site: int, dtype: DType = float) -> _LocalO
     return _LocalOperator(hilbert, mat, [site], dtype=dtype)
 
 
-def sigmam(hilbert: AbstractHilbert, site: int, dtype: DType = float) -> _LocalOperator:
+def sigmam(
+    hilbert: _AbstractHilbert, site: int, dtype: _DType = float
+) -> _LocalOperator:
     """
     Builds the :math:`\\sigma^{-} = \\frac{1}{2}(\\sigma^x - i \\sigma^y)` operator acting on the
     `site`-th of the Hilbert space `hilbert`.
@@ -109,7 +116,9 @@ def sigmam(hilbert: AbstractHilbert, site: int, dtype: DType = float) -> _LocalO
     return _LocalOperator(hilbert, mat, [site], dtype=dtype)
 
 
-def sigmap(hilbert: AbstractHilbert, site: int, dtype: DType = float) -> _LocalOperator:
+def sigmap(
+    hilbert: _AbstractHilbert, site: int, dtype: _DType = float
+) -> _LocalOperator:
     """
     Builds the :math:`\\sigma^{+} = \\frac{1}{2}(\\sigma^x + i \\sigma^y)` operator acting on the
     `site`-th of the Hilbert space `hilbert`.
@@ -130,7 +139,3 @@ def sigmap(hilbert: AbstractHilbert, site: int, dtype: DType = float) -> _LocalO
     D = np.array([np.sqrt(S2 - m * (m + 1)) for m in np.arange(S - 1, -(S + 1), -1)])
     mat = np.diag(D, 1)
     return _LocalOperator(hilbert, mat, [site], dtype=dtype)
-
-
-# clean up the module
-del AbstractHilbert, DType


### PR DESCRIPTION
HilbertIndex is not supposed to be exposed to users, it's just an implementation detail.

Same for nk.operator.spin.AbstractHilbert