### PR TITLE
Set the default `n_chains_per_rank` for exact samplers to 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Breaking Changes
 * The method `sample_next` in `Sampler` and exact samplers (`ExactSampler` and `ARDirectSampler`) is removed, and it is only defined in `MetropolisSampler`. The module function `nk.sampler.sample_next` also only works with `MetropolisSampler`. For exact samplers, please use the method `sample` instead. [#1016](https://github.com/netket/netket/pull/1016)
+* The default value of `n_chains_per_rank` in `Sampler` and exact samplers is changed to 1, and specifying `n_chains` or `n_chains_per_rank` when constructing them is deprecated. Please change `chain_length` when calling `sample`. For `MetropolisSampler`, the default value `n_chains = 16` (across all ranks) is unchanged. [#1017](https://github.com/netket/netket/pull/1017)
 
 ### Internal Changes
 * The definitions of `MCState` and `MCMixedState` have been moved to an internal module, `nk.vqs.mc` that is hidden by default. [#954](https://github.com/netket/netket/pull/954)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 ### Breaking Changes
 * The method `sample_next` in `Sampler` and exact samplers (`ExactSampler` and `ARDirectSampler`) is removed, and it is only defined in `MetropolisSampler`. The module function `nk.sampler.sample_next` also only works with `MetropolisSampler`. For exact samplers, please use the method `sample` instead. [#1016](https://github.com/netket/netket/pull/1016)
-* The default value of `n_chains_per_rank` in `Sampler` and exact samplers is changed to 1, and specifying `n_chains` or `n_chains_per_rank` when constructing them is deprecated. Please change `chain_length` when calling `sample`. For `MetropolisSampler`, the default value `n_chains = 16` (across all ranks) is unchanged. [#1017](https://github.com/netket/netket/pull/1017)
+* The default value of `n_chains_per_rank` in `Sampler` and exact samplers is changed to 1, and specifying `n_chains` or `n_chains_per_rank` when constructing them is deprecated. Please change `chain_length` when calling `sample`. For `MetropolisSampler`, the default value is changed from `n_chains = 16` (across all ranks) to `n_chains_per_rank = 16`. [#1017](https://github.com/netket/netket/pull/1017)
 
 ### Internal Changes
 * The definitions of `MCState` and `MCMixedState` have been moved to an internal module, `nk.vqs.mc` that is hidden by default. [#954](https://github.com/netket/netket/pull/954)

--- a/netket/sampler/autoreg.py
+++ b/netket/sampler/autoreg.py
@@ -19,6 +19,7 @@ from jax import numpy as jnp
 
 from netket.sampler import Sampler, SamplerState
 from netket.utils import struct
+from netket.utils.deprecation import warn_deprecation
 from netket.utils.types import PRNGKeyT
 
 
@@ -59,6 +60,14 @@ class ARDirectSampler(Sampler):
 
     `ARDirectSampler.machine_pow` has no effect. Please set the model's `machine_pow` instead.
     """
+
+    def __pre_init__(self, *args, **kwargs):
+        if "n_chains" in kwargs or "n_chains_per_rank" in kwargs:
+            warn_deprecation(
+                "Specifying `n_chains` or `n_chains_per_rank` when constructing exact samplers is deprecated."
+            )
+
+        return super().__pre_init__(*args, **kwargs)
 
     def __post_init__(self):
         super().__post_init__()

--- a/netket/sampler/base.py
+++ b/netket/sampler/base.py
@@ -87,25 +87,24 @@ class Sampler(abc.ABC):
                     "Cannot specify both `n_chains` and `n_chains_per_rank`"
                 )
         else:
-
-            # DEFAULT VALUE
             if n_chains is None:
-                n_chains = 16
+                # Default value
+                n_chains_per_rank = 1
+            else:
+                n_chains_per_rank = max(int(np.ceil(n_chains / mpi.n_nodes)), 1)
+                if mpi.n_nodes > 1 and mpi.rank == 0:
+                    if n_chains_per_rank * mpi.n_nodes != n_chains:
+                        import warnings
 
-            n_chains_per_rank = max(int(np.ceil(n_chains / mpi.n_nodes)), 1)
-            if mpi.n_nodes > 1 and mpi.rank == 0:
-                if n_chains_per_rank * mpi.n_nodes != n_chains:
-                    import warnings
-
-                    warnings.warn(
-                        f"Using {n_chains_per_rank} chains per rank among {mpi.n_nodes} ranks (total="
-                        f"{n_chains_per_rank*mpi.n_nodes} instead of n_chains={n_chains})."
-                        f"To directly control the number of chains on every rank, specify "
-                        f"`n_chains_per_rank` when constructing the sampler. "
-                        f"To silence this warning, either use `n_chains_per_rank` or use `n_chains` "
-                        f"that is a multiple of the number of mpi ranks.",
-                        category=UserWarning,
-                    )
+                        warnings.warn(
+                            f"Using {n_chains_per_rank} chains per rank among {mpi.n_nodes} ranks (total="
+                            f"{n_chains_per_rank*mpi.n_nodes} instead of n_chains={n_chains})."
+                            f"To directly control the number of chains on every rank, specify "
+                            f"`n_chains_per_rank` when constructing the sampler. "
+                            f"To silence this warning, either use `n_chains_per_rank` or use `n_chains` "
+                            f"that is a multiple of the number of mpi ranks.",
+                            category=UserWarning,
+                        )
 
             kwargs["n_chains_per_rank"] = n_chains_per_rank
 

--- a/netket/sampler/exact.py
+++ b/netket/sampler/exact.py
@@ -21,6 +21,7 @@ from jax.experimental import host_callback as hcb
 
 from netket.nn import to_array
 from netket.utils import struct
+from netket.utils.deprecation import warn_deprecation
 from netket.utils.types import PyTree, SeedT
 
 from .base import Sampler, SamplerState
@@ -46,6 +47,14 @@ class ExactSampler(Sampler):
     for large systems, where Metropolis-based sampling are instead a viable
     option.
     """
+
+    def __pre_init__(self, *args, **kwargs):
+        if "n_chains" in kwargs or "n_chains_per_rank" in kwargs:
+            warn_deprecation(
+                "Specifying `n_chains` or `n_chains_per_rank` when constructing exact samplers is deprecated."
+            )
+
+        return super().__pre_init__(*args, **kwargs)
 
     @property
     def is_exact(sampler):

--- a/netket/sampler/metropolis.py
+++ b/netket/sampler/metropolis.py
@@ -238,7 +238,7 @@ class MetropolisSampler(Sampler):
             dtype: The dtype of the statees sampled (default = np.float32).
         """
         if "n_chains" not in kwargs and "n_chains_per_rank" not in kwargs:
-            kwargs["n_chains"] = 16
+            kwargs["n_chains_per_rank"] = 16
 
         # process arguments in the base
         args, kwargs = super().__pre_init__(hilbert=hilbert, **kwargs)

--- a/netket/sampler/metropolis.py
+++ b/netket/sampler/metropolis.py
@@ -237,6 +237,9 @@ class MetropolisSampler(Sampler):
             machine_pow: The power to which the machine should be exponentiated to generate the pdf (default = 2).
             dtype: The dtype of the statees sampled (default = np.float32).
         """
+        if "n_chains" not in kwargs and "n_chains_per_rank" not in kwargs:
+            kwargs["n_chains"] = 16
+
         # process arguments in the base
         args, kwargs = super().__pre_init__(hilbert=hilbert, **kwargs)
 

--- a/test/driver/test_steadystate.py
+++ b/test/driver/test_steadystate.py
@@ -36,7 +36,7 @@ def _setup_ss(dtype=np.float32, sr=True):
     hi, lind = _setup_system()
 
     ma = nk.models.NDM()
-    # sa = nk.sampler.ExactSampler(hilbert=nk.hilbert.DoubledHilber(hi), n_chains=16)
+    # sa = nk.sampler.ExactSampler(hilbert=nk.hilbert.DoubledHilber(hi))
 
     sa = nk.sampler.MetropolisLocal(hilbert=nk.hilbert.DoubledHilbert(hi))
     sa_obs = nk.sampler.MetropolisLocal(hilbert=hi)

--- a/test/dynamics/test_driver.py
+++ b/test/dynamics/test_driver.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from functools import partial
+
 import jax
 import jax.numpy as jnp
 import pytest
@@ -146,6 +148,7 @@ def test_one_step_lindbladian(integrator):
         vstate,
         integrator,
         propagation_type="real",
+        linear_solver=partial(nk.optimizer.solver.svd, rcond=1e-3),
     )
     te.run(T=0.01, callback=_stop_after_one_step)
     assert te.t > 0.0

--- a/test/groundstate/test_vmc.py
+++ b/test/groundstate/test_vmc.py
@@ -26,7 +26,7 @@ def _setup_vmc(dtype=np.float32, sr=True):
     hi = nk.hilbert.Spin(s=0.5, N=g.n_nodes)
 
     ma = nk.models.RBM(alpha=1, dtype=dtype)
-    sa = nk.sampler.ExactSampler(hilbert=hi, n_chains=16)
+    sa = nk.sampler.ExactSampler(hilbert=hi)
 
     vs = nk.vqs.MCState(sa, ma, n_samples=1000, seed=SEED)
 

--- a/test/optimizer/test_qgt_itersolve.py
+++ b/test/optimizer/test_qgt_itersolve.py
@@ -113,7 +113,7 @@ def vstate(request, model, chunk_size):
     "solver",
     [pytest.param(solver, id=name) for name, solver in solvers.items()],
 )
-@pytest.mark.parametrize("chunk_size", [None, 18])
+@pytest.mark.parametrize("chunk_size", [None, 16])
 def test_qgt_solve(qgt, vstate, solver, _mpi_size, _mpi_rank):
     S = qgt(vstate)
     x, _ = S.solve(solver, vstate.parameters)
@@ -145,7 +145,7 @@ def test_qgt_solve(qgt, vstate, solver, _mpi_size, _mpi_rank):
     "qgt",
     [pytest.param(sr, id=name) for name, sr in QGT_objects.items()],
 )
-@pytest.mark.parametrize("chunk_size", [None, 18])
+@pytest.mark.parametrize("chunk_size", [None, 16])
 def test_qgt_matmul(qgt, vstate, _mpi_size, _mpi_rank):
     S = qgt(vstate)
     rng = nkjax.PRNGSeq(0)
@@ -190,7 +190,7 @@ def test_qgt_matmul(qgt, vstate, _mpi_size, _mpi_rank):
     "qgt",
     [pytest.param(sr, id=name) for name, sr in QGT_objects.items()],
 )
-@pytest.mark.parametrize("chunk_size", [None, 18])
+@pytest.mark.parametrize("chunk_size", [None, 16])
 def test_qgt_dense(qgt, vstate, _mpi_size, _mpi_rank):
     S = qgt(vstate)
 

--- a/test/sampler/test_sampler.py
+++ b/test/sampler/test_sampler.py
@@ -58,30 +58,24 @@ hi_spin1 = nk.hilbert.Spin(s=1, N=g.n_nodes)
 hib = nk.hilbert.Fock(n_max=1, N=g.n_nodes, n_particles=1)
 hib_u = nk.hilbert.Fock(n_max=3, N=g.n_nodes)
 
-samplers["Exact: Spin"] = nk.sampler.ExactSampler(hi, n_chains=8)
-samplers["Exact: Fock"] = nk.sampler.ExactSampler(hib_u, n_chains=4)
+samplers["Exact: Spin"] = nk.sampler.ExactSampler(hi)
+samplers["Exact: Fock"] = nk.sampler.ExactSampler(hib_u)
 
-samplers["Metropolis(Local): Spin"] = nk.sampler.MetropolisLocal(hi, n_chains=16)
+samplers["Metropolis(Local): Spin"] = nk.sampler.MetropolisLocal(hi)
 
-samplers["MetropolisNumpy(Local): Spin"] = nk.sampler.MetropolisLocalNumpy(
-    hi, n_chains=16
-)
-# samplers["MetropolisNumpy(Local): Fock"] = nk.sampler.MetropolisLocalNumpy(
-#    hib_u, n_chains=8
-# )
+samplers["MetropolisNumpy(Local): Spin"] = nk.sampler.MetropolisLocalNumpy(hi)
+# samplers["MetropolisNumpy(Local): Fock"] = nk.sampler.MetropolisLocalNumpy(hib_u)
 # samplers["MetropolisNumpy(Local): Doubled-Spin"] = nk.sampler.MetropolisLocalNumpy(
-#    nk.hilbert.DoubledHilbert(nk.hilbert.Spin(s=0.5, N=2)), n_chains=8
+#    nk.hilbert.DoubledHilbert(nk.hilbert.Spin(s=0.5, N=2))
 # )
 
-samplers["MetropolisPT(Local): Spin"] = nkx.sampler.MetropolisLocalPt(
-    hi, n_chains=8, n_replicas=4
-)
+samplers["MetropolisPT(Local): Spin"] = nkx.sampler.MetropolisLocalPt(hi, n_replicas=4)
 samplers["MetropolisPT(Local): Fock"] = nkx.sampler.MetropolisLocalPt(
-    hib_u, n_chains=8, n_replicas=4
+    hib_u, n_replicas=4
 )
 
 samplers["Metropolis(Exchange): Fock-1particle"] = nk.sampler.MetropolisExchange(
-    hib, n_chains=16, graph=g
+    hib, graph=g
 )
 
 samplers["Metropolis(Hamiltonian,Jax): Spin"] = nk.sampler.MetropolisHamiltonian(
@@ -102,15 +96,15 @@ samplers["Metropolis(Custom: Sx): Spin"] = nk.sampler.MetropolisCustom(
 
 # samplers["MetropolisPT(Custom: Sx): Spin"] = nkx.sampler.MetropolisCustomPt(hi, move_operators=move_op, n_replicas=4)
 
-samplers["Autoregressive: Spin 1/2"] = nk.sampler.ARDirectSampler(hi, n_chains=16)
-samplers["Autoregressive: Spin 1"] = nk.sampler.ARDirectSampler(hi_spin1, n_chains=16)
-samplers["Autoregressive: Fock"] = nk.sampler.ARDirectSampler(hib_u, n_chains=16)
+samplers["Autoregressive: Spin 1/2"] = nk.sampler.ARDirectSampler(hi)
+samplers["Autoregressive: Spin 1"] = nk.sampler.ARDirectSampler(hi_spin1)
+samplers["Autoregressive: Fock"] = nk.sampler.ARDirectSampler(hib_u)
 
 
 # Hilbert space and sampler for particles
 hi_particles = nk.hilbert.Particle(N=3, L=(np.inf,), pbc=(False,))
 samplers["Metropolis(Gaussian): Gaussian"] = nk.sampler.MetropolisGaussian(
-    hi_particles, sigma=1.0, n_chains=16
+    hi_particles, sigma=1.0
 )
 
 
@@ -414,5 +408,7 @@ def test_exact_sampler(sampler):
     known_exact_samplers = (nk.sampler.ExactSampler, nk.sampler.ARDirectSampler)
     if isinstance(sampler, known_exact_samplers):
         assert sampler.is_exact is True
+        assert sampler.n_chains_per_rank == 1
     else:
         assert sampler.is_exact is False
+        assert sampler.n_chains == 16

--- a/test/sampler/test_sampler.py
+++ b/test/sampler/test_sampler.py
@@ -411,4 +411,4 @@ def test_exact_sampler(sampler):
         assert sampler.n_chains_per_rank == 1
     else:
         assert sampler.is_exact is False
-        assert sampler.n_chains == 16
+        assert sampler.n_chains_per_rank == 16

--- a/test/variational/test_autoreg.py
+++ b/test/variational/test_autoreg.py
@@ -168,7 +168,7 @@ def test_vmc_same(partial_model_pair, hilbert, dtype, machine_pow, skip):
     model1 = partial_model_pair[0](hilbert, dtype, machine_pow)
     model2 = partial_model_pair[1](hilbert, dtype, machine_pow)
 
-    sampler1 = nk.sampler.ARDirectSampler(hilbert, n_chains=3)
+    sampler1 = nk.sampler.ARDirectSampler(hilbert)
     vstate1 = nk.vqs.MCState(sampler1, model1, n_samples=6, seed=123, sampler_seed=456)
     assert vstate1.n_discard_per_chain == 0
     samples1 = vstate1.sample()
@@ -180,7 +180,7 @@ def test_vmc_same(partial_model_pair, hilbert, dtype, machine_pow, skip):
     vmc1.run(n_iter=3)
     samples_trained1 = vstate1.sample()
 
-    sampler2 = nk.sampler.ARDirectSampler(hilbert, n_chains=3)
+    sampler2 = nk.sampler.ARDirectSampler(hilbert)
     vstate2 = nk.vqs.MCState(sampler2, model2, n_samples=6, seed=123, sampler_seed=456)
     samples2 = vstate2.sample()
 

--- a/test/variational/test_variational.py
+++ b/test/variational/test_variational.py
@@ -89,7 +89,7 @@ operators["operator:(Non Hermitian)"] = H
 def vstate(request):
     ma = request.param
 
-    sa = nk.sampler.ExactSampler(hilbert=hi, n_chains=16)
+    sa = nk.sampler.ExactSampler(hilbert=hi)
 
     vs = nk.vqs.MCState(sa, ma, n_samples=1000, seed=SEED)
 
@@ -169,8 +169,8 @@ def test_chunk_size_api(vstate, _mpi_size):
     ):
         vstate.chunk_size = 1500
 
-    s = vstate.sample()
-    s = vstate.sample(n_samples=vstate.n_samples)
+    _ = vstate.sample()
+    _ = vstate.sample(n_samples=vstate.n_samples)
     with raises(
         ValueError,
     ):

--- a/test/variational/test_variational.py
+++ b/test/variational/test_variational.py
@@ -122,8 +122,8 @@ def test_n_samples_api(vstate, _mpi_size):
     ):
         vstate.n_discard_per_chain = -1
 
-    vstate.n_samples = 2
-    assert vstate.samples.shape[0:2] == (1, vstate.sampler.n_chains)
+    vstate.n_samples = 3
+    assert vstate.samples.shape[0:2] == (3, vstate.sampler.n_chains)
 
     vstate.chain_length = 2
     assert vstate.n_samples == 2 * vstate.sampler.n_chains

--- a/test/variational/test_variational_mixed.py
+++ b/test/variational/test_variational_mixed.py
@@ -94,8 +94,8 @@ def test_n_samples_api(vstate):
     ):
         vstate.n_discard_per_chain = -1
 
-    vstate.n_samples = 2
-    assert vstate.samples.shape[0:2] == (1, vstate.sampler.n_chains)
+    vstate.n_samples = 3
+    assert vstate.samples.shape[0:2] == (3, vstate.sampler.n_chains)
 
     vstate.chain_length = 2
     assert vstate.n_samples == 2 * vstate.sampler.n_chains

--- a/test/variational/test_variational_mixed.py
+++ b/test/variational/test_variational_mixed.py
@@ -128,11 +128,11 @@ def test_n_samples_diag_api(vstate):
     ):
         vstate.n_discard_per_chain = -1
 
-    vstate.n_samples_diag = 2
+    vstate.n_samples_diag = 3
     assert (
         vstate.diagonal.samples.shape[0:2]
-        == (1, vstate.sampler_diag.n_chains)
-        == (1, vstate.diagonal.sampler.n_chains)
+        == (3, vstate.sampler_diag.n_chains)
+        == (3, vstate.diagonal.sampler.n_chains)
     )
 
     vstate.chain_length_diag = 2

--- a/test/variational/test_variational_mixed.py
+++ b/test/variational/test_variational_mixed.py
@@ -22,8 +22,6 @@ import jax
 import netket as nk
 from jax.nn.initializers import normal
 
-from netket.operator import AbstractSuperOperator
-
 from .. import common
 
 pytestmark = common.skipif_mpi
@@ -73,7 +71,7 @@ operators["operator:sigmam"] = jump_ops[0]
 def vstate(request):
     ma = request.param
 
-    sa = nk.sampler.ExactSampler(hilbert=nk.hilbert.DoubledHilbert(hi), n_chains=16)
+    sa = nk.sampler.ExactSampler(hilbert=nk.hilbert.DoubledHilbert(hi))
 
     vs = nk.vqs.MCMixedState(sa, ma, n_samples=1000, seed=SEED)
 


### PR DESCRIPTION
The second PR in the #1013 series.

API changes:
* The default value of `n_chains_per_rank` in `Sampler` and exact samplers is changed to 1, and specifying `n_chains` or `n_chains_per_rank` when constructing them is deprecated. Please change `chain_length` when calling `sample`. For `MetropolisSampler`, the default value `n_chains = 16` (across all ranks) is unchanged.

In `test/sampler/test_sampler.py::test_exact_sampler` I added the test for the default value of `n_chains` or `n_chains_per_rank`, and I removed all specified `n_chains` when constructing the samplers.