### PR TITLE
Deprecate `netket.nn.initializers`

### DIFF
--- a/netket/models/autoreg.py
+++ b/netket/models/autoreg.py
@@ -19,12 +19,12 @@ from typing import Any, Callable, Iterable, Tuple, Union
 import jax
 from flax import linen as nn
 from jax import numpy as jnp
+from jax.nn.initializers import zeros
 from plum import dispatch
 
 from netket.hilbert import Fock, Spin
 from netket.hilbert.homogeneous import HomogeneousHilbert
 from netket.nn import MaskedConv1D, MaskedConv2D, MaskedDense1D
-from netket.nn.initializers import zeros
 from netket.nn.masked_linear import default_kernel_init
 from netket.utils.types import Array, DType, NNInitFunc
 

--- a/netket/models/equivariant.py
+++ b/netket/models/equivariant.py
@@ -20,14 +20,13 @@ import numpy as np
 import jax
 from jax import numpy as jnp
 from flax import linen as nn
+from jax.nn.initializers import zeros
+from jax.scipy.special import logsumexp
 
 from netket.utils import HashableArray
 from netket.utils.types import NNInitFunc
 from netket.utils.group import PermutationGroup
 from netket.graph import Graph, Lattice
-from jax.scipy.special import logsumexp
-
-from netket.nn.initializers import zeros
 from netket.nn.activation import reim_selu
 from netket.nn.symmetric_linear import (
     DenseSymmMatrix,

--- a/netket/models/fast_autoreg.py
+++ b/netket/models/fast_autoreg.py
@@ -17,6 +17,7 @@ from typing import Any, Callable, Iterable, Tuple, Union
 
 import jax
 from jax import numpy as jnp
+from jax.nn.initializers import zeros
 from plum import dispatch
 
 from netket.models.autoreg import (
@@ -27,7 +28,6 @@ from netket.models.autoreg import (
     l2_normalize,
 )
 from netket.nn import FastMaskedConv1D, FastMaskedConv2D, FastMaskedDense1D
-from netket.nn.initializers import zeros
 from netket.nn.masked_linear import default_kernel_init
 from netket.utils.types import Array, DType, NNInitFunc
 

--- a/netket/models/gaussian.py
+++ b/netket/models/gaussian.py
@@ -1,7 +1,7 @@
 import flax.linen as nn
 import jax.numpy as jnp
+from jax.nn.initializers import normal
 
-from netket.nn.initializers import normal
 from netket.utils.types import DType, Array, NNInitFunc
 
 

--- a/netket/models/jastrow.py
+++ b/netket/models/jastrow.py
@@ -14,8 +14,8 @@
 
 import flax.linen as nn
 import jax.numpy as jnp
+from jax.nn.initializers import normal
 
-from netket.nn.initializers import normal
 from netket.utils.types import DType, Array, NNInitFunc
 
 

--- a/netket/models/mps.py
+++ b/netket/models/mps.py
@@ -20,6 +20,7 @@ from flax import linen as nn
 import jax
 from jax import numpy as jnp
 import numpy as np
+from jax.nn.initializers import normal
 
 from netket.graph import AbstractGraph, Chain
 from netket.hilbert import AbstractHilbert
@@ -55,7 +56,7 @@ class MPSPeriodic(nn.Module):
     unit cells consisting of symperiod tensors. if None, symperiod equals the
     number of physical degrees of freedom.
     """
-    kernel_init: NNInitFunc = jax.nn.initializers.normal(
+    kernel_init: NNInitFunc = normal(
         stddev=0.01
     )  # default standard deviation equals 1e-2
     """the initializer for the MPS weights."""

--- a/netket/models/ndm.py
+++ b/netket/models/ndm.py
@@ -19,12 +19,11 @@ import numpy as np
 import jax
 from jax import numpy as jnp
 from flax import linen as nn
+from jax.nn.initializers import zeros, normal
 
 from netket.utils.types import NNInitFunc
-
 from netket import jax as nkjax
 from netket import nn as nknn
-from netket.nn.initializers import zeros, normal
 
 default_kernel_init = normal(stddev=0.001)
 

--- a/netket/models/rbm.py
+++ b/netket/models/rbm.py
@@ -19,12 +19,12 @@ import numpy as np
 import jax
 from jax import numpy as jnp
 from flax import linen as nn
+from jax.nn.initializers import normal
+
 from netket.utils import HashableArray
 from netket.utils.types import NNInitFunc
 from netket.utils.group import PermutationGroup
-
 from netket import nn as nknn
-from netket.nn.initializers import normal
 
 default_kernel_init = normal(stddev=0.01)
 

--- a/netket/nn/fast_masked_linear.py
+++ b/netket/nn/fast_masked_linear.py
@@ -18,8 +18,8 @@ import flax
 from flax import linen as nn
 from jax import lax
 from jax import numpy as jnp
+from jax.nn.initializers import zeros
 
-from netket.nn.initializers import zeros
 from netket.nn.masked_linear import (
     MaskedConv1D,
     MaskedConv2D,

--- a/netket/nn/initializers.py
+++ b/netket/nn/initializers.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 import jax
-from flax.linen.initializers import *
 from jax import numpy as jnp
+from jax.nn import initializers
 from netket.jax.utils import dtype_real
+from netket.utils.deprecation import deprecated
 
 
 def _complex_truncated_normal(key, upper, shape, dtype):
@@ -29,3 +30,27 @@ def _complex_truncated_normal(key, upper, shape, dtype):
     r = jnp.sqrt(-jnp.log(1 - t))
     theta = 2 * jnp.pi * jax.random.uniform(key_theta, shape, dtype)
     return r * jnp.exp(1j * theta)
+
+
+_func_names = [
+    "glorot_normal",
+    "glorot_uniform",
+    "he_normal",
+    "he_uniform",
+    "kaiming_normal",
+    "kaiming_uniform",
+    "lecun_normal",
+    "lecun_uniform",
+    "normal",
+    "ones",
+    "orthogonal",
+    "delta_orthogonal",
+    "uniform",
+    "variance_scaling",
+    "xavier_normal",
+    "xavier_uniform",
+    "zeros",
+]
+_msg = "`netket.nn.initializers` is deprecated. Use `jax.nn.initializers` instead."
+for func_name in _func_names:
+    locals()[func_name] = deprecated(_msg, func_name)(getattr(initializers, func_name))

--- a/netket/nn/initializers.py
+++ b/netket/nn/initializers.py
@@ -12,31 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from functools import partial
-
 import jax
 from flax.linen.initializers import *
 from jax import numpy as jnp
 from netket.jax.utils import dtype_real
-
-
-def _compute_fans(shape, in_axis=-2, out_axis=-1):
-    receptive_field_size = shape.total / shape[in_axis] / shape[out_axis]
-    fan_in = shape[in_axis] * receptive_field_size
-    fan_out = shape[out_axis] * receptive_field_size
-    return fan_in, fan_out
-
-
-def _complex_uniform(key, shape, dtype):
-    """
-    Sample uniform random values within a disk on the complex plane,
-    with zero mean and unit variance.
-    """
-    key_r, key_theta = jax.random.split(key)
-    dtype = dtype_real(dtype)
-    r = jnp.sqrt(2 * jax.random.uniform(key_r, shape, dtype))
-    theta = 2 * jnp.pi * jax.random.uniform(key_theta, shape, dtype)
-    return r * jnp.exp(1j * theta)
 
 
 def _complex_truncated_normal(key, upper, shape, dtype):
@@ -50,91 +29,3 @@ def _complex_truncated_normal(key, upper, shape, dtype):
     r = jnp.sqrt(-jnp.log(1 - t))
     theta = 2 * jnp.pi * jax.random.uniform(key_theta, shape, dtype)
     return r * jnp.exp(1j * theta)
-
-
-def variance_scaling(
-    scale, mode, distribution, in_axis=-2, out_axis=-1, dtype=jnp.float32
-):
-    """
-    Initializer capable of adapting its scale to the shape of the weights tensor.
-
-    With `distribution="truncated_normal" or "normal"`, samples are
-    drawn from a truncated/untruncated normal distribution with a mean of zero and
-    a standard deviation (after truncation, if used) `stddev = sqrt(scale / n)`,
-    where `n` is:
-    - number of input units in the weights tensor, if `mode="fan_in"`
-    - number of output units, if `mode="fan_out"`
-    - average of the numbers of input and output units, if `mode="fan_avg"`
-
-    With `distribution="truncated_normal"`, the absolute values of the samples are
-    truncated below 2 standard deviations before truncation.
-
-    With `distribution="uniform"`, samples are drawn from:
-    - a uniform interval, if `dtype` is real
-    - a uniform disk, if `dtype` is complex
-    with a mean of zero and a standard deviation of `stddev`.
-
-    The generalization of variance scaling initializers to complex numbers is discussed in,
-    e.g., `Trabelsi et. {\\it al} <https://arxiv.org/abs/1705.09792>`_.
-    They proposed an axisymmetric distribution implemented by first sampling the modulus
-    from the radial CDF, then uniformly sampling the phase.
-
-    Args:
-      scale: scaling factor (positive float).
-      mode: one of "fan_in", "fan_out", and "fan_avg".
-      distribution: random distribution to use. One of "truncated_normal",
-        "normal" and "uniform".
-      in_axis: axis of the input dimension in the weights tensor (default: -2).
-      out_axis: axis of the output dimension in the weights tensor (default: -1).
-      dtype: the dtype of the weights (default: float32).
-    """
-
-    def init(key, shape, dtype=dtype):
-        shape = jax.core.as_named_shape(shape)
-        fan_in, fan_out = _compute_fans(shape, in_axis, out_axis)
-        if mode == "fan_in":
-            denominator = fan_in
-        elif mode == "fan_out":
-            denominator = fan_out
-        elif mode == "fan_avg":
-            denominator = (fan_in + fan_out) / 2
-        else:
-            raise ValueError(
-                "invalid mode for variance scaling initializer: {}".format(mode)
-            )
-
-        variance = jnp.array(scale / denominator, dtype=dtype)
-
-        if distribution == "truncated_normal":
-            if jnp.issubdtype(dtype, jnp.floating):
-                # constant is stddev of standard normal truncated to (-2, 2)
-                stddev = jnp.sqrt(variance) / 0.87962566103423978
-                return jax.random.truncated_normal(key, -2, 2, shape, dtype) * stddev
-            else:
-                stddev = jnp.sqrt(variance) / 0.95311164380491208
-                return _complex_truncated_normal(key, 2, shape, dtype) * stddev
-        elif distribution == "normal":
-            return jax.random.normal(key, shape, dtype) * jnp.sqrt(variance)
-        elif distribution == "uniform":
-            if jnp.issubdtype(dtype, jnp.floating):
-                stddev = jnp.sqrt(3 * variance)
-                return jax.random.uniform(key, shape, dtype, -1) * stddev
-            else:
-                return _complex_uniform(key, shape, dtype) * jnp.sqrt(variance)
-        else:
-            raise ValueError("invalid distribution for variance scaling initializer")
-
-    return init
-
-
-glorot_uniform = partial(variance_scaling, 1, "fan_avg", "uniform")
-glorot_normal = partial(variance_scaling, 1, "fan_avg", "truncated_normal")
-lecun_uniform = partial(variance_scaling, 1, "fan_in", "uniform")
-lecun_normal = partial(variance_scaling, 1, "fan_in", "truncated_normal")
-he_uniform = partial(variance_scaling, 2, "fan_in", "uniform")
-he_normal = partial(variance_scaling, 2, "fan_in", "truncated_normal")
-
-xavier_uniform = glorot_uniform
-xavier_normal = glorot_normal
-kaiming_uniform = he_uniform
-kaiming_normal = he_normal

--- a/netket/nn/linear.py
+++ b/netket/nn/linear.py
@@ -17,12 +17,11 @@
 from typing import Any, Callable, Iterable, Optional, Tuple, Union
 
 import flax
-from flax.linen.module import Module, compact
-from jax import lax
 import jax.numpy as jnp
 import numpy as np
-
-from netket.nn.initializers import lecun_normal, zeros
+from flax.linen.module import Module, compact
+from jax import lax
+from jax.nn.initializers import lecun_normal, zeros
 
 PRNGKey = Any
 Shape = Iterable[int]

--- a/netket/nn/masked_linear.py
+++ b/netket/nn/masked_linear.py
@@ -18,7 +18,8 @@ import flax
 from flax import linen as nn
 from jax import lax
 from jax import numpy as jnp
-from netket.nn.initializers import lecun_normal, zeros
+from jax.nn.initializers import lecun_normal, zeros
+
 from netket.utils.types import Array, DType, NNInitFunc
 
 default_kernel_init = lecun_normal()

--- a/netket/nn/symmetric_linear.py
+++ b/netket/nn/symmetric_linear.py
@@ -20,14 +20,9 @@ from jax import lax
 import jax.numpy as jnp
 import numpy as np
 import jax
+from jax.nn.initializers import normal, zeros, lecun_normal, variance_scaling
 
-from netket.nn.initializers import (
-    normal,
-    zeros,
-    lecun_normal,
-    variance_scaling,
-    _complex_truncated_normal,
-)
+from netket.nn.initializers import _complex_truncated_normal
 from netket.utils import HashableArray
 from netket.utils.types import Array, DType, PRNGKeyT, Shape, NNInitFunc
 from netket.utils.group import PermutationGroup

--- a/netket/utils/deprecation.py
+++ b/netket/utils/deprecation.py
@@ -19,7 +19,7 @@ import inspect
 from textwrap import dedent
 
 
-def deprecated(reason=None):
+def deprecated(reason=None, func_name=None):
     r"""
     This is a decorator which can be used to mark functions as deprecated. It
     will result in a warning being emitted when the function is used.
@@ -27,7 +27,9 @@ def deprecated(reason=None):
 
     def decorator(func):
         object_type = "class" if inspect.isclass(func) else "function"
-        message = "Call to deprecated {} {!r}".format(object_type, func.__name__)
+        message = "Call to deprecated {} {!r}".format(
+            object_type, func_name or func.__name__
+        )
         if reason is not None:
             message += f" ({dedent(reason)})"
 

--- a/netket/vqs/base.py
+++ b/netket/vqs/base.py
@@ -18,12 +18,11 @@ from typing import Any, Optional, Tuple
 import jax
 import flax
 from flax.core.frozen_dict import FrozenDict
-
 import numpy as np
 import jax.numpy as jnp
+from jax.nn.initializers import normal
 
 import netket.jax as nkjax
-import netket.nn as nknn
 from netket.operator import AbstractOperator
 from netket.hilbert import AbstractHilbert
 from netket.utils.types import PyTree, PRNGKeyT, NNInitFunc
@@ -124,14 +123,14 @@ class VariationalState(abc.ABC):
             model. DO NOT SPECIFY IT INSIDE THE INIT FUNCTION
 
         Args:
-            init_fun: a jax initializer such as :ref:`netket.nn.initializers.normal`. Must be a Callable
+            init_fun: a jax initializer such as :ref:`jax.nn.initializers.normal`. Must be a Callable
                 taking 3 inputs, the jax PRNG key, the shape and the dtype, and outputting an array with
-                the valid dtype and shape. If left unspecified, defaults to :code:`netket.nn.initializers.normal(stddev=0.01)`
+                the valid dtype and shape. If left unspecified, defaults to :code:`jax.nn.initializers.normal(stddev=0.01)`
             seed: Optional seed to be used. The seed is synced across all MPI processes. If unspecified, uses
                 a random seed.
         """
         if init_fun is None:
-            init_fun = nknn.initializers.normal(stddev=0.01)
+            init_fun = normal(stddev=0.01)
 
         rng = nkjax.PRNGSeq(nkjax.PRNGKey(seed))
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ BASE_DEPENDENCIES = [
     "plum-dispatch~=1.5.1",
     "numba>=0.52, <0.55",
     "python-igraph~=0.9",
-    "jax>0.2.16, <0.2.22",
+    "jax>=0.2.21, <0.2.22",
     "jaxlib>=0.1.69",
     "flax>=0.3.0, <0.4",
     "orjson~=3.4",

--- a/test/logging/test_state_log.py
+++ b/test/logging/test_state_log.py
@@ -4,6 +4,7 @@ import tarfile
 import glob
 
 import netket as nk
+from jax.nn.initializers import normal
 
 from .. import common
 
@@ -18,8 +19,8 @@ def vstate(request):
     ma = nk.models.RBM(
         alpha=1,
         dtype=float,
-        hidden_bias_init=nk.nn.initializers.normal(),
-        visible_bias_init=nk.nn.initializers.normal(),
+        hidden_bias_init=normal(),
+        visible_bias_init=normal(),
     )
 
     return nk.vqs.MCState(

--- a/test/models/test_nn.py
+++ b/test/models/test_nn.py
@@ -18,14 +18,13 @@ import jax.numpy as jnp
 import jax.random as random
 import numpy as np
 import scipy.sparse
-from jax.lax import dot
+from jax.nn.initializers import uniform
 from netket.utils.group import PermutationGroup
 
 import pytest
 
 
 def _setup_symm(symmetries, N, lattice=nk.graph.Chain):
-
     g = lattice(N)
 
     hi = nk.hilbert.Spin(1 / 2, g.n_nodes)
@@ -54,7 +53,7 @@ def test_DenseSymm(symmetries, use_bias, mode):
             mode=mode,
             features=8,
             use_bias=use_bias,
-            bias_init=nk.nn.initializers.uniform(),
+            bias_init=uniform(),
         )
     else:
         ma = nk.nn.DenseSymm(
@@ -63,7 +62,7 @@ def test_DenseSymm(symmetries, use_bias, mode):
             mode=mode,
             features=8,
             use_bias=use_bias,
-            bias_init=nk.nn.initializers.uniform(),
+            bias_init=uniform(),
         )
 
     pars = ma.init(rng.next(), hi.random_state(rng.next(), 1))
@@ -78,13 +77,10 @@ def test_DenseSymm(symmetries, use_bias, mode):
 def test_DenseEquivariant_creation(mode):
     g = nk.graph.Chain(8)
     space_group = g.space_group()
-    hi = nk.hilbert.Spin(1 / 2, N=8)
 
     def check_init(creator):
         ma = creator()
         _ = ma.init(nk.jax.PRNGKey(0), np.ones([1, 4, 16]))
-
-    perms = [[0, 1, 2, 3, 4, 5, 6, 7], [7, 6, 5, 4, 3, 2, 1, 0]]
 
     # Init with graph
     check_init(
@@ -174,7 +170,7 @@ def test_DenseEquivariant(symmetries, use_bias, lattice, mode, mask):
             out_features=1,
             mask=mask,
             use_bias=use_bias,
-            bias_init=nk.nn.initializers.uniform(),
+            bias_init=uniform(),
         )
     else:
         ma = nk.nn.DenseEquivariant(
@@ -185,7 +181,7 @@ def test_DenseEquivariant(symmetries, use_bias, lattice, mode, mask):
             out_features=1,
             mask=mask,
             use_bias=use_bias,
-            bias_init=nk.nn.initializers.uniform(),
+            bias_init=uniform(),
         )
 
     pars = ma.init(rng.next(), np.random.normal(0, 1, [1, 1, n_symm]))
@@ -220,13 +216,13 @@ def test_modes_DenseSymm(lattice, symmetries):
         mode="fft",
         features=4,
         shape=tuple(g.extent),
-        bias_init=nk.nn.initializers.uniform(),
+        bias_init=uniform(),
     )
     ma_matrix = nk.nn.DenseSymm(
         symmetries=perms,
         mode="matrix",
         features=4,
-        bias_init=nk.nn.initializers.uniform(),
+        bias_init=uniform(),
     )
 
     dum_input = np.random.normal(0, 1, [1, g.n_nodes])
@@ -249,21 +245,21 @@ def test_modes_DenseEquivariant(lattice, symmetries):
         in_features=1,
         out_features=1,
         shape=tuple(g.extent),
-        bias_init=nk.nn.initializers.uniform(),
+        bias_init=uniform(),
     )
     ma_irreps = nk.nn.DenseEquivariant(
         symmetries=perms,
         mode="irreps",
         in_features=1,
         out_features=1,
-        bias_init=nk.nn.initializers.uniform(),
+        bias_init=uniform(),
     )
     ma_matrix = nk.nn.DenseEquivariant(
         symmetries=perms,
         mode="matrix",
         in_features=1,
         out_features=1,
-        bias_init=nk.nn.initializers.uniform(),
+        bias_init=uniform(),
     )
 
     dum_input = np.random.normal(0, 1, [1, 1, len(perms)])

--- a/test/models/test_rbm.py
+++ b/test/models/test_rbm.py
@@ -14,9 +14,9 @@
 
 import netket as nk
 import numpy as np
-import jax.numpy as jnp
-
 import jax
+import jax.numpy as jnp
+from jax.nn.initializers import uniform
 
 from .test_nn import _setup_symm
 
@@ -34,8 +34,8 @@ def test_RBMSymm(use_hidden_bias, use_visible_bias, symmetries):
         alpha=4,
         use_visible_bias=use_visible_bias,
         use_hidden_bias=use_hidden_bias,
-        hidden_bias_init=nk.nn.initializers.uniform(),
-        visible_bias_init=nk.nn.initializers.uniform(),
+        hidden_bias_init=uniform(),
+        visible_bias_init=uniform(),
     )
     pars = ma.init(nk.jax.PRNGKey(), hi.random_state(nk.jax.PRNGKey()))
 
@@ -70,7 +70,7 @@ def test_gcnn(parity, symmetries, lattice, mode):
         layers=2,
         features=2,
         parity=parity,
-        bias_init=nk.nn.initializers.uniform(),
+        bias_init=uniform(),
     )
 
     pars = ma.init(nk.jax.PRNGKey(), hi.random_state(nk.jax.PRNGKey(), 1))
@@ -242,8 +242,8 @@ def test_RBMMultiVal(use_hidden_bias, use_visible_bias):
         n_classes=M + 1,
         use_visible_bias=use_visible_bias,
         use_hidden_bias=use_hidden_bias,
-        hidden_bias_init=nk.nn.initializers.uniform(),
-        visible_bias_init=nk.nn.initializers.uniform(),
+        hidden_bias_init=uniform(),
+        visible_bias_init=uniform(),
     )
     _ = ma.init(nk.jax.PRNGKey(), hi.random_state(nk.jax.PRNGKey(), 1))
 

--- a/test/nn/test_initializers.py
+++ b/test/nn/test_initializers.py
@@ -19,8 +19,8 @@ import netket as nk
 import numpy as np
 import pytest
 from jax import numpy as jnp
+from jax.nn.initializers import lecun_normal, lecun_uniform
 from netket.jax.utils import dtype_real
-from netket.nn.initializers import lecun_normal, lecun_uniform
 from scipy.stats import kstest
 
 seed = 12345

--- a/test/nn/test_utils.py
+++ b/test/nn/test_utils.py
@@ -16,6 +16,7 @@ import pytest
 
 import jax.numpy as jnp
 import numpy as np
+from jax.nn.initializers import normal
 
 import netket as nk
 
@@ -35,8 +36,8 @@ def vstate(request):
     ma = nk.models.RBM(
         alpha=1,
         dtype=float,
-        hidden_bias_init=nk.nn.initializers.normal(),
-        visible_bias_init=nk.nn.initializers.normal(),
+        hidden_bias_init=normal(),
+        visible_bias_init=normal(),
     )
 
     return nk.vqs.MCState(

--- a/test/optimizer/test_qgt_itersolve.py
+++ b/test/optimizer/test_qgt_itersolve.py
@@ -17,11 +17,10 @@ import pytest
 from functools import partial
 
 import jax
-
 import numpy as np
 from numpy import testing
-
 import jax.flatten_util
+from jax.nn.initializers import normal
 
 import netket as nk
 import netket.jax as nkjax
@@ -60,13 +59,13 @@ solvers_tol[solvers["cholesky"]] = 1e-8
 
 RBM = partial(
     nk.models.RBM,
-    hidden_bias_init=nk.nn.initializers.normal(),
-    visible_bias_init=nk.nn.initializers.normal(),
+    hidden_bias_init=normal(),
+    visible_bias_init=normal(),
 )
 RBMModPhase = partial(
     nk.models.RBMModPhase,
-    hidden_bias_init=nk.nn.initializers.normal(),
-    kernel_init=nk.nn.initializers.normal(),
+    hidden_bias_init=normal(),
+    kernel_init=normal(),
 )
 
 models = {
@@ -97,9 +96,7 @@ def vstate(request, model):
         nk.sampler.MetropolisLocal(hi),
         model,
     )
-    vstate.init_parameters(
-        nk.nn.initializers.normal(stddev=0.001), seed=jax.random.PRNGKey(3)
-    )
+    vstate.init_parameters(normal(stddev=0.001), seed=jax.random.PRNGKey(3))
 
     vstate.sample()
 

--- a/test/optimizer/test_qgt_solvers.py
+++ b/test/optimizer/test_qgt_solvers.py
@@ -16,10 +16,9 @@ import pytest
 
 from functools import partial
 
-
 import jax
-
 import jax.flatten_util
+from jax.nn.initializers import normal
 
 import netket as nk
 from netket.optimizer import qgt
@@ -49,17 +48,15 @@ def vstate(request):
     ma = nk.models.RBM(
         alpha=1,
         dtype=dtype,
-        hidden_bias_init=nk.nn.initializers.normal(),
-        visible_bias_init=nk.nn.initializers.normal(),
+        hidden_bias_init=normal(),
+        visible_bias_init=normal(),
     )
 
     vstate = nk.vqs.MCState(
         nk.sampler.MetropolisLocal(hi),
         ma,
     )
-    vstate.init_parameters(
-        nk.nn.initializers.normal(stddev=0.001), seed=jax.random.PRNGKey(3)
-    )
+    vstate.init_parameters(normal(stddev=0.001), seed=jax.random.PRNGKey(3))
 
     vstate.sample()
 

--- a/test/sampler/test_sampler.py
+++ b/test/sampler/test_sampler.py
@@ -21,8 +21,9 @@ from netket.hilbert import DiscreteHilbert, ContinuousBoson
 import numpy as np
 import pytest
 from scipy.stats import combine_pvalues, chisquare, multivariate_normal, kstest
-
 import jax
+from jax.nn.initializers import normal
+
 from jax.config import config
 
 config.update("jax_enable_x64", True)
@@ -123,8 +124,8 @@ def model_and_weights(request):
             ma = nk.models.RBM(
                 alpha=1,
                 dtype=complex,
-                kernel_init=nk.nn.initializers.normal(stddev=0.1),
-                hidden_bias_init=nk.nn.initializers.normal(stddev=0.1),
+                kernel_init=normal(stddev=0.1),
+                hidden_bias_init=normal(stddev=0.1),
             )
 
         # init network

--- a/test/variational/test_experimental.py
+++ b/test/variational/test_experimental.py
@@ -17,11 +17,11 @@ import pytest
 import jax
 import jax.flatten_util
 import numpy as np
+from flax import serialization
+from jax.nn.initializers import normal
 
 import tarfile
 from io import BytesIO
-
-from flax import serialization
 
 import netket as nk
 
@@ -40,8 +40,8 @@ def vstate(request):
     ma = nk.models.RBM(
         alpha=1,
         dtype=float,
-        hidden_bias_init=nk.nn.initializers.normal(),
-        visible_bias_init=nk.nn.initializers.normal(),
+        hidden_bias_init=normal(),
+        visible_bias_init=normal(),
     )
 
     return nk.vqs.MCState(

--- a/test/variational/test_variational.py
+++ b/test/variational/test_variational.py
@@ -20,7 +20,7 @@ from pytest import approx, raises, warns
 import numpy as np
 import jax
 import netket as nk
-import flax
+from jax.nn.initializers import normal
 
 from .. import common
 
@@ -32,7 +32,7 @@ SEED = 2148364
 
 machines = {}
 
-standard_init = flax.linen.initializers.normal()
+standard_init = normal()
 RBM = partial(
     nk.models.RBM, hidden_bias_init=standard_init, visible_bias_init=standard_init
 )
@@ -41,26 +41,26 @@ RBMModPhase = partial(nk.models.RBMModPhase, hidden_bias_init=standard_init)
 nk.models.RBM(
     alpha=1,
     dtype=complex,
-    kernel_init=nk.nn.initializers.normal(stddev=0.1),
-    hidden_bias_init=nk.nn.initializers.normal(stddev=0.1),
+    kernel_init=normal(stddev=0.1),
+    hidden_bias_init=normal(stddev=0.1),
 )
 machines["model:(R->R)"] = RBM(
     alpha=1,
     dtype=float,
-    kernel_init=nk.nn.initializers.normal(stddev=0.1),
-    hidden_bias_init=nk.nn.initializers.normal(stddev=0.1),
+    kernel_init=normal(stddev=0.1),
+    hidden_bias_init=normal(stddev=0.1),
 )
 machines["model:(R->C)"] = RBMModPhase(
     alpha=1,
     dtype=float,
-    kernel_init=nk.nn.initializers.normal(stddev=0.1),
-    hidden_bias_init=nk.nn.initializers.normal(stddev=0.1),
+    kernel_init=normal(stddev=0.1),
+    hidden_bias_init=normal(stddev=0.1),
 )
 machines["model:(C->C)"] = RBM(
     alpha=1,
     dtype=complex,
-    kernel_init=nk.nn.initializers.normal(stddev=0.1),
-    hidden_bias_init=nk.nn.initializers.normal(stddev=0.1),
+    kernel_init=normal(stddev=0.1),
+    hidden_bias_init=normal(stddev=0.1),
 )
 
 operators = {}
@@ -175,7 +175,7 @@ def test_serialization(vstate):
 def test_init_parameters(vstate):
     vstate.init_parameters(seed=SEED)
     pars = vstate.parameters
-    vstate.init_parameters(nk.nn.initializers.normal(stddev=0.01), seed=SEED)
+    vstate.init_parameters(normal(stddev=0.01), seed=SEED)
     pars2 = vstate.parameters
 
     def _f(x, y):

--- a/test/variational/test_variational_mixed.py
+++ b/test/variational/test_variational_mixed.py
@@ -20,7 +20,7 @@ from pytest import raises
 import numpy as np
 import jax
 import netket as nk
-import flax
+from jax.nn.initializers import normal
 
 from .. import common
 
@@ -32,21 +32,21 @@ SEED = 2148364
 
 machines = {}
 
-standard_init = flax.linen.initializers.normal()
+standard_init = normal()
 NDM = partial(nk.models.NDM, bias_init=standard_init, visible_bias_init=standard_init)
 
 machines["model:(R->C)"] = NDM(
     alpha=1,
     beta=1,
     dtype=float,
-    kernel_init=nk.nn.initializers.normal(stddev=0.1),
-    bias_init=nk.nn.initializers.normal(stddev=0.1),
+    kernel_init=normal(stddev=0.1),
+    bias_init=normal(stddev=0.1),
 )
 # machines["model:(C->C)"] = RBM(
 #    alpha=1,
 #    dtype=complex,
-#    kernel_init=nk.nn.initializers.normal(stddev=0.1),
-#    bias_init=nk.nn.initializers.normal(stddev=0.1),
+#    kernel_init=normal(stddev=0.1),
+#    bias_init=normal(stddev=0.1),
 # )
 
 operators = {}


### PR DESCRIPTION
`netket.nn.initializers._complex_truncated_normal` is left there because `netket.nn.symmetric_linear` uses it, and the corresponding function in jax is internal.

I added an argument `func_name` in `netket.utils.deprecation.deprecated`, because the deprecated function may be a `functools.partial` and have no `__name__`.