### PR TITLE
Improve device information in `netket.tools.info`

### DIFF
--- a/netket/tools/info.py
+++ b/netket/tools/info.py
@@ -39,6 +39,10 @@ def printfmt(key, value=None, *, indent=0, pre="", alignment=STD_SPACE):
         print(f"{pre}{key : <{alignment}}", flush=True)
 
 
+def _fmt_device(dev):
+    return f"<{dev.id}: {dev.device_kind}>"
+
+
 def info():
     """
     When called via::
@@ -106,7 +110,11 @@ def info():
         backends = _jax_backends()
         printfmt("backends", backends, indent=1)
         for backend in backends:
-            printfmt(f"{backend}", jax.devices(backend), indent=2)
+            printfmt(
+                f"{backend}",
+                [_fmt_device(dev) for dev in jax.devices(backend)],
+                indent=2,
+            )
         print()
 
     if is_available("mpi4jax"):

--- a/netket/tools/info.py
+++ b/netket/tools/info.py
@@ -114,7 +114,7 @@ def info():
         import mpi4jax
 
         if hasattr(mpi4jax, "has_cuda_support"):
-            printfmt("HAS_GPU_EXT", mpi4jax.has_cuda_support, indent=1)
+            printfmt("HAS_GPU_EXT", mpi4jax.has_cuda_support(), indent=1)
         elif hasattr(mpi4jax, "_src"):
             if hasattr(mpi4jax._src, "xla_bridge"):
                 if hasattr(mpi4jax._src.xla_bridge, "HAS_GPU_EXT"):


### PR DESCRIPTION
This fixes as small display bug in `netket.tools.info`:

Before:
```
$ python3 -m netket.tools.info
[...]
# MPI4JAX
  - HAS_GPU_EXT      : <function has_cuda_support at 0x...>
[...]
```
After:
```
$ python3 -m netket.tools.info
[...]
# MPI4JAX
  - HAS_GPU_EXT      : True
[...]
```

Edit: Since I already had that file open: I've added some code to print nicer looking device information:
```
# Jax 
  - backends         : ['cpu', 'gpu']
    - cpu            : ['<0: cpu>']
    - gpu            : ['<0: Tesla V100-PCIE-32GB>', '<1: Tesla V100-PCIE-32GB>'
```