### PR TITLE
GraphOperator: Add option to map graph to Hilbert space sites

### DIFF
--- a/netket/operator/_graph_operator.py
+++ b/netket/operator/_graph_operator.py
@@ -12,12 +12,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import List, Tuple, Union
+
 from netket.utils.types import DType
 
 from netket.graph import AbstractGraph
 from netket.hilbert import AbstractHilbert
 
 from ._local_operator import LocalOperator
+
+
+def check_acting_on_subspace(acting_on_subspace, hilbert, graph):
+    if acting_on_subspace is None:
+        acting_on_subspace = list(range(hilbert.size))
+    elif isinstance(acting_on_subspace, int):
+        start = acting_on_subspace
+        acting_on_subspace = [start + i for i in range(graph.n_nodes)]
+    elif isinstance(acting_on_subspace, list):
+        if len(acting_on_subspace) != graph.n_nodes:
+            raise ValueError(
+                "acting_on_subspace must be a list of length graph.n_nodes"
+            )
+    else:
+        raise TypeError("acting_on_subspace must be a list or single integer")
+
+    return acting_on_subspace
 
 
 class GraphOperator(LocalOperator):
@@ -34,6 +53,8 @@ class GraphOperator(LocalOperator):
         bond_ops=[],
         bond_ops_colors=[],
         dtype: DType = None,
+        *,
+        acting_on_subspace: Union[List[int], int] = None,
     ):
         r"""
         A graph-based quantum operator. In its simplest terms, this is the sum of
@@ -57,6 +78,12 @@ class GraphOperator(LocalOperator):
              specified, the user must give a list of site operators.
          bond_ops_colors: A list of edge colors, specifying the color each
              bond operator acts on. The default is an empty list.
+         dtype: Data type type of the matrix elements.
+         acting_on_subspace: Specifies the mapping between nodes of the graph and
+            Hilbert space sites, so that graph node :code:`i ∈ [0, ..., graph.n_nodes]`,
+            corresponds to :code:`acting_on_subspace[i] ∈ [0, ..., hilbert.n_sites]`.
+            Must be a list of length `graph.n_nodes`. Passing a single integer :code:`start`
+            is equivalent to :code:`[start, ..., start + graph.n_nodes - 1]`.
 
         Examples:
          Constructs a ``GraphOperator`` operator for a 2D system.
@@ -74,12 +101,10 @@ class GraphOperator(LocalOperator):
          >>> print(op)
          GraphOperator(dim=20, #acting_on=40 locations, constant=0, dtype=float64, graph=Graph(n_nodes=20, n_edges=20))
         """
-
-        if graph.n_nodes != hilbert.size:
-            raise ValueError(
-                """The number of vertices in the graph ({graph.n_nodes})
-                                must match the hilbert space size ({hilbert.size})"""
-            )
+        acting_on_subspace = check_acting_on_subspace(
+            acting_on_subspace, hilbert, graph
+        )
+        self._acting_on_subspace = acting_on_subspace
 
         # Ensure that at least one of SiteOps and BondOps was initialized
         if len(bond_ops) == 0 and len(site_ops) == 0:
@@ -92,9 +117,10 @@ class GraphOperator(LocalOperator):
         # Site operators
         if len(site_ops) > 0:
             for i in range(graph.n_nodes):
-                for j, site_op in enumerate(site_ops):
+                for site_op in site_ops:
+                    i_prime = acting_on_subspace[i]
                     operators.append(site_op)
-                    acting_on.append([i])
+                    acting_on.append([i_prime])
 
         # Bond operators
         if len(bond_ops_colors) > 0:
@@ -107,17 +133,18 @@ class GraphOperator(LocalOperator):
             if len(bond_ops) > 0:
                 #  Use edge_colors to populate operators
                 for (u, v, color) in graph.edges(return_color=True):
-                    edge = u, v
+                    u, v = acting_on_subspace[u], acting_on_subspace[v]
                     for c, bond_color in enumerate(bond_ops_colors):
                         if bond_color == color:
                             operators.append(bond_ops[c])
-                            acting_on.append(edge)
+                            acting_on.append([u, v])
         else:
             assert len(bond_ops) == 1
 
-            for edge in graph.edges():
+            for u, v in graph.edges():
+                u, v = acting_on_subspace[u], acting_on_subspace[v]
                 operators.append(bond_ops[0])
-                acting_on.append(edge)
+                acting_on.append([u, v])
 
         super().__init__(hilbert, operators, acting_on, dtype=dtype)
         self._graph = graph
