### PR TITLE
Fix documentation for samplers

### DIFF
--- a/docs/docs/api-experimental.md
+++ b/docs/docs/api-experimental.md
@@ -48,7 +48,7 @@ several CPUs, but you have to start jax with a specific environment variable.
 
 (experimental-variational-api)=
 
-### Variational State Interface
+## Variational State Interface
 
 ```{eval-rst}
 .. currentmodule:: netket
@@ -64,7 +64,7 @@ several CPUs, but you have to start jax with a specific environment variable.
 
 ```
 
-### Time Evolution Driver
+## Time Evolution Driver
 
 ```{eval-rst}
 .. currentmodule:: netket

--- a/netket/sampler/autoreg.py
+++ b/netket/sampler/autoreg.py
@@ -57,11 +57,19 @@ class ARDirectSamplerState(SamplerState):
 class ARDirectSampler(Sampler):
     """
     Direct sampler for autoregressive neural networks.
-
-    `ARDirectSampler.machine_pow` has no effect. Please set the model's `machine_pow` instead.
     """
 
     def __pre_init__(self, *args, **kwargs):
+        """
+        Construct an autoregressive direct sampler.
+
+        Args:
+            hilbert: The Hilbert space to sample.
+            dtype: The dtype of the states sampled (default = np.float64).
+
+        Note:
+            `ARDirectSampler.machine_pow` has no effect. Please set the model's `machine_pow` instead.
+        """
         if "n_chains" in kwargs or "n_chains_per_rank" in kwargs:
             warn_deprecation(
                 "Specifying `n_chains` or `n_chains_per_rank` when constructing exact samplers is deprecated."
@@ -102,6 +110,9 @@ class ARDirectSampler(Sampler):
 
 @partial(jax.jit, static_argnums=(1, 4))
 def _sample_chain(sampler, model, variables, state, chain_length):
+    """
+    Internal method used for jitting calls.
+    """
     if "cache" in variables:
         variables, _ = variables.pop("cache")
 

--- a/netket/sampler/base.py
+++ b/netket/sampler/base.py
@@ -157,16 +157,16 @@ class Sampler(abc.ABC):
         """
         Returns a closure with the log-pdf function encoded by this sampler.
 
-        Note:
-            The result is returned as a `HashablePartial` so that the closure
-            does not trigger recompilation.
-
         Args:
             model: A Flax module or callable with the forward pass of the log-pdf.
                 If it is a callable, it should have the signature :code:`f(parameters, σ) -> jnp.ndarray`.
 
         Returns:
             The log-probability density function.
+
+        Note:
+            The result is returned as a `HashablePartial` so that the closure
+            does not trigger recompilation.
         """
         apply_fun = get_afun_if_module(model)
         log_pdf = HashablePartial(


### PR DESCRIPTION
The final one in the #1013 series (except the tests for PT samplers). Now I think the sampler API is ready for the NetKet 3.3 release.

I reviewed all docstrings and type annotations in `sampler/base.py` and `sampler/metropolis.py`, which made me confused when I read them for the first time. But I didn't touch numpy, PT, and pmap samplers.

Most type annotations for `model` are actually not just `nn.Module`, but `Union[nn.module, WrappedApplyFun, HaikuWrapper, ...]`, because we once stated that we would support other frameworks like Haiku, although there is not much effort into that recently. For now as we're not doing strict type linting, let's just use duck typing and put `nn.Module` there.