### PR TITLE
[RFC] Autonomous schedules

### DIFF
--- a/netket/optimizer/__init__.py
+++ b/netket/optimizer/__init__.py
@@ -184,4 +184,26 @@ def RmsProp(
     return rmsprop(learning_rate, decay=beta, eps=epscut, centered=centered)
 
 
+def autonomous(schedule):
+    r"""Decorator to convert optax schedules into autonomous schedules.
+
+    The output function keeps track of its own step count, so it can be called without
+    arguments to return elements of the schedule successively. It also takes two
+    optional arguments:
+       fwd: the number of steps to forward the counter with
+       reset: step count to reset the counter to
+    """
+    n = 0
+
+    def aut_sch(fwd=1, reset=None):
+        nonlocal n
+        if reset is not None:
+            n = reset
+        rate = schedule(n)
+        n = n + fwd
+        return rate
+
+    return aut_sch
+
+
 _hide_submodules(__name__)

--- a/netket/optimizer/qgt/qgt_jacobian_dense.py
+++ b/netket/optimizer/qgt/qgt_jacobian_dense.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Union
+from typing import Optional, Union, Callable
 from functools import partial
 
 import jax
@@ -35,6 +35,7 @@ def QGTJacobianDense(
     mode: str = None,
     holomorphic: bool = None,
     rescale_shift=False,
+    diag_shift: Union[float, Callable[[], float]] = 0.00,
     **kwargs,
 ) -> "QGTJacobianDenseT":
     """
@@ -64,6 +65,7 @@ def QGTJacobianDense(
             mode=mode,
             holomorphic=holomorphic,
             rescale_shift=rescale_shift,
+            diag_shift=diag_shift,
             **kwargs,
         )
 
@@ -100,7 +102,12 @@ def QGTJacobianDense(
         chunk_size,
     )
 
-    return QGTJacobianDenseT(O=O, scale=scale, mode=mode, **kwargs)
+    if isinstance(diag_shift, Callable):
+        diag_shift = diag_shift()
+
+    return QGTJacobianDenseT(
+        O=O, scale=scale, mode=mode, diag_shift=diag_shift, **kwargs
+    )
 
 
 @struct.dataclass

--- a/netket/optimizer/qgt/qgt_jacobian_pytree.py
+++ b/netket/optimizer/qgt/qgt_jacobian_pytree.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Union
+from typing import Optional, Union, Callable
 from functools import partial
 
 import jax
@@ -38,6 +38,7 @@ def QGTJacobianPyTree(
     mode: str = None,
     holomorphic: bool = None,
     rescale_shift=False,
+    diag_shift: Union[float, Callable[[], float]] = 0.00,
     **kwargs,
 ) -> "QGTJacobianPyTreeT":
     """
@@ -66,6 +67,7 @@ def QGTJacobianPyTree(
             mode=mode,
             holomorphic=holomorphic,
             rescale_shift=rescale_shift,
+            diag_shift=diag_shift,
             **kwargs,
         )
 
@@ -108,8 +110,16 @@ def QGTJacobianPyTree(
         chunk_size,
     )
 
+    if isinstance(diag_shift, Callable):
+        diag_shift = diag_shift()
+
     return QGTJacobianPyTreeT(
-        O=O, scale=scale, params=vstate.parameters, mode=mode, **kwargs
+        O=O,
+        scale=scale,
+        params=vstate.parameters,
+        mode=mode,
+        diag_shift=diag_shift,
+        **kwargs,
     )
 
 


### PR DESCRIPTION
We sometimes have hyperparameters we'd like to change during the training procedure, but they aren't learning rates (so they don't fit with full `optax` optimizers) nor is it convenient to store them in the object that uses them. The best example is `diag_shift` in QGT: literature suggests it's good to lower its value as SR goes on, but the QGT object lives for a single iteration, so it has no memory of such evolution. In #1060, we'd have double the problem, as the pseudo-Hessian object would have to tune both `diag_shift` and the learning rate that no longer fits in the `optax` paradigm.

This PR solves this problem by introducing a decorator that turns a schedule (i.e. a step count → parameter function) into an "autonomous schedule" (i.e. a function with internal state that can be called without arguments to return `schedule(0), schedule(1),...` on each call). E.g.:
```python
@nk.optimizer.autonomous
def schedule(x):
    return 3*x
schedule()
>>> 0
schedule()
>>> 3
schedule()
>>> 6
```

The QGT "smart constructors" are also modified to take such autonomous schedules for `diag_shift` in addition to numbers. If a function is passed to them, they call it without arguments to convert it into the desired value of `diag_shift` for that iteration. It would be nice to place this logic closer to the definition of `LinearOperator`, but I can't think of a way to do this with a `dataclass` (without breaking the contract with using `setattr`).