### PR TITLE
Restore to_qobj for discreteoperators

### DIFF
--- a/netket/operator/_discrete_operator.py
+++ b/netket/operator/_discrete_operator.py
@@ -189,6 +189,17 @@ class DiscreteOperator(AbstractOperator):
         """
         return self.to_sparse().todense().A
 
+    def to_qobj(self) -> "qutip.Qobj":  # noqa: F821
+        r"""Convert the operator to a qutip's Qobj.
+        Returns:
+            A `qutip.Qobj` object.
+        """
+        from qutip import Qobj
+
+        return Qobj(
+            self.to_sparse(), dims=[list(self.hilbert.shape), list(self.hilbert.shape)]
+        )
+
     def __call__(self, v: np.ndarray) -> np.ndarray:
         return self.apply(v)
 

--- a/test/operator/test_local_operator.py
+++ b/test/operator/test_local_operator.py
@@ -327,6 +327,7 @@ def test_raises_unsorted_hilbert():
     with pytest.raises(ValueError):
         nk.operator.LocalOperator(hi)
 
+
 def test_qutip_conversion():
     # skip test if qutip not installed
     pytest.importorskip("qutip")
@@ -343,4 +344,3 @@ def test_qutip_conversion():
 
     assert q_obj.shape == (op.hilbert.n_states, op.hilbert.n_states)
     np.testing.assert_allclose(q_obj.data.todense(), op.to_dense())
-

--- a/test/operator/test_local_operator.py
+++ b/test/operator/test_local_operator.py
@@ -326,3 +326,21 @@ def test_raises_unsorted_hilbert():
     hi = nk.hilbert.CustomHilbert([-1, 1, 0], N=3)
     with pytest.raises(ValueError):
         nk.operator.LocalOperator(hi)
+
+def test_qutip_conversion():
+    # skip test if qutip not installed
+    pytest.importorskip("qutip")
+
+    hi = nk.hilbert.Spin(s=1 / 2, N=2)
+    op = nk.operator.spin.sigmax(hi, 0)
+
+    q_obj = op.to_qobj()
+
+    assert q_obj.type == "oper"
+    assert len(q_obj.dims) == 2
+    assert q_obj.dims[0] == list(op.hilbert.shape)
+    assert q_obj.dims[1] == list(op.hilbert.shape)
+
+    assert q_obj.shape == (op.hilbert.n_states, op.hilbert.n_states)
+    np.testing.assert_allclose(q_obj.data.todense(), op.to_dense())
+


### PR DESCRIPTION
was erroneously deleted in #929, and those are not tested (the test is there, it's not run yet)