### PR TITLE
add a test for local operator

### DIFF
--- a/test/operator/test_local_operator.py
+++ b/test/operator/test_local_operator.py
@@ -376,3 +376,21 @@ def test_qutip_conversion():
 
     assert q_obj.shape == (op.hilbert.n_states, op.hilbert.n_states)
     np.testing.assert_allclose(q_obj.data.todense(), op.to_dense())
+
+
+def test_notsharing():
+    # This test will fail if operators alias some underlying arrays upon copy().
+    a = nk.operator.spin.sigmax(nk.hilbert.Spin(0.5, 2), 0) * nk.operator.spin.sigmax(
+        nk.hilbert.Spin(0.5, 2), 1, dtype=complex
+    )
+    b = nk.operator.spin.sigmay(nk.hilbert.Spin(0.5, 2), 0) * nk.operator.spin.sigmaz(
+        nk.hilbert.Spin(0.5, 2), 1
+    )
+    delta = b - a
+
+    a_orig = a.to_dense()
+    a_copy = a.copy()
+    a_copy += delta
+
+    np.testing.assert_allclose(a_orig, a.to_dense())
+    np.testing.assert_allclose(a_copy.to_dense(), b.to_dense())

--- a/test/operator/test_local_operator.py
+++ b/test/operator/test_local_operator.py
@@ -380,12 +380,9 @@ def test_qutip_conversion():
 
 def test_notsharing():
     # This test will fail if operators alias some underlying arrays upon copy().
-    a = nk.operator.spin.sigmax(nk.hilbert.Spin(0.5, 2), 0) * nk.operator.spin.sigmax(
-        nk.hilbert.Spin(0.5, 2), 1, dtype=complex
-    )
-    b = nk.operator.spin.sigmay(nk.hilbert.Spin(0.5, 2), 0) * nk.operator.spin.sigmaz(
-        nk.hilbert.Spin(0.5, 2), 1
-    )
+    hi = nk.hilbert.Spin(0.5, 2)
+    a = nk.operator.spin.sigmax(hi, 0) * nk.operator.spin.sigmax(hi, 1, dtype=complex)
+    b = nk.operator.spin.sigmay(hi, 0) * nk.operator.spin.sigmaz(hi, 1)
     delta = b - a
 
     a_orig = a.to_dense()


### PR DESCRIPTION
This adds an aliasing test to LocalOperator.
It fails if the underlying arrays are aliased upon copy