### PR TITLE
Capping random numbers for filtering in CustomRuleNumpy transition

### DIFF
--- a/netket/sampler/rules/custom_numpy.py
+++ b/netket/sampler/rules/custom_numpy.py
@@ -72,7 +72,7 @@ class CustomRuleNumpy(MetropolisRule):
         # numba does not support jitting np.random number generators
         # so we have to generate the random numbers outside the jit
         # block
-        filters = rng.integers(0, len(rule.weight_list), size=σ.shape[0])
+        filters = rng.choice(len(rule.weight_list), size=σ.shape[0], p=rule.weight_list)
         σ_conns, mels = rule.operator.get_conn_filtered(
             state.σ, rule_state.sections, filters
         )

--- a/netket/sampler/rules/custom_numpy.py
+++ b/netket/sampler/rules/custom_numpy.py
@@ -93,15 +93,6 @@ class CustomRuleNumpy(MetropolisRule):
 
 
 @jit(nopython=True)
-def _pick_random_and_init(batch_size, move_cumulative, rnd_uniform, out):
-    for i in range(batch_size):
-        p = rnd_uniform[i]
-        out[i] = np.searchsorted(move_cumulative, p)
-
-    # return out
-
-
-@jit(nopython=True)
 def _choose_and_return(σp, x_prime, mels, sections, log_prob_corr, rnd_uniform):
     low = 0
     for i in range(σp.shape[0]):

--- a/netket/sampler/rules/custom_numpy.py
+++ b/netket/sampler/rules/custom_numpy.py
@@ -68,7 +68,7 @@ class CustomRuleNumpy(MetropolisRule):
         return CustomRuleState(
             sections=np.empty(sampler.n_batches, dtype=np.int32),
             rand_op_n=np.empty(sampler.n_batches, dtype=np.int32),
-            weight_cumsum=cum_weights / cum_weights[-1],
+            weight_cumsum=cum_weights,
         )
 
     def transition(rule, sampler, machine, parameters, state, rng, σ):

--- a/netket/sampler/rules/custom_numpy.py
+++ b/netket/sampler/rules/custom_numpy.py
@@ -108,7 +108,7 @@ class CustomRuleNumpy(MetropolisRule):
 @jit(nopython=True)
 def _pick_random_and_init(batch_size, move_cumulative, rnd_uniform, out):
     for i in range(batch_size):
-        p = rnd_uniform[i]
+        p = move_cumulative[-1] * (1 - rnd_uniform[i])
         out[i] = np.searchsorted(move_cumulative, p)
 
 

--- a/test/sampler/test_sampler.py
+++ b/test/sampler/test_sampler.py
@@ -29,8 +29,12 @@ from scipy.stats import (
     chisquare,
     multivariate_normal,
     kstest,
-    binomtest,
 )
+
+try:
+    from scipy.stats import binomtest
+except ImportError:
+    from scipy.stats import binom_test as binomtest
 import jax
 from jax.nn.initializers import normal
 

--- a/test/sampler/test_sampler.py
+++ b/test/sampler/test_sampler.py
@@ -447,4 +447,4 @@ def test_custom_metropolis_sampler(model_and_weights):
     for i, n in enumerate(number_of_flips):
         p = move_weights[i]
         pval = binomtest(int(n), n_trials, p).pvalue
-        assert pval < 0.05
+        assert pval > 0.01  # , str(p) + " " + str(n) + " " + str(n_trials)

--- a/test/sampler/test_sampler.py
+++ b/test/sampler/test_sampler.py
@@ -442,7 +442,7 @@ def test_custom_metropolis_sampler(model_and_weights):
         ma, w, state=sampler_state, chain_length=n_samples
     )
     samples_diffs = np.abs(np.diff(samples, axis=0)) / 2
-    number_of_flips = np.sum(np.sum(samples_diffs, axis=0), axis=0)
+    number_of_flips = np.sum(samples_diffs, axis=(0, 1))
     n_trials = samples_diffs.shape[0] * samples_diffs.shape[1]
     for i, n in enumerate(number_of_flips):
         p = move_weights[i]

--- a/test/sampler/test_sampler.py
+++ b/test/sampler/test_sampler.py
@@ -59,7 +59,7 @@ g = nk.graph.Hypercube(length=4, n_dim=1)
 hi = nk.hilbert.Spin(s=0.5, N=g.n_nodes)
 ha = nk.operator.Ising(hilbert=hi, graph=g, h=1.0)
 move_op = sum([nk.operator.spin.sigmax(hi, i) for i in range(hi.size)])
-move_weights = np.array([2 ** i for i in range(hi.size)])
+move_weights = np.random.rand(hi.size)
 move_weights = move_weights / move_weights.sum()
 
 hi_spin1 = nk.hilbert.Spin(s=1, N=g.n_nodes)
@@ -441,6 +441,6 @@ def test_custom_metropolis_sampler(model_and_weights):
     number_of_flips = np.sum(np.sum(samples_diffs, axis=0), axis=0)
     n_trials = samples_diffs.shape[0] * samples_diffs.shape[1]
     for i, n in enumerate(number_of_flips):
-        p = 2 ** i / 15
+        p = move_weights[i]
         pval = binomtest(int(n), n_trials, p).pvalue
         assert pval < 0.05

--- a/test/sampler/test_sampler.py
+++ b/test/sampler/test_sampler.py
@@ -31,6 +31,8 @@ from scipy.stats import (
     kstest,
 )
 
+# TODO: Remove fallback. 
+# `binom_test` is deprecated in favour of `binomtest` and will be removed in SciPy 1.9
 try:
     from scipy.stats import binomtest
 except ImportError:


### PR DESCRIPTION
When using the `MetropolisCustom` sampler, the `CustomRuleNumpy` makes transitions based on the move operators passed to `MetropolisCustom`. This makes use of the operator's `get_conn_filtered` method, for which a list `filters` has to be provided. At the moment, this is done by the `_pick_random_and_init` function which works like this:

```python
@jit(nopython=True)
def _pick_random_and_init(batch_size, move_cumulative, rnd_uniform, out):
    for i in range(batch_size):
        p = rnd_uniform[i]
        out[i] = np.searchsorted(move_cumulative, p)
```

Here `move_cumulative` is a monotonically increasing vector of numbers coming from an expression like `(weights/weights.sum()).cumsum()`. Thus, the maximum of this vector should be 1, and the `out` vector should be filled with indices between 0 and batch_size - 1, as `rnd_uniform` is a bunch of random numbers between 0 and 1. The only way for `np.searchsorted(move_cumulative, p)` to return `batch_size` is if `p=1`, which would be problematic, as `out` is the `filters` vector.

In practice, the maximum of `move_cumulative`, however, is 0.9999995. If we generate `rnd_uniform` between 0 and 1, there is a small chance that one of those numbers is greater than 0.9999995, which would lead to having a filter which is `batch_size`. This has happened to me:

```zsh
...
File "/Users/vladimirvargas/Documents/Projects/physics/netket/netket/sampler/rules/custom_numpy.py", line 93, in transition
    state.σ, rule_state.sections, rule_state.rand_op_n
  File "/Users/vladimirvargas/Documents/Projects/physics/netket/netket/operator/_local_operator.py", line 1043, in get_conn_filtered
    filters,
  File "/Users/vladimirvargas/Documents/Projects/physics/netket/netket/operator/_local_operator.py", line 1081, in _get_conn_filtered_kernel
    assert i < n_o
```

Thus, this PR fixes the way that `rnd_uniform` is generated, capping the upper bound of the random generator to the maximum value in `move_cumulative`.