### PR TITLE
Fix #917

### DIFF
--- a/netket/hilbert/fock.py
+++ b/netket/hilbert/fock.py
@@ -29,6 +29,7 @@ It is `maxvalue(np.int64)-1` because we use N+1 in several formulas
 and it would overflow.
 """
 
+
 @jit(nopython=True)
 def _sum_constraint(x, n_particles):
     return np.sum(x, axis=1) == n_particles

--- a/netket/hilbert/fock.py
+++ b/netket/hilbert/fock.py
@@ -158,7 +158,7 @@ class Fock(HomogeneousHilbert):
             if self._n_particles is not None
             else ""
         )
-        nmax = self._n_max if self._n_max < FOCK_MAX else "INT_MAX"
+        nmax = self._n_max if self._n_max < FOCK_MAX else "FOCK_MAX"
         return "Fock(n_max={}{}, N={})".format(nmax, n_particles, self._size)
 
     @property

--- a/netket/hilbert/fock.py
+++ b/netket/hilbert/fock.py
@@ -22,6 +22,12 @@ from netket.graph import AbstractGraph
 from .homogeneous import HomogeneousHilbert
 from ._deprecations import graph_to_N_depwarn
 
+FOCK_MAX = np.iinfo(np.intp).max - 1
+"""
+Maximum number of particles in the fock space.
+It is `maxvalue(np.int64)-1` because we use N+1 in several formulas
+and it would overflow.
+"""
 
 @jit(nopython=True)
 def _sum_constraint(x, n_particles):
@@ -90,8 +96,7 @@ class Fock(HomogeneousHilbert):
             # assert self._n_max > 0
             local_states = np.arange(self._n_max + 1)
         else:
-            max_ind = np.iinfo(np.intp).max
-            self._n_max = max_ind
+            self._n_max = FOCK_MAX
             local_states = None
 
         super().__init__(local_states, N, constraints)
@@ -152,7 +157,7 @@ class Fock(HomogeneousHilbert):
             if self._n_particles is not None
             else ""
         )
-        nmax = self._n_max if self._n_max < np.iinfo(np.intp).max else "INT_MAX"
+        nmax = self._n_max if self._n_max < FOCK_MAX else "INT_MAX"
         return "Fock(n_max={}{}, N={})".format(nmax, n_particles, self._size)
 
     @property

--- a/test/hilbert/test_hilbert.py
+++ b/test/hilbert/test_hilbert.py
@@ -174,11 +174,13 @@ def test_random_states_homogeneous(hi: HomogeneousHilbert):
         for state in rstate:
             assert state in local_states
 
+
 def test_random_states_fock_infinite():
     hi = Fock(N=2)
     rstate = hi.random_state(jax.random.PRNGKey(14), 20)
     assert np.all(rstate >= 0)
-    assert rstate.shape == (20,2)
+    assert rstate.shape == (20, 2)
+
 
 @pytest.mark.parametrize("hi", particle_hilbert_params)
 def test_random_states_particle(hi: Particle):
@@ -262,7 +264,7 @@ def test_flip_state_fock_infinite():
 
     assert new_states.shape == states.shape
 
-    assert np.all(states>=0)
+    assert np.all(states >= 0)
 
     states_np = np.asarray(states)
     states_new_np = np.array(new_states)
@@ -271,6 +273,7 @@ def test_flip_state_fock_infinite():
         states_new_np[row, col] = states_np[row, col]
 
     np.testing.assert_allclose(states_np, states_new_np)
+
 
 @pytest.mark.parametrize("hi", discrete_hilbert_params)
 def test_hilbert_index_discrete(hi: DiscreteHilbert):


### PR DESCRIPTION
changes int_max to be 1 less, so that it does not overflow 64 bit integers.

Note that to use such a large Hilbert space you need an integer sampler..