### PR TITLE
Fix bugs in ContinuousOperator

### DIFF
--- a/netket/operator/_kinetic.py
+++ b/netket/operator/_kinetic.py
@@ -55,7 +55,6 @@ class KineticEnergy(ContinuousOperator):
     def is_hermitian(self):
         return self._is_hermitian
 
-    @partial(jax.vmap, in_axes=(None, None, None, 0, None))
     def _expect_kernel(
         self, logpsi: Callable, params: PyTree, x: Array, mass: Optional[PyTree]
     ):
@@ -72,6 +71,12 @@ class KineticEnergy(ContinuousOperator):
         dp_dx = dlogpsi_x(x) ** 2
 
         return -0.5 * jnp.sum(mass * (dp_dx2 + dp_dx), axis=-1)
+
+    @partial(jax.vmap, in_axes=(None, None, None, 0, None))
+    def _expect_kernel_batched(
+        self, logpsi: Callable, params: PyTree, x: Array, coefficient: Optional[PyTree]
+    ):
+        return self._expect_kernel(logpsi, params, x, coefficient)
 
     def _pack_arguments(self) -> PyTree:
         return 1.0 / self._mass

--- a/netket/operator/_kinetic.py
+++ b/netket/operator/_kinetic.py
@@ -44,7 +44,7 @@ class KineticEnergy(ContinuousOperator):
         self._mass = jnp.asarray(mass, dtype=dtype)
 
         self._is_hermitian = np.allclose(self._mass.imag, 0.0)
-        
+
         super().__init__(hilbert, self._mass.dtype)
 
     @property

--- a/netket/operator/_potential.py
+++ b/netket/operator/_potential.py
@@ -47,11 +47,16 @@ class PotentialEnergy(ContinuousOperator):
 
         super().__init__(hilbert, self.coefficient.dtype)
 
-    @partial(jax.vmap, in_axes=(None, None, None, 0, None))
     def _expect_kernel(
         self, logpsi: Callable, params: PyTree, x: Array, coefficient: Optional[PyTree]
     ):
         return coefficient * self._afun(x)
+
+    @partial(jax.vmap, in_axes=(None, None, None, 0, None))
+    def _expect_kernel_batched(
+        self, logpsi: Callable, params: PyTree, x: Array, coefficient: Optional[PyTree]
+    ):
+        return self._expect_kernel(logpsi, params, x, coefficient)
 
     @property
     def is_hermitian(self):

--- a/netket/operator/_potential.py
+++ b/netket/operator/_potential.py
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from typing import Optional, Callable
+from functools import partial
 
 from netket.utils.types import DType, PyTree, Array
 
 from netket.hilbert import AbstractHilbert
 from netket.operator import ContinuousOperator
 
+import jax
 import jax.numpy as jnp
 
 
@@ -45,10 +47,15 @@ class PotentialEnergy(ContinuousOperator):
 
         super().__init__(hilbert, self.coefficient.dtype)
 
+    @partial(jax.vmap, in_axes=(None, None, None, 0, None))
     def _expect_kernel(
         self, logpsi: Callable, params: PyTree, x: Array, coefficient: Optional[PyTree]
     ):
         return coefficient * self._afun(x)
+
+    @property
+    def is_hermitian(self):
+        return True
 
     def _pack_arguments(self):
         return self.coefficient

--- a/netket/operator/_sumoperators.py
+++ b/netket/operator/_sumoperators.py
@@ -74,6 +74,16 @@ class SumOperator(ContinuousOperator):
 
         return sum(result)
 
+    def _expect_kernel_batched(
+        self, logpsi: Callable, params: PyTree, x: Array, data: Optional[PyTree]
+    ):
+        result = [
+            op._expect_kernel_batched(logpsi, params, x, data[i])
+            for i, op in enumerate(self._ops)
+        ]
+
+        return sum(result)
+
     def _pack_arguments(self):
         return [self._coeff * jnp.array(op._pack_arguments()) for op in self._ops]
 

--- a/netket/operator/_sumoperators.py
+++ b/netket/operator/_sumoperators.py
@@ -58,6 +58,12 @@ class SumOperator(ContinuousOperator):
 
         super().__init__(hil[0], self._dtype)
 
+        self._is_hermitian = all([op.is_hermitian for op in operators])
+
+    @property
+    def is_hermitian(self):
+        return self._is_hermitian
+
     def _expect_kernel(
         self, logpsi: Callable, params: PyTree, x: Array, data: Optional[PyTree]
     ):

