### PR TITLE
Error handling and warnings for `TDVP` solver

### DIFF
--- a/netket/experimental/driver/tdvp.py
+++ b/netket/experimental/driver/tdvp.py
@@ -14,6 +14,7 @@
 
 from functools import partial
 from typing import Callable, Optional, Sequence, Union
+import warnings
 
 import jax
 import jax.numpy as jnp
@@ -239,6 +240,15 @@ class TDVP(AbstractVariationalDriver):
                 else:
                     max_dt = None
                 step_accepted = self._integrator.step(max_dt=max_dt)
+                if self._integrator.errors:
+                    raise RuntimeError(
+                        f"RK solver: {self._integrator.errors.message()}"
+                    )
+                elif self._integrator.warnings:
+                    warnings.warn(
+                        f"RK solver: {self._integrator.warnings.message()}",
+                        UserWarning,
+                    )
             self._step_count += 1
 
         # Yield one last time if the remaining tstop is at t_end

--- a/netket/experimental/driver/tdvp.py
+++ b/netket/experimental/driver/tdvp.py
@@ -25,7 +25,6 @@ import netket as nk
 from netket.driver import AbstractVariationalDriver
 from netket.driver.abstract_variational_driver import _to_iterable
 from netket.driver.vmc_common import info
-from netket.experimental.dynamics.runge_kutta import euclidean_norm, maximum_norm
 from netket.logging.json_log import JsonLog
 from netket.operator import AbstractOperator
 from netket.optimizer import LinearOperator
@@ -36,6 +35,7 @@ from netket.utils.types import PyTree
 from netket.vqs import VariationalState, VariationalMixedState, MCState
 
 from netket.experimental.dynamics import RKIntegratorConfig
+from netket.experimental.dynamics._rk_solver import euclidean_norm, maximum_norm
 
 
 @dispatch

--- a/netket/experimental/dynamics/__init__.py
+++ b/netket/experimental/dynamics/__init__.py
@@ -25,8 +25,8 @@ __all__ = [
     "RK45",
 ]
 
-from .runge_kutta import RungeKuttaIntegrator, RKIntegratorConfig
-from .runge_kutta import Euler, Heun, Midpoint, RK4, RK12, RK23, RK45
+from ._rk_solver import RungeKuttaIntegrator, RKIntegratorConfig
+from ._rk_solver import Euler, Heun, Midpoint, RK4, RK12, RK23, RK45
 
 from netket.utils import _hide_submodules
 

--- a/netket/experimental/dynamics/_rk_solver.py
+++ b/netket/experimental/dynamics/_rk_solver.py
@@ -54,8 +54,8 @@ class SolverFlags(IntFlag):
 def set_flag_jax(condition, flags, flag):
     return jax.lax.cond(
         condition,
-        lambda x: x,
         lambda x: x | flag,
+        lambda x: x,
         flags,
     )
 
@@ -194,7 +194,7 @@ def general_time_step_adaptive(
     )
 
     # check if next dt is NaN
-    flags = set_flag_jax(not jnp.isfinite(next_dt), flags, SolverFlags.ERROR_INVALID_DT)
+    flags = set_flag_jax(~jnp.isfinite(next_dt), flags, SolverFlags.ERROR_INVALID_DT)
 
     # check if we are at lower bound for dt
     if dt_limits[0] is not None:

--- a/netket/experimental/dynamics/_rk_solver.py
+++ b/netket/experimental/dynamics/_rk_solver.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO: aenum could be replaced by (standard library) enum  in Python 3.11
-from aenum import IntFlag, auto
+from enum import IntFlag, auto
 from functools import partial
 from typing import Callable, Optional, Tuple, Union
 
@@ -38,17 +37,16 @@ class SolverFlags(IntFlag):
     WARNINGS_FLAGS = WARN_MIN_DT | WARN_MAX_DT
     ERROR_FLAGS = ERROR_INVALID_DT
 
