### PR TITLE
Change `jax.experimental.stax` to `jax.example_libraries.stax` (JAX 0.2.25)

### DIFF
--- a/Tutorials/jax.ipynb
+++ b/Tutorials/jax.ipynb
@@ -98,7 +98,7 @@
    "outputs": [],
    "source": [
     "import jax\n",
-    "from jax.experimental import stax\n",
+    "from jax.example_libraries import stax\n",
     "\n",
     "#We define a custom layer that performs the sum of its inputs \n",
     "def SumLayer():\n",

--- a/Tutorials/jax.ipynb
+++ b/Tutorials/jax.ipynb
@@ -99,6 +99,8 @@
    "source": [
     "import jax\n",
     "from jax.example_libraries import stax\n",
+    "# NOTE: for JAX version prior to 0.2.25, use the following import instead:\n",
+    "# from jax.experimental import stax\n",
     "\n",
     "#We define a custom layer that performs the sum of its inputs \n",
     "def SumLayer():\n",

--- a/Tutorials/jax.ipynb
+++ b/Tutorials/jax.ipynb
@@ -88,7 +88,7 @@
    "source": [
     "## Defining a JAX module to be used as a wave function\n",
     "\n",
-    "We now want to define a suitable JAX wave function to be used as a wave function ansatz. To simplify the discusssion, we consider here a simple single-layer fully connected network with complex weights and a $tanh$ activation function. These are easy to define in JAX, using for example a model built with [STAX](https://github.com/google/jax/tree/master/jax/experimental). The only requirement is that these networks take as  inputs JAX arrays of shape ```(batch_size,n)```, where batch_size is an arbitrary ```batch size``` and ```n``` is the number of quantum degrees of freedom (for example, the number of spins, in the previous example). Notice that regardless of the dimensionality of the problem, the last dimension is always flattened into a single index.  \n"
+    "We now want to define a suitable JAX wave function to be used as a wave function ansatz. To simplify the discusssion, we consider here a simple single-layer fully connected network with complex weights and a $tanh$ activation function. These are easy to define in JAX, using for example a model built with [`stax`](https://jax.readthedocs.io/en/latest/jax.example_libraries.stax.html). The only requirement is that these networks take as  inputs JAX arrays of shape ```(batch_size,n)```, where batch_size is an arbitrary ```batch size``` and ```n``` is the number of quantum degrees of freedom (for example, the number of spins, in the previous example). Notice that regardless of the dimensionality of the problem, the last dimension is always flattened into a single index.  \n"
    ]
   },
   {

--- a/docs/docs/custom_models.rst
+++ b/docs/docs/custom_models.rst
@@ -14,7 +14,7 @@ some examples.
 The 3 frameworks that are supported are:
 
 * `Flax Linen API <https://flax.readthedocs.io/en/latest/examples.html>`_, which is an easy-to-use framework to define complex neural networks
-* `Barebone Jax/Stax <https://jax.readthedocs.io/en/latest/jax.experimental.stax.html>`_, which is an experimental module of jax.
+* `Barebone `stax` <https://jax.readthedocs.io/en/latest/jax.example_libraries.stax.html>`_, which is an example module included with JAX.
 * `Haiku <https://github.com/deepmind/dm-haiku>`_, which is a competitor to Flax, and offers somewhat equivalent expressivity with a rather different syntax.
 
 

--- a/docs/docs/getting_started.rst
+++ b/docs/docs/getting_started.rst
@@ -75,7 +75,7 @@ Jax/Flax extensions
 Netket v3 API is centered around `flax <https://flax.readthedocs.io>`_, a jax library to simplify the definition and
 usage of Neural-Networks. 
 If you want to define more complex custom models, you should read Flax documentation on how to define a Linen module.
-However, you can also use :code:`jax.stax` or `haiku <https://github.com/deepmind/dm-haiku>`_.
+However, you can also use :code:`jax.example_libraries.stax` or `haiku <https://github.com/deepmind/dm-haiku>`_.
 
 Flax supports complex numbers but does not make it overly easy to work with them.
 As such, netket exports a module, `netket.nn` which re-exports the functionality in `flax.nn`, but 

--- a/docs/docs/sharp-bits.rst
+++ b/docs/docs/sharp-bits.rst
@@ -89,7 +89,7 @@ If you find NaNs while training, especially if you are using your own model, the
  
 * It might simply be a precision issue, as you might be using single precision (:code:`np.float32`, :code:`np.complex64`) instead of double precision (:code:`np.float64`, :code:`np.complex128`). Be careful that if you use :code:`float` and :code:`complex` as dtype, they will not always behave as you expect! 
   They are known as `weak dtypes <https://jax.readthedocs.io/en/latest/type_promotion.html?highlight=type-promotion>`_, and when multiplied by a single-precision number they will be converted to single precision. 
-  This issue might manifest especially when using Flax, which respects type promotion, as opposed to `jax.experimental.stax`, which does not.
+  This issue might manifest especially when using Flax, which respects type promotion, as opposed to `jax.example_libraries.stax`, which does not.
 
 * Check the initial parameters. In the NetKet 2 models were always initialized with weights normally distributed.
   In Netket 3, `netket.nn` layers use the same default (normal distribution with standard deviation 0.01) but


### PR DESCRIPTION
This updates our references to `stax`, which has been moved to `jax.example_libraries.stax` in the latest JAX release (see #981).