--- a/netket/vqs/mc/mc_state/expect.py
+++ b/netket/vqs/mc/mc_state/expect.py
@@ -83,7 +83,7 @@ def get_local_kernel_arguments(vstate: MCState, Ô: ContinuousOperator):
 @dispatch
 def get_local_kernel(vstate: MCState, Ô: ContinuousOperator):
     # TODO: this should be moved other to dispatch in order to support MCMixedState
-    return Ô._expect_kernel
+    return Ô._expect_kernel_batched
 
 
 # Standard implementation of expect for an MCState (pure) and a generic operator

--- a/netket/vqs/mc/mc_state/expect_grad.py
+++ b/netket/vqs/mc/mc_state/expect_grad.py
@@ -74,6 +74,7 @@ def expect_and_grad(  # noqa: F811
 # pure state, squared operator
 @dispatch.multi(
     (MCState, Squared[DiscreteOperator], TrueT, Any),
+    (MCState, Squared[AbstractOperator], TrueT, Any),
     (MCState, DiscreteOperator, FalseT, Any),
 )
 def expect_and_grad(

--- a/netket/vqs/mc/mc_state/expect_grad.py
+++ b/netket/vqs/mc/mc_state/expect_grad.py
@@ -28,6 +28,7 @@ from netket.utils.types import PyTree
 from netket.utils.dispatch import dispatch, TrueT, FalseT
 
 from netket.operator import (
+    AbstractOperator,
     DiscreteOperator,
     AbstractSuperOperator,
     Squared,
@@ -47,7 +48,7 @@ from .state import MCState
 @dispatch
 def expect_and_grad(  # noqa: F811
     vstate: MCState,
-    Ô: DiscreteOperator,
+    Ô: AbstractOperator,
     use_covariance: TrueT,
     mutable: Any,
 ) -> Tuple[Stats, PyTree]:
@@ -69,30 +70,6 @@ def expect_and_grad(  # noqa: F811
         vstate.model_state = new_model_state
 
     return Ō, Ō_grad
-
-
-@dispatch
-def expect_and_grad(  # noqa: F811
-    vstate: MCState,
-    Ô: ContinuousOperator,
-    use_covariance: Any,
-    mutable: Any,
-) -> Tuple[Stats, PyTree]:
-    σ, args = get_local_kernel_arguments(vstate, Ô)
-
-    local_estimator_fun = get_local_kernel(vstate, Ô)
-
-    Ō, Ō_grad = _grad_expect_continuous(
-        local_estimator_fun,
-        vstate._apply_fun,
-        vstate.parameters,
-        vstate.model_state,
-        σ,
-        args,
-    )
-
-    return Ō, Ō_grad
-
 
 # pure state, squared operator
 @dispatch.multi(
@@ -248,60 +225,3 @@ def grad_expect_operator_kernel(
         jax.tree_map(lambda x: mpi.mpi_mean_jax(x)[0], Ō_pars_grad),
         model_state,
     )
-
-
-@partial(jax.jit, static_argnums=(0, 1))
-def _grad_expect_continuous(
-    local_estimator_fun: Callable,
-    model_apply_fun: Callable,
-    parameters: PyTree,
-    model_state: PyTree,
-    x: jnp.ndarray,
-    additional_data: PyTree,
-) -> Tuple[PyTree, PyTree]:
-
-    x_shape = x.shape
-    if jnp.ndim(x) != 2:
-        x = x.reshape((-1, x_shape[-1]))
-
-    n_samples = x.shape[0] * mpi.n_nodes
-
-    def logpsi(w, σ):
-        return model_apply_fun({"params": w, **model_state}, σ)
-
-    # local_value_vmap = jax.vmap(
-    #    partial(local_estimator_fun, logpsi),
-    #    in_axes=(None, 0, None),
-    #    out_axes=0,
-    # )
-    # TODO: Once batching/chunking is implemented, should be made available here too.
-    x = x.reshape((-1, 1, x_shape[-1]))
-
-    def compute_kernel(i, x):
-        Oloc = local_estimator_fun(logpsi, parameters, x, additional_data)
-        return i, Oloc
-
-    _, O_loc = jax.lax.scan(compute_kernel, 0, x)
-    O_loc = O_loc.reshape(-1)
-
-    Ō = statistics(O_loc.reshape(x_shape[:-1]).T)
-    x = x.reshape((-1, x_shape[-1]))
-    O_loc -= Ō.mean
-
-    _, vjp_fun = nkjax.vjp(
-        lambda w: model_apply_fun({"params": w}, x),
-        parameters,
-        conjugate=False,
-    )
-
-    Ō_grad = vjp_fun(jnp.conjugate(O_loc) / n_samples)[0]
-
-    Ō_grad = jax.tree_multimap(
-        lambda x, target: (x if jnp.iscomplexobj(target) else x.real).astype(
-            target.dtype
-        ),
-        Ō_grad,
-        parameters,
-    )
-
-    return Ō, jax.tree_map(lambda x: mpi.mpi_sum_jax(x)[0], Ō_grad)

--- a/netket/vqs/mc/mc_state/expect_grad.py
+++ b/netket/vqs/mc/mc_state/expect_grad.py
@@ -71,6 +71,7 @@ def expect_and_grad(  # noqa: F811
 
     return Ō, Ō_grad
 
+
 # pure state, squared operator
 @dispatch.multi(
     (MCState, Squared[DiscreteOperator], TrueT, Any),

--- a/test/operator/test_continuous_operator.py
+++ b/test/operator/test_continuous_operator.py
@@ -43,8 +43,8 @@ kinexact = lambda x: -0.5 * jnp.sum((3 * x ** 2) ** 2 + 6 * x, axis=-1)
 
 def test_potential_energy():
     x = jnp.zeros((1, 1))
-    energy1 = pot1._expect_kernel(model1, None, x, pot1._pack_arguments())
-    energy2 = pot2._expect_kernel(model1, None, x, pot2._pack_arguments())
+    energy1 = pot1._expect_kernel_batched(model1, None, x, pot1._pack_arguments())
+    energy2 = pot2._expect_kernel_batched(model1, None, x, pot2._pack_arguments())
     np.testing.assert_allclose(energy1, v1(x))
     np.testing.assert_allclose(energy2, v2_vec(x))
     with np.testing.assert_raises(NotImplementedError):
@@ -53,7 +53,7 @@ def test_potential_energy():
 
 def test_kinetic_energy():
     x = jnp.array([[1, 2, 3], [1, 2, 3]], dtype=float)
-    energy1 = kin1._expect_kernel(model2, 0.0, x, kin1._pack_arguments())
+    energy1 = kin1._expect_kernel_batched(model2, 0.0, x, kin1._pack_arguments())
     kinen1 = kinexact(x) / kin1.mass
     np.testing.assert_allclose(energy1, kinen1)
     np.testing.assert_allclose(kin1.mass * kin1._pack_arguments(), 1.0)
@@ -62,20 +62,24 @@ def test_kinetic_energy():
 
 def test_sumoperator():
     x = jnp.array([[1, 2, 3], [1, 2, 3]], dtype=float)
-    potenergy = pottot._expect_kernel(model2, 0.0, x, pottot._pack_arguments())
-    energy10p52 = pot10p52._expect_kernel(model2, 0.0, x, pot10p52._pack_arguments())
+    potenergy = pottot._expect_kernel_batched(model2, 0.0, x, pottot._pack_arguments())
+    energy10p52 = pot10p52._expect_kernel_batched(
+        model2, 0.0, x, pot10p52._pack_arguments()
+    )
 
     np.testing.assert_allclose(potenergy, v1(x) + v2_vec(x))
     np.testing.assert_allclose(energy10p52, v1(x) + 0.5 * v2_vec(x))
 
-    kinenergy = kintot._expect_kernel(model2, 0.0, x, kintot._pack_arguments())
+    kinenergy = kintot._expect_kernel_batched(model2, 0.0, x, kintot._pack_arguments())
     kinenergyex = kinexact(x) / kin1.mass + kinexact(x) / kin2.mass
     np.testing.assert_allclose(kinenergy, kinenergyex)
 
-    kinen10p52 = kin10p52._expect_kernel(model2, 0.0, x, kin10p52._pack_arguments())
+    kinen10p52 = kin10p52._expect_kernel_batched(
+        model2, 0.0, x, kin10p52._pack_arguments()
+    )
     kinenergy10p52ex = kinexact(x) / kin1.mass + 0.5 * kinexact(x) / kin2.mass
     np.testing.assert_allclose(kinen10p52, kinenergy10p52ex)
 
-    enertot = etot._expect_kernel(model2, 0.0, x, etot._pack_arguments())
+    enertot = etot._expect_kernel_batched(model2, 0.0, x, etot._pack_arguments())
     enerexact = v1(x) + v2_vec(x) + kinexact(x) / kin1.mass + kinexact(x) / kin2.mass
     np.testing.assert_allclose(enertot, enerexact)

--- a/test/operator/test_continuous_operator.py
+++ b/test/operator/test_continuous_operator.py
@@ -5,11 +5,14 @@ import jax.numpy as jnp
 
 import netket
 
+
 def v1(x):
     return jnp.sum(jnp.exp(-(x ** 2)), axis=-1)
 
+
 def v2(x):
     return jnp.sum(2.0 * jnp.exp(-(x ** 2)))
+
 
 v2_vec = jax.vmap(v2)
 
@@ -39,7 +42,7 @@ kinexact = lambda x: -0.5 * jnp.sum((3 * x ** 2) ** 2 + 6 * x, axis=-1)
 
 
 def test_potential_energy():
-    x = jnp.zeros((1,1))
+    x = jnp.zeros((1, 1))
     energy1 = pot1._expect_kernel(model1, None, x, pot1._pack_arguments())
     energy2 = pot2._expect_kernel(model1, None, x, pot2._pack_arguments())
     np.testing.assert_allclose(energy1, v1(x))

--- a/test/operator/test_continuous_operator.py
+++ b/test/operator/test_continuous_operator.py
@@ -13,6 +13,7 @@ def v1(x):
 def v2(x):
     return jnp.sum(2.0 * jnp.exp(-(x ** 2)))
 
+
 v2_vec = jax.vmap(v2)
 
 
@@ -44,7 +45,6 @@ model2 = lambda p, x: jnp.sum(x ** 3)
 kinexact = lambda x: -0.5 * jnp.sum((3 * x ** 2) ** 2 + 6 * x, axis=-1)
 
 
-
 def test_is_hermitean():
     epot = netket.operator.PotentialEnergy(hilb, v1)
     ekin = netket.operator.KineticEnergy(hilb, mass=20.0)
@@ -60,6 +60,7 @@ def test_is_hermitean():
 
     etot = epot + ekin
     assert not etot.is_hermitian
+
 
 def test_potential_energy():
     x = jnp.zeros((1, 1))

--- a/test/operator/test_continuous_operator.py
+++ b/test/operator/test_continuous_operator.py
@@ -13,15 +13,17 @@ def v1(x):
 def v2(x):
     return jnp.sum(2.0 * jnp.exp(-(x ** 2)))
 
-
 v2_vec = jax.vmap(v2)
+
 
 hilb = netket.hilbert.Particle(N=1, L=jnp.inf, pbc=False)
 hilb2 = netket.hilbert.Particle(N=2, L=5.0, pbc=True)
+
 # potential operators
 pot1 = netket.operator.PotentialEnergy(hilb, v1)
 pot2 = netket.operator.PotentialEnergy(hilb, v2)
 pot3 = netket.operator.PotentialEnergy(hilb2, v1)
+
 # sum of potential operators
 pottot = pot1 + pot2
 pot10p52 = pot1 + 0.5 * pot2
@@ -29,6 +31,7 @@ pot10p52 = pot1 + 0.5 * pot2
 # kinetic operators
 kin1 = netket.operator.KineticEnergy(hilb, mass=20.0)
 kin2 = netket.operator.KineticEnergy(hilb, mass=2.0)
+
 # sum of kinetic operators
 kintot = kin1 + kin2
 kin10p52 = kin1 + 0.5 * kin2
@@ -40,6 +43,23 @@ model1 = lambda p, x: 1.0
 model2 = lambda p, x: jnp.sum(x ** 3)
 kinexact = lambda x: -0.5 * jnp.sum((3 * x ** 2) ** 2 + 6 * x, axis=-1)
 
+
+
+def test_is_hermitean():
+    epot = netket.operator.PotentialEnergy(hilb, v1)
+    ekin = netket.operator.KineticEnergy(hilb, mass=20.0)
+    etot = epot + ekin
+
+    assert epot.is_hermitian
+    assert ekin.is_hermitian
+    assert etot.is_hermitian
+
+    ekin = netket.operator.KineticEnergy(hilb, mass=20.0j)
+    np.testing.assert_allclose(ekin.mass, 20.0j)
+    assert not ekin.is_hermitian
+
+    etot = epot + ekin
+    assert not etot.is_hermitian
 
 def test_potential_energy():
     x = jnp.zeros((1, 1))


### PR DESCRIPTION
In the last big PR I had assumed that the potential energy function of ContinuousOperators shuold be a vector, but that was not the case.
Now `Potential` should work both with functions that return a scalar and a vector.

Also makes this enables `Squared[ContinuousOperator]` to work.

Also removes the rudimentary chunking that @gpescia had implemented for continuous operators in order to use the new one