### PR TITLE
Allow mutable state in maybe_scalar_fun wrapper

### DIFF
--- a/netket/utils/jax.py
+++ b/netket/utils/jax.py
@@ -74,7 +74,12 @@ def wrap_to_support_scalar(fun):
     def maybe_scalar_fun(apply_fun, pars, x, *args, **kwargs):
         xb = jnp.atleast_2d(x)
         res = apply_fun(pars, xb, *args, **kwargs)
-        res = res.reshape(()) if x.ndim == 1 else res
+        if isinstance(res, tuple):
+            res_val = res[0]
+            res_val = res_val.reshape(()) if x.ndim == 1 else res_val
+            res = (res_val, res[1])
+        else:
+            res = res.reshape(()) if x.ndim == 1 else res
         return res
 
     return HashablePartial(maybe_scalar_fun, fun)

--- a/netket/utils/jax.py
+++ b/netket/utils/jax.py
@@ -74,6 +74,7 @@ def wrap_to_support_scalar(fun):
     def maybe_scalar_fun(apply_fun, pars, x, *args, **kwargs):
         xb = jnp.atleast_2d(x)
         res = apply_fun(pars, xb, *args, **kwargs)
+        # support models with mutable state
         if isinstance(res, tuple):
             res_val = res[0]
             res_val = res_val.reshape(()) if x.ndim == 1 else res_val


### PR DESCRIPTION
Hi all,
In general, mutable states of the models are supported by netket. If these are used, the model apply_fun will generally return a tuple where the second element contains the state indicated as mutable. The recent commit e27386c1483c531e788d977781caf85635b9074f does however explicitly assume that only the model value is returned by the model apply_fun (which breaks if a tuple is returned). This PR fixes this by checking if the return type is a tuple or not.

Hope this makes sense.

Best,
Yannic