### PR TITLE
Improve tests for ODE integrators and fix typos in tableaus

### DIFF
--- a/netket/experimental/dynamics/_rk_tableau.py
+++ b/netket/experimental/dynamics/_rk_tableau.py
@@ -179,7 +179,7 @@ class NamedTableau:
 bt_feuler = TableauRKExplicit(
                 order = (1,),
                 a = jnp.zeros((1,1), dtype=default_dtype),
-                b = jnp.ones((1,1), dtype=default_dtype),
+                b = jnp.ones((1,), dtype=default_dtype),
                 c = jnp.zeros((1), dtype=default_dtype),
                 c_error = None,
                 )

--- a/netket/experimental/dynamics/_rk_tableau.py
+++ b/netket/experimental/dynamics/_rk_tableau.py
@@ -213,7 +213,7 @@ bt_rk4  = TableauRKExplicit(
                 a = jnp.array([[0,   0,   0,   0],
                                [1/2, 0,   0,   0],
                                [0,   1/2, 0,   0],
-                               [0,   0,   1,   1]], dtype=default_dtype),
+                               [0,   0,   1,   0]], dtype=default_dtype),
                 b = jnp.array( [1/6,  1/3,  1/3,  1/6], dtype=default_dtype),
                 c = jnp.array( [0, 1/2, 1/2, 1], dtype=default_dtype),
                 c_error = None,


### PR DESCRIPTION
Prompted by #1056, this PR

1. fixes the typo in the RK4 tableau reported in the issue linked above. The typo was on the diagonal of the `a` matrix of the RK tableau. `a` is supposed to be a strictly lower triangular matrix and only those parts affect the result of `tableau.step`, so the typo did not cause any error in the actual results computed by the solver.
2. improves the tests for fixed-step ODE solvers to be more sensitive to errors in the tableaus. In particular, the previous tests are insensitive to errors in `tableau.a`, even those in the lower triangle which _would_ affect results if present.
3. adds a test case `test_tableau` which does some sanity checks on the tableaus themselves (such as asserting `a` is strictly lower triangular).
4. Fixes a typo in `bt_feuler`, which is fixed-step but did have a 2-dimensional `b`. This also should not have affected results, but is conceptually incorrect.