### PR TITLE
Mention  updating `pip` in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,17 +23,19 @@ It is a Python library built on [JAX](https://github.com/google/jax).
 
 ## Installation and Usage
 
-Netket runs on MacOS and Linux. We reccomend to install NetKet using `pip`, but it can also be installed with
-`conda`.
+Netket runs on MacOS and Linux. We reccomend to install NetKet using `pip`, but it can also be installed with `conda`. 
+It is often necessary to first update `pip` to a recent release (`>=20.3`) in order for upper compatibility bounds to be considered and avoid a broken installation.
 For instructions on how to install the latest stable/beta release of NetKet see the [Getting Started](https://www.netket.org/docs/getting_started.html) section of our website or run the following command (Apple M1 users, follow that link for more instructions):
 
 ```
+pip install --upgrade pip
 pip install --upgrade netket
 ```
 
 If you wish to install the current development version of NetKet, which is the master branch of this GitHub repository, together with the additional dependencies, you can run the following command:
 
 ```
+pip install --upgrade pip
 pip install 'git+https://github.com/netket/netket.git#egg=netket[all]'
 ```
 
@@ -41,6 +43,7 @@ To speed-up NetKet-computations, even on a single machine, you
 can install the MPI-related dependencies by using `[mpi]` between square brackets.
 
 ```
+pip install --upgrade pip
 pip install --upgrade "netket[mpi]"
 ```
 

--- a/docs/docs/getting_started.md
+++ b/docs/docs/getting_started.md
@@ -11,9 +11,11 @@ Please read the release notes to see what has changed since the last release.
 ## Installation and requirements
 
 Netket v3.0 requires `python>= 3.8` and optionally a recent MPI install.
-To install, run one of the two following commands
+Before attempting the installation, you should update `pip` to a recent version (`>=20.3`) to avoid getting a broken install.
+To install, run the following commands:
 
 ```bash
+pip install --upgrade pip
 pip install netket
 ```
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -24,8 +24,10 @@
 
         When using MPI, we recommend not to use Anaconda unless it's for small experimentation on a laptop. This is due to a dependency of netket, mpi4jax. You can read more about the limitations on the `mpi4jax documentation <https://mpi4jax.readthedocs.io/en/latest/installation.html>`_. 
 
-    .. dropdown:: :code:`pip install netket`
+    .. dropdown:: :code:`pip install --upgrade pip && pip install netket`
        Conda is also supported, but not reccomended. However you can use a conda environment and install netket with pip inside this environment.
+
+       If you are using pip, you should first upgrade it with `pip install --upgrade pip` to avoid issues with dependencies (any version after `pip>=20.3` will be good).
 
        If you want to use MPI, use :code:`pip install netket[mpi]`.
 


### PR DESCRIPTION
@gcarleo recently noticed that with `pip==19.xxx` installing netket fails in a clean `py3.7` environment. 
Looking into it, I found out that `pip<=20.3` completely ignored upper version bounds on dependencies.

This madness breaks several packages, in particular `numba` which upper bounds `numpy` and `flax/optax` who upper bound `typing_extensions` on `py3.7`.

now the installation instructions say to update pip first.
By the way, this is the same thing that jax says in its installation instructions, although for different reasons. 
Since they are a dependency, we should do the same.