### PR TITLE
Only require models to work with batches (not vector) inputs

### DIFF
--- a/docs/docs/custom_models.md
+++ b/docs/docs/custom_models.md
@@ -17,13 +17,11 @@ The 3 frameworks that are supported are:
 ## Commonalities
 
 Whatever the framework you pick, your model must be able to accept batches of states, so 2-Dimensonal matrices {code}`(B,N)` where $N$ is the number of local degrees of freedom in the hilbert space (spatial sites) and $B$ is the number of batches.
-The result *must* be a {code}`(B,)` vector  where every element is the evaluation of
-your network for that entry.
+The result *must* be a {code}`(B,)` vector  where every element is the evaluation of your network for that entry.
 
-If you have a model that is differnt to write in such a way to act on batches, you
-can use [jax.vmap](https://jax.readthedocs.io/en/latest/jax.html#jax.vmap) to vectorize it.
+If you have a model that is difficult to write in such a way to act on batches, you can use [jax.vmap](https://jax.readthedocs.io/en/latest/jax.html#jax.vmap) to vectorize it.
 
-Your model will be compilde with `jax.jit`. Therefore in general you should NEVER (unless you know what you are doing) use {code}`numpy`, but rather {code}`jax.numpy` inside of it.
+Your model will be compiled with `jax.jit`. Therefore in general you should NEVER (unless you know what you are doing) use {code}`numpy`, but rather {code}`jax.numpy` inside of it.
 If you want to understand why, read [Jax 101 guide](https://jax.readthedocs.io/en/latest/jax-101/index.html) ( however, even if you don't care, we think it's hard to us a tool you don't undrstand: so at least rad [Jax for the Impatient](https://flax.readthedocs.io/en/latest/notebooks/jax_for_the_impatient.html), which is shorter).
 
 ### Defining models: init and apply functions
@@ -96,7 +94,7 @@ class RBM(nknn.Module):
 ```
 
 For more advanced examples, you can check the [source-code](https://github.com/netket/netket/tree/master/netket/models)
-of the models included in netket  or Flax documentation.
+of the models included in netket or Flax documentation.
 
 ## Using Jax/Stax
 

--- a/netket/jax/__init__.py
+++ b/netket/jax/__init__.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from netket.utils import HashablePartial
+
 from .utils import (
     tree_ravel,
     is_complex,
@@ -29,7 +31,6 @@ from .utils import (
     tree_axpy,
     tree_to_real,
     compose,
-    HashablePartial,
     mpi_split,
     PRNGKey,
     PRNGSeq,

--- a/netket/operator/_local_operator.py
+++ b/netket/operator/_local_operator.py
@@ -568,9 +568,15 @@ class LocalOperator(DiscreteOperator):
             operator_row_index, operator_column_index = self._operators[
                 support_i
             ].nonzero()
-            operator_data = np.asarray(
-                self._operators[support_i][operator_row_index, operator_column_index]
-            ).squeeze(axis=0)
+            if len(operator_row_index) > 0:
+                operator_data = np.asarray(
+                    self._operators[support_i][
+                        operator_row_index, operator_column_index
+                    ]
+                ).squeeze(axis=0)
+            else:
+                operator_data = np.array([], dtype=self._operators[support_i].dtype)
+
             self._append_matrix(
                 operator_data,
                 operator_row_index,
@@ -688,9 +694,12 @@ class LocalOperator(DiscreteOperator):
         )
 
         operator_row_index, operator_column_index = operator.nonzero()
-        operator_data = np.asarray(
-            operator[operator_row_index, operator_column_index]
-        ).squeeze(axis=0)
+        if operator.nnz > 0:
+            operator_data = np.asarray(
+                operator[operator_row_index, operator_column_index]
+            ).squeeze(axis=0)
+        else:
+            operator_data = np.array([], dtype=operator.dtype)
         self._append_matrix(
             operator_data,
             operator_row_index,
@@ -726,6 +735,12 @@ class LocalOperator(DiscreteOperator):
     ):
         n_conns[:operator_size] = 0
         diag_mels[:operator_size] = 0
+        mels[:operator_size] = 0
+
+        # bail out early if the operator is empty
+        if len(operator_row_index) == 0:
+            return
+
         for element, ridx, cidx in zip(
             operator_data, operator_row_index, operator_column_index
         ):

--- a/netket/utils/__init__.py
+++ b/netket/utils/__init__.py
@@ -21,7 +21,8 @@ from . import types
 from . import float
 
 from .array import HashableArray
-from .jax import get_afun_if_module, wrap_afun
+from .partial import HashablePartial
+from .jax import get_afun_if_module, wrap_afun, wrap_to_support_scalar
 from .optional_deps import tensorboard_available
 from .seed import random_seed
 from .summation import KahanSum

--- a/netket/utils/partial.py
+++ b/netket/utils/partial.py
@@ -1,0 +1,72 @@
+# Copyright 2021 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+
+from functools import partial
+
+
+class HashablePartial(partial):
+    """
+    A class behaving like functools.partial, but that retains it's hash
+    if it's created with a lexically equivalent (the same) function and
+    with the same partially applied arguments and keywords.
+
+    It also stores the computed hash for faster hashing.
+    """
+
+    # TODO remove when dropping support for Python < 3.10
+    def __new__(cls, func, *args, **keywords):
+        # In Python 3.10+ if func is itself a functools.partial instance,
+        # functools.partial.__new__ would merge the arguments of this HashablePartial
+        # instance with the arguments of the func
+        # Pre 3.10 this does not happen, so here we emulate this behaviour recursively
+        # This is necessary since functools.partial objects do not have a __code__
+        # property which we use for the hash
+        if sys.version_info < (3, 10):
+            while isinstance(func, partial):
+                original_func = func
+                func = original_func.func
+                args = original_func.args + args
+                keywords = {**original_func.keywords, **keywords}
+        return super(HashablePartial, cls).__new__(cls, func, *args, **keywords)
+
+    def __init__(self, *args, **kwargs):
+        self._hash = None
+
+    def __eq__(self, other):
+        return (
+            type(other) is HashablePartial
+            and self.func.__code__ == other.func.__code__
+            and self.args == other.args
+            and self.keywords == other.keywords
+        )
+
+    def __hash__(self):
+        if self._hash is None:
+            self._hash = hash(
+                (self.func.__code__, self.args, frozenset(self.keywords.items()))
+            )
+
+        return self._hash
+
+    def __repr__(self):
+        return f"<hashable partial {self.func.__name__} with args={self.args} and kwargs={self.keywords}, hash={hash(self)}>"
+
+
+# jax.tree_util.register_pytree_node(
+#    HashablePartial,
+#    lambda partial_: ((), (partial_.func, partial_.args, partial_.keywords)),
+#    lambda args, _: StaticPartial(args[0], *args[1], **args[2]),
+# )

--- a/netket/vqs/exact/state.py
+++ b/netket/vqs/exact/state.py
@@ -24,7 +24,7 @@ from flax import serialization
 from netket import jax as nkjax
 from netket import nn
 from netket.hilbert import AbstractHilbert
-from netket.utils import maybe_wrap_module, wrap_afun
+from netket.utils import maybe_wrap_module, wrap_afun, wrap_to_support_scalar
 from netket.utils.types import PyTree, SeedT, NNInitFunc
 from netket.optimizer import LinearOperator
 from netket.optimizer.qgt import QGTAuto
@@ -109,12 +109,14 @@ class ExactState(VariationalState):
             self._init_fun = nkjax.HashablePartial(
                 lambda model, *args, **kwargs: model.init(*args, **kwargs), model
             )
-            self._apply_fun = nkjax.HashablePartial(
-                lambda model, *args, **kwargs: model.apply(*args, **kwargs), model
+            self._apply_fun = wrap_to_support_scalar(
+                nkjax.HashablePartial(
+                    lambda model, *args, **kwargs: model.apply(*args, **kwargs), model
+                )
             )
 
         elif apply_fun is not None:
-            self._apply_fun = apply_fun
+            self._apply_fun = wrap_to_support_scalar(apply_fun)
 
             if init_fun is not None:
                 self._init_fun = init_fun

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ MPI_DEPENDENCIES = ["mpi4py>=3.0.1, <4", "mpi4jax~=0.3.1"]
 EXTRA_DEPENDENCIES = ["tensorboardx>=2.0.0", "openfermion>=1.0.0"]
 BASE_DEPENDENCIES = [
     "numpy~=1.18",
-    "scipy~=1.5",
+    "scipy>=1.5.3, <2",
     "tqdm~=4.60",
     "plum-dispatch~=1.5.1",
     "numba>=0.52, <0.55",

--- a/test/operator/test_local_operator.py
+++ b/test/operator/test_local_operator.py
@@ -338,6 +338,16 @@ def test_type_promotion():
     assert promoted_op.dtype == np.complex128
 
 
+def test_empty_after_sum():
+    a = nk.operator.spin.sigmaz(nk.hilbert.Spin(0.5), 0)
+    zero_op = a - a
+    np.testing.assert_allclose(zero_op.to_dense(), 0.0)
+
+    a = nk.operator.spin.sigmay(nk.hilbert.Spin(0.5), 0)
+    zero_op = a - a
+    np.testing.assert_allclose(zero_op.to_dense(), 0.0)
+
+
 def test_is_hermitian():
     for op in herm_operators.values():
         assert op.is_hermitian == True

--- a/test/utils/test_utils.py
+++ b/test/utils/test_utils.py
@@ -74,3 +74,28 @@ def test_Kahan_sum():
 
     assert ksum1.value == pytest.approx(5.0, rel=1e-15, abs=1e-15)
     assert ksum2.value == pytest.approx(5.0, rel=1e-15, abs=1e-15)
+
+
+def test_batching_wrapper():
+    from netket.utils import wrap_to_support_scalar
+
+    def applyfun(pars, x):
+        # this assert fails if the wrapper is not working
+        assert x.ndim > 1
+        return x.sum(axis=-1)
+
+    # check same hash
+    assert hash(wrap_to_support_scalar(applyfun)) == hash(
+        wrap_to_support_scalar(applyfun)
+    )
+
+    afun = wrap_to_support_scalar(applyfun)
+
+    x = jnp.ones(5)
+    xb = jnp.ones((1, 5))
+    res = afun(None, x)
+    assert res.shape == ()
+    assert res == jnp.sum(x, axis=-1)
+    res = afun(None, xb)
+    assert res.shape == (1,)
+    assert res == jnp.sum(x, axis=-1)


### PR DESCRIPTION
Right now models provided by users must satisfy two conditions:
 - if input is a batch of bitstrings return a vector `(M,N) -> (M,)` 
 - If input is a single bitstring (vector) return a scalar `(N,) -> ()`

However this is confusing and annoying. After a discussion with @femtobit and @attila-i-szabo we agreed that the best choice is to require models to work with batches because (a) most models in ML are written with explicit batches and (b) it makes sure we can control batching behaviour and were it ends up in intermediate calculations, something we can't do under vmap.

There are 2 ways to ensure that models must only support batches and not scalars:
 1. Go through netket and make sure we never call `apply_fun` with a vector (there are about 4-5 places where this happens). We must also go through netket and make sure to reshape to a scalar before calling `jax.grad` (happens in 2 places: lindblad and continuous kinetic operator).
 2. Just wrap all `apply_fun` provided to `MCState` and `ExactState` to always reshape to a batch if the input is a vector.

I am unconvinced by (1) because it makes code more verbose, and, if you are writing a custom `expect` kernel you have to be careful to never call the scalar version of the code. I don't like enforcing more constraints on users so...
This PR opts for (2).

I think @femtobit won't fully agree with me?

Closes #629 