### PR TITLE
Fix bug in non-hermitian gradient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Bug Fixes
 * Initialisation of all implementations of `DenseSymm`, `DenseEquivariant`, `GCNN` now defaults to truncated normals with Lecun variance scaling. For layers without masking, there should be no noticeable change in behaviour. For masked layers, the same variance scaling now works correctly. [#1045](https://github.com/netket/netket/pull/1045)
+* Fix bug that prevented gradients of non-hermitian operators to be computed. The feature is still marked as experimental but will now run (we do not guarantee that results are correct). [#1045](https://github.com/netket/netket/pull/1045)
 
 
 ## NetKet 3.3 (🎁 20 December 2021)

--- a/netket/vqs/mc/mc_state/expect_grad.py
+++ b/netket/vqs/mc/mc_state/expect_grad.py
@@ -183,11 +183,9 @@ def grad_expect_operator_kernel(
         σ = σ.reshape((-1, σ_shape[-1]))
 
     is_mutable = mutable is not False
-
     logpsi = lambda w, σ: model_apply_fun(
         {"params": w, **model_state}, σ, mutable=mutable
     )
-
     log_pdf = (
         lambda w, σ: machine_pow * model_apply_fun({"params": w, **model_state}, σ).real
     )
@@ -205,7 +203,12 @@ def grad_expect_operator_kernel(
     Ō, Ō_pb, Ō_stats = nkjax.vjp(expect_closure_pars, parameters, has_aux=True)
     Ō_pars_grad = Ō_pb(jnp.ones_like(Ō))[0]
 
-    new_model_state = new_model_state[0] if is_mutable else None
+    if is_mutable:
+        raise NotImplementedError(
+            "gradient of non-hermitian operators over mutable models "
+            "is not yet implemented."
+        )
+    new_model_state = None
 
     return (
         Ō_stats,

--- a/test/variational/test_variational.py
+++ b/test/variational/test_variational.py
@@ -364,6 +364,13 @@ def test_expect(vstate, operator):
     same_derivatives(O_grad, grad_exact, abs_eps=err, rel_eps=err)
 
 
+# Have a different test because the above is marked as xfail.
+# This only checks that the code runs.
+def test_expect_grad_nonhermitian_works(vstate):
+    op = nk.operator.spin.sigmap(vstate.hilbert, 0)
+    O_stat, O_grad = vstate.expect_and_grad(op)
+
+
 @common.skipif_mpi
 @pytest.mark.parametrize(
     "operator",


### PR DESCRIPTION
In the refactor prior to chunking I forgot to update the code for non hermitian operators.
I did not notice because the test is marked as expect-fail (it would probably work if we generalise the finite difference gradient we use for tests, as I used it several times and results seem correct) and so I never noticed the code did not run anymore.

this fixes the bug and adds a test that checks that the code runs without checking correctness.