### PR TITLE
OperatorList class to keep memory usage low when storing operators

### DIFF
--- a/netket/operator/_local_operator.py
+++ b/netket/operator/_local_operator.py
@@ -24,6 +24,7 @@ from netket.hilbert import AbstractHilbert, Fock
 
 from ._abstract_operator import AbstractOperator
 from ._lazy import Transpose
+from ._operator_list import OperatorList
 
 
 @jit(nopython=True)
@@ -474,7 +475,7 @@ class LocalOperator(AbstractOperator):
         return self.__mul__(other)
 
     def _init_zero(self):
-        self._operators = []
+        self._operators = OperatorList()
         self._n_operators = 0
 
         self._max_op_size = 0

--- a/netket/operator/_operator_list.py
+++ b/netket/operator/_operator_list.py
@@ -15,6 +15,12 @@ class OperatorList:
         self._index2operatorkeys = []
 
     def __getitem__(self, key: Union[int, slice]) -> np.ndarray:
+        if isinstance(key, slice):
+            length = len(self._index2operatorkeys)
+            return [
+                self._operators[self._index2operatorkeys[k]]
+                for k in range(*key.indices(length))
+            ]
         return self._operators[self._index2operatorkeys[key]]
 
     def __setitem__(self, key: int, operator: np.ndarray) -> None:

--- a/netket/operator/_operator_list.py
+++ b/netket/operator/_operator_list.py
@@ -1,0 +1,48 @@
+from typing import Union
+import numpy as np
+
+
+class OperatorList:
+    """
+    Data class to be used internally to handle the matrix representation of
+    different operators. This class helps in storing only the necessary
+    matrices in memory. The instances of this class behave like a list,
+    but they only store unrepeated operators.
+    """
+
+    def __init__(self):
+        self._operators = {}
+        self._index2operatorkeys = []
+
+    def __getitem__(self, key: Union[int, slice]) -> np.ndarray:
+        return self._operators[self._index2operatorkeys[key]]
+
+    def __setitem__(self, key: int, operator: np.ndarray) -> None:
+        value_hash = hash(operator.tostring())
+        self._index2operatorkeys[key] = value_hash
+        if value_hash not in self._operators.keys():
+            self._operators[value_hash] = operator
+
+    def __delitem__(self, key: Union[int, slice]) -> None:
+        del self._index2operatorkeys[key]
+
+    def __iter__(self):
+        self._n_iter = 0
+        return self
+
+    def __next__(self):
+        length = len(self._index2operatorkeys)
+        if self._n_iter < length:
+            result = self._operators[self._index2operatorkeys[self._n_iter]]
+            self._n_iter += 1
+            return result
+        else:
+            raise StopIteration
+
+    def __repr__(self):
+        return f"OperatorList(n_operators={len(self._index2operatorkeys)}, n_unique_operators={len(self._operators)})"
+
+    def append(self, operator: np.ndarray) -> None:
+        initial_length = len(self._index2operatorkeys)
+        self._index2operatorkeys.append(0)  # dummy value
+        self[initial_length] = operator

--- a/netket/operator/_operator_list.py
+++ b/netket/operator/_operator_list.py
@@ -24,7 +24,7 @@ class OperatorList:
         return self._operators[self._index2operatorkeys[key]]
 
     def __setitem__(self, key: int, operator: np.ndarray) -> None:
-        value_hash = hash(operator.tostring())
+        value_hash = hash(operator.tobytes())
         self._index2operatorkeys[key] = value_hash
         if value_hash not in self._operators.keys():
             self._operators[value_hash] = operator


### PR DESCRIPTION
This PR presents a data class to handle the matrix representation of operators when building local operators, so that we don't keep unnecessary copies of the same operators over and over.

For fermionic two- and four-body operators, the memory overhead of storing many times the same matrix representation of an operator is not very costly. However, for bosonic two- and four-body operators, the matrix representations can become very large, and therefore, a lot of memory might be consumed unnecessarily.

This issue is resolved with this `OperatorList` class which handles the attribute `_operators` from a `LocalOperator`. Before, the `LocalOperator._operators` attribute was a list, and now it's an object of `OperatorList`. Before, every operator was stored in the list, even though in most of the applications the operators are actually repeated because they have the same form. Now, operators are hashed, and a lookup table is implemented so that no repetition of the matrix representation of the operators are stored.

I haven't checked the code, but maybe something similar can be done for operators in `LocalLiouvillian`. This was particularly intended to create `GraphOperator`s so that  it does not store the same operator over and over. In this PR I have not modified the `GraphOperator`'s logic. You tell me if you want me to do it here, or in other PRs, as I understand you want to have small PRs.