### PR TITLE
Allow unfrozen dataclasses

### DIFF
--- a/netket/utils/struct/dataclass.py
+++ b/netket/utils/struct/dataclass.py
@@ -389,7 +389,9 @@ def dataclass(clz=None, *, init_doc=MISSING, cache_hash=False, _frozen=True):
     """
 
     if clz is None:
-        return partial(dataclass, init_doc=init_doc, cache_hash=cache_hash, _frozen=_frozen)
+        return partial(
+            dataclass, init_doc=init_doc, cache_hash=cache_hash, _frozen=_frozen
+        )
 
     # get globals of the class to put generated methods in there
     _globals = get_class_globals(clz)

--- a/netket/utils/struct/dataclass.py
+++ b/netket/utils/struct/dataclass.py
@@ -355,7 +355,7 @@ def replace_hash_method(data_clz, *, globals={}):
     setattr(data_clz, "__hash__", fun)
 
 
-def dataclass(clz=None, *, init_doc=MISSING, cache_hash=False):
+def dataclass(clz=None, *, init_doc=MISSING, cache_hash=False, _frozen=True):
     """
     Decorator creating a NetKet-flavour dataclass.
     This behaves as a flax dataclass, that is a Frozen python dataclass, with a twist!
@@ -384,11 +384,12 @@ def dataclass(clz=None, *, init_doc=MISSING, cache_hash=False):
             from `__pre_init__`.
         cache_hash: If True the hash is computed only once and cached. Use if
             the computation is expensive.
-
+        _frozen: (default True) controls whever the resulting class is frozen or not.
+            If it is not frozen, extra care should be taken.
     """
 
     if clz is None:
-        return partial(dataclass, init_doc=init_doc, cache_hash=cache_hash)
+        return partial(dataclass, init_doc=init_doc, cache_hash=cache_hash, _frozen=_frozen)
 
     # get globals of the class to put generated methods in there
     _globals = get_class_globals(clz)
@@ -396,7 +397,7 @@ def dataclass(clz=None, *, init_doc=MISSING, cache_hash=False):
     # proces all cached properties
     process_cached_properties(clz, globals=_globals)
     # create the dataclass
-    data_clz = dataclasses.dataclass(frozen=True)(clz)
+    data_clz = dataclasses.dataclass(frozen=_frozen)(clz)
     purge_cache_fields(data_clz)
     # attach the custom preprocessing of init arguments
     attach_preprocess_init(


### PR DESCRIPTION
This is the only commit for ode4jax in https://github.com/PhilipVinc/netket_dynamics to work.

It's just an internal flag to control whever dataclasses are frozen or not. I use it in `ode4jax` to avoid writing repetitive code.
It should really go in it's own package, but since it's here, and it's a 3 liner.