### PR TITLE
Operators written purely in Jax

### DIFF
--- a/netket/operator/__init__.py
+++ b/netket/operator/__init__.py
@@ -19,7 +19,7 @@ from ._local_operator import LocalOperator
 from ._graph_operator import GraphOperator
 from ._pauli_strings import PauliStrings
 from ._lazy import Adjoint, Transpose, Squared
-from ._hamiltonian import Ising, Heisenberg, BoseHubbard
+from ._hamiltonian import Ising, IsingJax, Heisenberg, BoseHubbard
 
 from ._abstract_super_operator import AbstractSuperOperator
 from ._local_liouvillian import LocalLiouvillian

--- a/netket/operator/_der_local_values_jax.py
+++ b/netket/operator/_der_local_values_jax.py
@@ -14,7 +14,6 @@
 
 from functools import partial
 
-import numpy as np
 import jax
 from jax import numpy as jnp
 
@@ -31,7 +30,7 @@ local_energy_kernel = local_value_cost
 # Used to compute the gradient
 # \sum_i mel(i) * exp(vp(i)-v) * ( O_k(vp(i)) - O_k(v) )
 def _der_local_values_impl(op, machine, v, log_vals):
-    v_primes, mels = op.get_conn_padded(np.asarray(v))
+    v_primes, mels = op.get_conn_padded(v)
 
     val, grad = local_costs_and_grads_function(
         local_energy_kernel, machine.jax_forward, machine.parameters, v_primes, mels, v
@@ -108,7 +107,7 @@ def _local_values_and_grads_notcentered_kernel(logpsi, pars, vp, mel, v):
 
 
 def _der_local_values_notcentered_impl(op, machine, v, log_vals):
-    v_primes, mels = op.get_conn_padded(np.asarray(v))
+    v_primes, mels = op.get_conn_padded(v)
 
     val, grad = _local_values_and_grads_notcentered_kernel(
         machine.jax_forward, machine.parameters, v_primes, mels, v

--- a/netket/operator/_discrete_operator.py
+++ b/netket/operator/_discrete_operator.py
@@ -40,6 +40,9 @@ class DiscreteOperator(AbstractOperator):
             mels: A N-tensor containing the matrix elements :math:`O(x,x')`
                 associated to each x' for every batch.
         """
+
+        x = np.asarray(x)
+
         n_visible = x.shape[-1]
         n_samples = x.size // n_visible
 

--- a/netket/sampler/rules/__init__.py
+++ b/netket/sampler/rules/__init__.py
@@ -14,7 +14,7 @@
 
 from .local import LocalRule
 from .exchange import ExchangeRule
-from .hamiltonian import HamiltonianRule
+from .hamiltonian import HamiltonianRule, HamiltonianRuleJax
 from .continuous_gaussian import GaussianRule
 
 # numpy backend

--- a/netket/vqs/mc_expect.py
+++ b/netket/vqs/mc_expect.py
@@ -1,8 +1,6 @@
 from functools import partial
 from typing import Callable
 
-import numpy as np
-
 import jax
 from jax import numpy as jnp
 
@@ -57,7 +55,7 @@ def expect(vstate: MCState, Ô: Squared) -> Stats:  # noqa: F811
 
     σ = vstate.samples
 
-    σp, mels = Ô.parent.get_conn_padded(np.asarray(σ).reshape((-1, σ.shape[-1])))
+    σp, mels = Ô.parent.get_conn_padded(σ.reshape((-1, σ.shape[-1])))
 
     return _expect(
         vstate.sampler.machine_pow,
@@ -77,7 +75,7 @@ def expect(vstate: MCState, Ô: DiscreteOperator) -> Stats:  # noqa: F811
 
     σ = vstate.samples
 
-    σp, mels = Ô.get_conn_padded(np.asarray(σ).reshape((-1, σ.shape[-1])))
+    σp, mels = Ô.get_conn_padded(σ.reshape((-1, σ.shape[-1])))
 
     return _expect(
         vstate.sampler.machine_pow,
@@ -97,7 +95,7 @@ def expect(vstate: MCMixedState, Ô: DiscreteOperator) -> Stats:  # noqa: F811
 
     σ = vstate.diagonal.samples
 
-    σp, mels = Ô.get_conn_padded(np.asarray(σ).reshape((-1, σ.shape[-1])))
+    σp, mels = Ô.get_conn_padded(σ.reshape((-1, σ.shape[-1])))
 
     return _expect(
         vstate.sampler.machine_pow,

--- a/netket/vqs/mc_expect_grad.py
+++ b/netket/vqs/mc_expect_grad.py
@@ -1,8 +1,6 @@
 from functools import partial
 from typing import Any, Callable, Tuple
 
-import numpy as np
-
 import jax
 from jax import numpy as jnp
 from jax import tree_map
@@ -49,7 +47,7 @@ def expect_and_grad(
     Ô = Ô.parent
 
     σ = vstate.samples
-    σp, mels = Ô.get_conn_padded(np.asarray(σ.reshape((-1, σ.shape[-1]))))
+    σp, mels = Ô.get_conn_padded(σ.reshape((-1, σ.shape[-1])))
 
     Ō, Ō_grad, new_model_state = grad_expect_operator_kernel(
         vstate.sampler.machine_pow,
@@ -82,7 +80,7 @@ def expect_and_grad(  # noqa: F811
     Ô = Ô.parent
 
     σ = vstate.samples
-    σp, mels = Ô.get_conn_padded(np.asarray(σ.reshape((-1, σ.shape[-1]))))
+    σp, mels = Ô.get_conn_padded(σ.reshape((-1, σ.shape[-1])))
 
     Ō, Ō_grad, new_model_state = grad_expect_operator_Lrho2(
         vstate._apply_fun,
@@ -114,7 +112,7 @@ def expect_and_grad(  # noqa: F811
     _check_hilbert(vstate, Ô)
 
     σ = vstate.samples
-    σp, mels = Ô.get_conn_padded(np.asarray(σ.reshape((-1, σ.shape[-1]))))
+    σp, mels = Ô.get_conn_padded(σ.reshape((-1, σ.shape[-1])))
 
     Ō, Ō_grad, new_model_state = grad_expect_hermitian(
         vstate._apply_fun,
@@ -143,7 +141,7 @@ def expect_and_grad(  # noqa: F811
     _check_hilbert(vstate, Ô)
 
     σ = vstate.samples
-    σp, mels = Ô.get_conn_padded(np.asarray(σ.reshape((-1, σ.shape[-1]))))
+    σp, mels = Ô.get_conn_padded(σ.reshape((-1, σ.shape[-1])))
 
     Ō, Ō_grad, new_model_state = grad_expect_operator_kernel(
         vstate.sampler.machine_pow,

--- a/test/groundstate/test_vmc.py
+++ b/test/groundstate/test_vmc.py
@@ -57,7 +57,7 @@ def local_values(logpsi, variables, Ô, σ):
     """
     Returns loc_vals for an operator O
     """
-    σp, mels = Ô.get_conn_padded(np.asarray(σ).reshape((-1, σ.shape[-1])))
+    σp, mels = Ô.get_conn_padded(σ.reshape((-1, σ.shape[-1])))
     loc_vals = local_value_kernel(
         logpsi, variables, σ.reshape((-1, σ.shape[-1])), σp, mels
     )

--- a/test/operator/test_local_operator.py
+++ b/test/operator/test_local_operator.py
@@ -275,13 +275,21 @@ def test_mul_matmul():
         op @= 2.0
 
 
-def test_complicated_mul():
+ising_operators = {}
+ising_operators["Ising"] = nk.operator.Ising
+ising_operators["Ising Jax"] = nk.operator.IsingJax
+
+
+@pytest.mark.parametrize(
+    "Op", [pytest.param(op, id=name) for name, op in ising_operators.items()]
+)
+def test_complicated_mul(Op):
     # If this test fails probably we are tripping the reordering
     L = 5  # 10
     g = nk.graph.Hypercube(length=L, n_dim=1, pbc=True)
     hi = nk.hilbert.Spin(s=1 / 2, N=g.n_nodes)
 
-    ha = nk.operator.Ising(hi, graph=g, h=0.4)
+    ha = Op(hi, graph=g, h=0.4)
 
     assert np.allclose(ha.to_dense(), ha.to_local_operator().to_dense())
     assert np.allclose(ha.to_dense() @ ha.to_dense(), (ha @ ha).to_dense())

--- a/test/operator/test_operator.py
+++ b/test/operator/test_operator.py
@@ -10,6 +10,7 @@ operators = {}
 g = nk.graph.Hypercube(length=20, n_dim=1, pbc=True)
 hi = nk.hilbert.Spin(s=0.5, N=g.n_nodes)
 operators["Ising 1D"] = nk.operator.Ising(hi, g, h=1.321)
+operators["Ising 1D Jax"] = nk.operator.IsingJax(hi, g, h=1.321)
 
 # Heisenberg 1D
 g = nk.graph.Hypercube(length=20, n_dim=1, pbc=True)

--- a/test/sampler/test_sampler.py
+++ b/test/sampler/test_sampler.py
@@ -93,6 +93,12 @@ samplers["Metropolis(Hamiltonian,Numpy): Spin"] = nk.sampler.MetropolisHamiltoni
     reset_chains=True,
 )
 
+ha_jax = nk.operator.IsingJax(hilbert=hi, graph=g, h=1.0)
+
+samplers["Metropolis(HamiltonianRuleJax): Spin"] = nk.sampler.MetropolisSampler(
+    hi, reset_chains=True, rule=nk.sampler.rules.HamiltonianRuleJax(ha_jax)
+)
+
 samplers["Metropolis(Custom: Sx): Spin"] = nk.sampler.MetropolisCustom(
     hi, move_operators=move_op
 )

--- a/test/stats/test_stats.py
+++ b/test/stats/test_stats.py
@@ -40,7 +40,7 @@ def local_value_kernel(logpsi, pars, σ, σp, mel):
 
 
 def local_values(logpsi, variables, Ô, σ):
-    σp, mels = Ô.get_conn_padded(np.asarray(σ).reshape((-1, σ.shape[-1])))
+    σp, mels = Ô.get_conn_padded(σ.reshape((-1, σ.shape[-1])))
     loc_vals = local_value_kernel(
         logpsi, variables, σ.reshape((-1, σ.shape[-1])), σp, mels
     )


### PR DESCRIPTION
Currently the operators are written using numba  for the very valid reason that the array shapes (number of connected elements) are in general data-dependent which is something not (yet?) supported by jax.
These operators can only be evaluated on the cpu, and are called either outside of a jax jit block or via numba4jax which has some overhead.

This PR adds a Ising operator with padding written in jax and a branchless, jax-jittable MetropolisSampler (I wanted some way to test the operator...) that runs fully on the gpu.

For Paulistrings the same can also be done easily (apart from the constructor).  