### PR TITLE
Speedup continuous hilbert sampling (and Particle hilbert fix)

### DIFF
--- a/netket/hilbert/continuous_hilbert.py
+++ b/netket/hilbert/continuous_hilbert.py
@@ -33,7 +33,8 @@ class ContinuousHilbert(AbstractHilbert):
             domain: range of the continuous quantum numbers
         """
         self._extent = domain
-        if not len(self._L) == len(self._pbc):
+        self._pbc = pbc
+        if not len(self._extent) == len(self._pbc):
             raise ValueError(
                 """`pbc` must be either a bool or a tuple indicating the periodicity of each spatial dimension."""
             )

--- a/netket/hilbert/particle.py
+++ b/netket/hilbert/particle.py
@@ -45,14 +45,12 @@ class Particle(ContinuousHilbert):
             pbc = [pbc] * len(L)
 
         self._N = N
-        self._L = L
-        self._pbc = pbc
 
-        super().__init__(self._L, self._pbc)
+        super().__init__(L, pbc)
 
     @property
     def size(self) -> int:
-        return self._N * len(self._L)
+        return self._N * len(self._extent)
 
     @property
     def n_particles(self) -> int:
@@ -61,7 +59,7 @@ class Particle(ContinuousHilbert):
 
     @property
     def _attrs(self):
-        return (self._N, self._L, self._pbc)
+        return (self._N, self.extent, self.pbc)
 
     def __repr__(self):
         return "ContinuousParticle(N={}, d={})".format(

--- a/netket/hilbert/random/particle.py
+++ b/netket/hilbert/random/particle.py
@@ -36,7 +36,9 @@ def random_state(hilb: Particle, key, batches: int, *, dtype):
     min_modulus = np.min(modulus)
 
     # use real dtypes because this does not work with complex ones.
-    gaussian = jax.random.normal(key, shape=(batches, hilb.size), dtype=nkjax.dtype_real(dtype))
+    gaussian = jax.random.normal(
+        key, shape=(batches, hilb.size), dtype=nkjax.dtype_real(dtype)
+    )
     width = min_modulus / (4.0 * hilb.n_particles)
     # The width gives the noise level. In the periodic case the
     # particles are evenly distributed between 0 and min(L). The

--- a/netket/hilbert/random/particle.py
+++ b/netket/hilbert/random/particle.py
@@ -14,6 +14,9 @@
 import jax
 from jax import numpy as jnp
 
+import numpy as np
+
+from netket import jax as nkjax
 from netket.hilbert import ContinuousHilbert, Particle
 from netket.utils.dispatch import dispatch
 
@@ -25,14 +28,16 @@ def random_state(hilb: Particle, key, batches: int, *, dtype):
     in a spatial dimension. Otherwise the particles are
     positioned evenly along the box from 0 to L, with Gaussian noise
     of certain width."""
-    pbc = jnp.array(hilb.n_particles * hilb.pbc)
-    boundary = jnp.tile(pbc, (batches, 1))
+    pbc = np.array(hilb.n_particles * hilb.pbc)
+    boundary = np.tile(pbc, (batches, 1))
 
-    Ls = jnp.array(hilb.n_particles * hilb.extent)
-    modulus = jnp.where(jnp.equal(pbc, False), jnp.inf, Ls)
+    Ls = np.array(hilb.n_particles * hilb.extent)
+    modulus = np.where(np.equal(pbc, False), jnp.inf, Ls)
+    min_modulus = np.min(modulus)
 
-    gaussian = jax.random.normal(key, shape=(batches, hilb.size))
-    width = jnp.min(modulus) / (4.0 * hilb.n_particles)
+    # use real dtypes because this does not work with complex ones.
+    gaussian = jax.random.normal(key, shape=(batches, hilb.size), dtype=nkjax.dtype_real(dtype))
+    width = min_modulus / (4.0 * hilb.n_particles)
     # The width gives the noise level. In the periodic case the
     # particles are evenly distributed between 0 and min(L). The
     # distance between the particles coordinates is therefore given by
@@ -40,9 +45,10 @@ def random_state(hilb: Particle, key, batches: int, *, dtype):
     # positions the noise level should be smaller than half this distance.
     # We choose width = min(L) / (4*hilb.N)
     noise = gaussian * width
-    uniform = jnp.tile(jnp.linspace(0.0, jnp.min(modulus), hilb.size), (batches, 1))
+    uniform = jnp.tile(jnp.linspace(0.0, min_modulus, hilb.size), (batches, 1))
 
-    rs = jnp.where(jnp.equal(boundary, False), gaussian, (uniform + noise) % modulus)
+    select = np.equal(boundary, False)
+    rs = select * gaussian + np.logical_not(select) * ((uniform + noise) % modulus)
 
     return jnp.asarray(rs, dtype=dtype)
 

--- a/netket/sampler/rules/continuous_gaussian.py
+++ b/netket/sampler/rules/continuous_gaussian.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import jax
 import jax.numpy as jnp
+import numpy as np
 
 from flax import struct
 
@@ -34,14 +35,17 @@ class GaussianRule(MetropolisRule):
         n_chains = r.shape[0]
         hilb = sampler.hilbert
 
-        pbc = jnp.array(hilb.n_particles * hilb.pbc)
-        boundary = jnp.tile(pbc, (n_chains, 1))
+        pbc = np.array(hilb.n_particles * hilb.pbc)
+        boundary = np.tile(pbc, (n_chains, 1))
 
-        Ls = jnp.array(hilb.n_particles * hilb.extent)
-        modulus = jnp.where(jnp.equal(pbc, False), jnp.inf, Ls)
+        Ls = np.array(hilb.n_particles * hilb.extent)
+        modulus = np.where(np.equal(pbc, False), jnp.inf, Ls)
 
         prop = jax.random.normal(key, shape=(n_chains, hilb.size)) * rule.sigma
-        rp = jnp.where(jnp.equal(boundary, False), r + prop, (r + prop) % modulus)
+
+        opt_1 = np.equal(boundary, False)
+        opt_2 = np.logical_not(opt_1)
+        rp = opt_1 * (r+prop) + opt_2 * ((r+prop) % modulus)
 
         return rp, None
 

--- a/netket/sampler/rules/continuous_gaussian.py
+++ b/netket/sampler/rules/continuous_gaussian.py
@@ -45,7 +45,7 @@ class GaussianRule(MetropolisRule):
 
         opt_1 = np.equal(boundary, False)
         opt_2 = np.logical_not(opt_1)
-        rp = opt_1 * (r+prop) + opt_2 * ((r+prop) % modulus)
+        rp = opt_1 * (r + prop) + opt_2 * ((r + prop) % modulus)
 
         return rp, None
 


### PR DESCRIPTION
cc @gpescia 

There are two commits in this PR. The first simply removes the `_L` attribute that was duplicated between `Particle` and `ContinuouHilbert`. That not important

The latter speeds up gaussian sampling by using `np.*` instead of `jnp.*` on all calculations that are carried out on constants.
Since PBC/extent are compile-time constants, by using numpy we perform those calculation at compile time and the resulting code will be slightly faster.

Almost negligible, but still, that's a better way to write it down.