### PR TITLE
Enable tests for PT samplers

### DIFF
--- a/netket/experimental/sampler/metropolis_pt.py
+++ b/netket/experimental/sampler/metropolis_pt.py
@@ -380,30 +380,6 @@ class MetropolisPtSampler(MetropolisSampler):
 
         return new_state, new_state.σ[new_state.beta_0_index + offsets, :]
 
-    def __repr__(sampler):
-        return (
-            "MetropolisPTSampler("
-            + "\n  hilbert = {},".format(sampler.hilbert)
-            + "\n  rule = {},".format(sampler.rule)
-            + "\n  n_chains = {},".format(sampler.n_chains)
-            + "\n  machine_power = {},".format(sampler.machine_pow)
-            + "\n  reset_chain = {},".format(sampler.reset_chain)
-            + "\n  n_sweeps = {},".format(sampler.n_sweeps)
-            + "\n  dtype = {},".format(sampler.dtype)
-            + ")"
-        )
-
-    def __str__(sampler):
-        return (
-            "MetropolisPTSampler("
-            + "rule = {}, ".format(sampler.rule)
-            + "n_chains = {}, ".format(sampler.n_chains)
-            + "machine_power = {}, ".format(sampler.machine_pow)
-            + "reset_chain = {}, ".format(sampler.reset_chain)
-            + "n_sweeps = {}, ".format(sampler.n_sweeps)
-            + "dtype = {})".format(sampler.dtype)
-        )
-
 
 def MetropolisLocalPt(hilbert, *args, **kwargs):
     r"""

--- a/test/sampler/test_sampler.py
+++ b/test/sampler/test_sampler.py
@@ -211,10 +211,6 @@ def findrng(rng):
 
 # Mark tests that we know are failing on correctedness
 def failing_test(sampler):
-    if isinstance(sampler, nk.sampler.MetropolisSampler):
-        if isinstance(sampler, nkx.sampler.MetropolisPtSampler):
-            return True
-
     return False
 
 


### PR DESCRIPTION
The tests for PT samplers can pass on my machine. Let's see if they're really working now.

`MetropolisPtSampler.__repr__` and `__str__` are removed. Previously we did not rename `reset_chain` to `reset_chains` so they would cause errors. I checked that they actually did not override anything, so I removed them to reduce the future maintenance cost.