@@ -126,6 +153,14 @@ class GraphOperator(LocalOperator):
     def graph(self) -> AbstractGraph:
         """The graph on which this Operator is defined"""
         return self._graph
+
+    @property
+    def acting_on_subspace(self):
+        """
+        Mapping between nodes of the graph and Hilbert space sites as given in
+        the constructor.
+        """
+        return self._acting_on_subspace
 
     def __repr__(self):
         ao = self.acting_on

--- a/test/hilbert/test_hilbert.py
+++ b/test/hilbert/test_hilbert.py
@@ -271,3 +271,15 @@ def test_deprecations():
     with pytest.warns(FutureWarning):
         with pytest.raises(ValueError):
             Spin(s=0.5, graph=g, N=3)
+
+
+def test_composite_hilbert():
+    hi1 = Spin(s=1 / 2, N=8)
+    hi2 = Spin(s=3 / 2, N=8)
+
+    hi = hi1 * hi2
+
+    assert hi.size == hi1.size + hi2.size
+
+    for i in range(hi.size):
+        assert hi.size_at_index(i) == 2 if i < 8 else 4

--- a/test/operator/test_operator.py
+++ b/test/operator/test_operator.py
@@ -33,6 +33,15 @@ operators["Graph Hamiltonian"] = nk.operator.GraphOperator(
     hi, g, site_ops=[sigmax], bond_ops=[mszsz]
 )
 
+g_sub = nk.graph.Graph(edges=edges[:7])  # edges of first eight sites
+operators["Graph Hamiltonian (on subspace)"] = nk.operator.GraphOperator(
+    hi,
+    g_sub,
+    site_ops=[sigmax],
+    bond_ops=[mszsz],
+    acting_on_subspace=8,
+)
+
 # Graph Hamiltonian with colored edges
 edges_c = [(i, j, i % 2) for i, j in edges]
 g = nk.graph.Graph(edges=edges_c)
@@ -292,3 +301,30 @@ def test_pauli_order():
     vp, mels = op.get_conn_padded(v)
     assert vp.shape[1] == 1
     assert mels.shape[1] == 1
+
+
+def test_operator_on_subspace():
+    hi = nk.hilbert.Spin(1 / 2, N=3) * nk.hilbert.Qubit(N=3)
+    g = nk.graph.Chain(3, pbc=False)
+
+    h1 = nk.operator.GraphOperator(hi, g, bond_ops=[mszsz], acting_on_subspace=0)
+    assert h1.acting_on_subspace == list(range(3))
+    assert nk.exact.lanczos_ed(h1)[0] == pytest.approx(-2.0)
+
+    h2 = nk.operator.GraphOperator(hi, g, bond_ops=[mszsz], acting_on_subspace=3)
+    assert h2.acting_on_subspace == list(range(3, 6))
+    assert nk.exact.lanczos_ed(h2)[0] == pytest.approx(-2.0)
+
+    h12 = h1 + h2
+    assert sorted(h12.acting_on) == [[0, 1], [1, 2], [3, 4], [4, 5]]
+    assert nk.exact.lanczos_ed(h12)[0] == pytest.approx(-4.0)
+
+    h3 = nk.operator.GraphOperator(
+        hi, g, bond_ops=[mszsz], acting_on_subspace=[0, 2, 4]
+    )
+    assert h3.acting_on_subspace == [0, 2, 4]
+    assert nk.exact.lanczos_ed(h3)[0] == pytest.approx(-2.0)
+    assert h3.acting_on == [[0, 2], [2, 4]]
+
+    h4 = nk.operator.Heisenberg(hi, g, acting_on_subspace=0)
+    assert h4.acting_on == h1.acting_on


### PR DESCRIPTION
As brought up in #922, in composite systems like
```python
hi = Fock(N=1) * Spin(1/2, N=10)
```
it'd be nice to be able to define graph operators acting on subsets of Hilbert sites. This requires a mapping from the graph nodes to Hilbert sites.

With this PR, this can be provided when creating `GraphOperator` (and `Heisenberg`, which is a subclass):
```python
g = Chain(10)
h = Heisenberg(hi, g, acting_on_subspace=list(range(1, 11)))
# equivalently as a shorthand:
h = Heisenberg(hi, g, acting_on_subspace=1) 
#  acting_on_subspace=i is expanded to [i, i + 1, ..., i + g.n_nodes - 1].
```

I am not quite happy with the `acting_on_subspace` name. It's a bit long and also easy to confuse with `acting_on` of local operators, which is the set of (hyper)edges the operator acts on non-trivially.
Maybe a better name would be something like `site_mapping` or similar? Let me know what you think.