### PR TITLE
Allow `LazyOperator@densevector` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 
 ### Breaking Changes
 
+### Bug Fixes
+Allow `LazyOperator@densevector` for operators such as lazy `Adjoint`, `Transpose` and `Squared`. [#1068](https://github.com/netket/netket/pull/1068) 
+
 
 ## NetKet 3.3.1 (🐛 Bug Fixes)
 

--- a/netket/operator/_lazy.py
+++ b/netket/operator/_lazy.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
+import jax.numpy as jnp
+
 from netket.utils.dispatch import parametric
 
 from ._abstract_operator import AbstractOperator
@@ -63,6 +66,8 @@ class WrappedOperator(AbstractOperator):
                 return Squared(self)
             else:
                 return self._op__matmul__(other)
+        if isinstance(other, np.ndarray) or isinstance(other, jnp.ndarray):
+            return self._op__matmul__(other)
         else:
             return NotImplemented
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,8 @@ filterwarnings = [
     "ignore:the imp module is deprecated in favour of importlib.*:DeprecationWarning",
     "ignore:`np.long`",
     "ignore:`np.int` is a deprecated alias for the builtin `int`",
-    "ignore:Call to deprecated function 'Boson'"
+    "ignore:Call to deprecated function 'Boson'",
+    "ignore::DeprecationWarning:tensorboardX",
 ]
 testpaths = [
     "test",

--- a/test/operator/test_local_operator.py
+++ b/test/operator/test_local_operator.py
@@ -106,22 +106,23 @@ def test_local_operator_transpose_conjugation():
         math_h = oph.transpose().conjugate().to_dense()
         same_matrices(math_h, mat)
 
+
 def test_lazy_operator_matdensevec():
     sz0 = nk.operator.spin.sigmaz(hi, 0)
     v_np = np.random.rand(hi.n_states)
     v_jx = jax.numpy.asarray(v_np)
 
     sz0_t = sz0.transpose()
-    same_matrices(sz0_t@v_np, sz0_t.to_dense()@v_np)
-    same_matrices(sz0_t@v_jx, sz0_t.to_dense()@v_jx)
+    same_matrices(sz0_t @ v_np, sz0_t.to_dense() @ v_np)
+    same_matrices(sz0_t @ v_jx, sz0_t.to_dense() @ v_jx)
 
     sz0_h = sz0.transpose().conjugate()
-    same_matrices(sz0_h@v_np, sz0_h.to_dense()@v_np)
-    same_matrices(sz0_h@v_jx, sz0_h.to_dense()@v_jx)
+    same_matrices(sz0_h @ v_np, sz0_h.to_dense() @ v_np)
+    same_matrices(sz0_h @ v_jx, sz0_h.to_dense() @ v_jx)
 
-    sz0_2 = sz0_h@sz0
-    same_matrices(sz0_2@v_np, sz0_2.to_dense()@v_np)
-    same_matrices(sz0_2@v_jx, sz0_2.to_dense()@v_jx)
+    sz0_2 = sz0_h @ sz0
+    same_matrices(sz0_2 @ v_np, sz0_2.to_dense() @ v_np)
+    same_matrices(sz0_2 @ v_jx, sz0_2.to_dense() @ v_jx)
 
 
 def test_local_operator_add():

--- a/test/operator/test_local_operator.py
+++ b/test/operator/test_local_operator.py
@@ -10,6 +10,8 @@ import numpy as np
 import pytest
 from pytest import approx, raises
 
+import jax
+
 herm_operators = {}
 generic_operators = {}
 
@@ -103,6 +105,23 @@ def test_local_operator_transpose_conjugation():
 
         math_h = oph.transpose().conjugate().to_dense()
         same_matrices(math_h, mat)
+
+def test_lazy_operator_matdensevec():
+    sz0 = nk.operator.spin.sigmaz(hi, 0)
+    v_np = np.random.rand(hi.n_states)
+    v_jx = jax.numpy.asarray(v_np)
+
+    sz0_t = sz0.transpose()
+    same_matrices(sz0_t@v_np, sz0_t.to_dense()@v_np)
+    same_matrices(sz0_t@v_jx, sz0_t.to_dense()@v_jx)
+
+    sz0_h = sz0.transpose().conjugate()
+    same_matrices(sz0_h@v_np, sz0_h.to_dense()@v_np)
+    same_matrices(sz0_h@v_jx, sz0_h.to_dense()@v_jx)
+
+    sz0_2 = sz0_h@sz0
+    same_matrices(sz0_2@v_np, sz0_2.to_dense()@v_np)
+    same_matrices(sz0_2@v_jx, sz0_2.to_dense()@v_jx)
 
 
 def test_local_operator_add():


### PR DESCRIPTION
This functionality was not implemented, but it's handy in many cases.
Taken from #1065