### PR TITLE
dtype handling of graph and local operators

### DIFF
--- a/netket/operator/_graph_operator.py
+++ b/netket/operator/_graph_operator.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
+
 from netket.utils.types import DType
 
 from netket.graph import AbstractGraph
@@ -85,6 +87,10 @@ class GraphOperator(LocalOperator):
         if len(bond_ops) == 0 and len(site_ops) == 0:
             raise ValueError("Must input at least site_ops or bond_ops.")
 
+        # Convert input arrays if necessary
+        site_ops = [np.asarray(op, dtype=dtype) for op in site_ops]
+        bond_ops = [np.asarray(op, dtype=dtype) for op in bond_ops]
+
         # Create the local operator as the sum of all site and bond operators
         operators = []
         acting_on = []
@@ -92,7 +98,7 @@ class GraphOperator(LocalOperator):
         # Site operators
         if len(site_ops) > 0:
             for i in range(graph.n_nodes):
-                for j, site_op in enumerate(site_ops):
+                for _, site_op in enumerate(site_ops):
                     operators.append(site_op)
                     acting_on.append([i])
 

--- a/netket/operator/_hamiltonian.py
+++ b/netket/operator/_hamiltonian.py
@@ -402,7 +402,8 @@ class Heisenberg(GraphOperator):
                 [0, -1, 0, 0],
                 [0, 0, -1, 0],
                 [0, 0, 0, 1],
-            ]
+            ],
+            dtype=np.float64,
         )
         exchange = np.array(
             [
@@ -410,7 +411,8 @@ class Heisenberg(GraphOperator):
                 [0, 0, 2, 0],
                 [0, 2, 0, 0],
                 [0, 0, 0, 0],
-            ]
+            ],
+            dtype=np.float64,
         )
         if sign_rule:
             if not graph.is_bipartite():

--- a/netket/operator/_local_operator.py
+++ b/netket/operator/_local_operator.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import functools
 import numbers
 from typing import Union, List, Optional
 from netket.utils.types import DType, Array
@@ -251,9 +252,9 @@ class LocalOperator(AbstractOperator):
 
         # If we asked for a specific dtype, enforce it.
         if dtype is None:
-            dtype = np.promote_types(operators[0].dtype, np.float32)
-            for op in operators[1:]:
-                np.promote_types(dtype, op.dtype)
+            dtype = functools.reduce(
+                lambda dt, op: np.promote_types(dt, op.dtype), operators, np.float32
+            )
 
         self._dtype = dtype
         self._init_zero()


### PR DESCRIPTION
This PR mainly fixes some sources of unnecessary copies of the component operators of `GraphOperator`, which should results in a reduced memory consumption.

One example was `Heisenberg`: It was previously built as a `GraphOperator`, but since the coupling operator was specified as an integer array in the code, the constructor of `LocalOperator` performed `n_edges` copies of the same bond op, each time changing the type. Therefore this was true:
```python
>>> h = Heisenberg(hi, g)
>>> np.all(h._operators[0] == h._operators[1])  # same entries
True
>>> h._operators[0] is h._operators[1]  # different array object
False
```
With the change in the first commit of this PR, no more duplication occurs:
```python
# this PR
>>> h._operators[0] is h._operators[1]
True  # same objects, so no extra memory for the array contents is required
```

The second commit should fix similar potential issue and the third one fixes a bug in the logic which determined the default `dtype` of `LocalOperator`.

These changes likely don't make a noticeable difference with small local operators (like in Heisenberg) unless the graph is very large. But for higher-dimensional local Hilbert spaces, it might be useful.