### PR TITLE
No brackets around wave vectors in `little_group` and `space_group_irreps`

### DIFF
--- a/netket/graph/space_group.py
+++ b/netket/graph/space_group.py
@@ -196,13 +196,13 @@ class SpaceGroupBuilder:
         is_in_little_group = np.all(big_star == big_star[0], axis=1)
         return np.arange(len(self.point_group_))[is_in_little_group]
 
-    def little_group(self, k: Array) -> PointGroup:
+    def little_group(self, *k) -> PointGroup:
         """
         Returns the little co-group corresponding to wave vector *k*.
         This is the subgroup of the point group that leaves *k* invariant.
 
         Arguments:
-            k: the wave vector in Cartesian axes
+            *k: components of the wave vector in Cartesian axes
 
         Returns:
             the little co-group as a `PointGroup`
@@ -221,18 +221,18 @@ class SpaceGroupBuilder:
         This is convenient when calculating space group irreps.
         """
         idx = self._little_group_index(k)
-        CT = self.little_group(k).character_table()
+        CT = self.little_group(*k).character_table()
         CT_full = np.zeros((CT.shape[0], len(self.point_group_)))
         CT_full[:, idx] = CT
         return CT_full / idx.size if divide else CT_full
 
-    def space_group_irreps(self, k: Array) -> Array:
+    def space_group_irreps(self, *k) -> Array:
         """
         Returns the portion of the character table of the full space group corresponding
         to the star of the wave vector *k*.
 
         Arguments:
-            k: the wave vector in Cartesian axes
+            *k: components of the wave vector in Cartesian axes
 
         Returns:
             An array `CT` listing the characters for a number of irreps of the

--- a/test/graph/test_graph.py
+++ b/test/graph/test_graph.py
@@ -119,7 +119,7 @@ coordination_number = [4, 6, 3, 4, 6, 8, 12, 4, 6]
 
 dimension = [2, 2, 2, 2, 3, 3, 3, 3, 3]
 
-kvec = [[2 * pi / 3, 0]] + [[4 * pi / 3, 0]] * 3 + [[4 * pi / 3, 0, 0]] * 5
+kvec = [(2 * pi / 3, 0)] + [(4 * pi / 3, 0)] * 3 + [(4 * pi / 3, 0, 0)] * 5
 
 little_group_size = [2] + [6] * 3 + [8] * 5
 
@@ -263,14 +263,14 @@ def test_lattice_symmetry(i, name):
 
     # Try an invalid wave vector and fail
     with pytest.raises(_lattice.InvalidWaveVectorError):
-        _ = sgb.little_group([1] * dimension[i])
+        _ = sgb.little_group(*((1,) * dimension[i]))
 
     # The little group of Γ is the full point group
-    assert sgb.little_group(np.zeros(dimension[i])) == sgb.point_group_
+    assert sgb.little_group(*((0,) * dimension[i])) == sgb.point_group_
 
     # Generate little groups and their irreps
-    assert len(sgb.little_group(kvec[i])) == little_group_size[i]
-    irrep_from_lg = sgb.space_group_irreps(kvec[i])
+    assert len(sgb.little_group(*kvec[i])) == little_group_size[i]
+    irrep_from_lg = sgb.space_group_irreps(*kvec[i])
     irrep_from_sg = sgb.space_group.character_table()
     for irrep in irrep_from_lg:
         assert np.any(np.all(np.isclose(irrep, irrep_from_sg), axis=1))


### PR DESCRIPTION
Does what it says on the tin: write `spacegroupbuilder.little_group(pi,0)` instead of `little_group([pi,0])`, and the same for `space_group_irreps`. I didn't change the calling sequence of the private methods, for that is more convenient for writing the implementation. Solves https://github.com/netket/netket/issues/898