### PR TITLE
Recompute properties when setting `MCState.sampler`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * The constructor of `TensorHilbert` (which is used by the product operator `*` for inhomogeneous spaces) no longer fails when one of the component spaces is non-indexable. [#1004](https://github.com/netket/netket/pull/1004)
 * The {ref}`nk.hilbert.random.flip_state` method used by `MetropolisLocal` now throws an error when called on a {ref}`nk.hilbert.ContinuousHilbert` hilbert space instead of entering an endless loop. [#1014](https://github.com/netket/netket/pull/1014)
 * Fixed bug in conversion to qutip for `MCMixedState`, where the resulting shape (hilbert space size) was wrong. [#1020](https://github.com/netket/netket/pull/1020)
+* Setting `MCState.sampler` now recomputes `MCState.chain_length` according to `MCState.n_samples` and the new `sampler.n_chains`. [#1028](https://github.com/netket/netket/pull/1028)
 
 
 ## NetKet 3.2 (26 November 2021)

--- a/netket/vqs/mc/mc_state/state.py
+++ b/netket/vqs/mc/mc_state/state.py
@@ -324,12 +324,7 @@ class MCState(VariationalState):
     @n_samples.setter
     def n_samples(self, n_samples: int):
         chain_length = compute_chain_length(self.sampler.n_chains, n_samples)
-
-        n_samples = chain_length * self.sampler.n_chains
-        check_chunk_size(n_samples, self.chunk_size)
-
-        self._chain_length = chain_length
-        self.reset()
+        self.chain_length = chain_length
 
     @property
     def n_samples_per_rank(self) -> int:
@@ -351,7 +346,14 @@ class MCState(VariationalState):
 
     @chain_length.setter
     def chain_length(self, chain_length: int):
-        self.n_samples = chain_length * self.sampler.n_chains
+        if chain_length <= 0:
+            raise ValueError(f"Invalid chain length: chain_length={chain_length}")
+
+        n_samples = chain_length * self.sampler.n_chains
+        check_chunk_size(n_samples, self.chunk_size)
+
+        self._chain_length = chain_length
+        self.reset()
 
     @property
     def n_discard_per_chain(self) -> int:

--- a/test/variational/test_variational.py
+++ b/test/variational/test_variational.py
@@ -25,8 +25,6 @@ from jax.nn.initializers import normal
 
 from .. import common
 
-pytestmark = common.skipif_mpi
-
 nk.config.update("NETKET_EXPERIMENTAL", True)
 
 SEED = 2148364
@@ -96,6 +94,7 @@ def vstate(request):
     return vs
 
 
+@common.skipif_mpi
 def test_deprecated_name():
     with warns(FutureWarning):
         nk.variational.expect
@@ -127,24 +126,20 @@ def test_n_samples_api(vstate, _mpi_size):
     ):
         vstate.n_discard_per_chain = -1
 
-    def check_consistent():
-        assert vstate.n_samples == vstate.n_samples_per_rank * _mpi_size
-        assert vstate.n_samples == vstate.chain_length * vstate.sampler.n_chains
-
     # Tests for `ExactSampler` with `n_chains == 1`
     vstate.n_samples = 3
-    check_consistent()
+    check_consistent(vstate, _mpi_size)
     assert vstate.samples.shape[0:2] == (
         int(np.ceil(3 / _mpi_size)),
         vstate.sampler.n_chains_per_rank,
     )
 
     vstate.n_samples_per_rank = 4
-    check_consistent()
+    check_consistent(vstate, _mpi_size)
     assert vstate.samples.shape[0:2] == (4, vstate.sampler.n_chains_per_rank)
 
     vstate.chain_length = 2
-    check_consistent()
+    check_consistent(vstate, _mpi_size)
     assert vstate.samples.shape[0:2] == (2, vstate.sampler.n_chains_per_rank)
 
     vstate.n_samples = 1000
@@ -156,26 +151,27 @@ def test_n_samples_api(vstate, _mpi_size):
     # `n_samples` is rounded up
     assert vstate.n_samples == 1008
     assert vstate.chain_length == 63
-    check_consistent()
+    check_consistent(vstate, _mpi_size)
 
     vstate.n_discard_per_chain = None
     assert vstate.n_discard_per_chain == vstate.n_samples // 10
 
     vstate.n_samples = 3
-    check_consistent()
+    check_consistent(vstate, _mpi_size)
     # `n_samples` is rounded up
     assert vstate.samples.shape[0:2] == (1, vstate.sampler.n_chains_per_rank)
 
     vstate.n_samples_per_rank = 16 // _mpi_size + 1
-    check_consistent()
+    check_consistent(vstate, _mpi_size)
     # `n_samples` is rounded up
     assert vstate.samples.shape[0:2] == (2, vstate.sampler.n_chains_per_rank)
 
     vstate.chain_length = 2
-    check_consistent()
+    check_consistent(vstate, _mpi_size)
     assert vstate.samples.shape[0:2] == (2, vstate.sampler.n_chains_per_rank)
 
 
+@common.skipif_mpi
 def test_chunk_size_api(vstate, _mpi_size):
     assert vstate.chunk_size is None
 
@@ -213,6 +209,7 @@ def test_chunk_size_api(vstate, _mpi_size):
         vstate.sample(n_samples=1008 + 16)
 
 
+@common.skipif_mpi
 def test_deprecations(vstate):
     vstate.sampler = nk.sampler.MetropolisLocal(hilbert=hi, n_chains=16)
 
@@ -228,6 +225,7 @@ def test_deprecations(vstate):
     assert vstate.n_discard_per_chain == 10
 
 
+@common.skipif_mpi
 def test_serialization(vstate):
     from flax import serialization
 
@@ -248,6 +246,7 @@ def test_serialization(vstate):
     assert vstate.n_discard_per_chain == old_ndiscard
 
 
+@common.skipif_mpi
 def test_init_parameters(vstate):
     vstate.init_parameters(seed=SEED)
     pars = vstate.parameters
@@ -260,6 +259,7 @@ def test_init_parameters(vstate):
     jax.tree_multimap(_f, pars, pars2)
 
 
+@common.skipif_mpi
 @pytest.mark.parametrize(
     "operator",
     [
@@ -277,6 +277,7 @@ def test_expect_numpysampler_works(vstate, operator):
     assert isinstance(out, nk.stats.Stats)
 
 
+@common.skipif_mpi
 def test_qutip_conversion(vstate):
     # skip test if qutip not installed
     pytest.importorskip("qutip")
@@ -293,6 +294,7 @@ def test_qutip_conversion(vstate):
     np.testing.assert_allclose(q_obj.data.todense(), ket.reshape(q_obj.shape))
 
 
+@common.skipif_mpi
 @pytest.mark.parametrize(
     "operator",
     [
@@ -362,6 +364,7 @@ def test_expect(vstate, operator):
     same_derivatives(O_grad, grad_exact, abs_eps=err, rel_eps=err)
 
 
+@common.skipif_mpi
 @pytest.mark.parametrize(
     "operator",
     [
@@ -397,6 +400,8 @@ def test_expect_chunking(vstate, operator, n_chunks):
 
 
 ###
+
+
 def _expval(par, vstate, H, real=False):
     vstate.parameters = par
     psi = vstate.to_array()
@@ -444,3 +449,8 @@ def same_derivatives(der_log, num_der_log, abs_eps=1.0e-6, rel_eps=1.0e-6):
         rtol=rel_eps,
         atol=abs_eps,
     )
+
+
+def check_consistent(vstate, mpi_size):
+    assert vstate.n_samples == vstate.n_samples_per_rank * mpi_size
+    assert vstate.n_samples == vstate.chain_length * vstate.sampler.n_chains

--- a/test/variational/test_variational.py
+++ b/test/variational/test_variational.py
@@ -124,11 +124,14 @@ def test_n_samples_api(vstate, _mpi_size):
 
     # Tests for `ExactSampler` with `n_chains == 1`
     vstate.n_samples = 3
-    assert vstate.samples.shape[0:2] == (3, vstate.sampler.n_chains)
+    assert vstate.samples.shape[0:2] == (
+        int(np.ceil(3 / _mpi_size)),
+        vstate.sampler.n_chains_per_rank,
+    )
 
     vstate.chain_length = 2
     assert vstate.n_samples == 2 * vstate.sampler.n_chains
-    assert vstate.samples.shape[0:2] == (2, vstate.sampler.n_chains)
+    assert vstate.samples.shape[0:2] == (2, vstate.sampler.n_chains_per_rank)
 
     vstate.n_samples = 1000
     vstate.n_discard_per_chain = None
@@ -147,11 +150,11 @@ def test_n_samples_api(vstate, _mpi_size):
 
     vstate.n_samples = 3
     # `n_samples` is rounded up
-    assert vstate.samples.shape[0:2] == (1, vstate.sampler.n_chains)
+    assert vstate.samples.shape[0:2] == (1, vstate.sampler.n_chains_per_rank)
 
     vstate.chain_length = 2
     assert vstate.n_samples == 2 * vstate.sampler.n_chains
-    assert vstate.samples.shape[0:2] == (2, vstate.sampler.n_chains)
+    assert vstate.samples.shape[0:2] == (2, vstate.sampler.n_chains_per_rank)
 
 
 def test_chunk_size_api(vstate, _mpi_size):

--- a/test/variational/test_variational.py
+++ b/test/variational/test_variational.py
@@ -122,6 +122,7 @@ def test_n_samples_api(vstate, _mpi_size):
     ):
         vstate.n_discard_per_chain = -1
 
+    # Tests for `ExactSampler` with `n_chains == 1`
     vstate.n_samples = 3
     assert vstate.samples.shape[0:2] == (3, vstate.sampler.n_chains)
 
@@ -133,11 +134,24 @@ def test_n_samples_api(vstate, _mpi_size):
     vstate.n_discard_per_chain = None
     assert vstate.n_discard_per_chain == 0
 
+    # Tests for `MetropolisLocal` with `n_chains > 1`
     vstate.sampler = nk.sampler.MetropolisLocal(hilbert=hi, n_chains=16)
+    # `n_samples` is rounded up
+    assert vstate.n_samples == 1008
+    assert vstate.chain_length == 63
+
     vstate.n_discard_per_chain = None
     assert vstate.n_discard_per_chain == vstate.n_samples // 10
 
     assert vstate.n_samples_per_rank == vstate.n_samples // _mpi_size
+
+    vstate.n_samples = 3
+    # `n_samples` is rounded up
+    assert vstate.samples.shape[0:2] == (1, vstate.sampler.n_chains)
+
+    vstate.chain_length = 2
+    assert vstate.n_samples == 2 * vstate.sampler.n_chains
+    assert vstate.samples.shape[0:2] == (2, vstate.sampler.n_chains)
 
 
 def test_chunk_size_api(vstate, _mpi_size):

--- a/test/variational/test_variational_mixed.py
+++ b/test/variational/test_variational_mixed.py
@@ -96,11 +96,14 @@ def test_n_samples_api(vstate, _mpi_size):
 
     # Tests for `ExactSampler` with `n_chains == 1`
     vstate.n_samples = 3
-    assert vstate.samples.shape[0:2] == (3, vstate.sampler.n_chains)
+    assert vstate.samples.shape[0:2] == (
+        int(np.ceil(3 / _mpi_size)),
+        vstate.sampler.n_chains_per_rank,
+    )
 
     vstate.chain_length = 2
     assert vstate.n_samples == 2 * vstate.sampler.n_chains
-    assert vstate.samples.shape[0:2] == (2, vstate.sampler.n_chains)
+    assert vstate.samples.shape[0:2] == (2, vstate.sampler.n_chains_per_rank)
 
     vstate.n_samples = 1000
     vstate.n_discard_per_chain = None
@@ -119,11 +122,11 @@ def test_n_samples_api(vstate, _mpi_size):
     assert vstate.n_samples_per_rank == vstate.n_samples // _mpi_size
 
     vstate.n_samples = 3
-    assert vstate.samples.shape[0:2] == (1, vstate.sampler.n_chains)
+    assert vstate.samples.shape[0:2] == (1, vstate.sampler.n_chains_per_rank)
 
     vstate.chain_length = 2
     assert vstate.n_samples == 2 * vstate.sampler.n_chains
-    assert vstate.samples.shape[0:2] == (2, vstate.sampler.n_chains)
+    assert vstate.samples.shape[0:2] == (2, vstate.sampler.n_chains_per_rank)
 
 
 def test_n_samples_diag_api(vstate, _mpi_size):
@@ -146,8 +149,8 @@ def test_n_samples_diag_api(vstate, _mpi_size):
     vstate.n_samples_diag = 3
     assert (
         vstate.diagonal.samples.shape[0:2]
-        == (3, vstate.sampler_diag.n_chains)
-        == (3, vstate.diagonal.sampler.n_chains)
+        == (int(np.ceil(3 / _mpi_size)), vstate.sampler_diag.n_chains_per_rank)
+        == (int(np.ceil(3 / _mpi_size)), vstate.diagonal.sampler.n_chains_per_rank)
     )
 
     vstate.chain_length_diag = 2
@@ -158,8 +161,8 @@ def test_n_samples_diag_api(vstate, _mpi_size):
     )
     assert (
         vstate.diagonal.samples.shape[0:2]
-        == (2, vstate.sampler_diag.n_chains)
-        == (2, vstate.diagonal.sampler.n_chains)
+        == (2, vstate.sampler_diag.n_chains_per_rank)
+        == (2, vstate.diagonal.sampler.n_chains_per_rank)
     )
 
     vstate.n_samples_diag = 1000
@@ -185,8 +188,8 @@ def test_n_samples_diag_api(vstate, _mpi_size):
     # `n_samples_diag` is rounded up
     assert (
         vstate.diagonal.samples.shape[0:2]
-        == (1, vstate.sampler_diag.n_chains)
-        == (1, vstate.diagonal.sampler.n_chains)
+        == (1, vstate.sampler_diag.n_chains_per_rank)
+        == (1, vstate.diagonal.sampler.n_chains_per_rank)
     )
 
     vstate.chain_length_diag = 2
@@ -197,8 +200,8 @@ def test_n_samples_diag_api(vstate, _mpi_size):
     )
     assert (
         vstate.diagonal.samples.shape[0:2]
-        == (2, vstate.sampler_diag.n_chains)
-        == (2, vstate.diagonal.sampler.n_chains)
+        == (2, vstate.sampler_diag.n_chains_per_rank)
+        == (2, vstate.diagonal.sampler.n_chains_per_rank)
     )
 
 


### PR DESCRIPTION
When setting a new sampler for a `MCState`, now we recompute `n_samples`, `n_samples_per_rank`, and `chain_length` according to the new `sampler.n_chains`, such that `n_samples == chain_length * n_chains` is ensured, and `n_samples` is unchanged if possible.

I also wrote more tests in `test/variational/test_variational.py::test_n_samples_api` and `test_variational_mixed.py::test_n_samples_api` for both exact and Metropolis samplers. Those tests should pass with MPI (although some other tests in those files still do not).

There are a few other things in `MCState` to fix, and I would like to apply them one by one in case they would interfere with the tests in bizarre ways.