### PR TITLE
Fix TensorHilbert of non-indexable spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### Internal Changes
 
 ### Bug Fixes
-
+* The constructor of `TensorHilbert` (which is used by the product operator `*` for inhomogeneous spaces) no longer fails when one of the component spaces is non-indexable. [#1004](https://github.com/netket/netket/pull/1004)
 
 ## NetKet 3.2 (26 November 2021)
 

--- a/netket/hilbert/discrete_hilbert.py
+++ b/netket/hilbert/discrete_hilbert.py
@@ -23,6 +23,15 @@ max_states = np.iinfo(np.int32).max
 """int: Maximum number of states that can be indexed"""
 
 
+def _is_indexable(shape):
+    """
+    Returns whether a discrete Hilbert space of shape `shape` is
+    indexable (i.e., its total number of states is below the maximum).
+    """
+    log_max = np.log(max_states)
+    return np.sum(np.log(shape)) <= log_max
+
+
 class NoneTypeT:
     pass
 
@@ -202,10 +211,7 @@ class DiscreteHilbert(AbstractHilbert):
         """Whever the space can be indexed with an integer"""
         if not self.is_finite:
             return False
-
-        log_max = np.log(max_states)
-
-        return np.sum(np.log(self.shape)) <= log_max
+        return _is_indexable(self.shape)
 
     def __mul__(self, other: "DiscreteHilbert"):
         if self == other:

--- a/netket/hilbert/tensor_hilbert.py
+++ b/netket/hilbert/tensor_hilbert.py
@@ -73,7 +73,6 @@ class TensorHilbert(DiscreteHilbert):
             )
             self._n_states = np.prod(self._ns_states)
 
-
         super().__init__(shape=shape)
 
     @property

--- a/netket/hilbert/tensor_hilbert.py
+++ b/netket/hilbert/tensor_hilbert.py
@@ -16,7 +16,7 @@ from typing import Optional, List, Union
 
 import numpy as np
 
-from .discrete_hilbert import DiscreteHilbert
+from .discrete_hilbert import DiscreteHilbert, _is_indexable
 
 
 # TODO: Make parametric class
@@ -55,23 +55,25 @@ class TensorHilbert(DiscreteHilbert):
         )
 
         self._sizes = tuple([hi.size for hi in hilb_spaces])
+        shape = np.concatenate([hi.shape for hi in hilb_spaces])
         self._cum_sizes = np.cumsum(self._sizes)
         self._cum_indices = np.concatenate([[0], self._cum_sizes])
         self._size = sum(self._sizes)
 
-        self._ns_states = [hi.n_states for hi in self._hilbert_spaces]
-        self._ns_states_r = np.flip(self._ns_states)
-        self._cum_ns_states = np.concatenate([[0], np.cumprod(self._ns_states)])
-        self._cum_ns_states_r = np.flip(
-            np.cumprod(np.concatenate([[1], np.flip(self._ns_states)]))[:-1]
-        )
-        self._n_states = np.prod(self._ns_states)
+        # pre-compute indexing data iff the tensor space is still indexable
+        if all(hi.is_indexable for hi in hilb_spaces) and _is_indexable(shape):
+            self._ns_states = [hi.n_states for hi in self._hilbert_spaces]
+            self._ns_states_r = np.flip(self._ns_states)
+            self._cum_ns_states = np.concatenate([[0], np.cumprod(self._ns_states)])
+            self._cum_ns_states_r = np.flip(
+                np.cumprod(np.concatenate([[1], np.flip(self._ns_states)]))[:-1]
+            )
+            self._n_states = np.prod(self._ns_states)
 
         self._delta_indices_i = np.array(
             [self._cum_indices[i] for i in self._hilbert_i]
         )
 
-        shape = np.concatenate([hi.shape for hi in hilb_spaces])
         super().__init__(shape=shape)
 
     @property
@@ -103,6 +105,8 @@ class TensorHilbert(DiscreteHilbert):
 
     @property
     def n_states(self) -> int:
