### PR TITLE
Add support for coloured graphs to `Heisenberg`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 [GitHub commits](https://github.com/netket/netket/compare/v3.0...master).
 
 ### New features
+* `Heisenberg` Hamiltonians support different coupling strengths on `Graph` edges with different colors. [#972](https://github.com/netket/netket/pull/972).
 
 ### Breaking Changes
 

--- a/netket/operator/_hamiltonian.py
+++ b/netket/operator/_hamiltonian.py
@@ -16,6 +16,8 @@ from numba import jit
 
 import numpy as np
 import math
+from typing import Union, Sequence
+#from collections.abc import Sequence
 
 from netket.graph import AbstractGraph, Graph
 from netket.hilbert import AbstractHilbert, Fock
@@ -363,7 +365,7 @@ class Heisenberg(GraphOperator):
         self,
         hilbert: AbstractHilbert,
         graph: AbstractGraph,
-        J: float = 1,
+        J: Union[float, Sequence[float]] = 1.0,
         sign_rule=None,
     ):
         """
@@ -374,11 +376,15 @@ class Heisenberg(GraphOperator):
             hilbert: Hilbert space the operator acts on.
             graph: The graph upon which this hamiltonian is defined.
             J: The strength of the coupling. Default is 1.
-            sign_rule: If enabled, Marshal's sign rule will be used. On a bipartite
+               Can pass a sequence of coupling strengths with coloured graphs:
+               edges of colour n will have coupling strength J[n]
+            sign_rule: If True, Marshal's sign rule will be used. On a bipartite
                        lattice, this corresponds to a basis change flipping the Sz direction
                        at every odd site of the lattice. For non-bipartite lattices, the
                        sign rule cannot be applied. Defaults to True if the lattice is
                        bipartite, False otherwise.
+                       If a sequence of coupling strengths is passed, defaults to False
+                       and a matching sequence of sign_rule must be specified to override it
 
         Examples:
          Constructs a ``Heisenberg`` operator for a 1D system.
@@ -390,8 +396,24 @@ class Heisenberg(GraphOperator):
             >>> print(op)
             Heisenberg(J=1, sign_rule=True; dim=20)
         """
-        if sign_rule is None:
-            sign_rule = graph.is_bipartite()
+        if isinstance(J, Sequence):
+            # check that the number of Js matches the number of colours
+            assert len(J) == max(graph.edge_colors)+1
+
+            if sign_rule is None:
+                sign_rule = [False] * len(J)
+            else:
+                assert len(sign_rule) == len(J)
+                for i in range(len(J)):
+                    subgraph = Graph(edges=graph.edges(filter_color=i))
+                    if sign_rule[i] and not subgraph.is_bipartite():
+                        raise ValueError("sign_rule=True specified for a non-bipartite lattice")
+        else:
+            if sign_rule is None:
+                sign_rule = graph.is_bipartite()
+            elif sign_rule and not graph.is_bipartite():
+                raise ValueError("sign_rule=True specified for a non-bipartite lattice")
+                
 
         self._J = J
         self._sign_rule = sign_rule
@@ -412,18 +434,25 @@ class Heisenberg(GraphOperator):
                 [0, 0, 0, 0],
             ]
         )
-        if sign_rule:
-            if not graph.is_bipartite():
-                raise ValueError("sign_rule=True specified for a non-bipartite lattice")
-            heis_term = sz_sz - exchange
-        else:
-            heis_term = sz_sz + exchange
 
-        super().__init__(
-            hilbert,
-            graph,
-            bond_ops=[J * heis_term],
-        )
+        if isinstance(J, Sequence):
+            super().__init__(
+                hilbert,
+                graph,
+                bond_ops=[J[i] * (sz_sz - exchange if sign_rule[i] else sz_sz + exchange) for i in range(len(J))],
+                bond_ops_colors = list(range(len(J)))
+            )
+        else:
+            if sign_rule:
+                heis_term = sz_sz - exchange
+            else:
+                heis_term = sz_sz + exchange
+                
+            super().__init__(
+                hilbert,
+                graph,
+                bond_ops=[J * heis_term],
+            )
 
     @property
     def J(self) -> float:

--- a/netket/operator/_hamiltonian.py
+++ b/netket/operator/_hamiltonian.py
@@ -17,7 +17,8 @@ from numba import jit
 import numpy as np
 import math
 from typing import Union, Sequence
-#from collections.abc import Sequence
+
+# from collections.abc import Sequence
 
 from netket.graph import AbstractGraph, Graph
 from netket.hilbert import AbstractHilbert, Fock
@@ -394,11 +395,11 @@ class Heisenberg(GraphOperator):
             >>> hi = nk.hilbert.Spin(s=0.5, total_sz=0, N=g.n_nodes)
             >>> op = nk.operator.Heisenberg(hilbert=hi, graph=g)
             >>> print(op)
