### PR TITLE
Improve generated code by nkjax.tree_to_real

### DIFF
--- a/netket/jax/utils.py
+++ b/netket/jax/utils.py
@@ -23,7 +23,6 @@ from jax import numpy as jnp
 from jax.tree_util import (
     tree_flatten,
     tree_unflatten,
-    tree_map,
     tree_leaves,
 )
 
@@ -70,7 +69,7 @@ def tree_size(tree: PyTree) -> int:
     Returns the sum of the size of all leaves in the tree.
     It's equivalent to the number of scalars in the pytree.
     """
-    return sum(tree_leaves(tree_map(lambda x: x.size, tree)))
+    return sum(tree_leaves(jax.tree_map(lambda x: x.size, tree)))
 
 
 def is_complex(x):
@@ -231,23 +230,42 @@ def tree_axpy(a: Scalar, x: PyTree, y: PyTree) -> PyTree:
     return jax.tree_multimap(lambda x_, y_: a * x_ + y_, x, y)
 
 
+def _unpack(*x):
+    """
+    Equivalent to identity but unpacking the result and checking that it has length 1
+    """
+    assert len(x) == 1
+    return x[0]
+
+
 def _to_real(x):
     if jnp.iscomplexobj(x):
-        return x.real, x.imag
-        # TODO find a way to make it a nop?
-        # return jax.vmap(lambda y: jnp.array((y.real, y.imag)))(x)
+        return (x.real, x.imag)
     else:
-        return x
+        return (x,)
 
 
-def _tree_to_real(x):
-    return jax.tree_map(_to_real, x)
+def _to_real_transpose(x):
+    if jnp.iscomplexobj(x):
+        return jax.lax.complex
+    else:
+        return _unpack
 
 
 # invert the transformation using linear_transpose (AD)
-def _tree_reassemble_complex(x, target, fun=_tree_to_real):
-    (res,) = jax.linear_transpose(fun, target)(x)
-    return tree_conj(res)
+def _tree_reassemble_complex(x, reassemble_tree_fun):
+    """
+    Reassemble the original tree that was split into real and imaginary part by
+    `nk.jax.tree_to_real`.
+
+    Args:
+        x: A real PyTree obtained by `nk.jax.tree_to_real`.
+        reassemble_tree_fun: A tree of functions to reassemble `x`.
+
+    Returns:
+        a PyTree.
+    """
+    return jax.tree_map(lambda fun, x: fun(*x), reassemble_tree_fun, x)
 
 
 def tree_to_real(pytree: PyTree) -> Tuple[PyTree, Callable]:
@@ -261,8 +279,9 @@ def tree_to_real(pytree: PyTree) -> Tuple[PyTree, Callable]:
       and the second element is a callable for converting back a real pytree
       to a complex pytree of of the same structure as the input pytree.
     """
-    return _tree_to_real(pytree), partial(
-        _tree_reassemble_complex, target=pytree, fun=_tree_to_real
+    return jax.tree_map(_to_real, pytree), partial(
+        _tree_reassemble_complex,
+        reassemble_tree_fun=jax.tree_map(_to_real_transpose, pytree),
     )
 
 

--- a/netket/optimizer/qgt/qgt_jacobian_dense_logic.py
+++ b/netket/optimizer/qgt/qgt_jacobian_dense_logic.py
@@ -100,7 +100,8 @@ def vec_to_real(vec: Array) -> Tuple[Array, Callable]:
             return reassemble(x)
 
     else:
-        reassemble_concat = reassemble
+        (out,) = out
+        reassemble_concat = lambda x: reassemble((x,))
 
     return out, reassemble_concat
 

--- a/test/jax/test_utils.py
+++ b/test/jax/test_utils.py
@@ -1,0 +1,41 @@
+import pytest
+
+import jax
+import jax.numpy as jnp
+import netket as nk
+import netket.jax as nkjax
+
+import numpy as np
+import numpy.testing as npt
+
+
+def _ones_complex(shape, dtype=jnp.float32):
+    xr = jnp.ones(shape, dtype)
+    xi = jnp.ones(shape, dtype)
+    return xr - 1j * xi
+
+
+def test_tree_to_real():
+    x = _ones_complex((3, 2))
+    (xr, xi), reassemble = nkjax.tree_to_real(x)
+
+    assert not jnp.iscomplexobj(xr)
+    assert not jnp.iscomplexobj(xi)
+
+    x2 = reassemble((xr, xi))
+
+    assert x2.dtype == x.dtype
+    npt.assert_array_equal(x, x2)
+
+    x = {"a": _ones_complex((3, 2)), "b": jnp.ones(2)}
+    xr, reassemble = nkjax.tree_to_real(x)
+
+    assert all([not jnp.iscomplexobj(_x) for _x in jax.tree_leaves(xr)])
+
+    x2 = reassemble(xr)
+
+    def _assert_same(x, x2):
+        assert x2.dtype == x.dtype
+        npt.assert_array_equal(x, x2)
+
+    jax.tree_map(_assert_same, x, x2)


### PR DESCRIPTION
This commit changes the transpose of nkjax.tree_to_real.
Before this commit, it was autogenerated using jax.linear_transpose, but jax was failing to infer that the transpose of `(x.real, x.imag)` is `x` (see discussion in google/jax#8816 ). With this PR we use explicitly jax.lax.complex and manually construct the transpose, which gives a speedup.

This gives a minor speedup to `JacobianPyTree`

TODO: add a test