+        if not self.is_indexable:
+            raise RuntimeError("The hilbert space is too large to be indexed.")
         return self._n_states
 
     def _numbers_to_states(self, numbers, out):

--- a/netket/hilbert/tensor_hilbert.py
+++ b/netket/hilbert/tensor_hilbert.py
@@ -59,6 +59,9 @@ class TensorHilbert(DiscreteHilbert):
         self._cum_sizes = np.cumsum(self._sizes)
         self._cum_indices = np.concatenate([[0], self._cum_sizes])
         self._size = sum(self._sizes)
+        self._delta_indices_i = np.array(
+            [self._cum_indices[i] for i in self._hilbert_i]
+        )
 
         # pre-compute indexing data iff the tensor space is still indexable
         if all(hi.is_indexable for hi in hilb_spaces) and _is_indexable(shape):
@@ -70,9 +73,6 @@ class TensorHilbert(DiscreteHilbert):
             )
             self._n_states = np.prod(self._ns_states)
 
-        self._delta_indices_i = np.array(
-            [self._cum_indices[i] for i in self._hilbert_i]
-        )
 
         super().__init__(shape=shape)
 

--- a/test/hilbert/test_hilbert.py
+++ b/test/hilbert/test_hilbert.py
@@ -197,12 +197,11 @@ def test_random_states_particle(hi):
     ) == jnp.sum(jnp.where(jnp.equal(boundary, True), 1, 0))
 
 
-@pytest.mark.parametrize("hi", homogeneous_hilbert_params)
-def test_flip_state_homogeneous(hi):
+@pytest.mark.parametrize("hi", discrete_hilbert_params)
+def test_flip_state_discrete(hi: DiscreteHilbert):
     rng = nk.jax.PRNGSeq(1)
     N_batches = 20
 
