### PR TITLE
Deprecate sampler module functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,13 @@
 * Chunking of `MCState.expect` and `MCState.expect_and_grad` computations is now supported, which allows to bound the memory cost in exchange of a minor increase in computation time. [#1006](https://github.com/netket/netket/pull/1006) (and discussions in [#918](https://github.com/netket/netket/pull/918) and [#830](https://github.com/netket/netket/pull/830))
 * {ref}`nk.operator.LocalOperator` now accepts sparse matrices as input operators [#919](https://github.com/netket/netket/pull/919)
 * A new variational state that performs exact summation over the whole Hilbert space has been added. It can be constructed with {ref}`nk.vqs.ExactState` and supports the same Jax neural networks as {ref}`nk.vqs.MCState`. [#953](https://github.com/netket/netket/pull/953)
-* [Experimental] A new time-evolution driver  {ref}`nk.experimental.TDVP` using the time-dependent variational principle (TDVP) has been added. It works with time-independent and time-dependent Hamiltonians and Liouvillians. [#1012](https://github.com/netket/netket/pull/1012) 
-* [Experimental] A set of JAX-compatible Runge-Kutta ODE integrators has been added for use together with the new TDVP driver. [#1012](https://github.com/netket/netket/pull/1012) 
+* [Experimental] A new time-evolution driver  {ref}`nk.experimental.TDVP` using the time-dependent variational principle (TDVP) has been added. It works with time-independent and time-dependent Hamiltonians and Liouvillians. [#1012](https://github.com/netket/netket/pull/1012)
+* [Experimental] A set of JAX-compatible Runge-Kutta ODE integrators has been added for use together with the new TDVP driver. [#1012](https://github.com/netket/netket/pull/1012)
 
 ### Breaking Changes
 * The method `sample_next` in `Sampler` and exact samplers (`ExactSampler` and `ARDirectSampler`) is removed, and it is only defined in `MetropolisSampler`. The module function `nk.sampler.sample_next` also only works with `MetropolisSampler`. For exact samplers, please use the method `sample` instead. [#1016](https://github.com/netket/netket/pull/1016)
 * The default value of `n_chains_per_rank` in `Sampler` and exact samplers is changed to 1, and specifying `n_chains` or `n_chains_per_rank` when constructing them is deprecated. Please change `chain_length` when calling `sample`. For `MetropolisSampler`, the default value is changed from `n_chains = 16` (across all ranks) to `n_chains_per_rank = 16`. [#1017](https://github.com/netket/netket/pull/1017)
+* The method `Sampler.samples` is added to return a generator of samples. The module functions `nk.sampler.sampler_state`, `reset`, `sample`, `samples`, and `sample_next` are deprecated in favor of the corresponding class methods. [#1025](https://github.com/netket/netket/pull/1025)
 
 ### Internal Changes
 * The definitions of `MCState` and `MCMixedState` have been moved to an internal module, `nk.vqs.mc` that is hidden by default. [#954](https://github.com/netket/netket/pull/954)

--- a/netket/sampler/metropolis.py
+++ b/netket/sampler/metropolis.py
@@ -410,6 +410,9 @@ class MetropolisSampler(Sampler):
         )
 
 
+@deprecated(
+    "The module function `sample_next` is deprecated in favor of the class method `sample_next`."
+)
 def sample_next(
     sampler: Sampler,
     machine: Union[Callable, nn.Module],

--- a/test/sampler/test_sampler.py
+++ b/test/sampler/test_sampler.py
@@ -187,7 +187,7 @@ def test_states_in_hilbert(sampler, model_and_weights):
 
         ma, w = model_and_weights(hi, sampler)
 
-        for sample in nk.sampler.samples(sampler, ma, w, chain_length=50):
+        for sample in sampler.samples(ma, w, chain_length=50):
             assert sample.shape == (sampler.n_chains, hi.size)
             for v in sample:
                 assert v in all_states
@@ -195,7 +195,7 @@ def test_states_in_hilbert(sampler, model_and_weights):
     elif isinstance(hi, Particle):
         ma, w = model_and_weights(hi, sampler)
 
-        for sample in nk.sampler.samples(sampler, ma, w, chain_length=50):
+        for sample in sampler.samples(ma, w, chain_length=50):
             assert sample.shape == (sampler.n_chains, hi.size)
 
     # if hasattr(sa, "acceptance"):


### PR DESCRIPTION
The third PR in the #1013 series. Those module functions don't really serve a purpose today and will be deprecated.

API changes:
* The method `Sampler.samples` is added to return a generator of samples. The module functions `nk.sampler.sampler_state`, `reset`, `sample`, `samples`, and `sample_next` are deprecated in favor of the corresponding class methods. [#1025](https://github.com/netket/netket/pull/1025)

I moved the logics from the module functions to the class methods, and replaced the module functions in the tests.