### PR TITLE
Instable sorting, use sorted explicitly in PauliStrings

### DIFF
--- a/netket/operator/_pauli_strings.py
+++ b/netket/operator/_pauli_strings.py
@@ -145,7 +145,7 @@ class PauliStrings(DiscreteOperator):
 
             def append(key, k):
                 # convert list to tuple
-                key = tuple(set(key))  # order of X and Y does not matter
+                key = tuple(sorted(key))  # order of X and Y does not matter
                 if key in acting:
                     acting[key].append(k)
                 else:


### PR DESCRIPTION
Not a bug, just improve the behavior.
Better to use sorted explicitly, set is (no longer?) safe. 