### PR TITLE
Support new PRNGKey structural interface

### DIFF
--- a/netket/jax/utils.py
+++ b/netket/jax/utils.py
@@ -317,8 +317,7 @@ def compose(*funcs):
 
     return reduce(_compose, funcs)
 
-
-def PRNGKey(seed: Optional[SeedT] = None, root: int = 0, comm=MPI_jax_comm) -> PRNGKeyT:
+def PRNGKey(seed: Optional[SeedT] = None, *, root: int = 0, comm=MPI_jax_comm) -> PRNGKeyT:
     """
     Initialises a PRNGKey using an optional starting seed.
     The same seed will be distributed to all processes.
@@ -330,12 +329,11 @@ def PRNGKey(seed: Optional[SeedT] = None, root: int = 0, comm=MPI_jax_comm) -> P
     else:
         key = seed
 
-    key, _ = mpi.mpi_bcast_jax(key, root=root, comm=comm)
+    key = jax.tree_map(lambda k: mpi.mpi_bcast_jax(k, root=root, comm=comm)[0], key)
 
     return key
 
-
-def mpi_split(key, root=0, comm=MPI_jax_comm) -> PRNGKeyT:
+def mpi_split(key, *, root=0, comm=MPI_jax_comm) -> PRNGKeyT:
     """
     Split a key across MPI nodes in the communicator.
     Only the input key on the root process matters.
@@ -353,7 +351,7 @@ def mpi_split(key, root=0, comm=MPI_jax_comm) -> PRNGKeyT:
     # on all MPI nodes?
     keys = jax.random.split(key, mpi.n_nodes)
 
-    keys, _ = mpi.mpi_bcast_jax(keys, root=root)
+    keys = jax.tree_map(lambda k: mpi.mpi_bcast_jax(k, root=root)[0], keys)
 
     return keys[mpi.rank]
 

--- a/netket/jax/utils.py
+++ b/netket/jax/utils.py
@@ -317,7 +317,10 @@ def compose(*funcs):
 
     return reduce(_compose, funcs)
 
-def PRNGKey(seed: Optional[SeedT] = None, *, root: int = 0, comm=MPI_jax_comm) -> PRNGKeyT:
+
+def PRNGKey(
+    seed: Optional[SeedT] = None, *, root: int = 0, comm=MPI_jax_comm
+) -> PRNGKeyT:
     """
     Initialises a PRNGKey using an optional starting seed.
     The same seed will be distributed to all processes.
@@ -332,6 +335,7 @@ def PRNGKey(seed: Optional[SeedT] = None, *, root: int = 0, comm=MPI_jax_comm) -
     key = jax.tree_map(lambda k: mpi.mpi_bcast_jax(k, root=root, comm=comm)[0], key)
 
     return key
+
 
 def mpi_split(key, *, root=0, comm=MPI_jax_comm) -> PRNGKeyT:
     """


### PR DESCRIPTION
Jax is currently experimenting with a new interface where the PRNGKey is a pytree instead of an array, in order to make their code more readable and safe, and also in order to support different kinds of PRNGs (They recently merged a new PRNG generator called RGB). https://github.com/google/jax/pull/6899

Anyhow, those changes are hidden for the time being, unless you use `export JAX_ENABLE_CUSTOM_PRNG=1` becaues I asked them not to break the API immediately.

The changes in this PR are needed to make NetKet work with Jax when they will switch to this interface.
