### PR TITLE
refactor abstract operator into discreteoperator

### DIFF
--- a/docs/docs/api.rst
+++ b/docs/docs/api.rst
@@ -54,6 +54,7 @@ Operators
    :nosignatures:
 
    netket.operator.AbstractOperator
+   netket.operator.DiscreteOperator
    netket.operator.BoseHubbard
    netket.operator.GraphOperator
    netket.operator.LocalOperator

--- a/netket/operator/__init__.py
+++ b/netket/operator/__init__.py
@@ -14,6 +14,7 @@
 
 from ._abstract_operator import AbstractOperator
 
+from ._discrete_operator import DiscreteOperator
 from ._local_operator import LocalOperator
 from ._graph_operator import GraphOperator
 from ._pauli_strings import PauliStrings

--- a/netket/operator/_abstract_operator.py
+++ b/netket/operator/_abstract_operator.py
@@ -110,40 +110,5 @@ class AbstractOperator(abc.ABC):
     def conj(self, *, concrete=False) -> "AbstractOperator":
         return self.conjugate(concrete=False)
 
-    def __matmul__(self, other):
-        if isinstance(other, np.ndarray) or isinstance(other, jnp.ndarray):
-            return self.apply(other)
-        elif isinstance(other, AbstractOperator):
-            if self == other and self.is_hermitian:
-                from ._lazy import Squared
-
-                return Squared(self)
-            else:
-                return self._op__matmul__(other)
-        else:
-            return NotImplemented
-
-    def _op__matmul__(self, other):
-        "Implementation on subclasses of __matmul__"
-        return NotImplemented
-
-    def __rmatmul__(self, other):
-        if isinstance(other, np.ndarray) or isinstance(other, jnp.ndarray):
-            # return self.apply(other)
-            return NotImplemented
-        elif isinstance(other, AbstractOperator):
-            if self == other and self.is_hermitian:
-                from ._lazy import Squared
-
-                return Squared(self)
-            else:
-                return self._op__rmatmul__(other)
-        else:
-            return NotImplemented
-
-    def _op__rmatmul__(self, other):
-        "Implementation on subclasses of __matmul__"
-        return NotImplemented
-
     def __repr__(self):
         return f"{type(self).__name__}(hilbert={self.hilbert})"

--- a/netket/operator/_abstract_operator.py
+++ b/netket/operator/_abstract_operator.py
@@ -111,7 +111,7 @@ class AbstractOperator(abc.ABC):
         return self.conjugate(concrete=False)
 
     def __matmul__(self, other):
-        if isinstance(other, jnp.ndarray) or isinstance(other, jnp.ndarray):
+        if isinstance(other, np.ndarray) or isinstance(other, jnp.ndarray):
             return self.apply(other)
         elif isinstance(other, AbstractOperator):
             if self == other and self.is_hermitian:

--- a/netket/operator/_abstract_operator.py
+++ b/netket/operator/_abstract_operator.py
@@ -13,34 +13,17 @@
 # limitations under the License.
 
 import abc
-from typing import Tuple
-
 import numpy as np
 import jax.numpy as jnp
-from netket.utils.types import DType
 
-from scipy.sparse import csr_matrix as _csr_matrix
-from numba import jit
+from netket.utils.types import DType
 
 from netket.hilbert import AbstractHilbert
 
 
-@jit(nopython=True)
-def compute_row_indices(rows, sections):
-    ntot = sections[-1]
-    res = np.empty(ntot, dtype=np.intp)
-
-    for i in range(1, sections.size):
-        res[sections[i - 1] : sections[i]] = rows[i - 1]
-
-    return res
-
-
 class AbstractOperator(abc.ABC):
     """Abstract class for quantum Operators. This class prototypes the methods
-    needed by a class satisfying the Operator concept. Users interested in
-    implementing new quantum Operators should derive they own class from this
-    class
+    needed by a class satisfying the Operator concept.
     """
 
     _hilbert: AbstractHilbert
