### PR TITLE
JIT-compile the ODE time step functions

### DIFF
--- a/docs/docs/api-experimental.md
+++ b/docs/docs/api-experimental.md
@@ -90,8 +90,8 @@ driver above.
 
 ```{eval-rst}
 .. autosummary::
-  :toctree: _generated/experimental/dynamics
-  :nosignatures:
+   :toctree: _generated/experimental/dynamics
+   :nosignatures:
 
   netket.experimental.dynamics.Euler
   netket.experimental.dynamics.Heun

--- a/netket/experimental/driver/tdvp.py
+++ b/netket/experimental/driver/tdvp.py
@@ -76,10 +76,10 @@ class TDVP(AbstractVariationalDriver):
             linear_solver_restart: If False (default), the last solution of the linear system
                 is used as initial value in subsequent steps.
             error_norm: Norm function used to calculate the error with adaptive integrators.
-                Can be either "euclidean" for the standard L2 vector norm :math:`x^\dagger \cdot x`,
-                "maximum" for the maximum norm :math:`\max_i |x_i|`
+                Can be either "euclidean" for the standard L2 vector norm :math:`w^\dagger w`,
+                "maximum" for the maximum norm :math:`\max_i |w_i|`
                 or "qgt", in which case the scalar product induced by the QGT :math:`S` is used
-                to compute the norm :math:`\Vert x \Vert^2_S = x^\dagger \cdot S \cdot x` as suggested
+                to compute the norm :math:`\Vert w \Vert^2_S = w^\dagger S w` as suggested
                 in PRL 125, 100503 (2020).
                 Additionally, it possible to pass a custom function with signature
                 :code:`norm(x: PyTree) -> float`
@@ -156,6 +156,7 @@ class TDVP(AbstractVariationalDriver):
             self.state.parameters,
             norm=error_norm,
         )
+
         self._stop_count = 0
 
     @property
@@ -175,18 +176,18 @@ class TDVP(AbstractVariationalDriver):
 
     def advance(self, T: float):
         """
-        Advance the time propagation by `T` to `self.t + T`.
+        Advance the time propagation by :code:`T` to :code:`self.t + T`.
 
-           Args:
-               T: Length of the integration interval.
+        Args:
+            T: Length of the integration interval.
         """
         for _ in self.iter(T):
             pass
 
     def iter(self, T: float, *, tstops: Optional[Sequence[float]] = None):
         """
-        Returns a generator which advances the time evolution in
-        steps of `step` for a total of `n_iter` times.
+        Returns a generator which advances the time evolution for an interval
+        of length :code:`T`, stopping at :code:`tstops`.
 
         Args:
             T: Length of the integration interval.

--- a/netket/experimental/dynamics/_rk_solver.py
+++ b/netket/experimental/dynamics/_rk_solver.py
@@ -156,7 +156,7 @@ def propose_time_step(
     )
 
 
-# @partial(jax.jit, static_argnames=["f", "norm_fn", "dt_limits"])
+@partial(jax.jit, static_argnames=["f", "norm_fn", "dt_limits"])
 def general_time_step_adaptive(
     tableau: rkt.TableauRKExplicit,
     f: Callable,
@@ -247,7 +247,7 @@ def general_time_step_adaptive(
     )
 
 
-# @partial(jax.jit, static_argnames=["f"])
+@partial(jax.jit, static_argnames=["f"])
 def general_time_step_fixed(
     tableau: rkt.TableauRKExplicit,
     f: Callable,

--- a/netket/experimental/dynamics/_rk_solver.py
+++ b/netket/experimental/dynamics/_rk_solver.py
@@ -410,9 +410,16 @@ class RKIntegratorConfig:
 # Solvers with preset tableaus
 
 Euler = partial(RKIntegratorConfig, tableau=rkt.bt_feuler)
+"""First-order Euler solver"""
 Midpoint = partial(RKIntegratorConfig, tableau=rkt.bt_midpoint)
+"""Second-order midpoint method solver"""
 Heun = partial(RKIntegratorConfig, tableau=rkt.bt_heun)
+"""Second-order Heun solver"""
 RK4 = partial(RKIntegratorConfig, tableau=rkt.bt_rk4)
+"""Fourth-order Runge-Kutta solver"""
 RK12 = partial(RKIntegratorConfig, tableau=rkt.bt_rk12)
+"""Heun-Euler solver (adaptive)"""
 RK23 = partial(RKIntegratorConfig, tableau=rkt.bt_rk23)
+"""Bogacki–Shampine method solver (adaptive)"""
 RK45 = partial(RKIntegratorConfig, tableau=rkt.bt_rk4_dopri)
+"""Dormand-Prince (dopri) method solver (adaptive)"""

--- a/netket/experimental/dynamics/_rk_tableau.py
+++ b/netket/experimental/dynamics/_rk_tableau.py
@@ -37,6 +37,28 @@ def expand_dim(tree: PyTree, sz: int):
 
 @dataclass
 class TableauRKExplicit:
+    r"""
+    Class representing the Butcher tableau of an explicit Runge-Kutta method [1,2],
+    which, given the ODE dy/dt = F(t, y), updates the solution as
+
+    .. math::
+        y_{t+dt} = y_t + \sum_l b_l k_l
+
+    with the intermediate slopes
+
+    .. math::
+        k_l = F(t + c_l dt, y_t + \sum_{m < l} a_{lm} k_m).
+
+    If :code:`self.is_adaptive`, the tableau also contains the coefficients :math:`b'_l`
+    which can be used to estimate the local truncation error by the formula
+
+    .. math::
+        y_{\mathrm{err}} = \sum_l (b_l - b'_l) k_l.
+
+    [1] https://en.wikipedia.org/w/index.php?title=Runge%E2%80%93Kutta_methods&oldid=1055669759
+    [2] J. Stoer and R. Bulirsch, Introduction to Numerical Analysis, Springer NY (2002).
+    """
+
     order: Tuple[int, int]
     """The order of the tableau"""
     a: jax.numpy.ndarray

--- a/netket/experimental/dynamics/_rk_tableau.py
+++ b/netket/experimental/dynamics/_rk_tableau.py
@@ -37,8 +37,6 @@ def expand_dim(tree: PyTree, sz: int):
 
 @dataclass
 class TableauRKExplicit:
-    name: str
-    """The name of the RK Tableau."""
     order: Tuple[int, int]
     """The order of the tableau"""
     a: jax.numpy.ndarray
@@ -90,7 +88,7 @@ class TableauRKExplicit:
         """Computes the intermediate slopes k_l."""
         times = t + self.c * dt
 
-        # TODO: Use FSALLast
+        # TODO: Use FSAL
 
         k = expand_dim(y_t, self.stages)
         for l in range(self.stages):
@@ -143,22 +141,30 @@ class TableauRKExplicit:
         return y_tp1, y_err
 
 
+@dataclass
+class NamedTableau:
+    name: str
+    data: TableauRKExplicit
+
+    def __repr__(self) -> str:
+        return self.name
+
+
 # fmt: off
 # flake8: noqa: E123, E126, E201, E202, E221, E226, E231, E241, E251
 
 # Fixed Step methods
 bt_feuler = TableauRKExplicit(
-                name = "feuler",
                 order = (1,),
                 a = jnp.zeros((1,1), dtype=default_dtype),
                 b = jnp.ones((1,1), dtype=default_dtype),
                 c = jnp.zeros((1), dtype=default_dtype),
                 c_error = None,
                 )
+bt_feuler = NamedTableau("Euler", bt_feuler)
 
 
 bt_midpoint = TableauRKExplicit(
-                name = "midpoint",
                 order = (2,),
                 a = jnp.array([[0,   0],
                                [1/2, 0]], dtype=default_dtype),
@@ -166,10 +172,10 @@ bt_midpoint = TableauRKExplicit(
                 c = jnp.array( [0, 1/2], dtype=default_dtype),
                 c_error = None,
                 )
+bt_midpoint = NamedTableau("Midpoint", bt_midpoint)
 
 
 bt_heun = TableauRKExplicit(
-                name = "heun",
                 order = (2,),
                 a = jnp.array([[0,   0],
                                [1,   0]], dtype=default_dtype),
@@ -177,9 +183,10 @@ bt_heun = TableauRKExplicit(
                 c = jnp.array( [0, 1], dtype=default_dtype),
                 c_error = None,
                 )
+bt_heun = NamedTableau("Heun", bt_heun)
+
 
 bt_rk4  = TableauRKExplicit(
-                name = "rk4",
                 order = (4,),
                 a = jnp.array([[0,   0,   0,   0],
                                [1/2, 0,   0,   0],
@@ -189,12 +196,12 @@ bt_rk4  = TableauRKExplicit(
                 c = jnp.array( [0, 1/2, 1/2, 1], dtype=default_dtype),
                 c_error = None,
                 )
+bt_rk4 = NamedTableau("RK4", bt_rk4)
 
 
 # Adaptive step:
 # Heun Euler https://en.wikipedia.org/wiki/Runge–Kutta_methods
 bt_rk12  = TableauRKExplicit(
-                name = "rk21",
                 order = (2,1),
                 a = jnp.array([[0,   0],
                                [1,   0]], dtype=default_dtype),
@@ -203,10 +210,11 @@ bt_rk12  = TableauRKExplicit(
                 c = jnp.array( [0, 1], dtype=default_dtype),
                 c_error = None,
                 )
+bt_rk12 = NamedTableau("RK12", bt_rk12)
+
 
 # Bogacki–Shampine coefficients
 bt_rk23  = TableauRKExplicit(
-                name = "rk23",
                 order = (2,3),
                 a = jnp.array([[0,   0,   0,   0],
                                [1/2, 0,   0,   0],
@@ -217,9 +225,10 @@ bt_rk23  = TableauRKExplicit(
                 c = jnp.array( [0, 1/2, 3/4, 1], dtype=default_dtype),
                 c_error = None,
                 )
+bt_rk23 = NamedTableau("RK23", bt_rk23)
+
 
 bt_rk4_fehlberg = TableauRKExplicit(
-                name = "fehlberg",
                 order = (4,5),
                 a = jnp.array([[ 0,          0,          0,           0,            0,      0 ],
                               [  1/4,        0,          0,           0,            0,      0 ],
@@ -232,9 +241,10 @@ bt_rk4_fehlberg = TableauRKExplicit(
                 c = jnp.array( [  0,         1/4,        3/8,         12/13,        1,      1/2], dtype=default_dtype),
                 c_error = None,
                 )
+bt_rk4_fehlberg = NamedTableau("RK45Fehlberg", bt_rk4_fehlberg)
+
 
 bt_rk4_dopri  = TableauRKExplicit(
-                name = "dopri",
                 order = (5,4),
                 a = jnp.array([[ 0,           0,           0,           0,        0,             0,         0 ],
                               [  1/5,         0,           0,           0,        0,             0,         0 ],
@@ -248,4 +258,6 @@ bt_rk4_dopri  = TableauRKExplicit(
                 c = jnp.array( [ 0,           1/5,         3/10,        4/5,      8/9,           1,         1], dtype=default_dtype),
                 c_error = None,
                 )
+bt_rk4_dopri = NamedTableau("RK45", bt_rk4_dopri)
+
 # fmt: on

--- a/test/dynamics/test_driver.py
+++ b/test/dynamics/test_driver.py
@@ -26,7 +26,7 @@ import netket.experimental as nkx
 SEED = 214748364
 
 
-def _setup_system(L, *, dtype=np.float64):
+def _setup_system(L, *, dtype=np.complex128):
     g = nk.graph.Chain(length=L)
     hi = nk.hilbert.Spin(s=0.5, N=g.n_nodes)
 
@@ -84,7 +84,7 @@ def test_one_fixed_step(integrator, propagation_type):
     assert te.t == 0.01
 
 
-def l4_norm(_, x):
+def l4_norm(x):
     """
     Custom L4 error norm.
     """
@@ -229,4 +229,4 @@ def test_repr_and_info():
     assert "TDVP" in info
     assert "generator" in info
     assert "integrator" in info
-    assert "rk23" in info
+    assert "RK23" in info

--- a/test/dynamics/test_solvers.py
+++ b/test/dynamics/test_solvers.py
@@ -28,13 +28,10 @@ explicit_fixed_step_solvers = {
 }
 
 explicit_adaptive_solvers = {
+    "RK12": RK12,
     "RK23": RK23,
     "RK45": RK45,
 }
-# Only add RK12 outside CI, as it adapts to smaller steps, making
-# test_adaptive_solver take more time.
-if os.environ.get("CI", "false") != "true":
-    explicit_adaptive_solvers["RK12"] = RK12
 
 
 @pytest.mark.parametrize("solver", explicit_fixed_step_solvers)


### PR DESCRIPTION
This PR makes the time-stepping routines of (adaptive and fixed-step) RK integrators fully compatible with `jax.jit` and enables it.

Our `MCState.expect_and_grad` code is not jit-able yet. Therefore, as a workaround, we use [`jax.experimental.host_callback`](https://jax.readthedocs.io/en/latest/jax.experimental.host_callback.html) in order to have the compiled solver code call back into the pure Python ODE function for now.

Enabling JIT shows a clear speed-up when used with jit-able ODE functions, like those `test_solvers.py`. These are timings for the tests on my machine, before and after:
```
# before
207.35s call     test/dynamics/test_solvers.py::test_adaptive_solver[RK12]
7.25s call     test/dynamics/test_solvers.py::test_adaptive_solver[RK23]
1.45s call     test/dynamics/test_solvers.py::test_adaptive_solver[RK45]
0.13s call     test/dynamics/test_solvers.py::test_ode_solver[RK4]
0.08s call     test/dynamics/test_solvers.py::test_ode_solver[Midpoint]
0.08s call     test/dynamics/test_solvers.py::test_ode_solver[Heun]
0.07s call     test/dynamics/test_solvers.py::test_ode_solver[Euler]
# after
1.53s call     test/dynamics/test_solvers.py::test_adaptive_solver[RK12]
0.41s call     test/dynamics/test_solvers.py::test_adaptive_solver[RK45]
0.34s call     test/dynamics/test_solvers.py::test_adaptive_solver[RK23]
0.13s call     test/dynamics/test_solvers.py::test_ode_solver[RK4]
0.08s call     test/dynamics/test_solvers.py::test_ode_solver[Heun]
0.08s call     test/dynamics/test_solvers.py::test_ode_solver[Midpoint]
0.07s call     test/dynamics/test_solvers.py::test_ode_solver[Euler]
```

In t-VMC, the complexity of sampling and solving the TDVP equation is more relevant and we need the `host_callback`, but at least on my machine I still see a slight speed-up.

Note that I needed to move the `name: str` attribute out of the tableau class, because `str` is not a JAX-compatible type and it is nice to be able to pass around the tableau in jit-ed functions.