### PR TITLE
Fix default value of `MCState.n_discard_per_chain`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * The {ref}`nk.hilbert.random.flip_state` method used by `MetropolisLocal` now throws an error when called on a {ref}`nk.hilbert.ContinuousHilbert` hilbert space instead of entering an endless loop. [#1014](https://github.com/netket/netket/pull/1014)
 * Fixed bug in conversion to qutip for `MCMixedState`, where the resulting shape (hilbert space size) was wrong. [#1020](https://github.com/netket/netket/pull/1020)
 * Setting `MCState.sampler` now recomputes `MCState.chain_length` according to `MCState.n_samples` and the new `sampler.n_chains`. [#1028](https://github.com/netket/netket/pull/1028)
+* The default value of `MCState.n_discard_per_chain` is now correctly set to 1/10 of the chain length, rather than 1/10 of the total number of samples. [#1034](https://github.com/netket/netket/pull/1034)
 
 
 ## NetKet 3.2 (26 November 2021)

--- a/netket/vqs/mc/mc_state/state.py
+++ b/netket/vqs/mc/mc_state/state.py
@@ -146,7 +146,7 @@ class MCState(VariationalState):
             n_samples_per_rank: the total number of samples across chains on one process when sampling. Cannot be
                 specified together with n_samples (default=None).
             n_discard_per_chain: number of discarded samples at the beginning of each monte-carlo chain (default=0 for exact sampler,
-                and n_samples/10 for approximate sampler).
+                and 1/10 of the chain length for approximate sampler).
             parameters: Optional PyTree of weights from which to start.
             seed: rng seed used to generate a set of parameters (only if parameters is not passed). Defaults to a random one.
             sampler_seed: rng seed used to initialise the sampler. Defaults to a random one.
@@ -382,7 +382,7 @@ class MCState(VariationalState):
         self._n_discard_per_chain = (
             int(n_discard_per_chain)
             if n_discard_per_chain is not None
-            else self.n_samples // 10
+            else self.chain_length // 10
         )
 
     # TODO: deprecate

--- a/test/variational/test_variational.py
+++ b/test/variational/test_variational.py
@@ -154,7 +154,7 @@ def test_n_samples_api(vstate, _mpi_size):
     check_consistent(vstate, _mpi_size)
 
     vstate.n_discard_per_chain = None
-    assert vstate.n_discard_per_chain == vstate.n_samples // 10
+    assert vstate.n_discard_per_chain == vstate.chain_length // 10
 
     vstate.n_samples = 3
     check_consistent(vstate, _mpi_size)

--- a/test/variational/test_variational_mixed.py
+++ b/test/variational/test_variational_mixed.py
@@ -127,7 +127,7 @@ def test_n_samples_api(vstate, _mpi_size):
     check_consistent(vstate, _mpi_size)
 
     vstate.n_discard_per_chain = None
-    assert vstate.n_discard_per_chain == vstate.n_samples // 10
+    assert vstate.n_discard_per_chain == vstate.chain_length // 10
 
     vstate.n_samples = 3
     check_consistent(vstate, _mpi_size)
@@ -192,7 +192,7 @@ def test_n_samples_diag_api(vstate, _mpi_size):
     assert (
         vstate.n_discard_per_chain_diag
         == vstate.diagonal.n_discard_per_chain
-        == vstate.n_samples_diag // 10
+        == vstate.chain_length_diag // 10
     )
 
     vstate.n_samples_diag = 3


### PR DESCRIPTION
The default value of `MCState.n_discard_per_chain` is now correctly set to 1/10 of the chain length, rather than 1/10 of the total number of samples.