### PR TITLE
Move `sample_next` to `MetropolisSampler`

### DIFF
--- a/netket/sampler/__init__.py
+++ b/netket/sampler/__init__.py
@@ -17,7 +17,6 @@ from .base import (
     SamplerState,
     sampler_state,
     reset,
-    sample_next,
     sample,
     samples,
 )
@@ -32,6 +31,7 @@ from .metropolis import (
     MetropolisSamplerState,
     MetropolisHamiltonian,
     MetropolisGaussian,
+    sample_next,
 )
 
 from .metropolis_numpy import (

--- a/netket/sampler/autoreg.py
+++ b/netket/sampler/autoreg.py
@@ -90,11 +90,6 @@ class ARDirectSampler(Sampler):
     def _sample_chain(sampler, model, variables, state, chain_length):
         return _sample_chain(sampler, model, variables, state, chain_length)
 
-    def _sample_next(sampler, model, variables, state):
-        σ, new_state = sampler._sample_chain(model, variables, state, 1)
-        σ = σ.squeeze(axis=0)
-        return new_state, σ
-
 
 @partial(jax.jit, static_argnums=(1, 4))
 def _sample_chain(sampler, model, variables, state, chain_length):


### PR DESCRIPTION
After discussion, we've decided that `n_chains` should not be completely removed in exact samplers, because we want a unified interface for all samplers, and `n_chains` can be used in PT and pmap samplers.

Now I'm going to break #1013 down to several smaller PRs.

---

API changes:
* The method `sample_next` in `Sampler` and exact samplers (`ExactSampler` and `ARDirectSampler`) is removed, and it is only defined in `MetropolisSampler`. The module function `nk.sampler.sample_next` also only works with `MetropolisSampler`. For exact samplers, please use the method `sample` instead.