### PR TITLE
Fix bug in MCMixedState.to_qobj()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 ### Bug Fixes
 * The constructor of `TensorHilbert` (which is used by the product operator `*` for inhomogeneous spaces) no longer fails when one of the component spaces is non-indexable. [#1004](https://github.com/netket/netket/pull/1004)
 * The {ref}`nk.hilbert.random.flip_state` method used by `MetropolisLocal` now throws an error when called on a {ref}`nk.hilbert.ContinuousHilbert` hilbert space instead of entering an endless loop. [#1014](https://github.com/netket/netket/pull/1014)
+* Fixed bug in conversion to qutip for `MCMixedState`, where the resulting shape (hilbert space size) was wrong. [#1020](https://github.com/netket/netket/pull/1020)
 
 
 ## NetKet 3.2 (26 November 2021)

--- a/netket/vqs/base.py
+++ b/netket/vqs/base.py
@@ -286,7 +286,7 @@ class VariationalMixedState(VariationalState):
         """
         from qutip import Qobj
 
-        q_dims = [list(self.hilbert.shape), list(self.hilbert.shape)]
+        q_dims = [list(self.hilbert_physical.shape), list(self.hilbert_physical.shape)]
         return Qobj(np.asarray(self.to_matrix()), dims=q_dims)
 
 

--- a/test/variational/test_variational_mixed.py
+++ b/test/variational/test_variational_mixed.py
@@ -271,6 +271,8 @@ def test_qutip_conversion(vstate):
     assert q_obj.dims[0] == list(vstate.hilbert_physical.shape)
     assert q_obj.dims[1] == list(vstate.hilbert_physical.shape)
 
-    assert q_obj.shape == (vstate.hilbert_physical.n_states, vstate.hilbert_physical.n_states)
+    assert q_obj.shape == (
+        vstate.hilbert_physical.n_states,
+        vstate.hilbert_physical.n_states,
+    )
     np.testing.assert_allclose(q_obj.data.todense(), rho)
-

--- a/test/variational/test_variational_mixed.py
+++ b/test/variational/test_variational_mixed.py
@@ -257,3 +257,20 @@ def test_expect_grad_chunking(vstate, n_chunks):
     jax.tree_multimap(
         partial(np.testing.assert_allclose, atol=1e-13), grad_nochunk, grad_chunk
     )
+
+
+def test_qutip_conversion(vstate):
+    # skip test if qutip not installed
+    pytest.importorskip("qutip")
+
+    rho = vstate.to_matrix()
+    q_obj = vstate.to_qobj()
+
+    assert q_obj.type == "oper"
+    assert len(q_obj.dims) == 2
+    assert q_obj.dims[0] == list(vstate.hilbert_physical.shape)
+    assert q_obj.dims[1] == list(vstate.hilbert_physical.shape)
+
+    assert q_obj.shape == (vstate.hilbert_physical.n_states, vstate.hilbert_physical.n_states)
+    np.testing.assert_allclose(q_obj.data.todense(), rho)
+


### PR DESCRIPTION
was using the doubled Hilbert space dimensions instead of the original one.

Was lacking a test. 