-    @classmethod
-    def _message(cls, flag):
-        return {
-            cls.INFO_STEP_ACCEPTED: "Step accepted",
-            cls.WARN_MIN_DT: "dt reached lower bound",
-            cls.WARN_MAX_DT: "dt reached upper bound",
-            cls.ERROR_INVALID_DT: "Invalid value of dt",
-        }.get(flag, "UNKNOWN FLAG")
+    __MESSAGES__ = {
+        INFO_STEP_ACCEPTED: "Step accepted",
+        WARN_MIN_DT: "dt reached lower bound",
+        WARN_MAX_DT: "dt reached upper bound",
+        ERROR_INVALID_DT: "Invalid value of dt",
+    }
 
     def message(self):
-        return ", ".join(self._message(flag) for flag in list(self))
+        msg = self.__MESSAGES__
+        return ", ".join(msg[flag] for flag in msg.keys() if flag & self != 0)
 
 
 def set_flag_jax(condition, flags, flag):

--- a/netket/experimental/dynamics/_rk_solver.py
+++ b/netket/experimental/dynamics/_rk_solver.py
@@ -358,6 +358,9 @@ class RungeKuttaIntegrator:
         return self._rkstate.dt
 
     def _get_solver_flags(self, intersect=SolverFlags.NONE) -> SolverFlags:
+        """Returns the currently set flags of the solver, intersected with `intersect`."""
+        # _rkstate.flags is turned into an int-valued DeviceArray by JAX,
+        # so we convert it back.
         return SolverFlags(int(self._rkstate.flags) & intersect)
 
     @property

