### PR TITLE
silence a warning

### DIFF
--- a/netket/utils/struct/dataclass.py
+++ b/netket/utils/struct/dataclass.py
@@ -435,7 +435,7 @@ def dataclass(clz=None, *, init_doc=MISSING, cache_hash=False, _frozen=True):
         for name in cache_fields:
             updates[name] = Uninitialized
 
-        return dataclasses.replace(self, **updates)
+        return dataclasses.replace(self, **updates, __skip_preprocess=True)
 
     data_clz.replace = replace
 


### PR DESCRIPTION
This is due to the deprecation warning added by @wdphy16 in `_pre_init` recently.
This PR simply bipasses `_pre_init` logic when `replace` is called.

master:
```python
netket on  pv/operators [⇕$!?] via netket_env via 🐍 system took 1m 12s 
➜ python                                                         
Python 3.8.12 (default, Aug 30 2021, 00:00:00) 
[GCC 11.2.1 20210728 (Red Hat 11.2.1-1)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import netket as nk
>>> sa = nk.sampler.ExactSampler(nk.hilbert.Spin(0.5, 3))
>>> sa.replace(hilbert=sa.hilbert)
/home/filippovicentini/Dropbox/Ricerca/Codes/Python/netket/netket/sampler/exact.py:62: FutureWarning: Specifying `n_chains` or `n_chains_per_rank` when constructing exact samplers is deprecated.
  warn_deprecation(
ExactSampler(
  hilbert = Spin(s=1/2, N=3),
  n_chains_per_rank = 1,
  machine_power = 2,
  dtype = <class 'numpy.float64'>)
>>> 
```

this pr                                                                                                                                                                                                           
```python
netket on  pv/op-tests [$] via netket_env via 🐍 system took 32s 
➜ python
Python 3.8.12 (default, Aug 30 2021, 00:00:00) 
[GCC 11.2.1 20210728 (Red Hat 11.2.1-1)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import netket as nk
>>> sa = nk.sampler.ExactSampler(nk.hilbert.Spin(0.5, 3))
>>> sa.replace(hilbert=sa.hilbert)
ExactSampler(
  hilbert = Spin(s=1/2, N=3),
  n_chains_per_rank = 1,
  machine_power = 2,
  dtype = <class 'numpy.float64'>)
>>> 
```