### PR TITLE
Fix documentation website

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,7 +73,7 @@ source_suffix = {
 }
 
 # Markdown parser latex support
-myst_enable_extensions = ["dollarmath", "amsmath"]
+myst_enable_extensions = ["dollarmath", "amsmath", "colon_fence"]
 myst_update_mathjax = False
 mathjax_path = "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"
 

--- a/docs/docs/varstate.md
+++ b/docs/docs/varstate.md
@@ -280,6 +280,7 @@ with open("parameters.mpack", 'rb') as file:
 
 In order to check the performance of a given model on small test systems, it is possible to use {class}`~netket.vqs.exact.ExactState` which can be used in place of {class}`~netket.vqs.MCState` and computes quantities not by stochastic sampling but by evaluation of the ansatz over the full Hilbert space basis. (Therefore, it is infeasible to use for system sizes beyond ED.)
 This can be helpful to diagnose potential errors arising from Monte Carlo sampling.
-.. code:: python
 
+```python
 > vs = nk.vqs.ExactState(hilbert, nk.models.RBM())
+```


### PR DESCRIPTION
I don't know when it broke, but admonition and note blocks are broken in https://www.netket.org/docs/varstate.html 

This fixes it