### PR TITLE
fix #965

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,6 +37,7 @@ jobs:
             mpi: ""
             main_tests: true
             oldest_deps: true
+            env: NUMBA_BOUNDSCHECK=1
 
         #python-version: [3.6, 3.7, 3.8]
         #os: [ubuntu-latest, macos-latest]

--- a/netket/operator/_local_operator.py
+++ b/netket/operator/_local_operator.py
@@ -976,12 +976,9 @@ class LocalOperator(DiscreteOperator):
                 c += 1
 
             for i in range(n_operators):
-
-                # Diagonal part
-                #  If nonzero_diagonal, this goes to c_diag = 0 ....
-                # if zero_diagonal this just sets the last element to 0
-                # so it's not worth it skipping it
-                mels[c_diag] += diag_mels[i, xs_n[b, i]]
+                if nonzero_diagonal:
+                    mels[c_diag] += diag_mels[i, xs_n[b, i]]
+                    
                 n_conn_i = n_conns[i, xs_n[b, i]]
 
                 if n_conn_i > 0:

--- a/netket/operator/_local_operator.py
+++ b/netket/operator/_local_operator.py
@@ -978,7 +978,7 @@ class LocalOperator(DiscreteOperator):
             for i in range(n_operators):
                 if nonzero_diagonal:
                     mels[c_diag] += diag_mels[i, xs_n[b, i]]
-                    
+
                 n_conn_i = n_conns[i, xs_n[b, i]]
 
                 if n_conn_i > 0:


### PR DESCRIPTION
fix #965 

Turns out it was technically not a bug because we were smart enough to only add 0 to OOB memory (which is probably why it never caused crashes). However, better avoid this bad practice.

Also runs one tester with NUMBA_BOUNDSCHECK=1