### PR TITLE
Remove everything about 'chain' in exact samplers

### DIFF
--- a/netket/experimental/sampler/metropolis_pt.py
+++ b/netket/experimental/sampler/metropolis_pt.py
@@ -380,30 +380,6 @@ class MetropolisPtSampler(MetropolisSampler):
 
         return new_state, new_state.σ[new_state.beta_0_index + offsets, :]
 
-    def __repr__(sampler):
-        return (
-            "MetropolisPTSampler("
-            + "\n  hilbert = {},".format(sampler.hilbert)
-            + "\n  rule = {},".format(sampler.rule)
-            + "\n  n_chains = {},".format(sampler.n_chains)
-            + "\n  machine_power = {},".format(sampler.machine_pow)
-            + "\n  reset_chain = {},".format(sampler.reset_chain)
-            + "\n  n_sweeps = {},".format(sampler.n_sweeps)
-            + "\n  dtype = {},".format(sampler.dtype)
-            + ")"
-        )
-
-    def __str__(sampler):
-        return (
-            "MetropolisPTSampler("
-            + "rule = {}, ".format(sampler.rule)
-            + "n_chains = {}, ".format(sampler.n_chains)
-            + "machine_power = {}, ".format(sampler.machine_pow)
-            + "reset_chain = {}, ".format(sampler.reset_chain)
-            + "n_sweeps = {}, ".format(sampler.n_sweeps)
-            + "dtype = {})".format(sampler.dtype)
-        )
-
 
 def MetropolisLocalPt(hilbert, *args, **kwargs):
     r"""

--- a/netket/sampler/__init__.py
+++ b/netket/sampler/__init__.py
@@ -17,9 +17,7 @@ from .base import (
     SamplerState,
     sampler_state,
     reset,
-    sample_next,
     sample,
-    samples,
 )
 
 from .exact import ExactSampler
@@ -32,6 +30,8 @@ from .metropolis import (
     MetropolisSamplerState,
     MetropolisHamiltonian,
     MetropolisGaussian,
+    sample_next,
+    samples,
 )
 
 from .metropolis_numpy import (

--- a/netket/sampler/__init__.py
+++ b/netket/sampler/__init__.py
@@ -31,6 +31,7 @@ from .metropolis import (
     MetropolisHamiltonian,
     MetropolisGaussian,
     sample_next,
+    sample_chain,
     samples,
 )
 

--- a/netket/sampler/autoreg.py
+++ b/netket/sampler/autoreg.py
@@ -93,6 +93,9 @@ class ARDirectSampler(Sampler):
 
 @partial(jax.jit, static_argnums=(1, 4))
 def _sample(sampler, model, variables, state, n_samples_per_rank):
+    """
+    Internal method used for jitting calls.
+    """
     if "cache" in variables:
         variables, _ = variables.pop("cache")
 

--- a/netket/sampler/base.py
+++ b/netket/sampler/base.py
@@ -237,7 +237,7 @@ class Sampler(abc.ABC):
         )
 
     @abc.abstractmethod
-    def _init_state(sampler, machine, parameters, seed) -> SamplerState:
+    def _init_state(sampler, machine, parameters, seed):
         """
         Implementation of `init_state` for subclasses of `Sampler`.
 
@@ -309,7 +309,7 @@ def reset(
     machine: Union[Callable, nn.Module],
     parameters: PyTree,
     state: Optional[SamplerState] = None,
-):
+) -> SamplerState:
     """
     Resets the state of the sampler. To be used every time the parameters are changed.
 
@@ -324,7 +324,7 @@ def reset(
     Returns:
         A valid sampler state.
     """
