### PR TITLE
Symmetries in RBMSymm can (must) be HashableArrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * `operator.size`, has been deprecated. If you were using this function, please transition to `operator.hilbert.size`. [#985](https://github.com/netket/netket/pull/985)
 
 ### Internal Changes
+* The `DenseSymm` layer checks if the provided `symmetries` is a `HashableArray`. If not, it tries to make it a `HashableArray`. [#989](https://github.com/netket/netket/pull/989)
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,9 @@
 * `operator.size`, has been deprecated. If you were using this function, please transition to `operator.hilbert.size`. [#985](https://github.com/netket/netket/pull/985)
 
 ### Internal Changes
-* The `DenseSymm` layer now also accepts objects of type `HashableArray` as `symmetries` argument. [#989](https://github.com/netket/netket/pull/989)
 
 ### Bug Fixes
+* The `DenseSymm` layer now also accepts objects of type `HashableArray` as `symmetries` argument. [#989](https://github.com/netket/netket/pull/989)
 
 
 ## NetKet 3.1 (20 October 2021)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 * `operator.size`, has been deprecated. If you were using this function, please transition to `operator.hilbert.size`. [#985](https://github.com/netket/netket/pull/985)
 
 ### Internal Changes
-* The `DenseSymm` layer checks if the provided `symmetries` is a `HashableArray`. If not, it tries to make it a `HashableArray`. [#989](https://github.com/netket/netket/pull/989)
+* The `DenseSymm` layer now also accepts objects of type `HashableArray` as `symmetries` argument. [#989](https://github.com/netket/netket/pull/989)
 
 ### Bug Fixes
 

--- a/netket/nn/symmetric_linear.py
+++ b/netket/nn/symmetric_linear.py
@@ -712,7 +712,7 @@ def DenseSymm(symmetries, point_group=None, mode="auto", shape=None, **kwargs):
                 "in order to construct the space group"
             )
         sym = HashableArray(np.asarray(symmetries.automorphisms()))
-    elif isinstance(symmetries, PermutationGroup) or hasattr(symmetries, "__len__"):
+    elif isinstance(symmetries, (PermutationGroup, Sequence)):
         sym = HashableArray(np.asarray(symmetries))
     elif isinstance(symmetries, HashableArray):
         sym = symmetries

--- a/netket/nn/symmetric_linear.py
+++ b/netket/nn/symmetric_linear.py
@@ -678,7 +678,7 @@ def DenseSymm(symmetries, point_group=None, mode="auto", shape=None, **kwargs):
 
     Args:
         symmetries: A specification of the symmetry group. Can be given by a
-            nk.graph.Graph, a nk.utils.PermuationGroup, or an array [n_symm, n_sites]
+            nk.graph.Graph, a nk.utils.PermuationGroup, or a HashableArray [n_symm, n_sites]
             specifying the permutations corresponding to symmetry transformations
             of the lattice.
         point_group: The point group, from which the space group is built.
@@ -698,7 +698,6 @@ def DenseSymm(symmetries, point_group=None, mode="auto", shape=None, **kwargs):
         kernel_init: Optional kernel initialization function. Defaults to variance scaling.
         bias_init: Optional bias initialization function. Defaults to zero initialization.
     """
-
     if isinstance(symmetries, Lattice) and (
         point_group is not None or symmetries._point_group is not None
     ):
@@ -715,6 +714,8 @@ def DenseSymm(symmetries, point_group=None, mode="auto", shape=None, **kwargs):
         sym = HashableArray(np.asarray(symmetries.automorphisms()))
     elif isinstance(symmetries, PermutationGroup) or hasattr(symmetries, "__len__"):
         sym = HashableArray(np.asarray(symmetries))
+    elif isinstance(symmetries, HashableArray):
+        sym = symmetries
     else:
         raise ValueError(
             "Symmetries must be specified as a Graph, PermutationGroup or Array"

--- a/netket/nn/symmetric_linear.py
+++ b/netket/nn/symmetric_linear.py
@@ -712,7 +712,7 @@ def DenseSymm(symmetries, point_group=None, mode="auto", shape=None, **kwargs):
                 "in order to construct the space group"
             )
         sym = HashableArray(np.asarray(symmetries.automorphisms()))
-    elif isinstance(symmetries, (PermutationGroup, Sequence)):
+    elif isinstance(symmetries, (PermutationGroup, Array, Sequence)):
         sym = HashableArray(np.asarray(symmetries))
     elif isinstance(symmetries, HashableArray):
         sym = symmetries

--- a/netket/nn/symmetric_linear.py
+++ b/netket/nn/symmetric_linear.py
@@ -678,7 +678,8 @@ def DenseSymm(symmetries, point_group=None, mode="auto", shape=None, **kwargs):
 
     Args:
         symmetries: A specification of the symmetry group. Can be given by a
-            nk.graph.Graph, a nk.utils.PermuationGroup, or a HashableArray [n_symm, n_sites]
+            nk.graph.Graph, a nk.utils.PermuationGroup, or an array that is either
+            hashable: HashableArray [n_symm, n_sites], or can be made hashable,
             specifying the permutations corresponding to symmetry transformations
             of the lattice.
         point_group: The point group, from which the space group is built.
@@ -712,14 +713,10 @@ def DenseSymm(symmetries, point_group=None, mode="auto", shape=None, **kwargs):
                 "in order to construct the space group"
             )
         sym = HashableArray(np.asarray(symmetries.automorphisms()))
-    elif isinstance(symmetries, (PermutationGroup, Array, Sequence)):
-        sym = HashableArray(np.asarray(symmetries))
     elif isinstance(symmetries, HashableArray):
         sym = symmetries
     else:
-        raise ValueError(
-            "Symmetries must be specified as a Graph, PermutationGroup or Array"
-        )
+        sym = HashableArray(np.asarray(symmetries))
 
     if mode == "fft":
         if shape is None:


### PR DESCRIPTION
When passing symmetries to `RBMSymm` as a custom array containing index permutations, the type of `symmetries` is `np.ndarray`, which is non-hashable. Thus, `nk.jax.HashablePartial` raises a hashing error when trying to hash the arguments of the `RBMSymm` model. However, when passing symmetries to `RBMSymm` as a `nk.utils.HashableArray`, the logic in the `nk.nn.DenseSymm` function does not recognise the symmetries. This PR fixes this. However, it is an ugly fix.

What I would like to do is for `RBMSymm` to initialise automatically the `RBMSymm.symmetries` attribute to be a `HashableArray`, even if the user passes a `np.ndarray`. We can't do this conversion in the `setup` method of `RBMSymm` because `setup` is like a lazy init, thus not fixing the problem. If you come up with a way to do this, I think it's a much nicer solution than what I'm offering in this PR.