@@ -124,221 +107,11 @@ class AbstractOperator(abc.ABC):
         """
         raise NotImplementedError
 
-    @property
-    def max_conn_size(self) -> int:
-        """The maximum number of non zero ⟨x|O|x'⟩ for every x."""
-        raise NotImplementedError
-
-    def get_conn_padded(self, x: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
-        r"""Finds the connected elements of the Operator.
-        Starting from a batch of quantum numbers x={x_1, ... x_n} of size B x M
-        where B size of the batch and M size of the hilbert space, finds all states
-        y_i^1, ..., y_i^K connected to every x_i.
-        Returns a matrix of size B x Kmax x M where Kmax is the maximum number of
-        connections for every y_i.
-
-        Args:
-            x : A N-tensor of shape (...,hilbert.size) containing
-                        the batch/batches of quantum numbers x.
-
-        Returns:
-            x_primes: The connected states x', in a N+1-tensor.
-            mels: A N-tensor containing the matrix elements :math:`O(x,x')`
-                associated to each x' for every batch.
-        """
-        n_visible = x.shape[-1]
-        n_samples = x.size // n_visible
-
-        sections = np.empty(n_samples, dtype=np.int32)
-        x_primes, mels = self.get_conn_flattened(
-            x.reshape(-1, x.shape[-1]), sections, pad=True
-        )
-
-        n_primes = sections[0]
-
-        x_primes_r = x_primes.reshape(*x.shape[:-1], n_primes, n_visible)
-        mels_r = mels.reshape(*x.shape[:-1], n_primes)
-
-        return x_primes_r, mels_r
-
-    @abc.abstractmethod
-    def get_conn_flattened(
-        self, x: np.ndarray, sections: np.ndarray
-    ) -> Tuple[np.ndarray, np.ndarray]:
-        r"""Finds the connected elements of the Operator. Starting
-        from a given quantum number x, it finds all other quantum numbers x' such
-        that the matrix element :math:`O(x,x')` is different from zero. In general there
-        will be several different connected states x' satisfying this
-        condition, and they are denoted here :math:`x'(k)`, for :math:`k=0,1...N_{\mathrm{connected}}`.
-
-        This is a batched version, where x is a matrix of shape (batch_size,hilbert.size).
-
-        Args:
-            x (matrix): A matrix of shape (batch_size,hilbert.size) containing
-                        the batch of quantum numbers x.
-            sections (array): An array of sections for the flattened x'.
-                        See numpy.split for the meaning of sections.
-
-        Returns:
-            matrix: The connected states x', flattened together in a single matrix.
-            array: An array containing the matrix elements :math:`O(x,x')` associated to each x'.
-
-        """
-        raise NotImplementedError()
-
-    def get_conn(self, x: np.ndarray):
-        r"""Finds the connected elements of the Operator. Starting
-        from a given quantum number x, it finds all other quantum numbers x' such
-        that the matrix element :math:`O(x,x')` is different from zero. In general there
-        will be several different connected states x' satisfying this
-        condition, and they are denoted here :math:`x'(k)`, for :math:`k=0,1...N_{\mathrm{connected}}`.
-
-        Args:
-            x (array): An array of shape (hilbert.size) containing the quantum numbers x.
-
-        Returns:
-            matrix: The connected states x' of shape (N_connected,hilbert.size)
-            array: An array containing the matrix elements :math:`O(x,x')` associated to each x'.
-
-        Raise:
-            ValueError: If the given quantum number is not compatible with the hilbert space.
-        """
-        if x.ndim != 1:
-            raise ValueError(
-                "get_conn does not support batches. Please use get_conn_flattened instead."
-            )
-        if x.shape[0] != self.hilbert.size:
-            raise ValueError(
-                "The given quantum numbers do not match the hilbert space."
-            )
-
-        return self.get_conn_flattened(
-            x.reshape((1, -1)),
-            np.ones(1),
-        )
-
-    def n_conn(self, x, out=None) -> np.ndarray:
-        r"""Return the number of states connected to x.
-
-        Args:
-            x (matrix): A matrix of shape (batch_size,hilbert.size) containing
-                        the batch of quantum numbers x.
-            out (array): If None an output array is allocated.
-
-        Returns:
-            array: The number of connected states x' for each x[i].
-
-        """
-        if out is None:
-            out = np.empty(x.shape[0], dtype=np.intc)
-        self.get_conn_flattened(x, out)
-        out = self._n_conn_from_sections(out)
-
-        return out
-
-    @staticmethod
-    @jit(nopython=True)
-    def _n_conn_from_sections(out):
-        low = 0
-        for i in range(out.shape[0]):
-            old_out = out[i]
-            out[i] = out[i] - low
-            low = old_out
-
-        return out
-
-    def to_sparse(self) -> _csr_matrix:
-        r"""Returns the sparse matrix representation of the operator. Note that,
-        in general, the size of the matrix is exponential in the number of quantum
-        numbers, and this operation should thus only be performed for
-        low-dimensional Hilbert spaces or sufficiently sparse operators.
-
-        This method requires an indexable Hilbert space.
-
-        Returns:
-            The sparse matrix representation of the operator.
-        """
-        concrete_op = self.collect()
-        hilb = self.hilbert
-
-        x = hilb.all_states()
-
-        sections = np.empty(x.shape[0], dtype=np.int32)
-        x_prime, mels = concrete_op.get_conn_flattened(x, sections)
-
-        numbers = hilb.states_to_numbers(x_prime)
-
-        sections1 = np.empty(sections.size + 1, dtype=np.int32)
-        sections1[1:] = sections
-        sections1[0] = 0
-
-        ## eliminate duplicates from numbers
-        # rows_indices = compute_row_indices(hilb.states_to_numbers(x), sections1)
-
-        return _csr_matrix(
-            (mels, numbers, sections1),
-            shape=(self.hilbert.n_states, self.hilbert.n_states),
-        )
-
-        # return _csr_matrix(
-        #    (mels, (rows_indices, numbers)),
-        #    shape=(self.hilbert.n_states, self.hilbert.n_states),
-        # )
-
-    def to_dense(self) -> np.ndarray:
-        r"""Returns the dense matrix representation of the operator. Note that,
-        in general, the size of the matrix is exponential in the number of quantum
-        numbers, and this operation should thus only be performed for
-        low-dimensional Hilbert spaces or sufficiently sparse operators.
-
-        This method requires an indexable Hilbert space.
-
-        Returns:
-            The dense matrix representation of the operator as a Numpy array.
-        """
-        return self.to_sparse().todense().A
-
-    def to_qobj(self) -> "qutip.Qobj":  # noqa: F821
-        r"""Convert the operator to a qutip's Qobj.
-
-        Returns:
-            A `qutip.Qobj` object.
-        """
-        from qutip import Qobj
-
-        return Qobj(
-            self.to_sparse(), dims=[list(self.hilbert.shape), list(self.hilbert.shape)]
-        )
-
-    def apply(self, v: np.ndarray) -> np.ndarray:
-        op = self.to_linear_operator()
-        return op.dot(v)
-
-    def __call__(self, v: np.ndarray) -> np.ndarray:
-        return self.apply(v)
-
     def conj(self, *, concrete=False) -> "AbstractOperator":
         return self.conjugate(concrete=False)
 
-    def to_linear_operator(self):
-        return self.to_sparse()
-
-    def _get_conn_flattened_closure(self):
-        raise NotImplementedError(
-            """
-            _get_conn_flattened_closure not implemented for this operator type.
-            You were probably trying to use an operator with a sampler.
-            Please report this bug.
-
-            numba4jax won't work.
-            """
-        )
-
-    def __repr__(self):
-        return f"{type(self).__name__}(hilbert={self.hilbert})"
-
     def __matmul__(self, other):
-        if isinstance(other, np.ndarray) or isinstance(other, jnp.ndarray):
+        if isinstance(other, jnp.ndarray) or isinstance(other, jnp.ndarray):
             return self.apply(other)
         elif isinstance(other, AbstractOperator):
             if self == other and self.is_hermitian:
@@ -371,3 +144,6 @@ class AbstractOperator(abc.ABC):
     def _op__rmatmul__(self, other):
         "Implementation on subclasses of __matmul__"
         return NotImplemented
+
+    def __repr__(self):
+        return f"{type(self).__name__}(hilbert={self.hilbert})"

--- a/netket/operator/_abstract_super_operator.py
+++ b/netket/operator/_abstract_super_operator.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ._abstract_operator import AbstractOperator
+from ._discrete_operator import DiscreteOperator
 from netket.hilbert import DoubledHilbert, AbstractHilbert
 
 
-class AbstractSuperOperator(AbstractOperator):
+class AbstractSuperOperator(DiscreteOperator):
     """
     Generic base class for super-operators acting on the tensor product (DoubledHilbert)
     space ℋ⊗ℋ, where ℋ is the physical space.

--- a/netket/operator/_discrete_operator.py
+++ b/netket/operator/_discrete_operator.py
@@ -1,0 +1,210 @@
+import abc
+from typing import Tuple
+import numpy as np
+import jax.numpy as jnp
+
+from numba import jit
+from scipy.sparse import csr_matrix as _csr_matrix
+
+from netket.hilbert import AbstractHilbert
+from netket.operator import AbstractOperator
+
+
+class DiscreteOperator(AbstractOperator):
+    r"""This class is the base class for operators defined on a
+    discrete Hilbert space. Users interested in implementing new
+    quantum Operators for discrete Hilbert spaces should derive
+    their own class from this class"""
+
+    def __init__(self, hilbert: AbstractHilbert):
+        super().__init__(hilbert)
+
+    @property
+    def max_conn_size(self) -> int:
+        """The maximum number of non zero ⟨x|O|x'⟩ for every x."""
+        raise NotImplementedError
+
+    def get_conn_padded(self, x: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+        r"""Finds the connected elements of the Operator.
+        Starting from a batch of quantum numbers x={x_1, ... x_n} of size B x M
+        where B size of the batch and M size of the hilbert space, finds all states
+        y_i^1, ..., y_i^K connected to every x_i.
+        Returns a matrix of size B x Kmax x M where Kmax is the maximum number of
+        connections for every y_i.
+        Args:
+            x : A N-tensor of shape (...,hilbert.size) containing
+                        the batch/batches of quantum numbers x.
+        Returns:
+            x_primes: The connected states x', in a N+1-tensor.
+            mels: A N-tensor containing the matrix elements :math:`O(x,x')`
+                associated to each x' for every batch.
+        """
+        n_visible = x.shape[-1]
+        n_samples = x.size // n_visible
+
+        sections = np.empty(n_samples, dtype=np.int32)
+        x_primes, mels = self.get_conn_flattened(
+            x.reshape(-1, x.shape[-1]), sections, pad=True
+        )
+
+        n_primes = sections[0]
+
+        x_primes_r = x_primes.reshape(*x.shape[:-1], n_primes, n_visible)
+        mels_r = mels.reshape(*x.shape[:-1], n_primes)
+
+        return x_primes_r, mels_r
+
+    @abc.abstractmethod
+    def get_conn_flattened(
+        self, x: np.ndarray, sections: np.ndarray
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        r"""Finds the connected elements of the Operator. Starting
+        from a given quantum number x, it finds all other quantum numbers x' such
+        that the matrix element :math:`O(x,x')` is different from zero. In general there
+        will be several different connected states x' satisfying this
+        condition, and they are denoted here :math:`x'(k)`, for :math:`k=0,1...N_{\mathrm{connected}}`.
+
+        This is a batched version, where x is a matrix of shape (batch_size,hilbert.size).
+
+        Args:
+            x (matrix): A matrix of shape (batch_size,hilbert.size) containing
+                        the batch of quantum numbers x.
+            sections (array): An array of sections for the flattened x'.
+                        See numpy.split for the meaning of sections.
+
+        Returns:
+            matrix: The connected states x', flattened together in a single matrix.
+            array: An array containing the matrix elements :math:`O(x,x')` associated to each x'.
+
+        """
+        raise NotImplementedError()
+
+    def get_conn(self, x: np.ndarray):
+        r"""Finds the connected elements of the Operator. Starting
+        from a given quantum number x, it finds all other quantum numbers x' such
+        that the matrix element :math:`O(x,x')` is different from zero. In general there
+        will be several different connected states x' satisfying this
+        condition, and they are denoted here :math:`x'(k)`, for :math:`k=0,1...N_{\mathrm{connected}}`.
+        Args:
+            x (array): An array of shape (hilbert.size) containing the quantum numbers x.
+        Returns:
+            matrix: The connected states x' of shape (N_connected,hilbert.size)
+            array: An array containing the matrix elements :math:`O(x,x')` associated to each x'.
+        Raise:
+            ValueError: If the given quantum number is not compatible with the hilbert space.
+        """
+        if x.ndim != 1:
+            raise ValueError(
+                "get_conn does not support batches. Please use get_conn_flattened instead."
+            )
+        if x.shape[0] != self.hilbert.size:
+            raise ValueError(
+                "The given quantum numbers do not match the hilbert space."
+            )
+
+        return self.get_conn_flattened(
+            x.reshape((1, -1)),
+            np.ones(1),
+        )
+
+    def n_conn(self, x, out=None) -> np.ndarray:
+        r"""Return the number of states connected to x.
+
+        Args:
+            x (matrix): A matrix of shape (batch_size,hilbert.size) containing
+                        the batch of quantum numbers x.
+            out (array): If None an output array is allocated.
+
+        Returns:
+            array: The number of connected states x' for each x[i].
+
+        """
+        if out is None:
+            out = np.empty(x.shape[0], dtype=np.intc)
+        self.get_conn_flattened(x, out)
+        out = self._n_conn_from_sections(out)
+
+        return out
+
+    @staticmethod
+    @jit(nopython=True)
+    def _n_conn_from_sections(out):
+        low = 0
+        for i in range(out.shape[0]):
+            old_out = out[i]
+            out[i] = out[i] - low
+            low = old_out
+
+        return out
+
+    def to_sparse(self) -> _csr_matrix:
+        r"""Returns the sparse matrix representation of the operator. Note that,
+        in general, the size of the matrix is exponential in the number of quantum
+        numbers, and this operation should thus only be performed for
+        low-dimensional Hilbert spaces or sufficiently sparse operators.
+
+        This method requires an indexable Hilbert space.
+
+        Returns:
+            The sparse matrix representation of the operator.
+        """
+        concrete_op = self.collect()
+        hilb = self.hilbert
+
+        x = hilb.all_states()
+
+        sections = np.empty(x.shape[0], dtype=np.int32)
+        x_prime, mels = concrete_op.get_conn_flattened(x, sections)
+
+        numbers = hilb.states_to_numbers(x_prime)
+
+        sections1 = np.empty(sections.size + 1, dtype=np.int32)
+        sections1[1:] = sections
+        sections1[0] = 0
+
+        ## eliminate duplicates from numbers
+        # rows_indices = compute_row_indices(hilb.states_to_numbers(x), sections1)
+
+        return _csr_matrix(
+            (mels, numbers, sections1),
+            shape=(self.hilbert.n_states, self.hilbert.n_states),
+        )
+
+        # return _csr_matrix(
+        #    (mels, (rows_indices, numbers)),
+        #    shape=(self.hilbert.n_states, self.hilbert.n_states),
+        # )
+
+    def to_dense(self) -> np.ndarray:
+        r"""Returns the dense matrix representation of the operator. Note that,
+        in general, the size of the matrix is exponential in the number of quantum
+        numbers, and this operation should thus only be performed for
+        low-dimensional Hilbert spaces or sufficiently sparse operators.
+
+        This method requires an indexable Hilbert space.
+
+        Returns:
+            The dense matrix representation of the operator as a Numpy array.
+        """
+        return self.to_sparse().todense().A
+
+    def __call__(self, v: np.ndarray) -> np.ndarray:
+        return self.apply(v)
+
+    def apply(self, v: np.ndarray) -> np.ndarray:
+        op = self.to_linear_operator()
+        return op.dot(v)
+
+    def to_linear_operator(self):
+        return self.to_sparse()
+
+    def _get_conn_flattened_closure(self):
+        raise NotImplementedError(
+            """
+            _get_conn_flattened_closure not implemented for this operator type.
+            You were probably trying to use an operator with a sampler.
+            Please report this bug.
+
+            numba4jax won't work.
+            """
+        )

--- a/netket/operator/_discrete_operator.py
+++ b/netket/operator/_discrete_operator.py
@@ -14,7 +14,8 @@ class DiscreteOperator(AbstractOperator):
     r"""This class is the base class for operators defined on a
     discrete Hilbert space. Users interested in implementing new
     quantum Operators for discrete Hilbert spaces should derive
-    their own class from this class"""
+    their own class from this class
+    """
 
     def __init__(self, hilbert: AbstractHilbert):
         super().__init__(hilbert)

--- a/netket/operator/_discrete_operator.py
+++ b/netket/operator/_discrete_operator.py
@@ -196,6 +196,41 @@ class DiscreteOperator(AbstractOperator):
         op = self.to_linear_operator()
         return op.dot(v)
 
+    def __matmul__(self, other):
+        if isinstance(other, np.ndarray) or isinstance(other, jnp.ndarray):
+            return self.apply(other)
+        elif isinstance(other, AbstractOperator):
+            if self == other and self.is_hermitian:
+                from ._lazy import Squared
+
+                return Squared(self)
+            else:
+                return self._op__matmul__(other)
+        else:
+            return NotImplemented
+
+    def _op__matmul__(self, other):
+        "Implementation on subclasses of __matmul__"
+        return NotImplemented
+
+    def __rmatmul__(self, other):
+        if isinstance(other, np.ndarray) or isinstance(other, jnp.ndarray):
+            # return self.apply(other)
+            return NotImplemented
+        elif isinstance(other, AbstractOperator):
+            if self == other and self.is_hermitian:
+                from ._lazy import Squared
+
+                return Squared(self)
+            else:
+                return self._op__rmatmul__(other)
+        else:
+            return NotImplemented
+
+    def _op__rmatmul__(self, other):
+        "Implementation on subclasses of __matmul__"
+        return NotImplemented
+
     def to_linear_operator(self):
         return self.to_sparse()
 

--- a/netket/operator/_hamiltonian.py
+++ b/netket/operator/_hamiltonian.py
@@ -24,11 +24,11 @@ from netket.utils.types import DType
 from . import spin, boson
 from ._local_operator import LocalOperator
 from ._graph_operator import GraphOperator
-from ._abstract_operator import AbstractOperator
+from ._discrete_operator import DiscreteOperator
 from ._lazy import Squared
 
 
-class SpecialHamiltonian(AbstractOperator):
+class SpecialHamiltonian(DiscreteOperator):
     def to_local_operator(self):
         raise NotImplementedError(
             "Must implemented to_local_operator for {}".format(type(self))

--- a/netket/operator/_lazy.py
+++ b/netket/operator/_lazy.py
@@ -14,10 +14,10 @@
 
 from netket.utils.dispatch import parametric
 
-from ._abstract_operator import AbstractOperator
+from ._discrete_operator import DiscreteOperator
 
 
-class WrappedOperator(AbstractOperator):
+class WrappedOperator(DiscreteOperator):
     def get_conn_flattened(self, *args):
         return NotImplementedError
 
@@ -52,7 +52,7 @@ class Transpose(WrappedOperator):
     A wrapper lazily representing the transpose of the wrapped object.
     """
 
-    parent: AbstractOperator
+    parent: DiscreteOperator
     """The wrapped object"""
 
     def __init__(self, op):
@@ -98,7 +98,7 @@ class Adjoint(WrappedOperator):
     A wrapper lazily representing the adjoint (conjugate-transpose) of the wrapped object.
     """
 
-    parent: AbstractOperator
+    parent: DiscreteOperator
     """The wrapped object"""
 
     def __init__(self, op):
@@ -159,7 +159,7 @@ class Squared(WrappedOperator):
     A wrapper lazily representing the matrix-squared (A^dag A) of the wrapped object A.
     """
 
-    parent: AbstractOperator
+    parent: DiscreteOperator
     """The wrapped object"""
 
     def __init__(self, op):

--- a/netket/operator/_local_liouvillian.py
+++ b/netket/operator/_local_liouvillian.py
@@ -21,7 +21,7 @@ from numba.typed import List
 
 from scipy.sparse.linalg import LinearOperator
 
-from ._abstract_operator import AbstractOperator
+from ._discrete_operator import DiscreteOperator
 from ._local_operator import LocalOperator
 from ._abstract_super_operator import AbstractSuperOperator
 
@@ -63,8 +63,8 @@ class LocalLiouvillian(AbstractSuperOperator):
 
     def __init__(
         self,
-        ham: AbstractOperator,
-        jump_ops: PyList[AbstractOperator] = [],
+        ham: DiscreteOperator,
+        jump_ops: PyList[DiscreteOperator] = [],
         dtype=complex,
     ):
         super().__init__(ham.hilbert)

--- a/netket/operator/_local_operator.py
+++ b/netket/operator/_local_operator.py
@@ -22,7 +22,7 @@ from numba import jit
 
 from netket.hilbert import AbstractHilbert, Fock
 
-from ._abstract_operator import AbstractOperator
+from ._discrete_operator import DiscreteOperator
 from ._lazy import Transpose
 
 
@@ -50,7 +50,7 @@ def is_hermitian(a: np.ndarray, rtol=1e-05, atol=1e-08) -> bool:
 def _dtype(obj: Union[numbers.Number, Array, "LocalOperator"]) -> DType:
     if isinstance(obj, numbers.Number):
         return type(obj)
-    elif isinstance(obj, AbstractOperator):
+    elif isinstance(obj, DiscreteOperator):
         return obj.dtype
     elif isinstance(obj, np.ndarray):
         return obj.dtype
@@ -189,7 +189,7 @@ def _reorder_kronecker_product(hi, mat, acting_on):
     return mat_sorted, acting_on_sorted
 
 
-class LocalOperator(AbstractOperator):
+class LocalOperator(DiscreteOperator):
     """A custom local operator. This is a sum of an arbitrary number of operators
     acting locally on a limited set of k quantum numbers (i.e. k-local,
     in the quantum information sense).
@@ -372,7 +372,7 @@ class LocalOperator(AbstractOperator):
         return -1 * self
 
     def __mul__(self, other):
-        if isinstance(other, AbstractOperator):
+        if isinstance(other, DiscreteOperator):
             op = self.copy(dtype=np.promote_types(self.dtype, _dtype(other)))
             return op.__imatmul__(other)
         elif not isinstance(other, numbers.Number):
@@ -392,7 +392,7 @@ class LocalOperator(AbstractOperator):
         return op
 
     def __imul__(self, other):
-        if isinstance(other, AbstractOperator):
+        if isinstance(other, DiscreteOperator):
             return self.__imatmul__(other)
         elif not isinstance(other, numbers.Number):
             return NotImplemented

--- a/netket/operator/_pauli_strings.py
+++ b/netket/operator/_pauli_strings.py
@@ -21,10 +21,10 @@ from numba import jit
 
 from netket.hilbert import Qubit
 
-from ._abstract_operator import AbstractOperator
+from ._discrete_operator import DiscreteOperator
 
 
-class PauliStrings(AbstractOperator):
+class PauliStrings(DiscreteOperator):
     """A Hamiltonian consisiting of the sum of products of Pauli operators."""
 
     def __init__(

--- a/netket/vqs/mc_expect.py
+++ b/netket/vqs/mc_expect.py
@@ -14,7 +14,7 @@ from netket.utils.types import PyTree
 from netket.utils.dispatch import dispatch
 
 from netket.operator import (
-    AbstractOperator,
+    DiscreteOperator,
     AbstractSuperOperator,
     Squared,
 )
@@ -78,8 +78,8 @@ def expect(vstate: MCState, Ô: Squared) -> Stats:  # noqa: F811
     )
 
 
-@dispatch.multi((MCState, AbstractOperator), (MCMixedState, AbstractSuperOperator))
-def expect(vstate: MCState, Ô: AbstractOperator) -> Stats:  # noqa: F811
+@dispatch.multi((MCState, DiscreteOperator), (MCMixedState, AbstractSuperOperator))
+def expect(vstate: MCState, Ô: DiscreteOperator) -> Stats:  # noqa: F811
     _check_hilbert(vstate, Ô)
 
     σ = vstate.samples
@@ -99,7 +99,7 @@ def expect(vstate: MCState, Ô: AbstractOperator) -> Stats:  # noqa: F811
 
 
 @dispatch
-def expect(vstate: MCMixedState, Ô: AbstractOperator) -> Stats:  # noqa: F811
+def expect(vstate: MCMixedState, Ô: DiscreteOperator) -> Stats:  # noqa: F811
     _check_hilbert(vstate.diagonal, Ô)
 
     σ = vstate.diagonal.samples


### PR DESCRIPTION
This PR refactors most functionality away from AbstractOperator into a new DiscreteOperator.
This contains the first commit to #823 , and @PhilipVinc (who is writing here) thinks it's best we merge this ASAP so to avoid more merge conflicts..
