### PR TITLE
fix netket tools info broken by mpi4jax

### DIFF
--- a/netket/tools/info.py
+++ b/netket/tools/info.py
@@ -113,8 +113,12 @@ def info():
         print("# MPI4JAX")
         import mpi4jax
 
-        if hasattr(mpi4jax._src.xla_bridge, "HAS_GPU_EXT"):
-            printfmt("HAS_GPU_EXT", mpi4jax._src.xla_bridge.HAS_GPU_EXT, indent=1)
+        if hasattr(mpi4jax, "has_cuda_support"):
+            printfmt("HAS_GPU_EXT", mpi4jax.has_cuda_support, indent=1)
+        else:
+            if hasattr(mpi4jax._src, "xla_bridge"):
+                if hasattr(mpi4jax._src.xla_bridge, "HAS_GPU_EXT"):
+                    printfmt("HAS_GPU_EXT", mpi4jax._src.xla_bridge.HAS_GPU_EXT, indent=1)
         print()
 
     if is_available("mpi4py"):

--- a/netket/tools/info.py
+++ b/netket/tools/info.py
@@ -115,10 +115,12 @@ def info():
 
         if hasattr(mpi4jax, "has_cuda_support"):
             printfmt("HAS_GPU_EXT", mpi4jax.has_cuda_support, indent=1)
-        else:
+        elif hasattr(mpi4jax, "_src"):
             if hasattr(mpi4jax._src, "xla_bridge"):
                 if hasattr(mpi4jax._src.xla_bridge, "HAS_GPU_EXT"):
-                    printfmt("HAS_GPU_EXT", mpi4jax._src.xla_bridge.HAS_GPU_EXT, indent=1)
+                    printfmt(
+                        "HAS_GPU_EXT", mpi4jax._src.xla_bridge.HAS_GPU_EXT, indent=1
+                    )
         print()
 
     if is_available("mpi4py"):


### PR DESCRIPTION
Before I was unsafely relying on some mpi4jax internals.
Now i use the exported function if available otherwise I check before accessing internals...

Should be merged only after https://github.com/mpi4jax/mpi4jax/pull/109 is merged, in case the name is changed.