-    local_states = hi.local_states
     states = hi.random_state(rng.next(), N_batches)
 
     ids = jnp.asarray(
@@ -214,7 +213,8 @@ def test_flip_state_homogeneous(hi):
 
     assert new_states.shape == states.shape
 
-    assert np.all(np.in1d(new_states.reshape(-1), local_states))
+    for state in states:
+        assert all(val in hi.states_at_index(i) for i, val in enumerate(state))
 
     states_np = np.asarray(states)
     states_new_np = np.array(new_states)

--- a/test/hilbert/test_hilbert.py
+++ b/test/hilbert/test_hilbert.py
@@ -136,7 +136,7 @@ particle_hilbert_params = [
 # Tests
 #
 @pytest.mark.parametrize("hi", homogeneous_hilbert_params)
-def test_consistent_size_homogeneous(hi):
+def test_consistent_size_homogeneous(hi: HomogeneousHilbert):
     assert hi.size > 0
     assert hi.local_size > 0
     assert len(hi.local_states) == hi.local_size
@@ -145,14 +145,14 @@ def test_consistent_size_homogeneous(hi):
 
 
 @pytest.mark.parametrize("hi", particle_hilbert_params)
-def test_consistent_size_particle(hi):
+def test_consistent_size_particle(hi: Particle):
     assert hi.size > 0
     assert hi.n_particles > 0
     assert len(hi.extent) == (hi.size // hi.n_particles)
 
 
 @pytest.mark.parametrize("hi", discrete_hilbert_params)
-def test_random_states_discrete(hi):
+def test_random_states_discrete(hi: DiscreteHilbert):
     assert hi.random_state(jax.random.PRNGKey(13)).shape == (hi.size,)
     assert hi.random_state(jax.random.PRNGKey(13), dtype=np.float32).dtype == np.float32
     assert (
@@ -166,7 +166,7 @@ def test_random_states_discrete(hi):
 
 
 @pytest.mark.parametrize("hi", homogeneous_hilbert_params)
-def test_random_states_homogeneous(hi):
+def test_random_states_homogeneous(hi: HomogeneousHilbert):
     assert len(hi.local_states) == hi.local_size
     local_states = hi.local_states
     for i in range(100):
@@ -176,7 +176,7 @@ def test_random_states_homogeneous(hi):
 
 
 @pytest.mark.parametrize("hi", particle_hilbert_params)
-def test_random_states_particle(hi):
+def test_random_states_particle(hi: Particle):
     assert hi.random_state(jax.random.PRNGKey(13)).shape == (hi.size,)
     assert hi.random_state(jax.random.PRNGKey(13), dtype=np.float32).dtype == np.float32
     assert (
@@ -226,7 +226,7 @@ def test_flip_state_discrete(hi: DiscreteHilbert):
 
 
 @pytest.mark.parametrize("hi", discrete_hilbert_params)
-def test_hilbert_index_discrete(hi):
+def test_hilbert_index_discrete(hi: DiscreteHilbert):
     log_max_states = np.log(nk.hilbert._abstract_hilbert.max_states)
 
     if hi.is_indexable:

--- a/test/hilbert/test_hilbert.py
+++ b/test/hilbert/test_hilbert.py
@@ -17,13 +17,14 @@ import netket as nk
 import numpy as np
 import pytest
 from netket.hilbert import (
-    Spin,
-    Fock,
-    CustomHilbert,
-    Qubit,
-    DoubledHilbert,
     DiscreteHilbert,
+    HomogeneousHilbert,
     Particle,
+    CustomHilbert,
+    DoubledHilbert,
+    Fock,
+    Qubit,
+    Spin,
 )
 
 import jax
@@ -56,6 +57,10 @@ hilberts["Fock"] = Fock(n_max=5, N=41)
 
 # Boson with total number
 hilberts["Fock with total number"] = Fock(n_max=3, n_particles=110, N=120)
+
+# Composite Fock
+hilberts["Fock * Fock (indexable)"] = Fock(n_max=5, N=4) * Fock(n_max=7, N=4)
+hilberts["Fock * Fock (non-indexable)"] = Fock(n_max=4, N=40) * Fock(n_max=7, N=40)
 
 # Qubit
 hilberts["Qubit"] = nk.hilbert.Qubit(100)
@@ -109,148 +114,148 @@ hilberts["ContinuousSpaceHilbert"] = nk.hilbert.Particle(
     N=5, L=(np.inf, 10.0), pbc=(False, True)
 )
 
+all_hilbert_params = [pytest.param(hi, id=name) for name, hi in hilberts.items()]
+discrete_hilbert_params = [
+    pytest.param(hi, id=name)
+    for name, hi in hilberts.items()
+    if isinstance(hi, DiscreteHilbert)
+]
+homogeneous_hilbert_params = [
+    pytest.param(hi, id=name)
+    for name, hi in hilberts.items()
+    if isinstance(hi, HomogeneousHilbert)
+]
+particle_hilbert_params = [
+    pytest.param(hi, id=name)
+    for name, hi in hilberts.items()
+    if isinstance(hi, Particle)
+]
+
 
 #
 # Tests
 #
-@pytest.mark.parametrize(
-    "hi", [pytest.param(hi, id=name) for name, hi in hilberts.items()]
-)
-def test_consistent_size(hi):
+@pytest.mark.parametrize("hi", homogeneous_hilbert_params)
+def test_consistent_size_homogeneous(hi):
     assert hi.size > 0
-    if isinstance(hi, DiscreteHilbert):
-        assert hi.local_size > 0
-        assert len(hi.local_states) == hi.local_size
-        for state in hi.local_states:
-            assert np.isfinite(state).all()
-    elif isinstance(hi, Particle):
-        assert hi.n_particles > 0
-        assert len(hi.extent) == (hi.size // hi.n_particles)
+    assert hi.local_size > 0
+    assert len(hi.local_states) == hi.local_size
+    for state in hi.local_states:
+        assert np.isfinite(state).all()
 
 
-@pytest.mark.parametrize(
-    "hi", [pytest.param(hi, id=name) for name, hi in hilberts.items()]
-)
-def test_random_states(hi):
+@pytest.mark.parametrize("hi", particle_hilbert_params)
+def test_consistent_size_particle(hi):
     assert hi.size > 0
-
-    if isinstance(hi, DiscreteHilbert):
-        assert hi.local_size > 0
-        assert len(hi.local_states) == hi.local_size
-        local_states = hi.local_states
-        for i in range(100):
-            rstate = hi.random_state(jax.random.PRNGKey(i * 14))
-            for state in rstate:
-                assert state in local_states
-
-        assert hi.random_state(jax.random.PRNGKey(13)).shape == (hi.size,)
-        assert (
-            hi.random_state(jax.random.PRNGKey(13), dtype=np.float32).dtype
-            == np.float32
-        )
-        assert (
-            hi.random_state(jax.random.PRNGKey(13), dtype=np.complex64).dtype
-            == np.complex64
-        )
-        assert hi.random_state(jax.random.PRNGKey(13), 10).shape == (10, hi.size)
-        assert hi.random_state(jax.random.PRNGKey(13), size=10).shape == (10, hi.size)
-        # assert hi.random_state(jax.random.PRNGKey(13), size=(10,)).shape == (10, hi.size)
-        # assert hi.random_state(jax.random.PRNGKey(13), size=(10, 2)).shape == (10, 2, hi.size)
-
-    elif isinstance(hi, Particle):
-        assert hi.random_state(jax.random.PRNGKey(13)).shape == (hi.size,)
-        assert (
-            hi.random_state(jax.random.PRNGKey(13), dtype=np.float32).dtype
-            == np.float32
-        )
-        assert (
-            hi.random_state(jax.random.PRNGKey(13), dtype=np.complex64).dtype
-            == np.complex64
-        )
-        assert hi.random_state(jax.random.PRNGKey(13), 10).shape == (10, hi.size)
-        assert hi.random_state(jax.random.PRNGKey(13), size=10).shape == (10, hi.size)
-
-        # check that boundary conditions are fulfilled if any are given
-        state = hi.random_state(jax.random.PRNGKey(13))
-        boundary = jnp.array(hi.n_particles * hi.pbc)
-        Ls = jnp.array(hi.n_particles * hi.extent)
-        extension = jnp.where(jnp.equal(boundary, False), jnp.inf, Ls)
-
-        assert jnp.sum(
-            jnp.where(jnp.equal(boundary, True), state < extension, 0)
-        ) == jnp.sum(jnp.where(jnp.equal(boundary, True), 1, 0))
+    assert hi.n_particles > 0
+    assert len(hi.extent) == (hi.size // hi.n_particles)
 
 
-@pytest.mark.parametrize(
-    "hi", [pytest.param(hi, id=name) for name, hi in hilberts.items()]
-)
-def test_flip_state(hi):
+@pytest.mark.parametrize("hi", discrete_hilbert_params)
+def test_random_states_discrete(hi):
+    assert hi.random_state(jax.random.PRNGKey(13)).shape == (hi.size,)
+    assert hi.random_state(jax.random.PRNGKey(13), dtype=np.float32).dtype == np.float32
+    assert (
+        hi.random_state(jax.random.PRNGKey(13), dtype=np.complex64).dtype
+        == np.complex64
+    )
+    assert hi.random_state(jax.random.PRNGKey(13), 10).shape == (10, hi.size)
+    assert hi.random_state(jax.random.PRNGKey(13), size=10).shape == (10, hi.size)
+    # assert hi.random_state(jax.random.PRNGKey(13), size=(10,)).shape == (10, hi.size)
+    # assert hi.random_state(jax.random.PRNGKey(13), size=(10, 2)).shape == (10, 2, hi.size)
+
+
+@pytest.mark.parametrize("hi", homogeneous_hilbert_params)
+def test_random_states_homogeneous(hi):
+    assert len(hi.local_states) == hi.local_size
+    local_states = hi.local_states
+    for i in range(100):
+        rstate = hi.random_state(jax.random.PRNGKey(i * 14))
+        for state in rstate:
+            assert state in local_states
+
+
+@pytest.mark.parametrize("hi", particle_hilbert_params)
+def test_random_states_particle(hi):
+    assert hi.random_state(jax.random.PRNGKey(13)).shape == (hi.size,)
+    assert hi.random_state(jax.random.PRNGKey(13), dtype=np.float32).dtype == np.float32
+    assert (
+        hi.random_state(jax.random.PRNGKey(13), dtype=np.complex64).dtype
+        == np.complex64
+    )
+    assert hi.random_state(jax.random.PRNGKey(13), 10).shape == (10, hi.size)
+    assert hi.random_state(jax.random.PRNGKey(13), size=10).shape == (10, hi.size)
+
+    # check that boundary conditions are fulfilled if any are given
+    state = hi.random_state(jax.random.PRNGKey(13))
+    boundary = jnp.array(hi.n_particles * hi.pbc)
+    Ls = jnp.array(hi.n_particles * hi.extent)
+    extension = jnp.where(jnp.equal(boundary, False), jnp.inf, Ls)
+
+    assert jnp.sum(
+        jnp.where(jnp.equal(boundary, True), state < extension, 0)
+    ) == jnp.sum(jnp.where(jnp.equal(boundary, True), 1, 0))
+
+
+@pytest.mark.parametrize("hi", homogeneous_hilbert_params)
+def test_flip_state_homogeneous(hi):
     rng = nk.jax.PRNGSeq(1)
     N_batches = 20
-    if isinstance(hi, DiscreteHilbert):
-        local_states = hi.local_states
-        states = hi.random_state(rng.next(), N_batches)
 
-        ids = jnp.asarray(
-            jnp.floor(hi.size * jax.random.uniform(rng.next(), shape=(N_batches,))),
-            dtype=int,
-        )
+    local_states = hi.local_states
+    states = hi.random_state(rng.next(), N_batches)
 
-        new_states, old_vals = nk.hilbert.random.flip_state(hi, rng.next(), states, ids)
+    ids = jnp.asarray(
+        jnp.floor(hi.size * jax.random.uniform(rng.next(), shape=(N_batches,))),
+        dtype=int,
+    )
 
-        assert new_states.shape == states.shape
+    new_states, old_vals = nk.hilbert.random.flip_state(hi, rng.next(), states, ids)
 
-        assert np.all(np.in1d(new_states.reshape(-1), local_states))
+    assert new_states.shape == states.shape
 
-        states_np = np.asarray(states)
-        states_new_np = np.array(new_states)
+    assert np.all(np.in1d(new_states.reshape(-1), local_states))
 
-        for (row, col) in enumerate(ids):
-            states_new_np[row, col] = states_np[row, col]
+    states_np = np.asarray(states)
+    states_new_np = np.array(new_states)
 
-        np.testing.assert_allclose(states_np, states_new_np)
+    for (row, col) in enumerate(ids):
+        states_new_np[row, col] = states_np[row, col]
+
+    np.testing.assert_allclose(states_np, states_new_np)
 
 
-@pytest.mark.parametrize(
-    "hi", [pytest.param(hi, id=name) for name, hi in hilberts.items()]
-)
-def test_hilbert_index(hi):
-    assert hi.size > 0
-    if isinstance(hi, DiscreteHilbert):
-        assert hi.local_size > 0
+@pytest.mark.parametrize("hi", discrete_hilbert_params)
+def test_hilbert_index_discrete(hi):
+    log_max_states = np.log(nk.hilbert._abstract_hilbert.max_states)
 
-        log_max_states = np.log(nk.hilbert._abstract_hilbert.max_states)
+    if hi.is_indexable:
+        local_sizes = [hi.size_at_index(i) for i in range(hi.size)]
+        assert np.sum(np.log(local_sizes)) < log_max_states
+        assert np.allclose(hi.states_to_numbers(hi.all_states()), range(hi.n_states))
 
-        if hi.is_indexable:
-            assert hi.size * np.log(hi.local_size) < log_max_states
-            assert np.allclose(
-                hi.states_to_numbers(hi.all_states()), range(hi.n_states)
-            )
+        # batched version of number to state
+        n_few = min(hi.n_states, 100)
+        few_states = np.zeros(shape=(n_few, hi.size))
+        for k in range(n_few):
+            few_states[k] = hi.numbers_to_states(k)
 
-            # batched version of number to state
-            n_few = min(hi.n_states, 100)
-            few_states = np.zeros(shape=(n_few, hi.size))
-            for k in range(n_few):
-                few_states[k] = hi.numbers_to_states(k)
+        assert np.allclose(hi.numbers_to_states(np.asarray(range(n_few))), few_states)
 
-            assert np.allclose(
-                hi.numbers_to_states(np.asarray(range(n_few))), few_states
-            )
-
-        else:
-            assert not hi.is_indexable
-
-            with pytest.raises(RuntimeError):
-                hi.n_states
-
-        # Check that a large hilbert space raises error when constructing matrices
-        g = nk.graph.Hypercube(length=100, n_dim=1)
-        op = nk.operator.Heisenberg(hilbert=Spin(s=0.5, N=g.n_nodes), graph=g)
+    else:
+        assert not hi.is_indexable
 
         with pytest.raises(RuntimeError):
-            op.to_dense()
-        with pytest.raises(RuntimeError):
-            op.to_sparse()
+            hi.n_states
+
+    # Check that a large hilbert space raises error when constructing matrices
+    g = nk.graph.Hypercube(length=100, n_dim=1)
+    op = nk.operator.Heisenberg(hilbert=Spin(s=0.5, N=g.n_nodes), graph=g)
+
+    with pytest.raises(RuntimeError):
+        op.to_dense()
+    with pytest.raises(RuntimeError):
+        op.to_sparse()
 
 
 def test_state_iteration():
@@ -273,7 +278,7 @@ def test_deprecations():
             Spin(s=0.5, graph=g, N=3)
 
 
-def test_composite_hilbert():
+def test_composite_hilbert_spin():
     hi1 = Spin(s=1 / 2, N=8)
     hi2 = Spin(s=3 / 2, N=8)
 
@@ -283,3 +288,19 @@ def test_composite_hilbert():
 
     for i in range(hi.size):
         assert hi.size_at_index(i) == 2 if i < 8 else 4
+
+
+def test_inhomogeneous_fock():
+    hi1 = Fock(n_max=7, N=40)
+    hi2 = Fock(n_max=2, N=40)
+    hi = hi1 * hi2
+
+    assert hi.size == hi1.size + hi2.size
+
+    for i in range(0, 40):
+        assert hi.size_at_index(i) == 8
+        assert hi.states_at_index(i) == list(range(8))
+
+    for i in range(40, 80):
+        assert hi.size_at_index(i) == 3
+        assert hi.states_at_index(i) == list(range(3))


### PR DESCRIPTION
When creating a `TensorHilbert` from a sequence of component spaces, the constructor was failing when one of the component spaces was non-indexable:
```
>>> nk.hilbert.Fock(n_max=5, N=40) * nk.hilbert.Fock(n_max=7, N=40)
[...]
RuntimeError: The hilbert space is too large to be indexed.
```
This happened because the `TensorHilbert` was pre-computing several attributes that are only relevant if the composite space itself is indexable. This PR fixes the exception by performing the pre-computation only if the product space itself is indexable.

Corresponding tests are also added. This made it necessary to disentangle the tests for `DiscreteHilbert` and `HomogeneousHilbert` objects, which where previously treated as equivalent, causing the tests to fail for discrete but non-homogeneous product spaces.