### PR TITLE
fix `VMC.info()` error

### DIFF
--- a/netket/driver/vmc.py
+++ b/netket/driver/vmc.py
@@ -163,10 +163,10 @@ class VMC(AbstractVariationalDriver):
         lines = [
             "{}: {}".format(name, info(obj, depth=depth + 1))
             for name, obj in [
-                ("Hamiltonian ", self._ham),
-                ("Optimizer   ", self._optimizer),
-                ("SR solver   ", self.sr),
-                ("State       ", self.state),
+                ("Hamiltonian    ", self._ham),
+                ("Optimizer      ", self._optimizer),
+                ("Preconditioner ", self.preconditioner),
+                ("State          ", self.state),
             ]
         ]
         return "\n{}".format(" " * 3 * (depth + 1)).join([str(self)] + lines)

--- a/netket/driver/vmc_common.py
+++ b/netket/driver/vmc_common.py
@@ -14,7 +14,7 @@
 
 
 def info(obj, depth=None):
-    if hasattr(obj, "info()"):
+    if hasattr(obj, "info") and callable(obj.info):
         return obj.info(depth)
     else:
         return str(obj)

--- a/netket/driver/vmc_common.py
+++ b/netket/driver/vmc_common.py
@@ -14,7 +14,7 @@
 
 
 def info(obj, depth=None):
-    if hasattr(obj, "info"):
+    if hasattr(obj, "info()"):
         return obj.info(depth)
     else:
         return str(obj)


### PR DESCRIPTION
Solves #983 by renaming `self.sr` to `self.preconditioner`.

Also fixes an error in the function `info(obj, depth=None)` when `obj` has an attribute `info` which is not a method.