### PR TITLE
Fix warning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     url="http://github.com/netket/netket",
     author_email="netket@netket.org",
     license="Apache 2.0",
-    summmary="Netket : Machine Learning techniques for many-body quantum systems.",
+    description="Netket : Machine Learning techniques for many-body quantum systems.",
     long_description="""NetKet is an open-source project delivering cutting-edge
          methods for the study of many-body quantum systems with artificial
          neural networks and machine learning techniques.""",


### PR DESCRIPTION
In `setup.py` we specify `summary` but that is not a valid string. It should be `summary` (as we have `long_summary` below.)
I have seen pip install complaining for a while now, so i'm just fixing it.