-            Heisenberg(J=1, sign_rule=True; dim=20)
+            Heisenberg(J=1.0, sign_rule=True; dim=20)
         """
         if isinstance(J, Sequence):
             # check that the number of Js matches the number of colours
-            assert len(J) == max(graph.edge_colors)+1
+            assert len(J) == max(graph.edge_colors) + 1
 
             if sign_rule is None:
                 sign_rule = [False] * len(J)
@@ -407,13 +408,14 @@ class Heisenberg(GraphOperator):
                 for i in range(len(J)):
                     subgraph = Graph(edges=graph.edges(filter_color=i))
                     if sign_rule[i] and not subgraph.is_bipartite():
-                        raise ValueError("sign_rule=True specified for a non-bipartite lattice")
+                        raise ValueError(
+                            "sign_rule=True specified for a non-bipartite lattice"
+                        )
         else:
             if sign_rule is None:
                 sign_rule = graph.is_bipartite()
             elif sign_rule and not graph.is_bipartite():
                 raise ValueError("sign_rule=True specified for a non-bipartite lattice")
-                
 
         self._J = J
         self._sign_rule = sign_rule
@@ -439,15 +441,18 @@ class Heisenberg(GraphOperator):
             super().__init__(
                 hilbert,
                 graph,
-                bond_ops=[J[i] * (sz_sz - exchange if sign_rule[i] else sz_sz + exchange) for i in range(len(J))],
-                bond_ops_colors = list(range(len(J)))
+                bond_ops=[
+                    J[i] * (sz_sz - exchange if sign_rule[i] else sz_sz + exchange)
+                    for i in range(len(J))
+                ],
+                bond_ops_colors=list(range(len(J))),
             )
         else:
             if sign_rule:
                 heis_term = sz_sz - exchange
             else:
                 heis_term = sz_sz + exchange
-                
+
             super().__init__(
                 hilbert,
                 graph,

--- a/netket/operator/_hamiltonian.py
+++ b/netket/operator/_hamiltonian.py
@@ -18,8 +18,6 @@ import numpy as np
 import math
 from typing import Union, Sequence
 
-# from collections.abc import Sequence
-
 from netket.graph import AbstractGraph, Graph
 from netket.hilbert import AbstractHilbert, Fock
 from netket.utils.types import DType

--- a/netket/operator/_hamiltonian.py
+++ b/netket/operator/_hamiltonian.py
@@ -436,26 +436,18 @@ class Heisenberg(GraphOperator):
         )
 
         if isinstance(J, Sequence):
-            super().__init__(
-                hilbert,
-                graph,
-                bond_ops=[
-                    J[i] * (sz_sz - exchange if sign_rule[i] else sz_sz + exchange)
-                    for i in range(len(J))
-                ],
-                bond_ops_colors=list(range(len(J))),
-            )
+            bond_ops = [
+                J[i] * (sz_sz - exchange if sign_rule[i] else sz_sz + exchange)
+                for i in range(len(J))
+            ]
+            bond_ops_colors = list(range(len(J)))
         else:
-            if sign_rule:
-                heis_term = sz_sz - exchange
-            else:
-                heis_term = sz_sz + exchange
+            bond_ops = [J * (sz_sz - exchange if sign_rule else sz_sz + exchange)]
+            bond_ops_colors = []
 
-            super().__init__(
-                hilbert,
-                graph,
-                bond_ops=[J * heis_term],
-            )
+        super().__init__(
+            hilbert, graph, bond_ops=bond_ops, bond_ops_colors=bond_ops_colors
+        )
 
     @property
     def J(self) -> float:

--- a/test/operator/test_operator.py
+++ b/test/operator/test_operator.py
@@ -45,6 +45,9 @@ operators["Graph Hamiltonian (colored edges)"] = nk.operator.GraphOperator(
     bond_ops_colors=[0, 1],
 )
 
+# Heisenberg with colored edges
+operators["Heisenberg (colored edges)"] = nk.operator.Heisenberg(hi, g, J = [1,2], sign_rule=[True,False])
+
 # Custom Hamiltonian
 sx = [[0, 1], [1, 0]]
 sy = [[0, -1.0j], [1.0j, 0]]

--- a/test/operator/test_operator.py
+++ b/test/operator/test_operator.py
@@ -46,7 +46,9 @@ operators["Graph Hamiltonian (colored edges)"] = nk.operator.GraphOperator(
 )
 
 # Heisenberg with colored edges
-operators["Heisenberg (colored edges)"] = nk.operator.Heisenberg(hi, g, J = [1,2], sign_rule=[True,False])
+operators["Heisenberg (colored edges)"] = nk.operator.Heisenberg(
+    hi, g, J=[1, 2], sign_rule=[True, False]
+)
 
 # Custom Hamiltonian
 sx = [[0, 1], [1, 0]]

--- a/test/operator/test_operator.py
+++ b/test/operator/test_operator.py
@@ -250,6 +250,17 @@ def test_Heisenberg():
 
         nk.operator.Heisenberg(hi, graph=g, sign_rule=True)
 
+    L = 8
+    edges = [(i, (i + 1) % L, 0) for i in range(L)] + [
+        (i, (i + 2) % L, 1) for i in range(L)
+    ]
+    hi = nk.hilbert.Spin(0.5) ** L
+    g = nk.graph.Graph(edges=edges)
+    ha1 = nk.operator.Heisenberg(hi, graph=g, J=[1, 0.5])
+    ha2 = nk.operator.Heisenberg(hi, graph=g, J=[1, 0.5], sign_rule=[True, False])
+
+    assert gs_energy(ha1) == pytest.approx(gs_energy(ha2))
+
 
 @pytest.mark.parametrize(
     "hilbert",


### PR DESCRIPTION
This PR allows to use `Heisenberg` operators on coloured graphs, using a different J and sign-rule policy on edges with different colours, so it can be used with #970 easily.

The original calling sequence is still valid. In addition, `J` can be a list with as many elements as colours in the graph: the first element is used for colour 0, etc. By default, there are no sign rules, but a `sign_rule` list can be passed (must have the same length as `J`).