--- a/netket/experimental/dynamics/_rk_tableau.py
+++ b/netket/experimental/dynamics/_rk_tableau.py
@@ -1,0 +1,251 @@
+# Copyright 2021 The NetKet Authors - All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Callable, Optional, Tuple
+
+import jax
+import jax.numpy as jnp
+
+from netket.utils.struct import dataclass
+from netket.utils.types import Array, PyTree
+
+default_dtype = jnp.float64
+
+
+def expand_dim(tree: PyTree, sz: int):
+    """
+    creates a new pytree with same structure as input `tree`, but where very leaf
+    has an extra dimension at 0 with size `sz`.
+    """
+
+    def _expand(x):
+        return jnp.zeros((sz,) + x.shape, dtype=x.dtype)
+
+    return jax.tree_map(_expand, tree)
+
+
+@dataclass
+class TableauRKExplicit:
+    name: str
+    """The name of the RK Tableau."""
+    order: Tuple[int, int]
+    """The order of the tableau"""
+    a: jax.numpy.ndarray
+    b: jax.numpy.ndarray
+    c: jax.numpy.ndarray
+    c_error: Optional[jax.numpy.ndarray]
+    """Coefficients for error estimation."""
+
+    @property
+    def is_explicit(self):
+        jnp.allclose(self.a, jnp.tril(self.a))  # check if lower triangular
+
+    @property
+    def is_adaptive(self):
+        return self.b.ndim == 2
+
+    @property
+    def is_fsal(self):
+        """Returns True if the first iteration is the same as last."""
+        # TODO: this is not yet supported
+        return False
+
+    @property
+    def stages(self):
+        """
+        Number of stages (equal to the number of evaluations of the ode function)
+        of the RK scheme.
+        """
+        return len(self.c)
+
+    @property
+    def error_order(self):
+        """
+        Returns the order of the embedded error estimate for a tableau
+        supporting adaptive step size. Otherwise, None is returned.
+        """
+        if not self.is_adaptive:
+            return None
+        else:
+            return self.order[1]
+
+    def _compute_slopes(
+        self,
+        f: Callable,
+        t: float,
+        dt: float,
+        y_t: Array,
+    ):
+        """Computes the intermediate slopes k_l."""
+        times = t + self.c * dt
+
+        # TODO: Use FSALLast
+
+        k = expand_dim(y_t, self.stages)
+        for l in range(self.stages):
+            dy_l = jax.tree_map(lambda k: jnp.tensordot(self.a[l], k, axes=1), k)
+            y_l = jax.tree_multimap(lambda y_t, dy_l: y_t + dt * dy_l, y_t, dy_l)
+            k_l = f(times[l], y_l, stage=l)
+            k = jax.tree_multimap(lambda k, k_l: k.at[l].set(k_l), k, k_l)
+
+        return k
+
+    def step(
+        self,
+        f: Callable,
+        t: float,
+        dt: float,
+        y_t: Array,
+    ):
+        """Perform one fixed-size RK step from `t` to `t + dt`."""
+        k = self._compute_slopes(f, t, dt, y_t)
+
+        b = self.b[0] if self.b.ndim == 2 else self.b
+        y_tp1 = jax.tree_multimap(
+            lambda y_t, k: y_t + dt * jnp.tensordot(b, k, axes=1), y_t, k
+        )
+
+        return y_tp1
+
+    def step_with_error(
+        self,
+        f: Callable,
+        t: float,
+        dt: float,
+        y_t: Array,
+    ):
+        """
+        Perform one fixed-size RK step from `t` to `t + dt` and additionally return the
+        error vector provided by the adaptive solver.
+        """
+        if not self.is_adaptive:
+            raise RuntimeError(f"{self} is not adaptive")
+
+        k = self._compute_slopes(f, t, dt, y_t)
+
+        y_tp1 = jax.tree_multimap(
+            lambda y_t, k: y_t + dt * jnp.tensordot(self.b[0], k, axes=1), y_t, k
+        )
+        db = self.b[0] - self.b[1]
+        y_err = jax.tree_map(lambda k: dt * jnp.tensordot(db, k, axes=1), k)
+
+        return y_tp1, y_err
+
+
+# fmt: off
+# flake8: noqa: E123, E126, E201, E202, E221, E226, E231, E241, E251
+
+# Fixed Step methods
+bt_feuler = TableauRKExplicit(
+                name = "feuler",
+                order = (1,),
+                a = jnp.zeros((1,1), dtype=default_dtype),
+                b = jnp.ones((1,1), dtype=default_dtype),
+                c = jnp.zeros((1), dtype=default_dtype),
+                c_error = None,
+                )
+
+
+bt_midpoint = TableauRKExplicit(
+                name = "midpoint",
+                order = (2,),
+                a = jnp.array([[0,   0],
+                               [1/2, 0]], dtype=default_dtype),
+                b = jnp.array( [0,   1], dtype=default_dtype),
+                c = jnp.array( [0, 1/2], dtype=default_dtype),
+                c_error = None,
+                )
+
+
+bt_heun = TableauRKExplicit(
+                name = "heun",
+                order = (2,),
+                a = jnp.array([[0,   0],
+                               [1,   0]], dtype=default_dtype),
+                b = jnp.array( [1/2, 1/2], dtype=default_dtype),
+                c = jnp.array( [0, 1], dtype=default_dtype),
+                c_error = None,
+                )
+
+bt_rk4  = TableauRKExplicit(
+                name = "rk4",
+                order = (4,),
+                a = jnp.array([[0,   0,   0,   0],
+                               [1/2, 0,   0,   0],
+                               [0,   1/2, 0,   0],
+                               [0,   0,   1,   1]], dtype=default_dtype),
+                b = jnp.array( [1/6,  1/3,  1/3,  1/6], dtype=default_dtype),
+                c = jnp.array( [0, 1/2, 1/2, 1], dtype=default_dtype),
+                c_error = None,
+                )
+
+
+# Adaptive step:
+# Heun Euler https://en.wikipedia.org/wiki/Runge–Kutta_methods
+bt_rk12  = TableauRKExplicit(
+                name = "rk21",
+                order = (2,1),
+                a = jnp.array([[0,   0],
+                               [1,   0]], dtype=default_dtype),
+                b = jnp.array([[1/2, 1/2],
+                               [1,   0]], dtype=default_dtype),
+                c = jnp.array( [0, 1], dtype=default_dtype),
+                c_error = None,
+                )
+
+# Bogacki–Shampine coefficients
+bt_rk23  = TableauRKExplicit(
+                name = "rk23",
+                order = (2,3),
+                a = jnp.array([[0,   0,   0,   0],
+                               [1/2, 0,   0,   0],
+                               [0,   3/4, 0,   0],
+                               [2/9, 1/3, 4/9, 0]], dtype=default_dtype),
+                b = jnp.array([[7/24,1/4, 1/3, 1/8],
+                               [2/9, 1/3, 4/9, 0]], dtype=default_dtype),
+                c = jnp.array( [0, 1/2, 3/4, 1], dtype=default_dtype),
+                c_error = None,
+                )
+
+bt_rk4_fehlberg = TableauRKExplicit(
+                name = "fehlberg",
+                order = (4,5),
+                a = jnp.array([[ 0,          0,          0,           0,            0,      0 ],
+                              [  1/4,        0,          0,           0,            0,      0 ],
+                              [  3/32,       9/32,       0,           0,            0,      0 ],
+                              [  1932/2197,  -7200/2197, 7296/2197,   0,            0,      0 ],
+                              [  439/216,    -8,         3680/513,    -845/4104,    0,      0 ],
+                              [  -8/27,      2,          -3544/2565,  1859/4104,    11/40,  0 ]], dtype=default_dtype),
+                b = jnp.array([[ 25/216,     0,          1408/2565,   2197/4104,    -1/5,   0 ],
+                               [ 16/135,     0,          6656/12825,  28561/56430,  -9/50,  2/55]], dtype=default_dtype),
+                c = jnp.array( [  0,         1/4,        3/8,         12/13,        1,      1/2], dtype=default_dtype),
+                c_error = None,
+                )
+
+bt_rk4_dopri  = TableauRKExplicit(
+                name = "dopri",
+                order = (5,4),
+                a = jnp.array([[ 0,           0,           0,           0,        0,             0,         0 ],
+                              [  1/5,         0,           0,           0,        0,             0,         0 ],
+                              [  3/40,        9/40,        0,           0,        0,             0,         0 ],
+                              [  44/45,       -56/15,      32/9,        0,        0,             0,         0 ],
+                              [  19372/6561,  -25360/2187, 64448/6561,  -212/729, 0,             0,         0 ],
+                              [  9017/3168,   -355/33,     46732/5247,  49/176,   -5103/18656,   0,         0 ],
+                              [  35/384,      0,           500/1113,    125/192,  -2187/6784,    11/84,     0 ]], dtype=default_dtype),
+                b = jnp.array([[ 35/384,      0,           500/1113,    125/192,  -2187/6784,    11/84,     0 ],
+                               [ 5179/57600,  0,           7571/16695,  393/640,  -92097/339200, 187/2100,  1/40 ]], dtype=default_dtype),
+                c = jnp.array( [ 0,           1/5,         3/10,        4/5,      8/9,           1,         1], dtype=default_dtype),
+                c_error = None,
+                )
+# fmt: on