-    sampler.reset(machine, parameters, state)
+    return sampler.reset(machine, parameters, state)
 
 
 def sample(

--- a/netket/sampler/exact.py
+++ b/netket/sampler/exact.py
@@ -92,12 +92,15 @@ class ExactSampler(Sampler):
 
 @partial(jax.jit, static_argnums=(1, 4))
 def _sample(
-    sampler,
+    sampler: ExactSampler,
     machine: nn.Module,
     parameters: PyTree,
     state: SamplerState,
     n_samples_per_rank: int,
 ) -> Tuple[jnp.ndarray, SamplerState]:
+    """
+    Internal method used for jitting calls.
+    """
     new_rng, rng = jax.random.split(state.rng)
     numbers = jax.random.choice(
         rng,

--- a/netket/sampler/metropolis.py
+++ b/netket/sampler/metropolis.py
@@ -759,7 +759,7 @@ def MetropolisExchange(
           >>> # Construct a MetropolisExchange Sampler
           >>> sa = nk.sampler.MetropolisExchange(hi, graph=g)
           >>> print(sa)
-          MetropolisSampler(rule = ExchangeRule(# of clusters: 200), n_chains = 16, machine_power = 2, n_sweeps = 100, dtype = <class 'numpy.float64'>)
+          MetropolisSampler(rule = ExchangeRule(# of clusters: 200), n_chains = 16, n_sweeps = 100, reset_chains = False, machine_power = 2, dtype = <class 'numpy.float64'>)
     """
     from .rules import ExchangeRule
 
@@ -811,7 +811,7 @@ def MetropolisHamiltonian(hilbert, hamiltonian, *args, **kwargs) -> MetropolisSa
        >>> # Construct a MetropolisHamiltonian Sampler
        >>> sa = nk.sampler.MetropolisHamiltonian(hi, hamiltonian=ha)
        >>> print(sa)
-       MetropolisSampler(rule = HamiltonianRule(Ising(J=1.0, h=1.0; dim=100)), n_chains = 16, machine_power = 2, n_sweeps = 100, dtype = <class 'numpy.float64'>)
+       MetropolisSampler(rule = HamiltonianRule(Ising(J=1.0, h=1.0; dim=100)), n_chains = 16, n_sweeps = 100, reset_chains = False, machine_power = 2, dtype = <class 'numpy.float64'>)
     """
     from .rules import HamiltonianRule
 

--- a/netket/sampler/metropolis.py
+++ b/netket/sampler/metropolis.py
@@ -640,11 +640,8 @@ def samples(
         state: The current state of the sampler. If not specified, then initialize and reset it.
         chain_length: The length of the chains (default = 1).
     """
-    if state is None:
-        state = sampler.reset(machine, parameters, state)
-
     for i in range(chain_length):
-        samples, state = sampler._sample_chain(machine, parameters, state, 1)
+        samples, state = sampler.sample_chain(machine, parameters, state, 1)
         yield samples[0, :, :]
 
 

--- a/netket/vqs/mc/mc_state/state.py
+++ b/netket/vqs/mc/mc_state/state.py
@@ -16,8 +16,6 @@ import warnings
 from functools import partial
 from typing import Any, Callable, Dict, Optional, Tuple
 
-import numpy as np
-
 import jax
 from jax import numpy as jnp
 
@@ -29,32 +27,13 @@ from netket import nn
 from netket.stats import Stats
 from netket.operator import AbstractOperator
 from netket.sampler import Sampler, SamplerState
+from netket.sampler.metropolis import compute_chain_length
 from netket.utils import maybe_wrap_module, deprecated, warn_deprecation, mpi, wrap_afun
 from netket.utils.types import PyTree, SeedT, NNInitFunc
 from netket.optimizer import LinearOperator
 from netket.optimizer.qgt import QGTAuto
 
 from netket.vqs.base import VariationalState, expect, expect_and_grad
-
-
-def compute_chain_length(n_chains, n_samples):
-    if n_samples <= 0:
-        raise ValueError("Invalid number of samples: n_samples={}".format(n_samples))
-
-    chain_length = int(np.ceil(n_samples / n_chains))
-
-    n_samples_new = chain_length * n_chains
-    n_samples_per_rank_new = n_samples_new // mpi.n_nodes
-
-    if n_samples_new != n_samples:
-        n_samples_per_rank = n_samples // mpi.n_nodes
-        warnings.warn(
-            f"n_samples={n_samples} ({n_samples_per_rank} per MPI rank) does not "
-            f"divide n_chains={n_chains}, increased to {n_samples_new} "
-            f"({n_samples_per_rank_new} per MPI rank)"
-        )
-
-    return chain_length
 
 
 def check_chunk_size(n_samples, chunk_size):
@@ -64,8 +43,8 @@ def check_chunk_size(n_samples, chunk_size):
         if chunk_size < n_samples_per_rank and n_samples_per_rank % chunk_size != 0:
             raise ValueError(
                 f"chunk_size={chunk_size}`<`n_samples_per_rank={n_samples_per_rank}, "
-                "chunk_size is not an integer fraction of `n_samples_per rank`. This is"
-                "unsupported. Please change `chunk_size` so that it divides evenly the"
+                "chunk_size is not an integer fraction of `n_samples_per_rank`. This is "
+                "unsupported. Please change `chunk_size` so that it divides evenly the "
                 "number of samples per rank or set it to `None` to disable chunking."
             )
 

--- a/test/driver/test_steadystate.py
+++ b/test/driver/test_steadystate.py
@@ -36,7 +36,7 @@ def _setup_ss(dtype=np.float32, sr=True):
     hi, lind = _setup_system()
 
     ma = nk.models.NDM()
-    # sa = nk.sampler.ExactSampler(hilbert=nk.hilbert.DoubledHilber(hi), n_chains=16)
+    # sa = nk.sampler.ExactSampler(hilbert=nk.hilbert.DoubledHilber(hi))
 
     sa = nk.sampler.MetropolisLocal(hilbert=nk.hilbert.DoubledHilbert(hi))
     sa_obs = nk.sampler.MetropolisLocal(hilbert=hi)

--- a/test/groundstate/test_vmc.py
+++ b/test/groundstate/test_vmc.py
@@ -26,7 +26,7 @@ def _setup_vmc(dtype=np.float32, sr=True):
     hi = nk.hilbert.Spin(s=0.5, N=g.n_nodes)
 
     ma = nk.models.RBM(alpha=1, dtype=dtype)
-    sa = nk.sampler.ExactSampler(hilbert=hi, n_chains=16)
+    sa = nk.sampler.ExactSampler(hilbert=hi)
 
     vs = nk.vqs.MCState(sa, ma, n_samples=1000, seed=SEED)
 

--- a/test/variational/test_autoreg.py
+++ b/test/variational/test_autoreg.py
@@ -168,7 +168,7 @@ def test_vmc_same(partial_model_pair, hilbert, dtype, machine_pow, skip):
     model1 = partial_model_pair[0](hilbert, dtype, machine_pow)
     model2 = partial_model_pair[1](hilbert, dtype, machine_pow)
 
-    sampler1 = nk.sampler.ARDirectSampler(hilbert, n_chains=3)
+    sampler1 = nk.sampler.ARDirectSampler(hilbert)
     vstate1 = nk.vqs.MCState(sampler1, model1, n_samples=6, seed=123, sampler_seed=456)
     assert vstate1.n_discard_per_chain == 0
     samples1 = vstate1.sample()
@@ -180,7 +180,7 @@ def test_vmc_same(partial_model_pair, hilbert, dtype, machine_pow, skip):
     vmc1.run(n_iter=3)
     samples_trained1 = vstate1.sample()
 
-    sampler2 = nk.sampler.ARDirectSampler(hilbert, n_chains=3)
+    sampler2 = nk.sampler.ARDirectSampler(hilbert)
     vstate2 = nk.vqs.MCState(sampler2, model2, n_samples=6, seed=123, sampler_seed=456)
     samples2 = vstate2.sample()
 


### PR DESCRIPTION
Implements #997. This is definitely not 'slightly' or 'straightforward', and I hurried this in the weekend so that others' work will not introduce more conflicts.

All the changes to `MCState` are in the commit 'Update MCState'. Before that, all the tests for samplers should pass.

---

API changes to samplers:
* Specifying `n_chains` and `n_chains_per_rank` when constructing `Sampler` and exact samplers (`ExactSampler` and `ARDirectSampler`) is deprecated. Please do not use them, as previously they had no effect. `MetropolisSampler` still implements them.
* The method `sample_next` in `Sampler` and exact samplers is removed. Please use the method `sample` instead. `MetropolisSampler` still implements it.
* `nk.sampler.sample_next` and `nk.sampler.samples` now only work with `MetropolisSampler`. For exact samplers, please use `nk.sampler.sample` instead.
* `MetropolisSampler.sample_chain` and `nk.sampler.sample_chain` become public.
* `Sampler.sample` and `nk.sampler.sample` have a new argument `n_samples`.
* Specifying `chain_length` in `Sampler.sample` and `nk.sampler.sample` is deprecated. For exact samplers, please specify `n_samples` instead. For Metropolis samplers, please use `sample_chain` instead.
* The shape of the returned samples of `Sampler.sample` and `nk.sampler.sample` now depends on the type of the sampler. For exact samplers it is a 2D array `(n_samples, hilbert.size)`, and for Metropolis samplers it is a 3D array `(n_chains, chain_length, hilbert.size)`.
* `nk.sampler.sampler_state` now accepts the argument `seed`, as in `Sampler.init_state`. (Why not?)

API changes to variational states:
* `MCState.chain_length` now has the type `Optional[int]`, and will be `None` if the sampler is exact.
* Specifying `chain_length` in `MCState.sample` when the sampler is exact is deprecated. Please specify `n_samples` instead.
* The shape of the returned samples of `MCState.sample` now depends on the type of the sampler, as in `Sampler.sample`.

---

Implementation notes on `Sampler`:
* The module functions `sample_next`, `sample_chain`, and `samples` are moved from `sampler/base.py` to `sampler/metropolis.py`.
* To help write deprecation messages, there are helper functions `compute_n_samples` and `compute_n_samples_per_rank` in `sampler/base.py`, and `compute_n_chains_per_rank` and `compute_chain_length` (moved from `vqs/mc/mc_state/state.py`) in `sampler/metropolis.py`.
* In exact samplers, `_sample_next` and `_sample_chain` are removed, and they only need to override `_sample`.
* `Sampler.sample` takes `n_samples` as an argument, while `_sample` takes `n_samples_per_rank`. This is because `sample` handles the logic of dividing `n_samples` into ranks, which may raise warnings and should not be jitted.
* I don't think we should allow to specify `n_samples_per_rank` as an argument in `Sampler.sample`, otherwise `MCState.sample` needs to be consistent with it and it will become more complicated.
* There is a property `Sampler.n_batches`. Currently chunked sampling is not implemented, and exact samplers only use `n_batches` to store `n_chains_per_rank` and make it possible to specify `chain_length` in `sample` before it's removed. After finishing this PR, we can continue discussing about chunked sampling for exact samplers, and even Metropolis samplers (in principle it's possible when the number of independent chains is too large to fit into the memory).

Implementation notes on `MetropolisSampler`:
* In `MetropolisSampler`, `sample` calls `_sample_chain` rather than `_sample`.
* The public method `sample_chain` has default values for `state` and `chain_length`, and uses `wrap_afun` to handle `machine`, while the private method `_sample_chain` does not. The public module function `sample_chain` just calls `MetropolisSampler.sample_chain`. The private module function `_sample_chain` is jitted, and is called by `MetropolisSampler._sample_chain` to avoid repeated jitting from different class instances. Similar fuctions `init`, `reset`, `sample`, and `sample_next` also follow this principle.
* `MetropolisPtSampler.__repr__` and `__str__` are removed. Previously we did not rename `reset_chain` to `reset_chains` so they would cause errors. I checked that they actually did not override anything, so I removed them to reduce the future maintenance cost.
* I reviewed all docstrings and type annotations in `sampler/base.py` and `sampler/metropolis.py`, which made me confusing when I read them for the first time. But I didn't touch numpy, PT, and pmap samplers.

Implementation notes on `MCState`:
* Attributes `_n_samples_per_rank` and `_chain_length` are now declared for the dataclass. There should be no missing attribute now.
* `MCState.n_samples.setter` is modified to support exact samplers.
* When setting `MCState.sampler`, it will recompute `n_samples`, `n_samples_per_rank`, and `chain_length` according to the type and `n_chains` of the new sampler.
* `MCState.sample` calls `sampler.sample` with `n_samples` if the sampler is exact, and calls `sampler.sample_chain` with `chain_length` otherwise.

Implementation notes on tests:
* In all tests, `n_chains` is removed when constructing exact samplers.
* The tests for PT samplers can pass now (on my machine), so I enabled them. But I don't know why they failed in the past.

---

Questions:
* Should we deprecate `Sampler.is_exact` in favor of `not isinstance(sampler, MetropolisSampler)`? Currently all the usages of `Sampler.is_exact` are actually 'the sampler does not have chains'.

After we agree on all this, I'll add the changelog.