### PR TITLE
Add time evolution driver with jax-based ODE solver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@
 * Chunking of `MCState.expect` and `MCState.expect_and_grad` computations is now supported, which allows to bound the memory cost in exchange of a minor increase in computation time. [#1006](https://github.com/netket/netket/pull/1006) (and discussions in [#918](https://github.com/netket/netket/pull/918) and [#830](https://github.com/netket/netket/pull/830))
 * {ref}`nk.operator.LocalOperator` now accepts sparse matrices as input operators [#919](https://github.com/netket/netket/pull/919)
 * A new variational state that performs exact summation over the whole Hilbert space has been added. It can be constructed with {ref}`nk.vqs.ExactState` and supports the same Jax neural networks as {ref}`nk.vqs.MCState`. [#953](https://github.com/netket/netket/pull/953)
-* A new time-evolution driver that uses the Time-dependent-variational-principle has been added to the experimental submodule as {ref}`nk.experimental.TDVP`. It works with time-independent and time-dependent hamiltonians and liouvillians. [#1012](https://github.com/netket/netket/pull/1012) 
-* A set of Runge-Kutta, jax-compatible integrators has been added to the experimental module to use together with the new TDVP driver. [#1012](https://github.com/netket/netket/pull/1012) 
+* [Experimental] A new time-evolution driver  {ref}`nk.experimental.TDVP` using the time-dependent variational principle (TDVP) has been added. It works with time-independent and time-dependent Hamiltonians and Liouvillians. [#1012](https://github.com/netket/netket/pull/1012) 
+* [Experimental] A set of JAX-compatible Runge-Kutta ODE integrators has been added for use together with the new TDVP driver. [#1012](https://github.com/netket/netket/pull/1012) 
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 * Chunking of `MCState.expect` and `MCState.expect_and_grad` computations is now supported, which allows to bound the memory cost in exchange of a minor increase in computation time. [#1006](https://github.com/netket/netket/pull/1006) (and discussions in [#918](https://github.com/netket/netket/pull/918) and [#830](https://github.com/netket/netket/pull/830))
 * {ref}`nk.operator.LocalOperator` now accepts sparse matrices as input operators [#919](https://github.com/netket/netket/pull/919)
 * A new variational state that performs exact summation over the whole Hilbert space has been added. It can be constructed with {ref}`nk.vqs.ExactState` and supports the same Jax neural networks as {ref}`nk.vqs.MCState`. [#953](https://github.com/netket/netket/pull/953)
+* A new time-evolution driver that uses the Time-dependent-variational-principle has been added to the experimental submodule as {ref}`nk.experimental.TDVP`. It works with time-independent and time-dependent hamiltonians and liouvillians. [#1012](https://github.com/netket/netket/pull/1012) 
+* A set of Runge-Kutta, jax-compatible integrators has been added to the experimental module to use together with the new TDVP driver. [#1012](https://github.com/netket/netket/pull/1012) 
 
 ### Breaking Changes
 
@@ -24,6 +26,8 @@
 
 ### Bug Fixes
 * The constructor of `TensorHilbert` (which is used by the product operator `*` for inhomogeneous spaces) no longer fails when one of the component spaces is non-indexable. [#1004](https://github.com/netket/netket/pull/1004)
+* The {ref}`nk.hilbert.random.flip_state` method used by `MetropolisLocal` now throws an error when called on a {ref}`nk.hilbert.ContinuousHilbert` hilbert space instead of entering an endless loop. [#1014](https://github.com/netket/netket/pull/1014)
+
 
 ## NetKet 3.2 (26 November 2021)
 

--- a/Examples/Dynamics/ising1d.py
+++ b/Examples/Dynamics/ising1d.py
@@ -14,6 +14,7 @@
 
 import netket as nk
 import netket.experimental as nkx
+import numpy as np
 
 # 1D chain
 L = 10  # 10
@@ -49,7 +50,8 @@ Sx = sum([nk.operator.spin.sigmax(hi, i) for i in range(L)])
 gs.run(n_iter=300, out="example_ising1d_GS", obs={"Sx": Sx})
 
 # Create integrator for time propagation
-integrator = nkx.dynamics.RK23(dt=0.01)
+integrator = nkx.dynamics.RK23(dt=0.01, adaptive=True, rtol=1e-2)
+print(integrator)
 
 ha1 = nk.operator.Ising(hilbert=hi, graph=g, h=0.5)
 te = nkx.TimeDependentVMC(
@@ -67,4 +69,5 @@ te.run(
     out=log,
     show_progress=True,
     obs={"Sx": Sx},
+    tstops=np.linspace(0.0, 1.0, 101, endpoint=True),
 )

--- a/Examples/Dynamics/ising1d.py
+++ b/Examples/Dynamics/ising1d.py
@@ -1,0 +1,70 @@
+# Copyright 2021 The NetKet Authors - All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#    http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import netket as nk
+import netket.experimental as nkx
+
+# 1D chain
+L = 10  # 10
+
+g = nk.graph.Hypercube(length=L, n_dim=1, pbc=True)
+
+# Hilbert space of spins on the graph
+hi = nk.hilbert.Spin(s=1 / 2, N=g.n_nodes)
+
+# Ising spin hamiltonian
+ha = nk.operator.Ising(hilbert=hi, graph=g, h=1.0)
+
+# RBM Spin Machine
+ma = nk.models.RBM(alpha=1, use_visible_bias=True, dtype=complex)
+
+# Metropolis Local Sampling
+sa = nk.sampler.MetropolisHamiltonian(hi, ha, n_chains=16)
+
+# Variational state
+vs = nk.vqs.MCState(sa, ma, n_samples=5000, n_discard_per_chain=100)
+
+# Optimizer
+op = nk.optimizer.Sgd(0.01)
+sr = nk.optimizer.SR(diag_shift=1e-4)
+
+# Variational monte carlo driver
+gs = nk.VMC(ha, op, sa, ma, n_samples=1000, n_discard_per_chain=50)
+
+# Create observable
+Sx = sum([nk.operator.spin.sigmax(hi, i) for i in range(L)])
+
+# Run the optimization for 300 iterations
+gs.run(n_iter=300, out="example_ising1d_GS", obs={"Sx": Sx})
+
+# Create integrator for time propagation
+integrator = nkx.dynamics.RK23(dt=0.01)
+
+ha1 = nk.operator.Ising(hilbert=hi, graph=g, h=0.5)
+te = nkx.TimeDependentVMC(
+    ha1,
+    variational_state=vs,
+    integrator=integrator,
+    t0=0.0,
+    qgt=nk.optimizer.qgt.QGTJacobianDense(holomorphic=True),
+)
+
+log = nk.logging.JsonLog("example_ising1d_TE")
+
+te.run(
+    T=1.0,
+    out=log,
+    show_progress=True,
+    obs={"Sx": Sx},
+)

--- a/Examples/Dynamics/ising1d.py
+++ b/Examples/Dynamics/ising1d.py
@@ -57,7 +57,7 @@ print(integrator)
 
 # Quenched hamiltonian: this has a different transverse field than `ha`
 ha1 = nk.operator.Ising(hilbert=hi, graph=g, h=0.5)
-te = nkx.TimeDependentVMC(
+te = nkx.TDVP(
     ha1,
     variational_state=vs,
     integrator=integrator,

--- a/Examples/Dynamics/ising1d.py
+++ b/Examples/Dynamics/ising1d.py
@@ -50,16 +50,17 @@ Sx = sum([nk.operator.spin.sigmax(hi, i) for i in range(L)])
 gs.run(n_iter=300, out="example_ising1d_GS", obs={"Sx": Sx})
 
 # Create integrator for time propagation
-integrator = nkx.dynamics.RK23(dt=0.01, adaptive=True, rtol=1e-2)
+integrator = nkx.dynamics.RK23(dt=0.01, adaptive=True, rtol=1e-3, atol=1e-3)
 print(integrator)
 
 ha1 = nk.operator.Ising(hilbert=hi, graph=g, h=0.5)
 te = nkx.TimeDependentVMC(
     ha1,
     variational_state=vs,
-    integrator=integrator,
+    integrator_config=integrator,
     t0=0.0,
     qgt=nk.optimizer.qgt.QGTJacobianDense(holomorphic=True),
+    error_norm="qgt",
 )
 
 log = nk.logging.JsonLog("example_ising1d_TE")
@@ -69,5 +70,5 @@ te.run(
     out=log,
     show_progress=True,
     obs={"Sx": Sx},
-    tstops=np.linspace(0.0, 1.0, 101, endpoint=True),
+    tstops=[0.10, 0.15, 0.40, 0.41, 0.45, 0.50, 0.999, 1.0],
 )

--- a/Examples/Dynamics/ising1d.py
+++ b/Examples/Dynamics/ising1d.py
@@ -46,13 +46,15 @@ gs = nk.VMC(ha, op, variational_state=vs, n_samples=1000, n_discard_per_chain=50
 # Create observable
 Sx = sum([nk.operator.spin.sigmax(hi, i) for i in range(L)])
 
-# Run the optimization for 300 iterations
+# Run the optimization for 300 iterations to determine the ground state, used as
+# initial state of the time-evolution
 gs.run(n_iter=300, out="example_ising1d_GS", obs={"Sx": Sx})
 
 # Create integrator for time propagation
 integrator = nkx.dynamics.RK23(dt=0.01, adaptive=True, rtol=1e-3, atol=1e-3)
 print(integrator)
 
+# Quenched hamiltonian: this has a different transverse field than `ha`
 ha1 = nk.operator.Ising(hilbert=hi, graph=g, h=0.5)
 te = nkx.TimeDependentVMC(
     ha1,
@@ -65,6 +67,7 @@ te = nkx.TimeDependentVMC(
 
 log = nk.logging.JsonLog("example_ising1d_TE")
 
+# perform the time-evolution saving the observable Sx at every `tstop` time
 te.run(
     T=1.0,
     out=log,

--- a/Examples/Dynamics/ising1d.py
+++ b/Examples/Dynamics/ising1d.py
@@ -1,11 +1,11 @@
 # Copyright 2021 The NetKet Authors - All rights reserved.
-
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 import netket as nk
-import netket.experimental as nkx
 import numpy as np
+
+import netket.experimental as nkx
 
 # 1D chain
 L = 10
@@ -34,7 +35,7 @@ ma = nk.models.RBM(alpha=1, use_visible_bias=True, dtype=complex)
 sa = nk.sampler.MetropolisHamiltonian(hi, ha, n_chains=16)
 
 # Variational state
-vs = nk.vqs.MCState(sa, ma, n_samples=5000, n_discard_per_chain=100)
+vs = nk.vqs.MCState(sa, ma, n_samples=1024, n_discard_per_chain=16)
 
 # Optimizer
 op = nk.optimizer.Sgd(0.01)
@@ -59,7 +60,7 @@ ha1 = nk.operator.Ising(hilbert=hi, graph=g, h=0.5)
 te = nkx.TimeDependentVMC(
     ha1,
     variational_state=vs,
-    integrator_config=integrator,
+    integrator=integrator,
     t0=0.0,
     qgt=nk.optimizer.qgt.QGTJacobianDense(holomorphic=True),
     error_norm="qgt",

--- a/Examples/Dynamics/ising1d.py
+++ b/Examples/Dynamics/ising1d.py
@@ -17,7 +17,7 @@ import netket.experimental as nkx
 import numpy as np
 
 # 1D chain
-L = 10  # 10
+L = 10
 
 g = nk.graph.Hypercube(length=L, n_dim=1, pbc=True)
 
@@ -41,7 +41,7 @@ op = nk.optimizer.Sgd(0.01)
 sr = nk.optimizer.SR(diag_shift=1e-4)
 
 # Variational monte carlo driver
-gs = nk.VMC(ha, op, sa, ma, n_samples=1000, n_discard_per_chain=50)
+gs = nk.VMC(ha, op, variational_state=vs, n_samples=1000, n_discard_per_chain=50)
 
 # Create observable
 Sx = sum([nk.operator.spin.sigmax(hi, i) for i in range(L)])
@@ -70,5 +70,5 @@ te.run(
     out=log,
     show_progress=True,
     obs={"Sx": Sx},
-    tstops=[0.10, 0.15, 0.40, 0.41, 0.45, 0.50, 0.999, 1.0],
+    tstops=np.linspace(0.0, 1.0, 101, endpoint=True),
 )

--- a/docs/docs/api-experimental.rst
+++ b/docs/docs/api-experimental.rst
@@ -87,11 +87,11 @@ driver above.
   :toctree: _generated/experimental/dynamics
   :nosignatures:
 
-  nkx.dynamics.Euler
-  nkx.dynamics.Heun
-  nkx.dynamics.Midpoint
-  nkx.dynamics.RK12
-  nkx.dynamics.RK23
-  nkx.dynamics.RK4
-  nkx.dynamics.RK45
+  netket.experimental.dynamics.Euler
+  netket.experimental.dynamics.Heun
+  netket.experimental.dynamics.Midpoint
+  netket.experimental.dynamics.RK12
+  netket.experimental.dynamics.RK23
+  netket.experimental.dynamics.RK4
+  netket.experimental.dynamics.RK45
   

--- a/docs/docs/api-experimental.rst
+++ b/docs/docs/api-experimental.rst
@@ -87,7 +87,6 @@ driver above.
   :toctree: _generated/experimental/dynamics
   :nosignatures:
 
-
   nkx.dynamics.Euler
   nkx.dynamics.Heun
   nkx.dynamics.Midpoint
@@ -95,3 +94,4 @@ driver above.
   nkx.dynamics.RK23
   nkx.dynamics.RK4
   nkx.dynamics.RK45
+  

--- a/docs/docs/api-experimental.rst
+++ b/docs/docs/api-experimental.rst
@@ -62,3 +62,36 @@ Variational State Interface
   netket.experimental.vqs.variables_from_file
   netket.experimental.vqs.variables_from_tar
 
+
+Time Evolution Driver
+---------------------
+
+.. currentmodule:: netket
+
+.. autosummary::
+  :toctree: _generated/experimental/dynamics
+  :nosignatures:
+
+  netket.experimental.driver.TDVP
+
+
+ODE Integrators
+~~~~~~~~~~~~~~~
+
+This is a collection of ODE integrators that can be used with the TDVP 
+driver above.
+
+.. currentmodule:: netket
+
+.. autosummary::
+  :toctree: _generated/experimental/dynamics
+  :nosignatures:
+
+
+  nkx.dynamics.Euler
+  nkx.dynamics.Heun
+  nkx.dynamics.Midpoint
+  nkx.dynamics.RK12
+  nkx.dynamics.RK23
+  nkx.dynamics.RK4
+  nkx.dynamics.RK45

--- a/netket/driver/abstract_variational_driver.py
+++ b/netket/driver/abstract_variational_driver.py
@@ -139,7 +139,8 @@ class AbstractVariationalDriver(abc.ABC):
     @optimizer.setter
     def optimizer(self, optimizer):
         self._optimizer = optimizer
-        self._optimizer_state = optimizer.init(self.state.parameters)
+        if optimizer is not None:
+            self._optimizer_state = optimizer.init(self.state.parameters)
 
     @property
     def step_count(self):

--- a/netket/experimental/__init__.py
+++ b/netket/experimental/__init__.py
@@ -20,3 +20,7 @@ from . import sampler
 from . import vqs
 
 from .driver import TDVP
+
+from netket.utils import _hide_submodules
+
+_hide_submodules(__name__)

--- a/netket/experimental/__init__.py
+++ b/netket/experimental/__init__.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__all__ = ["driver", "dynamics", "sampler", "vqs", "TimeDependentVMC"]
+__all__ = ["driver", "dynamics", "sampler", "vqs", "TDVP"]
 
 from . import driver
 from . import dynamics
 from . import sampler
 from . import vqs
 
-from .driver import TimeDependentVMC
+from .driver import TDVP

--- a/netket/experimental/driver/__init__.py
+++ b/netket/experimental/driver/__init__.py
@@ -13,3 +13,7 @@
 # limitations under the License.
 
 from .tdvp import TDVP
+
+from netket.utils import _hide_submodules
+
+_hide_submodules(__name__)

--- a/netket/experimental/driver/__init__.py
+++ b/netket/experimental/driver/__init__.py
@@ -12,11 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__all__ = ["driver", "dynamics", "sampler", "vqs", "TimeDependentVMC"]
-
-from . import driver
-from . import dynamics
-from . import sampler
-from . import vqs
-
-from .driver import TimeDependentVMC
+from .tvmc import TimeDependentVMC

--- a/netket/experimental/driver/__init__.py
+++ b/netket/experimental/driver/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .tvmc import TimeDependentVMC
+from .tdvp import TDVP

--- a/netket/experimental/driver/tdvp.py
+++ b/netket/experimental/driver/tdvp.py
@@ -94,7 +94,7 @@ class TDVP(AbstractVariationalDriver):
                 Lindbladian for density operators).
             variational_state: The variational state.
             integrator: Configuration of the algorithm used for solving the ODE.
-            t0: Initial time.
+            t0: Initial time at the start of the time evolution.
             propagation_type: Determines the equation of motion: "real"  for the
                 real-time Schödinger equation (SE), "imag" for the imaginary-time SE.
             qgt: The QGT specification.
@@ -356,10 +356,12 @@ class TDVP(AbstractVariationalDriver):
 
     @property
     def dt(self):
+        """Current time step."""
         return self._integrator.dt
 
     @property
     def t(self):
+        """Current time."""
         return self._integrator.t
 
     @t.setter

--- a/netket/experimental/driver/tdvp.py
+++ b/netket/experimental/driver/tdvp.py
@@ -66,9 +66,11 @@ def dwdt_mcstate(state: MCState, driver, t, w, *, stage: int = None):
     return driver._dw
 
 
-class TimeDependentVMC(AbstractVariationalDriver):
+class TDVP(AbstractVariationalDriver):
     """
-    Variational Time evolution using the time-dependent Variational Monte Carlo (t-VMC).
+    Variational time evolution based on the time-dependent variational principle which,
+    when used with Monte Carlo sampling via :ref:`~netket.vqs.MCState`, is the time-dependent VMC
+    (t-VMC) method.
     """
 
     def __init__(
@@ -106,7 +108,7 @@ class TimeDependentVMC(AbstractVariationalDriver):
                 to compute the norm :math:`\Vert x \Vert^2_S = x^\dagger \cdot S \cdot x` as suggested
                 in PRL 125, 100503 (2020).
                 Additionally, it possible to pass a custom function with signature
-                    :code:`norm(driver: TimeDependentVMC, x: PyTree) -> float`
+                    :code:`norm(driver: TDVP, x: PyTree) -> float`
                 which can access the driver maps its second argument, a PyTree of parameters :code:`x`,
                 to its norm.
         """
@@ -248,10 +250,7 @@ class TimeDependentVMC(AbstractVariationalDriver):
         callback=None,
     ):
         """
-        Executes the Monte Carlo Variational optimization, updating the weights of the network
-        stored in this driver for `n_iter` steps and dumping values of the observables `obs`
-        in the output `logger`. If no logger is specified, creates a json file at `out`,
-        overwriting files with the same prefix.
+        Runs the time evolution.
 
         By default uses :ref:`netket.logging.JsonLog`. To know about the output format
         check it's documentation. The logger object is also returned at the end of this function

--- a/netket/experimental/driver/tvmc.py
+++ b/netket/experimental/driver/tvmc.py
@@ -1,0 +1,275 @@
+# Copyright 2020 The Simons Foundation, Inc. - All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# from functools import singledispatch
+from typing import Tuple
+from netket.experimental.dynamics.runge_kutta import RungeKuttaSolver
+from netket.utils.types import PyTree
+
+import numpy as np
+
+import flax
+import jax
+import jax.numpy as jnp
+from jax.tree_util import tree_map
+
+import netket.jax as nkjax
+
+from netket.driver import AbstractVariationalDriver
+from netket.driver.vmc_common import info
+from netket.operator import AbstractOperator
+from netket.optimizer import LinearOperator, SR
+from netket.vqs import VariationalState, MCState, MCMixedState
+from netket.optimizer.qgt import QGTAuto
+
+# @singledispatch
+# def dwdt(state, driver, w, t, *, stage=None):
+#     raise NotImplementedError(f"dwdt not implemented for {type(state)}")
+
+
+# @dwdt.register
+def dwdt_mcstate(
+    state: MCState, driver: "TimeDependentVMC", w, t, *, stage: int = None
+):
+    state.parameters = driver._w_unravel(w)
+    state.reset()
+
+    driver._loss_stats, driver._loss_grad = state.expect_and_grad(
+        driver.generator(t),
+        use_covariance=True,
+    )
+    driver._loss_grad = tree_map(lambda x: -1.0j * x, driver._loss_grad)
+
+    driver._S_intermediate = driver.qgt(driver.state)
+    if stage == 0:  # TODO: This does not work with FSAL.
+        driver._S = driver._S_intermediate
+
+    x0 = driver._dw if driver.linear_solver_restart is False else None
+    driver._dw, driver._sr_info = driver._S_intermediate.solve(
+        driver.linear_solver, driver._loss_grad, x0=x0
+    )
+
+    return driver._dw
+
+
+# jstep = jax.jit(ode4jax.step)
+
+
+class TimeDependentVMC(AbstractVariationalDriver):
+    """
+    Variational Time evolution using the time-dependent Variational Monte Carlo (t-VMC).
+    """
+
+    def __init__(
+        self,
+        operator: AbstractOperator,
+        variational_state: VariationalState,
+        tspan: Tuple[float, float],
+        integrator,
+        qgt: LinearOperator,
+        *,
+        linear_solver=None,
+        linear_solver_restart: bool = False,
+        # **integrator_kwargs,
+    ):
+        """
+        Construct the time evolution driver.
+
+        Args:
+            operator: The generator of the dynamics (Hamiltonian for pure states,
+                Lindbladian for density operators).Optional
+            variational_state: The variational state
+            solver: the time evolution integrator (like runge kutta or euler)
+            qgt: The QGT storage format.
+            linear_solver: The solver for solving the linear system determining the time evolution.
+            linear_solver_restart: If False (default), the last solution of the linear system
+                is used as initial value in subsequent steps.
+            tspan: Specify this as (t0, tend) or the two separately
+            t0: initial time
+            tend: end time. stop integrating at this time
+        """
+        if variational_state.hilbert != operator.hilbert:
+            raise TypeError(
+                f"""the variational_state has hilbert space {variational_state.hilbert}
+                                (this is normally defined by the hilbert space in the sampler), but
+                                the operator has hilbert space {operator.hilbert}.
+                                The two should match."""
+            )
+
+        self._t0, self._tend = tspan
+
+        if linear_solver is None:
+            linear_solver = jax.numpy.linalg.lstsq
+        if qgt is None:
+            qgt = QGTAuto(solver=linear_solver)
+
+        super().__init__(
+            variational_state, optimizer=None, minimized_quantity_name="Generator"
+        )
+
+        if isinstance(operator, AbstractOperator):
+            self._generator = lambda _: operator.collect()  # type: AbstractOperator
+        else:
+            self._generator = operator
+
+        self.qgt = qgt  # type: SR
+        self.linear_solver = linear_solver
+        self.linear_solver_restart = linear_solver_restart
+
+        self._w, self._w_unravel = nkjax.tree_ravel(self.state.parameters)
+        self._dw = None  # type: PyTree
+
+        self._integrator = integrator(self._odefun, tspan, self._w)
+
+    @property
+    def generator(self) -> AbstractOperator:
+        """
+        The generator of the dynamics integrated by this driver.
+        """
+        return self._generator
+
+    @property
+    def integrator(self):
+        """
+        The solver used to integrate the dynamics
+        """
+        return self._integrator
+
+    def _odefun(self, w, t, **kwargs):
+        """
+        The ODE determining the dynamics passed to scipy solvers.
+
+        Args:
+            t: The current time (unused).
+            w: The parameters as a vector.
+
+        Returns:
+            dwdt, the derivative at time t
+        """
+        # do a timestep
+        dw = dwdt_mcstate(self.state, self, w, t, **kwargs)
+        return flax.core.unfreeze(dw)
+
+    def advance(self, dt=None, n_steps=None):
+        """
+        Advance the time propagation by `n_steps` simulation steps
+        of duration `self.dt`.
+
+           Args:
+               :n_steps (int): No. of steps to advance.
+        """
+        if (dt is None and n_steps is None) or (dt is not None and n_steps is not None):
+            raise ValueError("Both specified")
+
+        if n_steps is not None:
+            for _ in range(n_steps):
+                self._integrator.step()
+        elif dt is not None:
+            t_final = self.t + dt
+            while self.t <= t_final:
+                self._integrator.step()
+
+    # def iter(self, delta_t, t_interval=None):
+    #     """
+    #     Returns a generator which advances the time evolution in
+    #     steps of `step` for a total of `n_iter` times.
+
+    #     Args:
+    #         :n_iter (int): The total number of steps.
+    #         :step (int=1): The size of each step.
+
+    #     Yields:
+    #         :(int): The current step.
+    #     """
+    #     t_end = self.t + delta_t
+    #     while self.t < t_end:  # and self._integrator.status == "running":
+    #         t0 = self.t
+    #         yield self.t
+    #         self._step_count += 1
+    #         self._integrator = jstep(self._integrator, t_interval)
+
+    def _log_additional_data(self, obs, step):
+        obs["t"] = self.t
+
+    @property
+    def _default_step_size(self):
+        # Essentially means
+        return None
+
+    @property
+    def step_value(self):
+        return self.t
+
+    @property
+    def dt(self):
+        return self._integrator.step_size
+
+    @dt.setter
+    def dt(self, _dt):
+        success = False
+        try:
+            self._integrator.step_size = _dt
+            success = True
+        except AttributeError:
+            pass
+
+        if not success:
+            try:
+                self._integrator.h_abs = _dt
+                success = True
+            except AttributeError:
+                pass
+
+        if not success:
+            if self._integrator.h_abs == self._integrator.max_step:
+                self._integrator.h_abs = _dt
+                self.max_step = _dt
+            else:
+                self._integrator.h_abs = _dt
+            success = True
+
+    @property
+    def t(self):
+        return self._integrator.t
+
+    @t.setter
+    def t(self, t):
+        self._integrator.t = jnp.array(t, dtype=self._integrator.t)
+
+    @property
+    def t_end(self):
+        return self._integrator.opts.tstops[-1]
+
+    # @t_end.setter
+    # def t_end(self, t_end):
+    #    self._integrator.t_bound = t_end
+
+    @property
+    def t0(self):
+        return self._t0
+
+    def __repr__(self):
+        return f"{type(self)}(step_count={self.step_count}, t={self.t})"
+
+    def info(self, depth=0):
+        lines = [
+            "{}: {}".format(name, info(obj, depth=depth + 1))
+            for name, obj in [
+                ("generator     ", self._generator),
+                ("integrator    ", self._integrator),
+                ("linear solver ", self.linear_solver),
+                ("State         ", self.state),
+            ]
+        ]
+        return "\n{}".format(" " * 3 * (depth + 1)).join([str(self)] + lines)

--- a/netket/experimental/driver/tvmc.py
+++ b/netket/experimental/driver/tvmc.py
@@ -122,9 +122,10 @@ class TimeDependentVMC(AbstractVariationalDriver):
         )
 
         if isinstance(operator, AbstractOperator):
-            operator = operator.collect()
-            self._generator = lambda _: operator
+            self.generator = operator.collect()
+            self._generator = lambda _: self.generator
         else:
+            self.generator = operator
             self._generator = operator
 
         self.propagation_type = propagation_type
@@ -167,13 +168,6 @@ class TimeDependentVMC(AbstractVariationalDriver):
             )
         self._integrator = integrator(self._odefun, t0, self._w, norm=error_norm)
         self._stop_count = 0
-
-    @property
-    def generator(self) -> AbstractOperator:
-        """
-        The generator of the dynamics.
-        """
-        return self._generator
 
     @property
     def integrator(self):
@@ -379,10 +373,10 @@ class TimeDependentVMC(AbstractVariationalDriver):
         lines = [
             "{}: {}".format(name, info(obj, depth=depth + 1))
             for name, obj in [
-                ("generator     ", self._generator),
+                ("generator     ", self.generator),
                 ("integrator    ", self._integrator),
                 ("linear solver ", self.linear_solver),
-                ("State         ", self.state),
+                ("state         ", self.state),
             ]
         ]
         return "\n{}".format(" " * 3 * (depth + 1)).join([str(self)] + lines)

--- a/netket/experimental/driver/tvmc.py
+++ b/netket/experimental/driver/tvmc.py
@@ -320,7 +320,7 @@ class TimeDependentVMC(AbstractVariationalDriver):
                     pbar.unpause()
 
                 # Update the progress bar
-                pbar.update(self.step_value - old_step)
+                pbar.update(np.asarray(self.step_value - old_step))
                 old_step = self.step_value
 
             # Final update so that it shows up filled.

--- a/netket/experimental/driver/tvmc.py
+++ b/netket/experimental/driver/tvmc.py
@@ -36,7 +36,7 @@ from netket.utils import mpi
 from netket.utils.types import PyTree
 from netket.vqs import VariationalState, MCState, MCMixedState
 
-from netket.experimental.dynamics import RungeKuttaIntegrator
+from netket.experimental.dynamics import RungeKuttaIntegrator, RKIntegratorConfig
 
 
 @singledispatch
@@ -78,7 +78,7 @@ class TimeDependentVMC(AbstractVariationalDriver):
         self,
         operator: AbstractOperator,
         variational_state: VariationalState,
-        integrator: Callable,
+        integrator: RKIntegratorConfig,
         *,
         t0: float = 0.0,
         propagation_type="real",
@@ -390,7 +390,7 @@ class TimeDependentVMC(AbstractVariationalDriver):
         return self._t0
 
     def __repr__(self):
-        return f"{type(self)}(step_count={self.step_count}, t={self.t})"
+        return f"{type(self).__name__}(step_count={self.step_count}, t={self.t})"
 
     def info(self, depth=0):
         lines = [

--- a/netket/experimental/driver/tvmc.py
+++ b/netket/experimental/driver/tvmc.py
@@ -39,11 +39,13 @@ from netket.experimental.dynamics import RKIntegratorConfig
 
 @dispatch
 def dwdt(state, driver, t, w, *, stage=None):
+    # pylint: disable=unused-argument
     raise NotImplementedError(f"dwdt not implemented for {type(state)}")
 
 
 @dispatch
 def dwdt_mcstate(state: MCState, driver, t, w, *, stage: int = None):
+    # pylint: disable=protected-access
     state.parameters = w
     state.reset()
 
@@ -150,7 +152,9 @@ class TimeDependentVMC(AbstractVariationalDriver):
         elif error_norm == "qgt":
             error_norm = self._qgt_norm
         else:
-            raise ValueError("error_norm must be a callable or one of 'euclidean', 'qgt'.")
+            raise ValueError(
+                "error_norm must be a callable or one of 'euclidean', 'qgt', 'maximum'."
+            )
         self._integrator = integrator(self._odefun, t0, self._w, norm=error_norm)
         self._stop_count = 0
 
@@ -270,8 +274,10 @@ class TimeDependentVMC(AbstractVariationalDriver):
 
         # Log only non-root nodes
         if self._mynode == 0:
+            if out is None:
+                loggers = ()
             # if out is a path, create an overwriting Json Log for output
-            if isinstance(out, str):
+            elif isinstance(out, str):
                 loggers = (JsonLog(out, "w"),)
             else:
                 loggers = _to_iterable(out)

--- a/netket/experimental/dynamics/__init__.py
+++ b/netket/experimental/dynamics/__init__.py
@@ -13,5 +13,17 @@
 # limitations under the License.
 
 
+__all__ = [
+    "RungeKuttaIntegrator",
+    "RKIntegratorConfig",
+    "Euler",
+    "Heun",
+    "Midpoint",
+    "RK4",
+    "RK12",
+    "RK23",
+    "RK45",
+]
+
 from .runge_kutta import RungeKuttaIntegrator, RKIntegratorConfig
 from .runge_kutta import Euler, Heun, Midpoint, RK4, RK12, RK23, RK45

--- a/netket/experimental/dynamics/__init__.py
+++ b/netket/experimental/dynamics/__init__.py
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 
-from .runge_kutta import RungeKuttaSolver
-from .runge_kutta import Euler, Heun, Midpoint, RK4, RK12, RK23, RK45
+from .runge_kutta import RungeKuttaIntegrator
+from .runge_kutta import Euler, Heun, Midpoint, RK4, RK12, RK23, RK45, Tsit5

--- a/netket/experimental/dynamics/__init__.py
+++ b/netket/experimental/dynamics/__init__.py
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__all__ = ["driver", "dynamics", "sampler", "vqs", "TimeDependentVMC"]
 
-from . import driver
-from . import dynamics
-from . import sampler
-from . import vqs
-
-from .driver import TimeDependentVMC
+from .runge_kutta import RungeKuttaSolver
+from .runge_kutta import Euler, Heun, Midpoint, RK4, RK12, RK23, RK45

--- a/netket/experimental/dynamics/__init__.py
+++ b/netket/experimental/dynamics/__init__.py
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 
-from .runge_kutta import RungeKuttaIntegrator
+from .runge_kutta import RungeKuttaIntegrator, RKIntegratorConfig
 from .runge_kutta import Euler, Heun, Midpoint, RK4, RK12, RK23, RK45, Tsit5

--- a/netket/experimental/dynamics/__init__.py
+++ b/netket/experimental/dynamics/__init__.py
@@ -27,3 +27,7 @@ __all__ = [
 
 from .runge_kutta import RungeKuttaIntegrator, RKIntegratorConfig
 from .runge_kutta import Euler, Heun, Midpoint, RK4, RK12, RK23, RK45
+
+from netket.utils import _hide_submodules
+
+_hide_submodules(__name__)

--- a/netket/experimental/dynamics/__init__.py
+++ b/netket/experimental/dynamics/__init__.py
@@ -14,4 +14,4 @@
 
 
 from .runge_kutta import RungeKuttaIntegrator, RKIntegratorConfig
-from .runge_kutta import Euler, Heun, Midpoint, RK4, RK12, RK23, RK45, Tsit5
+from .runge_kutta import Euler, Heun, Midpoint, RK4, RK12, RK23, RK45

--- a/netket/experimental/dynamics/runge_kutta.py
+++ b/netket/experimental/dynamics/runge_kutta.py
@@ -1,0 +1,364 @@
+# Copyright 2021 The NetKet Authors - All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from builtins import RuntimeError, next
+import dataclasses
+from functools import partial
+from typing import Callable, Optional, Tuple
+
+import jax
+import jax.numpy as jnp
+
+from netket.utils.struct import dataclass
+from netket.utils.types import Array
+
+dtype = jnp.float64
+
+
+@dataclass
+class TableauRKExplicit:
+    name: str
+    """The name of the RK Tableau."""
+    order: Tuple[int, int]
+    """The order of the tableau"""
+    a: jax.numpy.ndarray
+    b: jax.numpy.ndarray
+    c: jax.numpy.ndarray
+    c_error: Optional[jax.numpy.ndarray]
+    """Coefficients for error estimation."""
+
+    @property
+    def is_explicit(self):
+        jnp.allclose(self.a, jnp.tril(self.a))  # check if lower triangular
+
+    @property
+    def is_adaptive(self):
+        return self.b.ndim == 2
+
+    @property
+    def is_fsal(self):
+        """Returns True if the first iteration is the same as last."""
+        # TODO: this is not yet supported
+        return False
+
+    @property
+    def stages(self):
+        """
+        Number of stages (equal to the number of evaluations of the ode function)
+        of the RK scheme.
+        """
+        return len(self.c)
+
+    def _get_ks(
+        self,
+        f: Callable,
+        t: float,
+        dt: float,
+        y_t: Array,
+    ):
+        """Computes the intermediate slopes k_l."""
+        times = t + self.c * dt
+
+        k = jnp.zeros((y_t.shape[0], self.stages), dtype=y_t.dtype)
+        for l in range(self.stages):
+            dy_l = jnp.sum(self.a[l, :] * k, axis=1)
+            k_l = f(times[l], y_t + dt * dy_l, stage=l)
+            k = k.at[:, l].set(k_l)
+
+        return k
+
+    def step(
+        self,
+        f: Callable,
+        t: float,
+        dt: float,
+        y_t: Array,
+    ):
+        """Perform one fixed-size RK step from `t` to `t + dt`."""
+        k = self._get_ks(f, t, dt, y_t)
+
+        b = self.b[0] if self.b.ndim == 2 else self.b
+        y_tp1 = y_t + dt * jnp.sum(b * k, axis=1)
+        return y_tp1
+
+    def step_with_error(
+        self,
+        f: Callable,
+        t: float,
+        dt: float,
+        y_t: Array,
+    ):
+        """
+        Perform one fixed-size RK step from `t` to `t + dt` and additionally return the
+        error vector provided by the adaptive solver.
+        """
+        if not self.is_adaptive:
+            raise RuntimeError(f"{self} is not adaptive")
+
+        k = self._get_ks(f, t, dt, y_t)
+
+        y_tp1 = y_t + dt * jnp.sum(self.b[0] * k, axis=1)
+        y_err = dt * jnp.sum((self.b[0] - self.b[1]) * k, axis=1)
+        return y_tp1, y_err
+
+
+@dataclass
+class RungeKuttaState:
+    step_no: int
+    t: float
+    y: Array
+    dt: float
+    last_norm: Optional[float]
+
+
+def scaled_error(y, y_err, atol, rtol, *, norm=None):
+    if norm is None:
+        norm = jnp.linalg.norm
+    scale = (atol + norm(y) * rtol) / y_err.shape[0]
+    return norm(y_err) / scale
+
+
+def adapt_time_step(dt, scaled_error):
+    safety_factor = 0.95
+    err_exponent = -1.0 / 5.0
+    return dt * jnp.clip(
+        safety_factor * scaled_error ** err_exponent,
+        1e-1,
+        1e1,
+    )
+
+
+@partial(jax.jit, static_argnames=["step_fn", "norm_fn"])
+def general_time_step_adaptive(
+    step_fn: Callable,
+    rkstate: RungeKuttaState,
+    atol: float,
+    rtol: float,
+    norm_fn: Callable,
+):
+    next_y, y_err = step_fn(rkstate.t, rkstate.dt, rkstate.y)
+    scaled_err = scaled_error(rkstate.y, y_err, atol, rtol, norm=norm_fn)
+    next_dt = adapt_time_step(rkstate.dt, scaled_err)
+    return jax.lax.cond(
+        scaled_err < 1.0,
+        lambda _: rkstate.replace(
+            step_no=rkstate.step_no + 1,
+            y=next_y,
+            t=rkstate.t + rkstate.dt,
+            dt=next_dt,
+        ),
+        lambda _: rkstate.replace(dt=next_dt),
+        None,
+    )
+
+
+@partial(jax.jit, static_argnames=["step_fn", "norm_fn"])
+def general_time_step_fixed(step_fn: Callable, rkstate: RungeKuttaState):
+    next_y = step_fn(rkstate.t, rkstate.dt, rkstate.y)
+    r = rkstate.replace(t=rkstate.t + rkstate.dt, y=next_y, step_no=rkstate.step_no + 1)
+    return r
+
+
+@dataclasses.dataclass
+class RungeKuttaSolver:
+    tableau: TableauRKExplicit
+
+    f: Callable
+    t0: float
+    y0: Array
+
+    dt: float
+
+    tend: float
+
+    use_adaptive: bool
+    norm: Callable
+
+    atol: float = 0.0
+    rtol: float = 1e-7
+
+    def __post_init__(self):
+        if self.use_adaptive and not self.tableau.is_adaptive:
+            raise RuntimeError(
+                f"Solver {self.tablaeu} does not support adaptive step size"
+            )
+        if self.use_adaptive:
+            self._do_step = lambda state: general_time_step_adaptive(
+                lambda t, dt, y, **kw: self.tableau.step_with_error(
+                    self.f, t, dt, y, **kw
+                ),
+                state,
+                atol=self.atol,
+                rtol=self.rtol,
+                norm_fn=self.norm,
+            )
+        else:
+            self._do_step = lambda state: general_time_step_fixed(
+                lambda t, dt, y, **kw: self.tableau.step(self.f, t, dt, y, **kw),
+                state,
+            )
+
+        self._rkstate = RungeKuttaState(
+            step_no=0,
+            t=self.t0,
+            y=self.y0,
+            dt=self.dt,
+            last_norm=None,
+        )
+
+    def step(self):
+        self._rkstate = self._do_step(self._rkstate)
+
+    @property
+    def status(self):
+        if self.t < self.tend:
+            return "running"
+        else:
+            return "done"
+
+    @property
+    def t(self):
+        return self._rkstate.t
+
+    @property
+    def y(self):
+        return self._rkstate.y
+
+    @property
+    def current_dt(self):
+        return self._rkstate.dt
+
+
+def RKSolver(dt, tableau, adaptive=False, norm=None, **kwargs):
+    def make(f, tspan, y0):
+        y0 = jnp.asarray(y0)
+        t0, tend = tspan
+        return RungeKuttaSolver(
+            tableau, f, t0, y0, dt, tend, use_adaptive=adaptive, norm=norm, **kwargs
+        )
+
+    return make
+
+
+# fmt: off
+# Fixed Step methods
+bt_feuler = TableauRKExplicit(
+                name = "feuler", 
+                order = (1,),
+                a = jnp.zeros((1,1), dtype=dtype),
+                b = jnp.ones((1,1), dtype=dtype),
+                c = jnp.zeros((1), dtype=dtype),
+                c_error = None,
+                )
+Euler = partial(RKSolver, tableau=bt_feuler)
+
+
+bt_midpoint = TableauRKExplicit(
+                name = "midpoint", 
+                order = (2,),
+                a = jnp.array([[0,   0],
+                               [1/2, 0]], dtype=dtype),
+                b = jnp.array( [0,   1], dtype=dtype),
+                c = jnp.array( [0, 1/2], dtype=dtype),
+                c_error = None,
+                )
+Midpoint = partial(RKSolver, tableau=bt_midpoint)
+
+
+bt_heun = TableauRKExplicit(
+                name = "heun", 
+                order = (2,),
+                a = jnp.array([[0,   0],
+                               [1,   0]], dtype=dtype),
+                b = jnp.array( [1/2, 1/2], dtype=dtype),
+                c = jnp.array( [0, 1], dtype=dtype),
+                c_error = None,
+                )
+Heun = partial(RKSolver, tableau=bt_heun)
+
+bt_rk4  = TableauRKExplicit(
+                name = "rk4", 
+                order = (4,),
+                a = jnp.array([[0,   0,   0,   0],
+                               [1/2, 0,   0,   0],
+                               [0,   1/2, 0,   0],
+                               [0,   0,   1,   1]], dtype=dtype),
+                b = jnp.array( [1/6,  1/3,  1/3,  1/6], dtype=dtype),
+                c = jnp.array( [0, 1/2, 1/2, 1], dtype=dtype),
+                c_error = None,
+                )
+RK4 = partial(RKSolver, tableau=bt_rk4)
+
+
+# Adaptive step:
+# Heun Euler https://en.wikipedia.org/wiki/Runge–Kutta_methods
+bt_rk12  = TableauRKExplicit(
+                name = "rk21", 
+                order = (2,1),
+                a = jnp.array([[0,   0],
+                               [1,   0]], dtype=dtype),
+                b = jnp.array([[1/2, 1/2],
+                               [1,   0]], dtype=dtype),
+                c = jnp.array( [0, 1], dtype=dtype),
+                c_error = None,
+                )
+RK12 = partial(RKSolver, tableau=bt_rk12)
+
+# Bogacki–Shampine coefficients
+bt_rk23  = TableauRKExplicit(
+                name = "rk23", 
+                order = (2,3),
+                a = jnp.array([[0,   0,   0,   0],
+                               [1/2, 0,   0,   0],
+                               [0,   3/4, 0,   0],
+                               [2/9, 1/3, 4/9, 0]], dtype=dtype),
+                b = jnp.array([[7/24,1/4, 1/3, 1/8],
+                               [2/9, 1/3, 4/9, 0]], dtype=dtype),
+                c = jnp.array( [0, 1/2, 3/4, 1], dtype=dtype),
+                c_error = None,
+                )
+RK23 = partial(RKSolver, tableau=bt_rk23)
+
+bt_rk4_fehlberg  = TableauRKExplicit(
+                name = "fehlberg", 
+                order = (4,5),
+                a = jnp.array([[ 0,          0,          0,           0,            0,      0 ],
+                              [  1/4,        0,          0,           0,            0,      0 ],
+                              [  3/32,       9/32,       0,           0,            0,      0 ],
+                              [  1932/2197,  -7200/2197, 7296/2197,   0,            0,      0 ],
+                              [  439/216,    -8,         3680/513,    -845/4104,    0,      0 ],
+                              [  -8/27,      2,          -3544/2565,  1859/4104,    11/40,  0 ]], dtype=dtype),
+                b = jnp.array([[ 25/216,     0,          1408/2565,   2197/4104,    -1/5,   0 ],
+                               [ 16/135,     0,          6656/12825,  28561/56430,  -9/50,  2/55]], dtype=dtype),
+                c = jnp.array( [  0,         1/4,        3/8,         12/13,        1,      1/2], dtype=dtype),
+                c_error = None,
+                )
+
+bt_rk4_dopri  = TableauRKExplicit(
+                name = "dopri", 
+                order = (5,4),
+                a = jnp.array([[ 0,           0,           0,           0,        0,             0,         0 ],
+                              [  1/5,         0,           0,           0,        0,             0,         0 ],
+                              [  3/40,        9/40,        0,           0,        0,             0,         0 ],
+                              [  44/45,       -56/15,      32/9,        0,        0,             0,         0 ],
+                              [  19372/6561,  -25360/2187, 64448/6561,  -212/729, 0,             0,         0 ],
+                              [  9017/3168,   -355/33,     46732/5247,  49/176,   -5103/18656,   0,         0 ],
+                              [  35/384,      0,           500/1113,    125/192,  -2187/6784,    11/84,     0 ]], dtype=dtype),
+                b = jnp.array([[ 35/384,      0,           500/1113,    125/192,  -2187/6784,    11/84,     0 ],
+                               [ 5179/57600,  0,           7571/16695,  393/640,  -92097/339200, 187/2100,  1/40 ]], dtype=dtype),
+                c = jnp.array( [ 0,           1/5,         3/10,        4/5,      8/9,           1,         1], dtype=dtype),
+                c_error = None,
+                )
+RK45 = partial(RKSolver, tableau=bt_rk4_dopri)
+# fmt: on

--- a/netket/experimental/dynamics/runge_kutta.py
+++ b/netket/experimental/dynamics/runge_kutta.py
@@ -53,6 +53,21 @@ def euclidean_norm(x: Union[PyTree, Array]):
         )
 
 
+def maximum_norm(x: Union[PyTree, Array]):
+    """
+    Computes the maximum norm of the Array or PyTree intended as a flattened array
+    """
+    if isinstance(x, jnp.ndarray):
+        return jnp.max(jnp.abs(x))
+    else:
+        return jnp.sqrt(
+            jax.tree_util.tree_reduce(
+                jnp.maximum,
+                jax.tree_map(lambda x: jnp.max(jnp.abs(x)), x),
+            )
+        )
+
+
 @dataclass
 class TableauRKExplicit:
     name: str

--- a/netket/experimental/dynamics/runge_kutta.py
+++ b/netket/experimental/dynamics/runge_kutta.py
@@ -13,13 +13,16 @@
 # limitations under the License.
 
 from builtins import RuntimeError, next
+from ctypes import c_buffer
 import dataclasses
 from functools import partial
 from typing import Callable, Optional, Tuple
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 
+from netket.utils import KahanSum
 from netket.utils.struct import dataclass
 from netket.utils.types import Array
 
@@ -60,7 +63,7 @@ class TableauRKExplicit:
         """
         return len(self.c)
 
-    def _get_ks(
+    def _compute_slopes(
         self,
         f: Callable,
         t: float,
@@ -86,10 +89,11 @@ class TableauRKExplicit:
         y_t: Array,
     ):
         """Perform one fixed-size RK step from `t` to `t + dt`."""
-        k = self._get_ks(f, t, dt, y_t)
+        k = self._compute_slopes(f, t, dt, y_t)
 
         b = self.b[0] if self.b.ndim == 2 else self.b
         y_tp1 = y_t + dt * jnp.sum(b * k, axis=1)
+
         return y_tp1
 
     def step_with_error(
@@ -106,146 +110,210 @@ class TableauRKExplicit:
         if not self.is_adaptive:
             raise RuntimeError(f"{self} is not adaptive")
 
-        k = self._get_ks(f, t, dt, y_t)
+        k = self._compute_slopes(f, t, dt, y_t)
 
         y_tp1 = y_t + dt * jnp.sum(self.b[0] * k, axis=1)
         y_err = dt * jnp.sum((self.b[0] - self.b[1]) * k, axis=1)
+
         return y_tp1, y_err
 
 
 @dataclass
 class RungeKuttaState:
     step_no: int
-    t: float
+    """Number of successful steps since the start of the iteration."""
+    step_no_total: int
+    """Number of steps since the start of the iteration, including rejected steps."""
+    t: KahanSum
+    """Current time."""
     y: Array
+    """Solution at current time."""
     dt: float
-    last_norm: Optional[float]
+    """Current step size."""
+    last_norm: Optional[float] = None
+    """Solution norm at previous time step."""
+    accepted: bool = True
+    """Whether the last RK step was accepted or should be repeated."""
+
+    def __repr__(self):
+        return "RKState(step_no(total)={}({}), t={}, dt={:.2e}{}{})".format(
+            self.step_no,
+            self.step_no_total,
+            self.t.value,
+            self.dt,
+            f", {self.last_norm:.2e}" if self.last_norm else "",
+            f", {'A' if self.accepted else 'R'}",
+        )
 
 
-def scaled_error(y, y_err, atol, rtol, *, norm=None):
-    if norm is None:
-        norm = jnp.linalg.norm
+def scaled_error(y, y_err, atol, rtol, *, norm=jnp.linalg.norm):
     scale = (atol + norm(y) * rtol) / y_err.shape[0]
     return norm(y_err) / scale
 
 
-def adapt_time_step(dt, scaled_error):
+LimitsType = Tuple[Optional[float], Optional[float]]
+
+
+def propose_time_step(dt, scaled_error, limits: LimitsType):
     safety_factor = 0.95
     err_exponent = -1.0 / 5.0
-    return dt * jnp.clip(
-        safety_factor * scaled_error ** err_exponent,
-        1e-1,
-        1e1,
+    return jnp.clip(
+        dt * safety_factor * scaled_error ** err_exponent,
+        limits[0],
+        limits[1],
     )
 
 
-@partial(jax.jit, static_argnames=["step_fn", "norm_fn"])
+# @partial(jax.jit, static_argnames=["step_fn", "norm_fn"])
 def general_time_step_adaptive(
     step_fn: Callable,
-    rkstate: RungeKuttaState,
+    rk_state: RungeKuttaState,
     atol: float,
     rtol: float,
     norm_fn: Callable,
+    max_dt: Optional[float],
+    dt_limits: LimitsType,
 ):
-    next_y, y_err = step_fn(rkstate.t, rkstate.dt, rkstate.y)
-    scaled_err = scaled_error(rkstate.y, y_err, atol, rtol, norm=norm_fn)
-    next_dt = adapt_time_step(rkstate.dt, scaled_err)
+    if max_dt is None:
+        actual_dt = rk_state.dt
+    else:
+        actual_dt = jnp.minimum(rk_state.dt, max_dt)
+    print(f"        {actual_dt=}")
+    next_y, y_err = step_fn(rk_state.t.value, actual_dt, rk_state.y)
+    scaled_err = scaled_error(rk_state.y, y_err, atol, rtol, norm=norm_fn)
+    next_dt = propose_time_step(
+        actual_dt,
+        scaled_err,
+        limits=(
+            jnp.maximum(0.1 * rk_state.dt, dt_limits[0])
+            if dt_limits[0]
+            else 0.1 * rk_state.dt,
+            jnp.minimum(10.0 * rk_state.dt, dt_limits[1])
+            if dt_limits[1]
+            else 10.0 * rk_state.dt,
+        ),
+    )
     return jax.lax.cond(
         scaled_err < 1.0,
-        lambda _: rkstate.replace(
-            step_no=rkstate.step_no + 1,
+        lambda _: rk_state.replace(
+            step_no=rk_state.step_no + 1,
+            step_no_total=rk_state.step_no_total + 1,
             y=next_y,
-            t=rkstate.t + rkstate.dt,
+            t=rk_state.t + actual_dt,
             dt=next_dt,
+            accepted=True,
         ),
-        lambda _: rkstate.replace(dt=next_dt),
+        lambda _: rk_state.replace(
+            step_no_total=rk_state.step_no_total + 1,
+            dt=next_dt,
+            accepted=False,
+        ),
         None,
     )
 
 
-@partial(jax.jit, static_argnames=["step_fn", "norm_fn"])
-def general_time_step_fixed(step_fn: Callable, rkstate: RungeKuttaState):
-    next_y = step_fn(rkstate.t, rkstate.dt, rkstate.y)
-    r = rkstate.replace(t=rkstate.t + rkstate.dt, y=next_y, step_no=rkstate.step_no + 1)
-    return r
+# @partial(jax.jit, static_argnames=["step_fn", "norm_fn"])
+def general_time_step_fixed(step_fn: Callable, rk_state: RungeKuttaState):
+    next_y = step_fn(rk_state.t.value, rk_state.dt, rk_state.y)
+    return rk_state.replace(
+        step_no=rk_state.step_no + 1,
+        step_no_total=rk_state.step_no_total + 1,
+        t=rk_state.t + rk_state.dt,
+        y=next_y,
+        accepted=True,
+    )
 
 
 @dataclasses.dataclass
-class RungeKuttaSolver:
+class RungeKuttaIntegrator:
     tableau: TableauRKExplicit
 
     f: Callable
     t0: float
     y0: Array
 
-    dt: float
-
-    tend: float
+    initial_dt: float
 
     use_adaptive: bool
     norm: Callable
 
     atol: float = 0.0
     rtol: float = 1e-7
+    dt_limits: Optional[LimitsType] = None
 
     def __post_init__(self):
         if self.use_adaptive and not self.tableau.is_adaptive:
             raise RuntimeError(
-                f"Solver {self.tablaeu} does not support adaptive step size"
+                f"Solver {self.tableau} does not support adaptive step size"
             )
         if self.use_adaptive:
-            self._do_step = lambda state: general_time_step_adaptive(
-                lambda t, dt, y, **kw: self.tableau.step_with_error(
-                    self.f, t, dt, y, **kw
-                ),
-                state,
-                atol=self.atol,
-                rtol=self.rtol,
-                norm_fn=self.norm,
-            )
+            self._do_step = self._do_step_adaptive
         else:
-            self._do_step = lambda state: general_time_step_fixed(
-                lambda t, dt, y, **kw: self.tableau.step(self.f, t, dt, y, **kw),
-                state,
-            )
+            self._do_step = self._do_step_fixed
+
+        if self.dt_limits is None:
+            self.dt_limits = (None, 10 * self.initial_dt)
 
         self._rkstate = RungeKuttaState(
             step_no=0,
-            t=self.t0,
+            step_no_total=0,
+            t=KahanSum(self.t0),
             y=self.y0,
-            dt=self.dt,
-            last_norm=None,
+            dt=self.initial_dt,
         )
 
-    def step(self):
-        self._rkstate = self._do_step(self._rkstate)
+    def step(self, max_dt=None):
+        """
+        Perform one full Runge-Kutta step.
+        """
+        print(f"RK.step (t={self.t}, {max_dt=})")
+        print(f"      => {self._rkstate}")
+        self._rkstate = self._do_step(self._rkstate, max_dt)
+        print(f"      <= {self._rkstate}")
+        return self._rkstate.accepted
 
-    @property
-    def status(self):
-        if self.t < self.tend:
-            return "running"
-        else:
-            return "done"
+    def _do_step_fixed(self, rk_state, max_dt=None):
+        return general_time_step_fixed(
+            lambda t, dt, y, **kw: self.tableau.step(self.f, t, dt, y, **kw),
+            rk_state,
+        )
+
+    def _do_step_adaptive(self, rk_state, max_dt=None):
+        return general_time_step_adaptive(
+            lambda t, dt, y, **kw: self.tableau.step_with_error(self.f, t, dt, y, **kw),
+            rk_state,
+            atol=self.atol,
+            rtol=self.rtol,
+            norm_fn=self.norm,
+            max_dt=max_dt,
+            dt_limits=self.dt_limits,
+        )
 
     @property
     def t(self):
-        return self._rkstate.t
+        return self._rkstate.t.value
 
     @property
     def y(self):
         return self._rkstate.y
 
     @property
-    def current_dt(self):
+    def dt(self):
         return self._rkstate.dt
 
 
-def RKSolver(dt, tableau, adaptive=False, norm=None, **kwargs):
-    def make(f, tspan, y0):
+def RKSolver(dt, tableau, adaptive=False, norm=jnp.linalg.norm, **kwargs):
+    def make(f, t0, y0):
         y0 = jnp.asarray(y0)
-        t0, tend = tspan
-        return RungeKuttaSolver(
-            tableau, f, t0, y0, dt, tend, use_adaptive=adaptive, norm=norm, **kwargs
+        return RungeKuttaIntegrator(
+            tableau,
+            f,
+            t0,
+            y0,
+            initial_dt=dt,
+            use_adaptive=adaptive,
+            norm=norm,
+            **kwargs,
         )
 
     return make
@@ -330,7 +398,7 @@ bt_rk23  = TableauRKExplicit(
                 )
 RK23 = partial(RKSolver, tableau=bt_rk23)
 
-bt_rk4_fehlberg  = TableauRKExplicit(
+bt_rk4_fehlberg = TableauRKExplicit(
                 name = "fehlberg", 
                 order = (4,5),
                 a = jnp.array([[ 0,          0,          0,           0,            0,      0 ],
@@ -361,4 +429,65 @@ bt_rk4_dopri  = TableauRKExplicit(
                 c_error = None,
                 )
 RK45 = partial(RKSolver, tableau=bt_rk4_dopri)
+
+# Tsit5 method. Tableau entries taken from DiffEqDevTools.jl:
+# https://github.com/SciML/DiffEqDevTools.jl/blob/37fde034a03b8dcf440613a81df1483a06ea25f9/src/ode_tableaus.jl#L988-L1042
+def _make_tsit5(dtype=None):
+    a = np.zeros((7, 7), dtype)
+    b = np.zeros((2, 7), dtype)
+    c = np.zeros((7,), dtype)
+
+    a[1, 0] = 161 / 1000
+    a[2, 0] = -.8480655492356988544426874250230774675121177393430391537369234245294192976164141156943e-2
+    a[2, 1] = .3354806554923569885444268742502307746751211773934303915373692342452941929761641411569
+    a[3, 0] = 2.897153057105493432130432594192938764924887287701866490314866693455023795137503079289
+    a[3, 1] = -6.359448489975074843148159912383825625952700647415626703305928850207288721235210244366
+    a[3, 2] = 4.362295432869581411017727318190886861027813359713760212991062156752264926097707165077
+    a[4, 0] = 5.325864828439256604428877920840511317836476253097040101202360397727981648835607691791
+    a[4, 1] = -11.74888356406282787774717033978577296188744178259862899288666928009020615663593781589
+    a[4, 2] = 7.495539342889836208304604784564358155658679161518186721010132816213648793440552049753
+    a[4, 3] = -.9249506636175524925650207933207191611349983406029535244034750452930469056411389539635e-1
+    a[5, 0] = 5.861455442946420028659251486982647890394337666164814434818157239052507339770711679748
+    a[5, 1] = -12.92096931784710929170611868178335939541780751955743459166312250439928519268343184452
+    a[5, 2] = 8.159367898576158643180400794539253485181918321135053305748355423955009222648673734986
+    a[5, 3] = -.7158497328140099722453054252582973869127213147363544882721139659546372402303777878835e-1
+    a[5, 4] = -.2826905039406838290900305721271224146717633626879770007617876201276764571291579142206e-1
+    a[6, 0] = .9646076681806522951816731316512876333711995238157997181903319145764851595234062815396e-1
+    a[6, 1] = 1 / 100
+    a[6, 2] = .4798896504144995747752495322905965199130404621990332488332634944254542060153074523509
+    a[6, 3] = 1.379008574103741893192274821856872770756462643091360525934940067397245698027561293331
+    a[6, 4] = -3.290069515436080679901047585711363850115683290894936158531296799594813811049925401677
+    a[6, 5] = 2.324710524099773982415355918398765796109060233222962411944060046314465391054716027841
+    
+    b[0, 0] = .9646076681806522951816731316512876333711995238157997181903319145764851595234062815396e-1
+    b[0, 1] = 1 / 100
+    b[0, 2] = .4798896504144995747752495322905965199130404621990332488332634944254542060153074523509
+    b[0, 3] = 1.379008574103741893192274821856872770756462643091360525934940067397245698027561293331
+    b[0, 4] = -3.290069515436080679901047585711363850115683290894936158531296799594813811049925401677
+    b[0, 5] = 2.324710524099773982415355918398765796109060233222962411944060046314465391054716027841
+    b[1, 0] = .9468075576583945807478876255758922856117527357724631226139574065785592789071067303271e-1
+    b[1, 1] = .9183565540343253096776363936645313759813746240984095238905939532922955247253608687270e-2
+    b[1, 2] = .4877705284247615707855642599631228241516691959761363774365216240304071651579571959813
+    b[1, 3] = 1.234297566930478985655109673884237654035539930748192848315425833500484878378061439761
+    b[1, 4] = -2.707712349983525454881109975059321670689605166938197378763992255714444407154902012702
+    b[1, 5] = 1.866628418170587035753719399566211498666255505244122593996591602841258328965767580089
+    b[1, 6] = 1 / 66
+
+    c[1] = 161 / 1000
+    c[2] = 327 / 1000
+    c[3] =   9 / 10
+    c[4] = 0.9800255409045096857298102862870245954942137979563024768854764293221195950761080302604
+    c[5] = 1.0
+    c[6] = 1.0
+
+    return TableauRKExplicit(
+        name="Tsit5",
+        order=(5, 4),
+        a=jnp.asarray(a),
+        b=jnp.asarray(b),
+        c=jnp.asarray(c),
+        c_error=None,
+    )
+
+Tsit5 = partial(RKSolver, tableau=_make_tsit5())
 # fmt: on

--- a/netket/experimental/dynamics/runge_kutta.py
+++ b/netket/experimental/dynamics/runge_kutta.py
@@ -440,9 +440,11 @@ class RKIntegratorConfig:
 
 
 # fmt: off
+# flake8: noqa: E123, E126, E201, E202, E221, E226, E231, E241, E251
+
 # Fixed Step methods
 bt_feuler = TableauRKExplicit(
-                name = "feuler", 
+                name = "feuler",
                 order = (1,),
                 a = jnp.zeros((1,1), dtype=dtype),
                 b = jnp.ones((1,1), dtype=dtype),
@@ -453,7 +455,7 @@ Euler = partial(RKIntegratorConfig, tableau=bt_feuler)
 
 
 bt_midpoint = TableauRKExplicit(
-                name = "midpoint", 
+                name = "midpoint",
                 order = (2,),
                 a = jnp.array([[0,   0],
                                [1/2, 0]], dtype=dtype),
@@ -465,7 +467,7 @@ Midpoint = partial(RKIntegratorConfig, tableau=bt_midpoint)
 
 
 bt_heun = TableauRKExplicit(
-                name = "heun", 
+                name = "heun",
                 order = (2,),
                 a = jnp.array([[0,   0],
                                [1,   0]], dtype=dtype),
@@ -476,7 +478,7 @@ bt_heun = TableauRKExplicit(
 Heun = partial(RKIntegratorConfig, tableau=bt_heun)
 
 bt_rk4  = TableauRKExplicit(
-                name = "rk4", 
+                name = "rk4",
                 order = (4,),
                 a = jnp.array([[0,   0,   0,   0],
                                [1/2, 0,   0,   0],
@@ -492,7 +494,7 @@ RK4 = partial(RKIntegratorConfig, tableau=bt_rk4)
 # Adaptive step:
 # Heun Euler https://en.wikipedia.org/wiki/Runge–Kutta_methods
 bt_rk12  = TableauRKExplicit(
-                name = "rk21", 
+                name = "rk21",
                 order = (2,1),
                 a = jnp.array([[0,   0],
                                [1,   0]], dtype=dtype),
@@ -505,7 +507,7 @@ RK12 = partial(RKIntegratorConfig, tableau=bt_rk12)
 
 # Bogacki–Shampine coefficients
 bt_rk23  = TableauRKExplicit(
-                name = "rk23", 
+                name = "rk23",
                 order = (2,3),
                 a = jnp.array([[0,   0,   0,   0],
                                [1/2, 0,   0,   0],
@@ -519,7 +521,7 @@ bt_rk23  = TableauRKExplicit(
 RK23 = partial(RKIntegratorConfig, tableau=bt_rk23)
 
 bt_rk4_fehlberg = TableauRKExplicit(
-                name = "fehlberg", 
+                name = "fehlberg",
                 order = (4,5),
                 a = jnp.array([[ 0,          0,          0,           0,            0,      0 ],
                               [  1/4,        0,          0,           0,            0,      0 ],
@@ -534,7 +536,7 @@ bt_rk4_fehlberg = TableauRKExplicit(
                 )
 
 bt_rk4_dopri  = TableauRKExplicit(
-                name = "dopri", 
+                name = "dopri",
                 order = (5,4),
                 a = jnp.array([[ 0,           0,           0,           0,        0,             0,         0 ],
                               [  1/5,         0,           0,           0,        0,             0,         0 ],

--- a/netket/utils/__init__.py
+++ b/netket/utils/__init__.py
@@ -24,6 +24,7 @@ from .array import HashableArray
 from .jax import get_afun_if_module, wrap_afun
 from .optional_deps import tensorboard_available
 from .seed import random_seed
+from .summation import KahanSum
 
 from .deprecation import warn_deprecation, deprecated, deprecated_new_name
 from .moduletools import _hide_submodules, rename_class, auto_export as _auto_export

--- a/netket/utils/summation.py
+++ b/netket/utils/summation.py
@@ -28,13 +28,6 @@ class KahanSum:
     value: Scalar
     compensator: Scalar = 0.0
 
-    def tree_flatten(self):
-        return (self.value, self.compensator), None
-
-    @classmethod
-    def tree_unflatten(cls, _, children):
-        return cls(*children)
-
     def __add__(self, other: Scalar):
         delta = other - self.compensator
         new_value = self.value + delta

--- a/netket/utils/summation.py
+++ b/netket/utils/summation.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Sequence
-
 from .struct import dataclass
 from .types import Scalar
 

--- a/netket/utils/summation.py
+++ b/netket/utils/summation.py
@@ -33,9 +33,3 @@ class KahanSum:
         new_value = self.value + delta
         new_compensator = (new_value - self.value) - delta
         return KahanSum(new_value, new_compensator)
-
-    def __radd__(self, other: Scalar):
-        delta = other - self.compensator
-        new_value = self.value + delta
-        self.compensator = (new_value - self.value) - delta
-        self.value = new_value

--- a/netket/utils/summation.py
+++ b/netket/utils/summation.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import jax
+from typing import Sequence
 
 from .struct import dataclass
 from .types import Scalar

--- a/netket/utils/summation.py
+++ b/netket/utils/summation.py
@@ -1,0 +1,50 @@
+# Copyright 2021 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import jax
+
+from .struct import dataclass
+from .types import Scalar
+
+
+@dataclass
+class KahanSum:
+    """
+    Accumulator implementing Kahan summation [1], which reduces
+    the effect of accumulated floating-point error.
+
+    [1] https://en.wikipedia.org/wiki/Kahan_summation_algorithm
+    """
+
+    value: Scalar
+    compensator: Scalar = 0.0
+
+    def tree_flatten(self):
+        return (self.value, self.compensator), None
+
+    @classmethod
+    def tree_unflatten(cls, _, children):
+        return cls(*children)
+
+    def __add__(self, other: Scalar):
+        delta = other - self.compensator
+        new_value = self.value + delta
+        new_compensator = (new_value - self.value) - delta
+        return KahanSum(new_value, new_compensator)
+
+    def __radd__(self, other: Scalar):
+        delta = other - self.compensator
+        new_value = self.value + delta
+        self.compensator = (new_value - self.value) - delta
+        self.value = new_value

--- a/netket/utils/types.py
+++ b/netket/utils/types.py
@@ -37,6 +37,7 @@ Shape = Sequence[int]
 DType = Any  # this could be a real type?
 
 Array = Union[_np.ndarray, _DeviceArray, _jax.core.Tracer]
+ArrayLike = Any  # Objects that are valid inputs to (np|jnp).asarray.
 
 NNInitFunc = Callable[[PRNGKeyT, Shape, DType], Array]
 

--- a/netket/vqs/mc/mc_mixed_state/expect.py
+++ b/netket/vqs/mc/mc_mixed_state/expect.py
@@ -42,6 +42,21 @@ def get_local_kernel_arguments(  # noqa: F811
 
 
 @dispatch
+def get_local_kernel_arguments(
+    vstate: MCMixedState, Ô: AbstractSuperOperator
+):  # noqa: F811
+    check_hilbert(vstate.hilbert, Ô.hilbert)
+    σ = vstate.samples
+    σp, mels = Ô.get_conn_padded(σ)
+    return σ, (σp, mels)
+
+
+@dispatch
+def get_local_kernel(vstate: MCMixedState, Ô: AbstractSuperOperator):  # noqa: F811
+    return kernels.local_value_kernel
+
+
+@dispatch
 def get_local_kernel(vstate: MCMixedState, Ô: DiscreteOperator):  # noqa: F811
     return kernels.local_value_op_op_cost
 

--- a/test/dynamics/test_driver.py
+++ b/test/dynamics/test_driver.py
@@ -71,7 +71,7 @@ all_integrators = fixed_step_integrators + adaptive_step_integrators
 @pytest.mark.parametrize("propagation_type", ["real", "imag"])
 def test_one_fixed_step(integrator, propagation_type):
     ha, vstate, _ = _setup_system(L=2)
-    te = nkx.TimeDependentVMC(
+    te = nkx.TDVP(
         ha,
         vstate,
         integrator,
@@ -100,7 +100,7 @@ def l4_norm(_, x):
 @pytest.mark.parametrize("propagation_type", ["real", "imag"])
 def test_one_adaptive_step(integrator, error_norm, propagation_type):
     ha, vstate, _ = _setup_system(L=2)
-    te = nkx.TimeDependentVMC(
+    te = nkx.TDVP(
         ha,
         vstate,
         integrator,
@@ -141,7 +141,7 @@ def test_one_step_lindbladian(integrator):
         return lind, vstate
 
     lind, vstate = _setup_lindbladian_system()
-    te = nkx.TimeDependentVMC(
+    te = nkx.TDVP(
         lind,
         vstate,
         integrator,
@@ -155,7 +155,7 @@ def test_one_step_lindbladian(integrator):
 def test_stop_times(integrator):
     def make_driver():
         ha, vstate, _ = _setup_system(L=2)
-        return nkx.TimeDependentVMC(
+        return nkx.TDVP(
             ha,
             vstate,
             integrator,
@@ -201,17 +201,17 @@ def test_stop_times(integrator):
 
 def test_repr_and_info():
     ha, vstate, _ = _setup_system(L=2)
-    driver = nkx.TimeDependentVMC(
+    driver = nkx.TDVP(
         ha,
         vstate,
         nkx.dynamics.RK23(dt=0.01),
     )
     print(str(driver))
-    assert "TimeDependentVMC" in str(driver)
+    assert "TDVP" in str(driver)
 
     info = driver.info()
     print(info)
-    assert "TimeDependentVMC" in info
+    assert "TDVP" in info
     assert "generator" in info
     assert "integrator" in info
     assert "rk23" in info

--- a/test/dynamics/test_driver.py
+++ b/test/dynamics/test_driver.py
@@ -44,8 +44,12 @@ def _setup_system(L, *, dtype=np.float64):
 integrator_params = [
     pytest.param(nkx.dynamics.Heun(dt=0.01), id="Heun(dt=0.01)"),
     pytest.param(
-        nkx.dynamics.RK23(dt=0.01, adaptive=True, rtol=1e-2),
+        nkx.dynamics.RK23(dt=0.01, adaptive=True, rtol=1e-3),
         id="RK23(dt=0.01, adaptive=True)",
+    ),
+    pytest.param(
+        nkx.dynamics.RK45(dt=0.01, adaptive=True, rtol=1e-3),
+        id="RK45(dt=0.01, adaptive=True)",
     ),
 ]
 

--- a/test/dynamics/test_driver.py
+++ b/test/dynamics/test_driver.py
@@ -45,12 +45,12 @@ integrator_params = [
     pytest.param(nkx.dynamics.Euler(dt=0.01), id="Euler(dt=0.01)"),
     pytest.param(nkx.dynamics.Heun(dt=0.01), id="Heun(dt=0.01)"),
     pytest.param(
-        nkx.dynamics.RK23(dt=0.01, adaptive=True, rtol=1e-2),
-        id="RK23(dt=0.01, adaptive=True)",
+        nkx.dynamics.RK23(dt=0.01, adaptive=True, rtol=1e-2, atol=1e-2),
+        id="RK23(dt=0.01, adaptive)",
     ),
     pytest.param(
-        nkx.dynamics.RK45(dt=0.01, adaptive=True, rtol=1e-3),
-        id="RK45(dt=0.01, adaptive=True)",
+        nkx.dynamics.RK45(dt=0.01, adaptive=True, rtol=1e-3, atol=1e-3),
+        id="RK45(dt=0.01, adaptive)",
     ),
 ]
 

--- a/test/dynamics/test_driver.py
+++ b/test/dynamics/test_driver.py
@@ -1,0 +1,98 @@
+# Copyright 2021 The NetKet Authors - All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import numpy as np
+
+import netket as nk
+import netket.experimental as nkx
+
+
+SEED = 214748364
+
+
+def _setup_system(L, *, dtype=np.float64):
+    g = nk.graph.Chain(length=L)
+    hi = nk.hilbert.Spin(s=0.5, N=g.n_nodes)
+
+    ma = nk.models.RBM(alpha=1, dtype=dtype)
+    sa = nk.sampler.ExactSampler(hilbert=hi, n_chains=16)
+
+    vs = nk.vqs.MCState(sa, ma, n_samples=1000, seed=SEED)
+
+    ha = nk.operator.Ising(hi, graph=g, h=1.0)
+
+    # Add custom observable
+    X = [[0, 1], [1, 0]]
+    sx = nk.operator.LocalOperator(hi, [X] * L, [[i] for i in range(g.n_nodes)])
+    obs = {"sx": sx}
+
+    return ha, vs, obs
+
+
+integrator_params = [
+    pytest.param(nkx.dynamics.Heun(dt=0.01), id="Heun(dt=0.01)"),
+    pytest.param(
+        nkx.dynamics.RK23(dt=0.01, adaptive=True, rtol=1e-2),
+        id="RK23(dt=0.01, adaptive=True)",
+    ),
+]
+
+
+@pytest.mark.parametrize("integrator", integrator_params)
+def test_stop_times(integrator):
+    ha, vstate, _ = _setup_system(L=4)
+    driver = nkx.TimeDependentVMC(
+        ha,
+        vstate,
+        integrator,
+        qgt=nk.optimizer.qgt.QGTJacobianDense(holomorphic=True),
+        propagation_type="imag",
+    )
+    ts = []
+    for i, t in enumerate(driver.iter(T=1.0)):
+        assert t == driver.t
+        assert t == driver.step_value
+        assert i == driver.step_count
+        ts.append(t)
+    if driver.integrator.use_adaptive:
+        assert np.all(np.less_equal(ts, 1.0))
+        assert np.all(np.greater_equal(ts, 0.0))
+    else:
+        np.testing.assert_allclose(ts, np.linspace(0.0, 1.0, 101))
+
+    ha, vstate, _ = _setup_system(L=4)
+    driver = nkx.TimeDependentVMC(
+        ha,
+        vstate,
+        integrator,
+        qgt=nk.optimizer.qgt.QGTJacobianDense(holomorphic=True),
+        propagation_type="imag",
+    )
+    tstops = [0.0, 0.2, 0.4, 0.6, 0.8, 1.0]
+    ts = []
+    for i, t in enumerate(driver.iter(T=1.0, tstops=tstops)):
+        assert t == driver.t
+        assert t == driver.step_value
+        ts.append(t)
+    np.testing.assert_allclose(ts, tstops)
+
+    with pytest.raises(ValueError, match="All tstops must be in range"):
+        list(driver.iter(T=1.0, tstops=tstops))
+    with pytest.raises(ValueError, match="All tstops must be in range"):
+        list(driver.iter(T=1.0, tstops=[42.0]))
+
+
+def test_run():
+    pass

--- a/test/dynamics/test_driver.py
+++ b/test/dynamics/test_driver.py
@@ -197,3 +197,21 @@ def test_stop_times(integrator):
         assert t == driver.step_value
         ts.append(t)
     np.testing.assert_allclose(ts, tstops)
+
+
+def test_repr_and_info():
+    ha, vstate, _ = _setup_system(L=2)
+    driver = nkx.TimeDependentVMC(
+        ha,
+        vstate,
+        nkx.dynamics.RK23(dt=0.01),
+    )
+    print(str(driver))
+    assert "TimeDependentVMC" in str(driver)
+
+    info = driver.info()
+    print(info)
+    assert "TimeDependentVMC" in info
+    assert "generator" in info
+    assert "integrator" in info
+    assert "rk23" in info

--- a/test/dynamics/test_solvers.py
+++ b/test/dynamics/test_solvers.py
@@ -33,7 +33,7 @@ explicit_adaptive_solvers = {
 }
 # Only add RK12 outside CI, as it adapts to smaller steps, making
 # test_adaptive_solver take more time.
-if not os.environ["CI"] == "true":
+if os.environ.get("CI", "false") != "true":
     explicit_adaptive_solvers["RK12"] = RK12
 
 
@@ -41,12 +41,12 @@ if not os.environ["CI"] == "true":
 def test_ode_solver(solver):
     if solver == "Euler":  # first order
 
-        def ode(t, x, **_):
+        def ode(_t, _x, **_):
             return 1.0
 
     else:  # quadratic function for higher-order solvers
 
-        def ode(t, x, **_):
+        def ode(t, _x, **_):
             return t
 
     solver = explicit_fixed_step_solvers[solver]
@@ -61,7 +61,7 @@ def test_ode_solver(solver):
 
     t = []
     y_t = []
-    for i in range(10):
+    for _ in range(10):
         t.append(solv.t)
         y_t.append(solv.y)
         solv.step()

--- a/test/dynamics/test_solvers.py
+++ b/test/dynamics/test_solvers.py
@@ -17,7 +17,7 @@ import numpy as np
 
 import scipy.integrate as sci
 
-from netket.experimental.dynamics import Euler, Heun, Midpoint, RK4, RK45, Tsit5
+from netket.experimental.dynamics import Euler, Heun, Midpoint, RK4, RK12, RK23, RK45
 
 explicit_fixed_step_solvers = {
     "Euler": Euler,
@@ -27,8 +27,9 @@ explicit_fixed_step_solvers = {
 }
 
 explicit_adaptive_solvers = {
+    "RK12": RK12,
+    "RK23": RK23,
     "RK45": RK45,
-    "Tsit5": Tsit5,
 }
 
 

--- a/test/dynamics/test_solvers.py
+++ b/test/dynamics/test_solvers.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import pytest
 import numpy as np
 
@@ -27,10 +28,13 @@ explicit_fixed_step_solvers = {
 }
 
 explicit_adaptive_solvers = {
-    "RK12": RK12,
     "RK23": RK23,
     "RK45": RK45,
 }
+# Only add RK12 outside CI, as it adapts to smaller steps, making
+# test_adaptive_solver take more time.
+if not os.environ["CI"] == "true":
+    explicit_adaptive_solvers["RK12"] = RK12
 
 
 @pytest.mark.parametrize("solver", explicit_fixed_step_solvers)

--- a/test/dynamics/test_solvers.py
+++ b/test/dynamics/test_solvers.py
@@ -1,0 +1,99 @@
+# Copyright 2021 The NetKet Authors - All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import numpy as np
+
+import scipy.integrate as sci
+
+from netket.experimental.dynamics import Euler, Heun, Midpoint, RK4, RK45, Tsit5
+
+explicit_fixed_step_solvers = {
+    "Euler": Euler,
+    "Heun": Heun,
+    "Midpoint": Midpoint,
+    "RK4": RK4,
+}
+
+explicit_adaptive_solvers = {
+    "RK45": RK45,
+    "Tsit5": Tsit5,
+}
+
+
+@pytest.mark.parametrize("solver", explicit_fixed_step_solvers)
+def test_ode_solver(solver):
+    if solver == "Euler":  # first order
+
+        def ode(t, x, **_):
+            return 1.0
+
+    else:  # quadratic function for higher-order solvers
+
+        def ode(t, x, **_):
+            return t
+
+    solver = explicit_fixed_step_solvers[solver]
+
+    y0 = np.array([1.0])
+    times = np.linspace(0, 2, 10, endpoint=False)
+
+    sol = sci.solve_ivp(ode, (0.0, 2.0), y0, t_eval=times)
+    y_ref = sol.y[0]
+
+    solv = solver(dt=0.2)(ode, 0.0, y0)
+
+    t = []
+    y_t = []
+    for i in range(10):
+        t.append(solv.t)
+        y_t.append(solv.y)
+        solv.step()
+    y_t = np.asarray(y_t)
+
+    np.testing.assert_allclose(t, times)
+    np.testing.assert_allclose(y_t[:, 0], y_ref)
+
+
+@pytest.mark.parametrize("solver", explicit_adaptive_solvers)
+def test_adaptive_solver(solver):
+    solver = explicit_adaptive_solvers[solver]
+
+    tol = 1e-7
+
+    def ode(t, x, **_):
+        return -t * x
+
+    y0 = np.array([1.0])
+    solv = solver(dt=0.2, adaptive=True, atol=0.0, rtol=tol)(ode, 0.0, y0)
+
+    t = []
+    y_t = []
+    last_step = -1
+    while solv.t <= 2.0:
+        print(solv._rkstate)
+        if solv._rkstate.step_no != last_step:
+            last_step = solv._rkstate.step_no
+            t.append(solv.t)
+            y_t.append(solv.y)
+        solv.step()
+    y_t = np.asarray(y_t)
+
+    print(t)
+    sol = sci.solve_ivp(
+        ode, (0.0, 2.0), y0, t_eval=t, atol=0.0, rtol=tol, method="RK45"
+    )
+    y_ref = sol.y[0]
+
+    np.testing.assert_allclose(y_t[:, 0], y_ref, rtol=1e-5)

--- a/test/utils/test_utils.py
+++ b/test/utils/test_utils.py
@@ -61,3 +61,7 @@ def test_HashableArray(numpy):
 
     assert_equal(wa.wrapped, np.asarray(wa))
     assert wa.wrapped is not wa
+
+
+def test_kahan_summation():
+    numbers = np.arange(1000)

--- a/test/utils/test_utils.py
+++ b/test/utils/test_utils.py
@@ -65,12 +65,10 @@ def test_HashableArray(numpy):
 
 
 def test_Kahan_sum():
-    sum = 0.0
     ksum1 = KahanSum(0.0)
     ksum2 = KahanSum(0.0)
     vals = 0.01 * np.ones(500)
     for val in vals:
-        sum += val
         ksum1 += val
         ksum2 = ksum2 + val
 

--- a/test/utils/test_utils.py
+++ b/test/utils/test_utils.py
@@ -61,7 +61,3 @@ def test_HashableArray(numpy):
 
     assert_equal(wa.wrapped, np.asarray(wa))
     assert wa.wrapped is not wa
-
-
-def test_kahan_summation():
-    numbers = np.arange(1000)

--- a/test/utils/test_utils.py
+++ b/test/utils/test_utils.py
@@ -20,6 +20,7 @@ from numpy.testing import assert_equal
 
 from netket.jax import PRNGKey, PRNGSeq
 from netket.utils import HashableArray
+from netket.utils.summation import KahanSum
 
 from .. import common
 
@@ -61,3 +62,17 @@ def test_HashableArray(numpy):
 
     assert_equal(wa.wrapped, np.asarray(wa))
     assert wa.wrapped is not wa
+
+
+def test_Kahan_sum():
+    sum = 0.0
+    ksum1 = KahanSum(0.0)
+    ksum2 = KahanSum(0.0)
+    vals = 0.01 * np.ones(500)
+    for val in vals:
+        sum += val
+        ksum1 += val
+        ksum2 = ksum2 + val
+
+    assert ksum1.value == pytest.approx(5.0, rel=1e-15, abs=1e-15)
+    assert ksum2.value == pytest.approx(5.0, rel=1e-15, abs=1e-15)


### PR DESCRIPTION
This PR adds an implementation of t-VMC based on the synthesis of @PhilipVinc's and my ideas for t-VMC propagation using `jax`. This is added to the `netket.experimental` submodule for the moment, to give us more freedom to continue improving the API (in particular of the included ODE solver routines).

This PR contains two main parts:

1.  A jax-based implementation of Runge-Kutta integration schemes (both adaptive and with fixed step size) in `netket.experimental.dynamics.runge_kutta`. These are not tied to t-VMC or even variational quantum states, but can in principle be applied to any explicit ODE defined as a Python function `dx/dt = f(x, t)`. The code is written with the goal of making the whole solver jitable by `jax` (although this is not enabled in this PR, since our VMC code is not yet jitable.)
2. The `netket.experimental.TDVP` driver, which supports t-VMC propagation of pure NQS (that is, `MCState`) based on either the real-time or imaginary-time Schrödinger equation. Lindbladian real-time dynamics for NDMs using `MCMixedState` are also supported.

Basic usage of the driver looks like this:
```python3
integrator = nkx.dynamics.RK23(dt=0.01, adaptive=True, rtol=1e-3, atol=1e-3)
te = nkx.TDVP(
    hamiltonian,
    variational_state=vstate,
    integrator=integrator,
)
te.run(
    T=1.0,
    out="example_dynamics",
    tstops=np.linspace(0.0, 1.0, 101, endpoint=True),
)
```
See the included example (`Examples/Dynamics/ising1d.py`) for a complete demo.
There are also tests under `test/dynamics` that show some of the parts of this PR in action.

Closes #289, closes #435.