--- a/netket/utils/mpi/__init__.py
+++ b/netket/utils/mpi/__init__.py
@@ -22,12 +22,21 @@ from .mpi import (
     rank,
 )
 
-from .primitives import mpi_sum, mpi_mean, mpi_any, mpi_bcast, mpi_allgather, mpi_max
 from .primitives import (
-    mpi_sum_jax,
-    mpi_mean_jax,
+    mpi_all,
+    mpi_allgather,
+    mpi_any,
+    mpi_bcast,
+    mpi_max,
+    mpi_mean,
+    mpi_sum,
+)
+from .primitives import (
+    mpi_all_jax,
+    mpi_allgather_jax,
     mpi_any_jax,
     mpi_bcast_jax,
-    mpi_allgather_jax,
     mpi_max_jax,
+    mpi_mean_jax,
+    mpi_sum_jax,
 )

--- a/netket/utils/mpi/primitives.py
+++ b/netket/utils/mpi/primitives.py
@@ -169,6 +169,45 @@ def mpi_any_jax(x, *, token=None, comm=MPI_jax_comm):
         return mpi4jax.allreduce(x, op=MPI.LOR, comm=comm, token=token)
 
 
+def mpi_all(x, *, comm=MPI_py_comm):
+    """
+    Computes the elementwise logical AND of an array or a scalar across all MPI
+    processes.
+
+    Args:
+        a: The input array, which will usually be overwritten in place.
+    Returns:
+        out: The reduced array.
+    """
+    ar = np.asarray(x)
+
+    if n_nodes > 1:
+        comm.Allreduce(MPI.IN_PLACE, ar.reshape(-1), op=MPI.LAND)
+
+    return ar
+
+
+def mpi_all_jax(x, *, token=None, comm=MPI_jax_comm):
+    """
+    Computes the elementwise logical AND of an array or a scalar across all MPI
+    processes.
+
+    Args:
+        a: The input array.
+        token: An optional token to impose ordering of MPI operations
+
+    Returns:
+        out: The reduced array.
+        token: an output token
+    """
+    if n_nodes == 1:
+        return x, token
+    else:
+        import mpi4jax
+
+        return mpi4jax.allreduce(x, op=MPI.LAND, comm=comm, token=token)
+
+
 def mpi_max(x, *, comm=MPI_py_comm):
     """
     Computes the elementwise logical OR of an array or a scalar across all MPI

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ BASE_DEPENDENCIES = [
     "orjson~=3.4",
     "optax>=0.0.2, <0.2",
     "numba4jax>=0.0.1, <0.1",
+    "aenum>=3.1.5, <3.2"
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ BASE_DEPENDENCIES = [
     "orjson~=3.4",
     "optax>=0.0.2, <0.2",
     "numba4jax>=0.0.1, <0.1",
-    "aenum>=3.1.5, <3.2"
+    "aenum>=3.1.5, <3.2",
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ BASE_DEPENDENCIES = [
     "orjson~=3.4",
     "optax>=0.0.2, <0.2",
     "numba4jax>=0.0.1, <0.1",
-    "aenum>=3.1.5, <3.2",
 ]
 
 setup(

--- a/test/dynamics/test_driver.py
+++ b/test/dynamics/test_driver.py
@@ -151,6 +151,18 @@ def test_one_step_lindbladian(integrator):
     assert te.t > 0.0
 
 
+def test_dt_bounds():
+    ha, vstate, _ = _setup_system(L=2, dtype=np.complex128)
+    te = nkx.TDVP(
+        ha,
+        vstate,
+        nkx.dynamics.RK23(dt=0.1, adaptive=True, dt_limits=(1e-2, None)),
+        propagation_type="real",
+    )
+    with pytest.warns(UserWarning, match="RK solver: dt reached lower bound"):
+        te.run(T=0.1, callback=_stop_after_one_step)
+
+
 @pytest.mark.parametrize("integrator", all_integrators)
 def test_stop_times(integrator):
     def make_driver():


### PR DESCRIPTION
This PR does the following:

1) Add a way to signal warnings and errors to the RK solvers. This is done by adding a field `.flags` to the RK state, which is set by the step methods. Right now, the possible flags are the following:
```python
class SolverFlags(IntFlag):
    NONE = 0
    INFO_STEP_ACCEPTED = auto()
    WARN_MIN_DT = auto()
    WARN_MAX_DT = auto()
    ERROR_INVALID_DT = auto()
```
The `TDVP` driver looks for these flags after each step, raising a warning or an exception if appropriate. The reason these (integer-valued) flags are used is that the RK solver function should be `jit`able (even though they are not jit-compiled at this time), preventing us from raising an exception directly.

This also catches errors arising from invalid `dt` values (such as `NaN`), which may be related to the issues in #1017.

2) Fix the handling of `dt_limits`. If a minimum for dt was set previously, the solver ended up in an infinite loop, because the step was not lowered but also not accepted. This is now fixed and steps are accepted (with a warning) if `dt` has reached the lower bound.

3) Split `runge_kutta.py` into separate files for tableaus and solvers for readability.

4) Accept an RK step only iff all MPI ranks agree it should be accepted. This should always be the case in a deterministic setting, but explicitly checking this might prevent potential rare MPI deadlocks (e.g., when different MPI processes run on hosts with slightly different floating-point handling).