### PR TITLE
Make randomly skipped tests deterministic

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -58,3 +58,18 @@ class netket_disable_mpi:
         nk.utils.mpi.n_nodes = self._orig_nodes
         nk.utils.mpi.mpi.n_nodes = self._orig_nodes
         nk.utils.mpi.primitives.n_nodes = self._orig_nodes
+
+
+def hash_for_seed(obj):
+    """
+    Hash any object into an int that can be used in `np.random.seed`, and does not change between Python sessions.
+
+    Args:
+      obj: any object with `repr` defined to show its states.
+    """
+
+    bs = repr(obj).encode()
+    out = 0
+    for b in bs:
+        out = (out * 256 + b) % 4294967291  # Output in [0, 2**32 - 1]
+    return out

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -32,7 +32,7 @@ def _mpi_comm(request):
 def pytest_addoption(parser):
     parser.addoption(
         "--arnn_test_rate",
-        action="store",
-        default=0.1,
+        type=float,
+        default=0.2,
         help="rate of running a test for ARNN",
     )

--- a/test/models/test_autoreg.py
+++ b/test/models/test_autoreg.py
@@ -19,11 +19,13 @@ import pytest
 from flax.core import freeze
 from jax import numpy as jnp
 
+from .. import common
+
 
 @pytest.fixture
 def skip(request):
     rate = request.config.getoption("--arnn_test_rate")
-    rng = np.random.default_rng(abs(hash(str(request.node.callspec.id))))
+    rng = np.random.default_rng(common.hash_for_seed(request.node.callspec.id))
     if rng.random() > rate:
         pytest.skip(
             "Running only a portion of the tests for ARNN. Use --arnn_test_rate=1 to run all tests."

--- a/test/sampler/conftest.py
+++ b/test/sampler/conftest.py
@@ -18,14 +18,14 @@ import pytest  # noqa: F401
 def pytest_addoption(parser):
     parser.addoption(
         "--sampler",
-        action="store",
+        type=str,
         default="",
         help="sampler: exact, metropolis, metropolispt or pt, local, hamiltonian, custom, autoregressive, gaussian",
     )
 
     parser.addoption(
         "--mpow",
-        action="store",
+        type=str,
         default="single",
         help="mpow: single, all, 1,2,3...",
     )

--- a/test/sampler/test_sampler.py
+++ b/test/sampler/test_sampler.py
@@ -166,7 +166,7 @@ def set_pdf_power(request):
             pass
         elif cmdline_mpow == "single":
             # same sampler leads to same rng
-            rng = np.random.default_rng(abs(hash((type(sampler), repr(sampler)))))
+            rng = np.random.default_rng(common.hash_for_seed(sampler))
             exponent = rng.integers(1, 3)  # 1 or 2
             if exponent != request.param:
                 pytest.skip(

--- a/test/variational/test_autoreg.py
+++ b/test/variational/test_autoreg.py
@@ -26,7 +26,7 @@ pytestmark = common.skipif_mpi
 @pytest.fixture
 def skip(request):
     rate = request.config.getoption("--arnn_test_rate")
-    rng = np.random.default_rng(abs(hash(str(request.node.callspec.id))))
+    rng = np.random.default_rng(common.hash_for_seed(request.node.callspec.id))
     if rng.random() > rate:
         pytest.skip(
             "Running only a portion of the tests for ARNN. Use --arnn_test_rate=1 to run all tests."


### PR DESCRIPTION
By default Python's hash for objects (including types and strings) uses memory addresses and is subject to change between Python sessions, so we need to hash the content of the string.