### PR TITLE
Add support for k-nearest neighbor edges in `Lattice`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### New features
 
+* In addition to nearest-neighbor edges, `Lattice` can now generate edges between next-nearest and, more generally, k-nearest neighbors via the constructor argument `max_neighbor_order`. The edges can be distinguished by their `color` property (which is used, e.g., by `GraphOperator` to apply different bond operators). [#970](https://github.com/netket/netket/pull/970)
+
 ### Breaking Changes
 
 ### Internal Changes

--- a/netket/graph/common_lattices.py
+++ b/netket/graph/common_lattices.py
@@ -65,6 +65,7 @@ def Grid(
     *,
     length: Sequence[int] = None,
     pbc: Union[bool, Sequence[bool]] = True,
+    **kwargs,
 ) -> Lattice:
     """
     Constructs a hypercubic lattice given its extent in all dimensions.
@@ -77,6 +78,8 @@ def Grid(
              This parameter can also be a list of booleans with same length as
              the parameter `length`, in which case each dimension will have
              PBC/OBC depending on the corresponding entry of `pbc`.
+        kwargs: Additional keyword arguments are passed on to the constructor of
+            :ref:`netket.graph.Lattice`.
 
     Examples:
         Construct a 5x10 square lattice with periodic boundary conditions:
@@ -118,10 +121,11 @@ def Grid(
         extent=extent,
         pbc=pbc,
         point_group=lambda: _grid_point_group(extent, pbc),
+        **kwargs,
     )
 
 
-def Hypercube(length: int, n_dim: int = 1, *, pbc: bool = True) -> Lattice:
+def Hypercube(length: int, n_dim: int = 1, *, pbc: bool = True, **kwargs) -> Lattice:
     r"""Constructs a hypercubic lattice with equal side length in all dimensions.
     Periodic boundary conditions can also be imposed.
 
@@ -130,6 +134,8 @@ def Hypercube(length: int, n_dim: int = 1, *, pbc: bool = True) -> Lattice:
         n_dim: Dimension of the hypercube; must be at least 1.
         pbc: Whether the hypercube should have periodic boundary conditions
             (in all directions)
+        kwargs: Additional keyword arguments are passed on to the constructor of
+            :ref:`netket.graph.Lattice`.
 
     Examples:
          A 10x10x10 cubic lattice with periodic boundary conditions can be
@@ -143,10 +149,10 @@ def Hypercube(length: int, n_dim: int = 1, *, pbc: bool = True) -> Lattice:
     if not isinstance(length, int) or length <= 0:
         raise TypeError("Argument `length` must be a positive integer")
     length_vector = [length] * n_dim
-    return Grid(length_vector, pbc=pbc)
+    return Grid(length_vector, pbc=pbc, **kwargs)
 
 
-def Cube(length: int, *, pbc: bool = True) -> Lattice:
+def Cube(length: int, *, pbc: bool = True, **kwargs) -> Lattice:
     """Constructs a cubic lattice of side `length`
     Periodic boundary conditions can also be imposed
 
@@ -154,6 +160,8 @@ def Cube(length: int, *, pbc: bool = True) -> Lattice:
         length: Side length of the cube; must always be >=1
         pbc: Whether the cube should have periodic boundary conditions
             (in all directions)
+        kwargs: Additional keyword arguments are passed on to the constructor of
+            :ref:`netket.graph.Lattice`.
 
     Examples:
         A 10×10×10 cubic lattice with periodic boundary conditions can be
@@ -164,10 +172,10 @@ def Cube(length: int, *, pbc: bool = True) -> Lattice:
         >>> print(g.n_nodes)
         1000
     """
-    return Hypercube(length, pbc=pbc, n_dim=3)
+    return Hypercube(length, pbc=pbc, n_dim=3, **kwargs)
 
 
-def Square(length: int, *, pbc: bool = True) -> Lattice:
+def Square(length: int, *, pbc: bool = True, **kwargs) -> Lattice:
     """Constructs a square lattice of side `length`
     Periodic boundary conditions can also be imposed
 
@@ -175,6 +183,8 @@ def Square(length: int, *, pbc: bool = True) -> Lattice:
         length: Side length of the square; must always be >=1
         pbc: Whether the square should have periodic boundary
             conditions (in both directions)
+        kwargs: Additional keyword arguments are passed on to the constructor of
+            :ref:`netket.graph.Lattice`.
 
     Examples:
         A 10x10 square lattice with periodic boundary conditions can be
@@ -185,16 +195,18 @@ def Square(length: int, *, pbc: bool = True) -> Lattice:
         >>> print(g.n_nodes)
         100
     """
-    return Hypercube(length, pbc=pbc, n_dim=2)
+    return Hypercube(length, pbc=pbc, n_dim=2, **kwargs)
 
 
-def Chain(length: int, *, pbc: bool = True) -> Lattice:
+def Chain(length: int, *, pbc: bool = True, **kwargs) -> Lattice:
     r"""Constructs a chain of `length` sites.
     Periodic boundary conditions can also be imposed
 
     Args:
         length: Length of the chain. It must always be >=1
         pbc: Whether the chain should have periodic boundary conditions
+        kwargs: Additional keyword arguments are passed on to the constructor of
+            :ref:`netket.graph.Lattice`.
 
     Examples:
         A 10 site chain with periodic boundary conditions can be
@@ -205,7 +217,7 @@ def Chain(length: int, *, pbc: bool = True) -> Lattice:
         >>> print(g.n_nodes)
         10
     """
-    return Hypercube(length, pbc=pbc, n_dim=1)
+    return Hypercube(length, pbc=pbc, n_dim=1, **kwargs)
 
 
 def BCC(extent: Sequence[int], *, pbc: Union[bool, Sequence[bool]] = True) -> Lattice:

--- a/netket/graph/lattice.py
+++ b/netket/graph/lattice.py
@@ -104,6 +104,11 @@ def create_sites(
 
 
 def get_edges(positions, cutoff, order):
+    """
+    Given an array of spatial `positions`, returns a list `es`, so that
+    `es[k]` contains all pairs of (k + 1)-nearest neighbors up to `order`.
+    Only edges up to distance `cutoff` are considered.
+    """
     kdtree = cKDTree(positions)
     dist_matrix = kdtree.sparse_distance_matrix(kdtree, cutoff)
     row, col, dst = find(triu(dist_matrix))
@@ -255,7 +260,7 @@ class Lattice(Graph):
             max_neighbor_order: For :code:`max_neighbor_order == k`, edges between up
                 to :math:`k`-nearest neighbor sites (measured by their Euclidean distance)
                 are included in the graph. The edges can be distiguished by their color,
-                which is set to :math:`k`.
+                which is set to :math:`k - 1` (so nearest-neighbor edges have color 0).
 
         Examples:
             Constructs a Kagome lattice with 3 × 3 unit cells:

--- a/test/graph/test_graph.py
+++ b/test/graph/test_graph.py
@@ -134,20 +134,12 @@ def test_lattice_graphs(i, name):
     assert graph.n_edges == graph.n_nodes * coordination_number[i] // 2
 
 
-# netket#743 : multiple edges and self-loops in lattice
-@pytest.mark.parametrize(
-    "size,n_nodes,n_edges",
-    zip(
-        [[1], [2, 1], [3, 2]],
-        [1, 2, 6],
-        [0, 1, 9],
-    ),
-)
-def test_no_redundant_edges(size, n_nodes, n_edges):
-    g = Grid(size)
+# netket#743 : multiple edges
+def test_no_redundant_edges():
+    g = Grid([3, 2])
     print(g.edges())
-    assert g.n_nodes == n_nodes
-    assert g.n_edges == n_edges
+    assert g.n_nodes == 6
+    assert g.n_edges == 9
 
 
 @pytest.mark.parametrize("g", graphs + symmetric_graphs)

--- a/test/graph/test_graph.py
+++ b/test/graph/test_graph.py
@@ -734,3 +734,20 @@ def test_graph_conversions():
 def test_edge_colors():
     for g in graphs:
         assert all(isinstance(c, int) for c in g.edge_colors)
+
+
+def test_lattice_k_neighbors():
+    l0 = nk.graph.Chain(8, max_neighbor_order=1)
+    l1 = nk.graph.Chain(8, max_neighbor_order=2)
+    l2 = nk.graph.Chain(8, max_neighbor_order=3)
+
+    colors = set(c for *_, c in l1.edges(return_color=True))
+    assert colors == {0, 1}
+    colors = set(c for *_, c in l2.edges(return_color=True))
+    assert colors == {0, 1, 2}
+
+    assert set(l0.edges()) == set(l1.edges(filter_color=0))
+    assert set(l0.edges()) == set(l2.edges(filter_color=0))
+    assert set(l1.edges(filter_color=1)) == set(l2.edges(filter_color=1))
+
+    assert l0.n_edges < l1.n_edges < l2.n_edges

--- a/test/graph/test_graph.py
+++ b/test/graph/test_graph.py
@@ -751,3 +751,15 @@ def test_lattice_k_neighbors():
     assert set(l1.edges(filter_color=1)) == set(l2.edges(filter_color=1))
 
     assert l0.n_edges < l1.n_edges < l2.n_edges
+
+    with pytest.raises(RuntimeError, match="Lattice contains self-referential edge"):
+        nk.graph.Chain(length=3, max_neighbor_order=3)
+
+    for k in range(1, 11):
+        assert nk.graph.Chain(100, max_neighbor_order=k).n_edges == 100 * k
+
+    assert nk.graph.Square(10, pbc=True, max_neighbor_order=2).n_edges == 400
+
+    g = nk.graph.Square(10, pbc=True, max_neighbor_order=2)
+    assert len(g.edges(filter_color=0)) == 200
+    assert len(g.edges(filter_color=1)) == 200


### PR DESCRIPTION
This PR adds support for adding edges beyond nearest neighbors to `Lattice`. The edges are distinguished by color, i.e., an edge between _k_-th nearest neighbors has color _k_.

For example, this
```python
>>> g = Square(4, max_neighbor_order=2, pbc=False)
>>> g.draw()
```
gives you the following lattice:
![Figure_1](https://user-images.githubusercontent.com/4601206/140394421-6170fe98-9dd6-41e3-8342-fcbd7ce6fbbd.png)
and the edges are colored by _k_:
```python
>>> g.edges(return_color=True)
[(0, 1, 0),
 (0, 4, 0),
 (1, 2, 0),
...
 (0, 5, 1),
 (1, 4, 1),
 (1, 6, 1),
 ...
 (11, 14, 1)]
```

The benefit of this method is that it makes it very easy to use `GraphOperator` to implement different couplings depending on the distance. If separate graphs for the different distances are needed, this can be done by extracting the edges:
```python
>>> # next nearest neighbor graph
>>> g_nnn = Graph(edges=g.edges(filter_color=1))
```

This should work correctly with and without PBC. I can add some tests if everyone agrees with the general design.