### PR TITLE
Deprecate AbstractOperator.size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Breaking Changes
 * Moved `nk.vqs.variables_from_***` to `nk.experimental.vqs` module. Also moved the experimental samplers to `nk.sampler.MetropolisPt` and `nk.sampler.MetropolisPmap` to `nk.experimental.sampler`. [#976](https://github.com/netket/netket/pull/976)
+* `operator.size`, has been deprecated. If you were using this function, please transition to `operator.hilbert.size`. [#985](https://github.com/netket/netket/pull/985)
 
 ### Internal Changes
 

--- a/netket/operator/_abstract_operator.py
+++ b/netket/operator/_abstract_operator.py
@@ -15,6 +15,7 @@
 import abc
 
 from netket.utils.types import DType
+from netket.utils import deprecated
 
 from netket.hilbert import AbstractHilbert
 
@@ -35,7 +36,9 @@ class AbstractOperator(abc.ABC):
         r"""The hilbert space associated to this operator."""
         return self._hilbert
 
+    # TODO: eventually remove this
     @property
+    @deprecated(reason="Please use `operator.hilbert.size` instead.")
     def size(self) -> int:
         r"""The total number number of local degrees of freedom."""
         return self._hilbert.size
@@ -64,7 +67,6 @@ class AbstractOperator(abc.ABC):
     @abc.abstractmethod
     def dtype(self) -> DType:
         """The dtype of the operator's matrix elements ⟨σ|Ô|σ'⟩."""
-        raise NotImplementedError
 
     def collect(self) -> "AbstractOperator":
         """

--- a/netket/operator/_discrete_operator.py
+++ b/netket/operator/_discrete_operator.py
@@ -78,7 +78,6 @@ class DiscreteOperator(AbstractOperator):
             array: An array containing the matrix elements :math:`O(x,x')` associated to each x'.
 
         """
-        raise NotImplementedError()
 
     def get_conn(self, x: np.ndarray):
         r"""Finds the connected elements of the Operator. Starting


### PR DESCRIPTION
It calls `operator.hilbert.size`, saving only 7 characters so I think it makes no sense to keep it in the interface.

It was there only for backwards compatibility reasons.

I think we can start warning a bit so in the future we can delete it.