### PR TITLE
Raise error when flipping continuous Hilbert

### DIFF
--- a/netket/hilbert/random/particle.py
+++ b/netket/hilbert/random/particle.py
@@ -14,7 +14,7 @@
 import jax
 from jax import numpy as jnp
 
-from netket.hilbert import Particle
+from netket.hilbert import ContinuousHilbert, Particle
 from netket.utils.dispatch import dispatch
 
 
@@ -45,3 +45,13 @@ def random_state(hilb: Particle, key, batches: int, *, dtype):
     rs = jnp.where(jnp.equal(boundary, False), gaussian, (uniform + noise) % modulus)
 
     return jnp.asarray(rs, dtype=dtype)
+
+
+@dispatch
+def flip_state_scalar(hilb: ContinuousHilbert, key, x, i):
+    raise TypeError(
+        "Flipping state is undefined for continuous Hilbert spaces. "
+        "(Maybe you tried using `MetropolisLocal` on a continuous Hilbert space? "
+        "This won't work because 'flipping' a continuous variable is not defined. "
+        "You should try a different sampler.)"
+    )

--- a/test/hilbert/test_hilbert.py
+++ b/test/hilbert/test_hilbert.py
@@ -226,7 +226,7 @@ def test_flip_state_discrete(hi: DiscreteHilbert):
 
 
 @pytest.mark.parametrize("hi", particle_hilbert_params)
-def test_flip_state_particle(hi: DiscreteHilbert):
+def test_flip_state_particle(hi: Particle):
     rng = nk.jax.PRNGSeq(1)
     N_batches = 20
 

--- a/test/hilbert/test_hilbert.py
+++ b/test/hilbert/test_hilbert.py
@@ -225,6 +225,22 @@ def test_flip_state_discrete(hi: DiscreteHilbert):
     np.testing.assert_allclose(states_np, states_new_np)
 
 
+@pytest.mark.parametrize("hi", particle_hilbert_params)
+def test_flip_state_particle(hi: DiscreteHilbert):
+    rng = nk.jax.PRNGSeq(1)
+    N_batches = 20
+
+    states = hi.random_state(rng.next(), N_batches)
+
+    ids = jnp.asarray(
+        jnp.floor(hi.size * jax.random.uniform(rng.next(), shape=(N_batches,))),
+        dtype=int,
+    )
+
+    with pytest.raises(TypeError):
+        nk.hilbert.random.flip_state(hi, rng.next(), states, ids)
+
+
 @pytest.mark.parametrize("hi", discrete_hilbert_params)
 def test_hilbert_index_discrete(hi: DiscreteHilbert):
     log_max_states = np.log(nk.hilbert._abstract_hilbert.max_states)

--- a/test/sampler/test_sampler.py
+++ b/test/sampler/test_sampler.py
@@ -401,6 +401,14 @@ def test_throwing(model_and_weights):
     with pytest.raises(ValueError):
         nk.sampler.ARDirectSampler(hi, machine_pow=1)
 
+    # MetropolisLocal should not work with continuous Hilbert spaces
+    with pytest.raises(TypeError):
+        sampler = nk.sampler.MetropolisLocal(hi_particles)
+
+        ma, w = model_and_weights(hi)
+
+        sampler.sample(ma, w, seed=SAMPLER_SEED)
+
 
 def test_exact_sampler(sampler):
     known_exact_samplers = (nk.sampler.ExactSampler, nk.sampler.ARDirectSampler)


### PR DESCRIPTION
Previously if we use `MetropolisLocal` on a continuous Hilbert space, it will run into an infinite recursion, because both `flip_state_scalar` and `flip_state_batch` are not dispatched on `ContinuousHilbert`, and their default implementations just call each other.

Now we dispatch `flip_state_scalar` to raise an error, and we can state that `MetropolisLocal` only works with `DiscreteHilbert`.