### PR TITLE
refactor LocalOperator logic

### DIFF
--- a/netket/operator/_graph_operator.py
+++ b/netket/operator/_graph_operator.py
@@ -100,7 +100,7 @@ class GraphOperator(LocalOperator):
          >>> op = nk.operator.GraphOperator(
          ... hi, site_ops=[sigmax], bond_ops=[mszsz], graph=g)
          >>> print(op)
-         GraphOperator(dim=20, #acting_on=40 locations, constant=0, dtype=float64, graph=Graph(n_nodes=20, n_edges=20))
+         GraphOperator(dim=20, #acting_on=40 locations, constant=0.0, dtype=float64, graph=Graph(n_nodes=20, n_edges=20))
         """
         acting_on_subspace = check_acting_on_subspace(
             acting_on_subspace, hilbert, graph

--- a/netket/operator/_hamiltonian.py
+++ b/netket/operator/_hamiltonian.py
@@ -96,8 +96,6 @@ class SpecialHamiltonian(DiscreteOperator):
         return self.to_local_operator().__matmul__(other)
 
     def _op__rmatmul__(self, other):
-        if self == other and self.is_hermitian:
-            return Squared(self)
         if hasattr(other, "to_local_operator"):
             other = other.to_local_operator()
 

--- a/netket/operator/_hamiltonian.py
+++ b/netket/operator/_hamiltonian.py
@@ -91,16 +91,17 @@ class SpecialHamiltonian(DiscreteOperator):
         return self.to_local_operator().__rmul__(other)
 
     def _op__matmul__(self, other):
+        if hasattr(other, "to_local_operator"):
+            other = other.to_local_operator()
         return self.to_local_operator().__matmul__(other)
 
     def _op__rmatmul__(self, other):
         if self == other and self.is_hermitian:
             return Squared(self)
+        if hasattr(other, "to_local_operator"):
+            other = other.to_local_operator()
 
         return self.to_local_operator().__matmul__(other)
-
-    def _concrete_matmul_(self, other):
-        return self.to_local_operator() @ other
 
 
 class Ising(SpecialHamiltonian):

--- a/netket/operator/_lazy.py
+++ b/netket/operator/_lazy.py
@@ -208,7 +208,7 @@ class Squared(WrappedOperator):
         return self.parent.dtype
 
     def collect(self):
-        return self.parent.H.collect()._concrete_matmul_(self.parent)
+        return self.parent.H.collect()._op__matmul__(self.parent)
 
     @property
     def T(self):

--- a/netket/operator/_local_operator.py
+++ b/netket/operator/_local_operator.py
@@ -473,7 +473,7 @@ class LocalOperator(DiscreteOperator):
                     ba *= self.hilbert.shape[aon_size - s - 1]
 
                 # eventually could support sparse matrices
-                #if isinstance(op, sparse.spmatrix):
+                # if isinstance(op, sparse.spmatrix):
                 #    op = op.todense()
 
                 _append_matrix(

--- a/netket/operator/_local_operator.py
+++ b/netket/operator/_local_operator.py
@@ -611,6 +611,10 @@ class LocalOperator(DiscreteOperator):
         n_sites = x.shape[1]
         dtype = all_mels.dtype
 
+        # TODO remove this line when numba 0.53 is dropped 0.54 is minimum version
+        # workaround a bug in Numba arising when NUMBA_BOUNDSCHECK=1
+        constant = constant.item()
+
         assert sections.shape[0] == batch_size
 
         n_operators = n_conns.shape[0]
@@ -753,6 +757,10 @@ class LocalOperator(DiscreteOperator):
         dtype = all_mels.dtype
 
         assert filters.shape[0] == batch_size and sections.shape[0] == batch_size
+
+        # TODO remove this line when numba 0.53 is dropped 0.54 is minimum version
+        # workaround a bug in Numba arising when NUMBA_BOUNDSCHECK=1
+        constant = constant.item()
 
         n_operators = n_conns.shape[0]
         xs_n = np.empty((batch_size, n_operators), dtype=np.intp)

--- a/netket/operator/_local_operator.py
+++ b/netket/operator/_local_operator.py
@@ -1,4 +1,4 @@
-# Copyright 2021 The NetKet Authors - All rights reserved.
+# Copyright 2021-2022 The NetKet Authors - All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,25 +12,73 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Union, List, Optional
+from typing import Tuple, Union, List, Optional
 
 import functools
 import numbers
-import copy
 
 from textwrap import dedent
 
 import numpy as np
-from numba import jit
+from scipy import sparse
+import numba
 
-from netket.hilbert import AbstractHilbert, Fock
+from netket.hilbert import AbstractHilbert
 from netket.utils.types import DType, Array
 
 from ._discrete_operator import DiscreteOperator
 from ._lazy import Transpose
 
+from ._local_operator_helpers import (
+    _dtype,
+    canonicalize_input,
+    _multiply_operators,
+    cast_operator_matrix_dtype,
+)
 
-@jit(nopython=True)
+
+def is_hermitian(a: np.ndarray, rtol=1e-05, atol=1e-08) -> bool:
+    return np.allclose(a, a.T.conj(), rtol=rtol, atol=atol)
+
+
+def _is_sorted(a):
+    for i in range(len(a) - 1):
+        if a[i + 1] < a[i]:
+            return False
+    return True
+
+
+@numba.jit(nopython=True)
+def _append_matrix(
+    operator,
+    diag_mels,
+    mels,
+    x_prime,
+    n_conns,
+    acting_size,
+    local_states_per_site,
+    epsilon,
+    hilb_size_per_site,
+):
+    op_size = operator.shape[0]
+    assert op_size == operator.shape[1]
+    for i in range(op_size):
+        diag_mels[i] = operator[i, i]
+        n_conns[i] = 0
+        for j in range(op_size):
+            if i != j and np.abs(operator[i, j]) > epsilon:
+                k_conn = n_conns[i]
+                mels[i, k_conn] = operator[i, j]
+                _number_to_state(
+                    j,
+                    hilb_size_per_site,
+                    local_states_per_site[:acting_size, :],
+                    x_prime[i, k_conn, :acting_size],
+                )
+                n_conns[i] += 1
+
+
+@numba.jit(nopython=True)
 def _number_to_state(number, hilbert_size_per_site, local_states_per_site, out):
 
     out[:] = local_states_per_site[:, 0]
@@ -45,152 +93,6 @@ def _number_to_state(number, hilbert_size_per_site, local_states_per_site, out):
         k -= 1
 
     return out
-
-
-def is_hermitian(a: np.ndarray, rtol=1e-05, atol=1e-08) -> bool:
-    return np.allclose(a, a.T.conj(), rtol=rtol, atol=atol)
-
-
-def _dtype(obj: Union[numbers.Number, Array, "LocalOperator"]) -> DType:
-    if isinstance(obj, numbers.Number):
-        return type(obj)
-    elif isinstance(obj, DiscreteOperator):
-        return obj.dtype
-    elif isinstance(obj, np.ndarray):
-        return obj.dtype
-    else:
-        raise TypeError(f"cannot deduce dtype of object type {type(obj)}: {obj}")
-
-
-def has_nonzero_diagonal(op: "LocalOperator") -> bool:
-    """
-    Returns True if at least one element in the diagonal of the operator
-    is nonzero.
-    """
-    return (
-        np.any(np.abs(op._diag_mels) >= op.mel_cutoff)
-        or np.abs(op._constant) >= op.mel_cutoff
-    )
-
-
-def _is_sorted(a):
-    for i in range(len(a) - 1):
-        if a[i + 1] < a[i]:
-            return False
-    return True
-
-
-def resize(
-    arr: Array,
-    shape: List[int],
-    dtype: Optional[DType] = None,
-    init: Optional[numbers.Number] = None,
-) -> Array:
-    """
-    resizes the input array to the new shape that must be larger than the old.
-
-    The resulting array is initialized with the old array in the corresponding indices, and with init
-    in the rest.
-
-    Args:
-        arr: The array to be resized
-        shape: The new shape
-        dtype: optional dtype of the new array. If unspecified the old array dtype is used
-        init: optional initialization value for the new entries
-
-    Returns:
-        a numpy array with the chosen shape and dtype.
-    """
-    if dtype is None:
-        dtype = arr.dtype
-
-    if isinstance(shape, int):
-        shape = (shape,)
-
-    if arr.shape == shape:
-        return arr
-
-    arr_shape = arr.shape
-    if len(shape) != arr.ndim:
-        raise ValueError("the number of dimensions should not change.")
-
-    for (i, ip) in zip(arr_shape, shape):
-        if ip < i:
-            raise ValueError(
-                f"The new dimensions ({shape}) should all be larger than the old ({arr_shape})."
-            )
-
-    new_arr = np.empty(shape=shape, dtype=arr.dtype)
-    if init is not None:
-        new_arr[...] = init
-
-    if arr.ndim == 0:
-        raise ValueError("Cannot resize a 0-dimensional scalar")
-    elif arr.ndim == 1:
-        new_arr[: arr_shape[0]] = arr
-    elif arr.ndim == 2:
-        new_arr[: arr_shape[0], : arr_shape[1]] = arr
-    elif arr.ndim == 3:
-        new_arr[: arr_shape[0], : arr_shape[1], : arr_shape[2]] = arr
-    elif arr.ndim == 4:
-        new_arr[: arr_shape[0], : arr_shape[1], : arr_shape[2], : arr_shape[3]] = arr
-    else:
-        raise ValueError(f"unsupported number of dimensions: {arr.ndim}")
-
-    return new_arr
-
-
-def _reorder_kronecker_product(hi, mat, acting_on):
-    """
-    Reorders the matrix resulting from a kronecker product of several
-    operators in such a way to sort acting_on.
-
-    A conceptual example is the following:
-    if `mat = Â ⊗ B̂ ⊗ Ĉ` and `acting_on = [[2],[1],[3]`
-    you will get `result = B̂ ⊗ Â ⊗ Ĉ, [[1], [2], [3]].
-
-    However, essentially, A,B,C represent some operators acting on
-    thei sub-space acting_on[1], [2] and [3] of the hilbert space.
-
-    This function also handles any possible set of values in acting_on.
-
-    The inner logic uses the Fock.all_states(), number_to_state and
-    state_to_number to perform the re-ordering.
-    """
-    acting_on_sorted = np.sort(acting_on)
-    if np.array_equal(acting_on_sorted, acting_on):
-        return mat, acting_on
-
-    # could write custom binary <-> int logic instead of using Fock...
-    # Since i need to work with bit-strings (where instead of bits i
-    # have integers, in order to support arbitrary size spaces) this
-    # is exactly what hilbert.to_number() and viceversa do.
-
-    # target ordering binary representation
-    hi_subspace = Fock(hi.shape[acting_on_sorted[0]] - 1)
-    for site in acting_on_sorted[1:]:
-        hi_subspace = Fock(hi.shape[site] - 1) * hi_subspace
-
-    # find how to map target ordering back to unordered
-    acting_on_unsorted_ids = np.zeros(len(acting_on), dtype=np.intp)
-    for (i, site) in enumerate(acting_on):
-        acting_on_unsorted_ids[i] = np.argmax(site == acting_on_sorted)
-
-    # now it is valid that
-    # acting_on_sorted == acting_on[acting_on_unsorted_ids]
-
-    # generate n-bit strings in the target ordering
-    v = hi_subspace.all_states()
-
-    # convert them to origin (unordered) ordering
-    v_unsorted = v[:, acting_on_unsorted_ids]
-    # convert the unordered bit-strings to numbers in the target space.
-    n_unsorted = hi_subspace.states_to_numbers(v_unsorted)
-
-    # reorder the matrix
-    mat_sorted = mat[n_unsorted, :][:, n_unsorted]
-
-    return mat_sorted, acting_on_sorted
 
 
 class LocalOperator(DiscreteOperator):
@@ -228,7 +130,8 @@ class LocalOperator(DiscreteOperator):
            0
         """
         super().__init__(hilbert)
-        self._constant = constant
+        self.mel_cutoff = 1.0e-6
+        self._initialized = None
 
         if not all(
             [_is_sorted(hilbert.states_at_index(i)) for i in range(hilbert.size)]
@@ -241,43 +144,41 @@ class LocalOperator(DiscreteOperator):
                 )
             )
 
-        # check if passing a single operator or a list of operators
-        if isinstance(acting_on, numbers.Number):
-            acting_on = [acting_on]
-
-        is_nested = any(hasattr(i, "__len__") for i in acting_on)
-
-        if not is_nested:
-            operators = [operators]
-            acting_on = [acting_on]
-
-        operators = [np.asarray(operator) for operator in operators]
-
-        # If we asked for a specific dtype, enforce it.
-        if dtype is None:
-            dtype = functools.reduce(
-                lambda dt, op: np.promote_types(dt, op.dtype), operators, np.float32
-            )
-
+        # Canonicalize input. From now on input is guaranteed to be in canonical order
+        operators, acting_on, dtype = canonicalize_input(
+            self.hilbert, operators, acting_on, constant, dtype=dtype
+        )
         self._dtype = dtype
-        self._init_zero()
+        self._constant = np.array(constant, dtype=dtype)
 
-        self.mel_cutoff = 1.0e-6
+        self._operators_dict = {}
+        for (op, aon) in zip(operators, acting_on):
+            self._add_operator(aon, op)
 
-        self._nonzero_diagonal = np.abs(self._constant) >= self.mel_cutoff
-        """True if at least one element in the diagonal of the operator is
-        nonzero"""
+    def _add_operator(self, acting_on: Tuple, operator: "array"):
+        """
+        Adds an operator acting on a subset of sites.
 
-        for op, act in zip(operators, acting_on):
-            if len(act) > 0:
-                self._add_operator(op, act)
+        Does not modify in-place the operators themselves which are treated as
+        immutables.
+        """
+        assert isinstance(acting_on, tuple)
+        # acting_on_key = tuple(acting_on)
+        if acting_on in self._operators_dict:
+            operator = self._operators_dict[acting_on] + operator
+
+        self._operators_dict[acting_on] = operator
 
     @property
     def operators(self) -> List[np.ndarray]:
         """List of the matrices of the operators encoded in this Local Operator.
         Returns a copy.
         """
-        return self._operators_list()
+        return list(self._operators_dict.values())
+
+    @property
+    def _operators(self) -> List[np.ndarray]:
+        return self.operators
 
     @property
     def acting_on(self) -> List[List[int]]:
@@ -285,8 +186,11 @@ class LocalOperator(DiscreteOperator):
 
         Every operator `self.operators[i]` acts on the sites `self.acting_on[i]`
         """
-        actions = [action[action >= 0].tolist() for action in self._acting_on]
-        return actions
+        return list(self._operators_dict.keys())
+
+    @property
+    def n_operators(self) -> int:
+        return len(self._operators_dict)
 
     @property
     def dtype(self) -> DType:
@@ -304,7 +208,7 @@ class LocalOperator(DiscreteOperator):
         # TODO: (VolodyaCO) I guess that if we have an operator with diagonal elements equal to 1j*C+Y, some complex constant, and
         # self._constant=-1j*C, then the actual diagonal would be Y. How do we check hermiticity taking into account the diagonal
         # elements as well as the self._constant? For the moment I just check hermiticity of the added constant, which must be real.
-        return np.all(self._is_hermitian_op) and np.isreal(self._constant)
+        return all(map(is_hermitian, self.operators)) and np.isreal(self._constant)
 
     @property
     def mel_cutoff(self) -> float:
@@ -322,51 +226,52 @@ class LocalOperator(DiscreteOperator):
     def constant(self) -> numbers.Number:
         return self._constant
 
-    @property
-    def n_operators(self) -> int:
-        return self._n_operators
+    def copy(self, *, dtype: Optional[DType] = None):
+        """Returns a copy of the operator, while optionally changing the dtype
+        of the operator.
 
-    def __add__(self, other: Union["LocalOperator", numbers.Number]):
-        op = self.copy(dtype=np.promote_types(self.dtype, _dtype(other)))
-        op = op.__iadd__(other)
-        return op
+        Args:
+            dtype: optional dtype
+        """
+
+        if dtype is None:
+            dtype = self.dtype
+
+        if not np.can_cast(self.dtype, dtype, casting="same_kind"):
+            raise ValueError(f"Cannot cast {self.dtype} to {dtype}")
+
+        new = LocalOperator(self.hilbert, constant=self.constant, dtype=dtype)
+        new.mel_cutoff = self.mel_cutoff
+
+        if dtype == self.dtype:
+            new._operators_dict = self._operators_dict.copy()
+        else:
+            new._operators_dict = {
+                aon: cast_operator_matrix_dtype(op, dtype)
+                for aon, op in self._operators_dict.items()
+            }
+
+        return new
+
+    def transpose(self, *, concrete=False):
+        r"""LocalOperator: Returns the tranpose of this operator."""
+        if concrete:
+            new = self.copy()
+            for aon in new._operators_dict.keys():
+                new._operators_dict[aon] = new._operators_dict[aon].transpose()
+            return new
+        else:
+            return Transpose(self)
+
+    def conjugate(self, *, concrete=False):
+        r"""LocalOperator: Returns the complex conjugate of this operator."""
+        new = self.copy()
+        for aon in new._operators_dict.keys():
+            new._operators_dict[aon] = new._operators_dict[aon].copy().conjugate()
+        return new
 
     def __radd__(self, other):
         return self.__add__(other)
-
-    def __iadd__(self, other):
-        if isinstance(other, LocalOperator):
-            if self.hilbert != other.hilbert:
-                return NotImplemented
-
-            if not np.can_cast(other.dtype, self.dtype, casting="same_kind"):
-                raise ValueError(
-                    f"Cannot add inplace operator with dtype {other.dtype} to operator with dtype {self.dtype}"
-                )
-
-            assert other.mel_cutoff == self.mel_cutoff
-
-            for i in range(other._n_operators):
-                acting_on = other._acting_on[i, : other._acting_size[i]]
-                operator = other._operators[i]
-                self._add_operator(operator, acting_on)
-
-            self._constant += other.constant
-            self._nonzero_diagonal = has_nonzero_diagonal(self)
-
-            return self
-        if isinstance(other, numbers.Number):
-
-            if not np.can_cast(type(other), self.dtype, casting="same_kind"):
-                raise ValueError(
-                    f"Cannot add inplace operator with dtype {type(other)} to operator with dtype {self.dtype}"
-                )
-
-            self._constant += other
-            self._nonzero_diagonal = has_nonzero_diagonal(self)
-            return self
-
-        return NotImplemented
 
     def __sub__(self, other):
         return self + (-other)
@@ -380,49 +285,83 @@ class LocalOperator(DiscreteOperator):
     def __neg__(self):
         return -1 * self
 
+    def __add__(self, other: Union["LocalOperator", numbers.Number]):
+        op = self.copy(dtype=np.promote_types(self.dtype, _dtype(other)))
+        op = op.__iadd__(other)
+        return op
+
+    def __iadd__(self, other):
+        if isinstance(other, LocalOperator):
+            if self.hilbert != other.hilbert:
+                return NotImplemented
+
+            if not np.can_cast(other.dtype, self.dtype, casting="same_kind"):
+                raise ValueError(
+                    f"Cannot add inplace operator with dtype {other.dtype} "
+                    f"to operator with dtype {self.dtype}"
+                )
+
+            assert other.mel_cutoff == self.mel_cutoff
+            self._constant += other.constant.item()
+            for (aon, op) in other._operators_dict.items():
+                self._add_operator(aon, op)
+
+            self._reset_caches()
+            return self
+        if isinstance(other, numbers.Number):
+            if not np.can_cast(type(other), self.dtype, casting="same_kind"):
+                raise ValueError(
+                    f"Cannot add inplace operator with dtype {type(other)} "
+                    f"to operator with dtype {self.dtype}"
+                )
+
+            self._reset_caches()
+            self._constant += other
+            return self
+
+        return NotImplemented
+
+    def __truediv__(self, other):
+        if not isinstance(other, numbers.Number):
+            raise TypeError("Only divison by a scalar number is supported.")
+
+        if other == 0:
+            raise ValueError("Dividing by 0")
+        return self.__mul__(1.0 / other)
+
+    def __rmul__(self, other):
+        return self.__mul__(other)
+
     def __mul__(self, other):
         if isinstance(other, DiscreteOperator):
             op = self.copy(dtype=np.promote_types(self.dtype, _dtype(other)))
             return op.__imatmul__(other)
-        elif not isinstance(other, numbers.Number):
-            return NotImplemented
-
-        op = self.copy(dtype=np.promote_types(self.dtype, _dtype(other)))
-
-        op._diag_mels *= other
-        op._mels *= other
-        op._constant *= other
-
-        for i, _op in enumerate(op._operators):
-            _op *= other
-            op._is_hermitian_op[i] = is_hermitian(_op)
-
-        op._nonzero_diagonal = has_nonzero_diagonal(op)
-
-        return op
+        elif isinstance(other, numbers.Number):
+            op = self.copy(dtype=np.promote_types(self.dtype, _dtype(other)))
+            return op.__imul__(other)
+        return NotImplemented
 
     def __imul__(self, other):
         if isinstance(other, DiscreteOperator):
             return self.__imatmul__(other)
-        elif not isinstance(other, numbers.Number):
-            return NotImplemented
+        elif isinstance(other, numbers.Number):
+            if not np.can_cast(type(other), self.dtype, casting="same_kind"):
+                raise ValueError(
+                    f"Cannot add inplace operator with dtype {type(other)} "
+                    f"to operator with dtype {self.dtype}"
+                )
 
-        if not np.can_cast(type(other), self.dtype, casting="same_kind"):
-            raise ValueError(
-                f"Cannot add inplace operator with dtype {type(other)} to operator with dtype {self.dtype}"
-            )
+            self._constant *= other
+            if np.abs(other) <= self.mel_cutoff:
+                self._operators_dict = {}
+            else:
+                for key in self._operators_dict:
+                    self._operators_dict[key] = other * self._operators_dict[key]
 
-        self._diag_mels *= other
-        self._mels *= other
-        self._constant *= other
+            self._reset_caches()
+            return self
 
-        for i, _op in enumerate(self._operators):
-            _op *= other
-            self._is_hermitian_op[i] = is_hermitian(_op)
-
-        self._nonzero_diagonal = has_nonzero_diagonal(self)
-
-        return self
+        return NotImplemented
 
     def __imatmul__(self, other):
         if not isinstance(other, LocalOperator):
@@ -442,412 +381,141 @@ class LocalOperator(DiscreteOperator):
         if not isinstance(other, LocalOperator):
             return NotImplemented
         op = self.copy(dtype=np.promote_types(self.dtype, _dtype(other)))
-        op @= other
-        return op
+        return op._concrete_imatmul_(other)
 
     def _concrete_imatmul_(self, other: "LocalOperator") -> "LocalOperator":
         if not isinstance(other, LocalOperator):
             return NotImplemented
 
-        tot_operators = []
-        tot_act = []
-        for i in range(other._n_operators):
-            act_i = other._acting_on[i, : other._acting_size[i]].tolist()
-            ops, act = self._multiply_operator(other._operators[i], act_i)
-            tot_operators += ops
-            tot_act += act
+        # (α + ∑ᵢAᵢ)(β + ∑ᵢBᵢ) =
+        # = αβ + α ∑ᵢBᵢ + β ∑ᵢAᵢ + ∑ᵢⱼAᵢBⱼ
 
-        prod = LocalOperator(self.hilbert, tot_operators, tot_act, dtype=self.dtype)
-        self_constant = self._constant
-        if np.abs(other._constant) > self.mel_cutoff:
-            self *= other._constant
-            self += prod
-            self._constant = 0.0
-        else:
-            self = prod
+        A_const = self.constant.item()
+        B_const = other.constant.item()
+        A_op_dict = self._operators_dict
+        B_op_dict = other._operators_dict
 
-        if np.abs(self_constant) > self.mel_cutoff:
-            self += other * self_constant
+        # αβ + β ∑ᵢAᵢ
+        self.__imul__(B_const)
 
-        self._nonzero_diagonal = has_nonzero_diagonal(self)
+        # α ∑ᵢBᵢ
+        if np.abs(A_const) > self.mel_cutoff:
+            for aon, op in B_op_dict.items():
+                self._add_operator(aon, A_const * op)
 
+        # ∑ᵢⱼAᵢBⱼ
+        for supp_A_i, A_i in A_op_dict.items():
+            for supp_B_j, B_j in B_op_dict.items():
+                self._add_operator(
+                    *_multiply_operators(
+                        self.hilbert, supp_A_i, A_i, supp_B_j, B_j, dtype=self.dtype
+                    )
+                )
+
+        self._reset_caches()
         return self
 
-    def __truediv__(self, other):
-        if not isinstance(other, numbers.Number):
-            raise TypeError("Only divison by a scalar number is supported.")
-
-        if other == 0:
-            raise ValueError("Dividing by 0")
-        return self.__mul__(1.0 / other)
-
-    def __rmul__(self, other):
-        return self.__mul__(other)
-
-    def _init_zero(self):
-        self._operators = []
-        self._n_operators = 0
-
-        self._max_op_size = 0
-        self._max_acting_size = 0
-        self._max_local_hilbert_size = 0
-        self._size = 0
-
-        self._acting_on = np.zeros((0, 0), dtype=np.intp)
-        self._acting_size = np.zeros(0, dtype=np.intp)
-        self._diag_mels = np.zeros((0, 0), dtype=self.dtype)
-        self._mels = np.empty((0, 0, 0), dtype=self.dtype)
-        self._x_prime = np.empty((0, 0, 0, 0))
-        self._n_conns = np.empty((0, 0), dtype=np.intp)
-
-        self._local_states = np.zeros((0, 0, 0), dtype=np.float64)
-
-        self._basis = np.zeros((0, 0), dtype=np.int64)
-
-        # Array saving whether each operator is hermitian (plus one component to keep if self._constant is also hermitian).
-        self._is_hermitian_op = np.zeros((self._n_operators,), dtype=bool)
-
-    def _acting_on_list(self):
-        acting_on = []
-        for i in range(self.n_operators):
-            acting_on.append(np.copy(self._acting_on[i, : self._acting_size[i]]))
-
-        return acting_on
-
-    def _operators_list(self):
-        "A deep copy of the operators"
-        operators = [np.copy(op) for op in self._operators]
-        return operators
-
-    def _add_operator(self, operator: Array, acting_on: List[int]):
-        if not np.can_cast(operator, self.dtype, casting="same_kind"):
-            raise ValueError(f"Cannot cast type {operator.dtype} to {self.dtype}")
-
-        acting_on = np.asarray(acting_on, dtype=np.intp)
-        operator = np.asarray(operator, dtype=self.dtype)
-
-        if np.unique(acting_on).size != acting_on.size:
-            raise ValueError("acting_on contains repeated entries.")
-
-        if any(acting_on >= self.hilbert.size):
-            raise ValueError("acting_on points to a site not in the hilbert space.")
-
-        if operator.ndim != 2:
-            raise ValueError("The operator should be a matrix")
-
-        if np.all(np.abs(operator) < self.mel_cutoff):
-            return
-
-        # re-sort the operator
-        operator, acting_on = _reorder_kronecker_product(
-            self.hilbert, operator, acting_on
-        )
-
-        # find overlapping support
-        support_i = None
-        for (i, support) in enumerate(self._acting_on_list()):
-            if np.array_equal(acting_on, support):
-                support_i = i
-                break
-
-        # If overlapping support, add the local operators themselves
-        if support_i is not None:
-            dim = min(operator.shape[0], self._operators[support_i].shape[0])
-            _opv = self._operators[support_i][:dim, :dim]
-            _opv += operator[:dim, :dim]
-            self._is_hermitian_op[support_i] = is_hermitian(self._operators[support_i])
-
-            n_local_states_per_site = np.asarray(
-                [self.hilbert.size_at_index(i) for i in acting_on]
-            )
-
-            self._append_matrix(
-                self._operators[support_i],
-                self._diag_mels[support_i],
-                self._mels[support_i],
-                self._x_prime[support_i],
-                self._n_conns[support_i],
-                self._acting_size[support_i],
-                self._local_states[support_i],
-                self.mel_cutoff,
-                n_local_states_per_site,
-            )
-            self._nonzero_diagonal = has_nonzero_diagonal(self)
-        else:
-            self.__add_new_operator__(operator, acting_on)
-
-    def __add_new_operator__(self, operator: np.ndarray, acting_on: np.ndarray):
-        # Else, we must add a completely new operator
-        self._n_operators += 1
-        self._operators.append(operator)
-
-        # Add a new row and eventually resize the acting_on
-        self._acting_size = np.resize(self._acting_size, (self.n_operators,))
-        self._acting_size[-1] = acting_on.size
-        acting_size = acting_on.size
-
-        self._max_op_size = max((operator.shape[0], self._max_op_size))
-
-        n_local_states_per_site = np.asarray(
-            [self.hilbert.size_at_index(i) for i in acting_on]
-        )
-
-        if operator.shape[0] != np.prod(n_local_states_per_site):
-            raise RuntimeError(
-                r"""the given operator matrix has shape={} and acts on
-                    the sites={}, which have a local hilbert space size of
-                    sizes={} giving an expected shape
-                    for the operator expected_shape={}.""".format(
-                    operator.shape,
-                    acting_on,
-                    n_local_states_per_site,
-                    np.prod(n_local_states_per_site),
-                )
-            )
-
-        self._max_acting_size = max(self._max_acting_size, acting_on.size)
-        self._max_local_hilbert_size = max(
-            self._max_local_hilbert_size, np.max(n_local_states_per_site)
-        )
-
-        self._acting_on = resize(
-            self._acting_on, shape=(self.n_operators, self._max_acting_size), init=-1
-        )
-        self._acting_on[-1, :acting_size] = acting_on
-        if (
-            self._acting_on[-1, :acting_size].max() > self.hilbert.size
-            or self._acting_on[-1, :acting_size].min() < 0
-        ):
-            raise ValueError("Operator acts on an invalid set of sites")
-
-        self._local_states = resize(
-            self._local_states,
-            shape=(
-                self.n_operators,
-                self._max_acting_size,
-                self._max_local_hilbert_size,
-            ),
-            init=np.nan,
-        )
-        ## add an operator to local_states
-        for site in range(acting_size):
-            self._local_states[-1, site, : n_local_states_per_site[site]] = np.asarray(
-                self.hilbert.states_at_index(acting_on[site])
-            )
-        ## add an operator to basis
-        self._basis = resize(
-            self._basis, shape=(self.n_operators, self._max_acting_size), init=1e10
-        )
-        ba = 1
-        for s in range(acting_on.size):
-            self._basis[-1, s] = ba
-            ba *= n_local_states_per_site[acting_on.size - s - 1]
-        ##
-
-        self._diag_mels = resize(
-            self._diag_mels, shape=(self.n_operators, self._max_op_size), init=np.nan
-        )
-        self._mels = resize(
-            self._mels,
-            shape=(self.n_operators, self._max_op_size, self._max_op_size - 1),
-            init=np.nan,
-        )
-        self._x_prime = resize(
-            self._x_prime,
-            shape=(
-                self.n_operators,
-                self._max_op_size,
-                self._max_op_size - 1,
-                self._max_acting_size,
-            ),
-            init=-1,
-        )
-        self._n_conns = resize(
-            self._n_conns, shape=(self.n_operators, self._max_op_size), init=-1
-        )
-        if acting_on.max() + 1 >= self._size:
-            self._size = acting_on.max() + 1
-
-        self._is_hermitian_op = resize(
-            self._is_hermitian_op,
-            shape=(self.n_operators,),
-            init=is_hermitian(operator),
-        )
-
-        self._append_matrix(
-            operator,
-            self._diag_mels[-1],
-            self._mels[-1],
-            self._x_prime[-1],
-            self._n_conns[-1],
-            self._acting_size[-1],
-            self._local_states[-1],
-            self.mel_cutoff,
-            n_local_states_per_site,
-        )
-
-        self._nonzero_diagonal = has_nonzero_diagonal(self)
-
-    @staticmethod
-    @jit(nopython=True)
-    def _append_matrix(
-        operator,
-        diag_mels,
-        mels,
-        x_prime,
-        n_conns,
-        acting_size,
-        local_states_per_site,
-        epsilon,
-        hilb_size_per_site,
-    ):
-        op_size = operator.shape[0]
-        assert op_size == operator.shape[1]
-        for i in range(op_size):
-            diag_mels[i] = operator[i, i]
-            n_conns[i] = 0
-            for j in range(op_size):
-                if i != j and np.abs(operator[i, j]) > epsilon:
-                    k_conn = n_conns[i]
-                    mels[i, k_conn] = operator[i, j]
-                    _number_to_state(
-                        j,
-                        hilb_size_per_site,
-                        local_states_per_site[:acting_size, :],
-                        x_prime[i, k_conn, :acting_size],
-                    )
-                    n_conns[i] += 1
-
-    def _multiply_operator(self, op, act):
-        operators = []
-        acting_on = []
-        act = np.asarray(act)
-
-        for i in range(self.n_operators):
-            act_i = self._acting_on[i, : self._acting_size[i]]
-
-            inters = np.intersect1d(act_i, act, return_indices=False)
-
-            if act.size == act_i.size and np.array_equal(act, act_i):
-                # non-interesecting with same support
-                operators.append(self._operators[i] @ op)
-                acting_on.append(act_i.tolist())
-            elif inters.size == 0:
-                # disjoint supports
-                operators.append(np.kron(self._operators[i], op))
-                acting_on.append(act_i.tolist() + act.tolist())
-            else:
-                _act = list(act)
-                _act_i = list(act_i)
-                _op = op.copy()
-                _op_i = self._operators[i].copy()
-
-                # expand _act to match _act_i
-                actmin = min(act)
-                for site in act_i:
-                    if site not in act:
-                        I = np.eye(self.hilbert.shape[site], dtype=self.dtype)
-                        if site < actmin:
-                            _act = [site] + _act
-                            _op = np.kron(I, _op)
-                        else:  #  site > actmax
-                            _act = _act + [site]
-                            _op = np.kron(_op, I)
-
-                act_i_min = min(act_i)
-                for site in act:
-                    if site not in act_i:
-                        I = np.eye(self.hilbert.shape[site], dtype=self.dtype)
-                        if site < act_i_min:
-                            _act_i = [site] + _act_i
-                            _op_i = np.kron(I, _op_i)
-                        else:  #  site > actmax
-                            _act_i = _act_i + [site]
-                            _op_i = np.kron(_op_i, I)
-
-                # reorder
-                _op, _act = _reorder_kronecker_product(self.hilbert, _op, _act)
-                _op_i, _act_i = _reorder_kronecker_product(self.hilbert, _op_i, _act_i)
-
-                if len(_act) == len(_act_i) and np.array_equal(_act, _act_i):
-                    # non-interesecting with same support
-                    operators.append(_op_i @ _op)
-                    acting_on.append(_act_i)
-                else:
-                    raise ValueError("Something failed")
-
-        return operators, acting_on
-
-    def __deepcopy__(self, memo: dict) -> "LocalOperator":
-        cls = self.__class__
-        result = cls.__new__(cls)
-        memo[id(self)] = result
-        for k, v in self.__dict__.items():
-            if k != "_hilbert":
-                setattr(result, k, copy.deepcopy(v, memo))
-            else:
-                setattr(result, k, v)
-                memo[id(v)] = v
-        return result
-
-    def copy(self, *, dtype: Optional[DType] = None):
-        """Returns a copy of the operator, while optionally changing the dtype
-        of the operator.
-
-        Args:
-            dtype: optional dtype
+    def _reset_caches(self):
         """
+        Cleans the internal caches built on the operator.
+        """
+        self._initialized = False
 
-        if dtype is None:
-            dtype = self.dtype
-
-        if not np.can_cast(self.dtype, dtype, casting="same_kind"):
-            raise ValueError(f"Cannot cast {self.dtype} to {dtype}")
-
-        new = copy.deepcopy(self)
-        new._diag_mels = new._diag_mels.astype(dtype)
-        new._mels = new._mels.astype(dtype)
-        new._operators = [op.astype(dtype) for op in new._operators]
-        new._dtype = dtype
-        return new
-
-    def transpose(self, *, concrete=False):
-        r"""LocalOperator: Returns the tranpose of this operator."""
-        if concrete:
-
-            new_ops = [np.copy(ops.transpose()) for ops in self._operators]
-
-            return LocalOperator(
-                hilbert=self.hilbert,
-                operators=new_ops,
-                acting_on=self._acting_on_list(),
-                constant=self._constant,
+    def _setup(self, force: bool = False):
+        """Analyze the operator strings and precompute arrays for get_conn inference"""
+        if force or not self._initialized:
+            acting_size = np.array([len(aon) for aon in self.acting_on], dtype=np.intp)
+            max_acting_on_sz = np.max(acting_size)
+            max_local_hilbert_size = max(
+                [max(map(self.hilbert.size_at_index, aon)) for aon in self.acting_on]
             )
-        else:
-            return Transpose(self)
+            max_op_size = max(map(lambda x: x.shape[0], self.operators))
 
-    def conjugate(self, *, concrete=False):
-        r"""LocalOperator: Returns the complex conjugate of this operator."""
-        new_ops = [np.copy(ops).conjugate() for ops in self._operators]
+            acting_on = np.full((self.n_operators, max_acting_on_sz), -1, dtype=np.intp)
+            for (i, aon) in enumerate(self.acting_on):
+                acting_on[i][: len(aon)] = aon
 
-        return LocalOperator(
-            hilbert=self.hilbert,
-            operators=new_ops,
-            acting_on=self._acting_on_list(),
-            constant=np.conjugate(self._constant),
-        )
+            local_states = np.full(
+                (self.n_operators, max_acting_on_sz, max_local_hilbert_size), np.nan
+            )
+            basis = np.full((self.n_operators, max_acting_on_sz), 1e10, dtype=np.int64)
+
+            diag_mels = np.full(
+                (self.n_operators, max_op_size), np.nan, dtype=self.dtype
+            )
+            mels = np.full(
+                (self.n_operators, max_op_size, max_op_size - 1),
+                np.nan,
+                dtype=self.dtype,
+            )
+            x_prime = np.full(
+                (self.n_operators, max_op_size, max_op_size - 1, max_acting_on_sz),
+                -1,
+                dtype=np.float64,
+            )
+            n_conns = np.full((self.n_operators, max_op_size), -1, dtype=np.intp)
+
+            for (i, (aon, op)) in enumerate(self._operators_dict.items()):
+                aon_size = len(aon)
+                n_local_states_per_site = np.asarray(
+                    [self.hilbert.size_at_index(i) for i in aon]
+                )
+
+                ## add an operator to local_states
+                for (j, site) in enumerate(aon):
+                    local_states[i, j, : self.hilbert.shape[site]] = np.asarray(
+                        self.hilbert.states_at_index(site)
+                    )
+
+                ba = 1
+                for s in range(aon_size):
+                    basis[i, s] = ba
+                    ba *= self.hilbert.shape[aon_size - s - 1]
+
+                # eventually could support sparse matrices
+                #if isinstance(op, sparse.spmatrix):
+                #    op = op.todense()
+
+                _append_matrix(
+                    op,
+                    diag_mels[i],
+                    mels[i],
+                    x_prime[i],
+                    n_conns[i],
+                    aon_size,
+                    local_states[i],
+                    self.mel_cutoff,
+                    n_local_states_per_site,
+                )
+
+            nonzero_diagonal = (
+                np.any(np.abs(diag_mels) >= self.mel_cutoff)
+                or np.abs(self.constant) >= self.mel_cutoff
+            )
+
+            max_conn_size = self.n_operators if nonzero_diagonal else 0
+            for op in self.operators:
+                nnz_mat = np.abs(op) > self.mel_cutoff
+                nnz_mat[np.diag_indices(nnz_mat.shape[0])] = False
+                nnz_rows = np.sum(nnz_mat, axis=1)
+                max_conn_size += np.max(nnz_rows)
+
+            self._acting_on = acting_on
+            self._acting_size = acting_size
+            self._diag_mels = diag_mels
+            self._mels = mels
+            self._x_prime = x_prime
+            self._n_conns = n_conns
+            self._local_states = local_states
+            self._basis = basis
+            self._nonzero_diagonal = nonzero_diagonal
+            self._max_conn_size = max_conn_size
 
     @property
     def max_conn_size(self) -> int:
         """The maximum number of non zero ⟨x|O|x'⟩ for every x."""
-        max_size = self.n_operators if self._nonzero_diagonal else 0
-        for op in self._operators:
-            nnz_mat = np.abs(op) > self.mel_cutoff
-            nnz_mat[np.diag_indices(nnz_mat.shape[0])] = False
-            nnz_rows = np.sum(nnz_mat, axis=1)
-            max_size += np.max(nnz_rows)
-
-        return max_size
+        self._setup()
+        return self._max_conn_size
 
     def get_conn_flattened(self, x, sections, pad=False):
         r"""Finds the connected elements of the Operator. Starting
@@ -871,6 +539,7 @@ class LocalOperator(DiscreteOperator):
             array: An array containing the matrix elements :math:`O(x,x')` associated to each x'.
 
         """
+        self._setup()
 
         return self._get_conn_flattened_kernel(
             np.asarray(x),
@@ -889,6 +558,7 @@ class LocalOperator(DiscreteOperator):
         )
 
     def _get_conn_flattened_closure(self):
+        self._setup()
         _local_states = self._local_states
         _basis = self._basis
         _constant = self._constant
@@ -919,10 +589,10 @@ class LocalOperator(DiscreteOperator):
                 _nonzero_diagonal,
             )
 
-        return jit(nopython=True)(gccf_fun)
+        return numba.jit(nopython=True)(gccf_fun)
 
     @staticmethod
-    @jit(nopython=True)
+    @numba.jit(nopython=True)
     def _get_conn_flattened_kernel(
         x,
         sections,
@@ -1046,7 +716,7 @@ class LocalOperator(DiscreteOperator):
             array: An array containing the matrix elements :math:`O(x,x')` associated to each x'.
 
         """
-
+        self._setup()
         return self._get_conn_filtered_kernel(
             x,
             sections,
@@ -1063,7 +733,7 @@ class LocalOperator(DiscreteOperator):
         )
 
     @staticmethod
-    @jit(nopython=True)
+    @numba.jit(nopython=True)
     def _get_conn_filtered_kernel(
         x,
         sections,

--- a/netket/operator/_local_operator_compile_helpers.py
+++ b/netket/operator/_local_operator_compile_helpers.py
@@ -1,0 +1,181 @@
+# Copyright 2022 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This file contains functions generating the numba-packed representation of local
+operators.
+"""
+
+from typing import Tuple, Union, List, Optional
+
+import numpy as np
+from scipy import sparse
+import numba
+
+from netket.hilbert import AbstractHilbert
+from netket.utils.types import DType, Array
+
+
+def pack_internals(
+    hilbert: AbstractHilbert,
+    operators_dict: dict,
+    constant,
+    dtype: DType,
+    mel_cutoff: float,
+):
+    """
+    Take the internal lazy representation of a local operator and returns the arrays
+    needed for the numba implementation.
+
+    This takes as input a dictionary with Tuples as keys, the `acting_on` and matrices as values.
+    The keys represent the sites upon which the matrix acts.
+    It is assumed that the integer in the tuples are sorted.
+
+    Returns a dictionary with all the data fields
+    """
+    op_acting_on = list(operators_dict.keys())
+    operators = list(operators_dict.values())
+    n_operators = len(operators_dict)
+
+    """Analyze the operator strings and precompute arrays for get_conn inference"""
+    acting_size = np.array([len(aon) for aon in op_acting_on], dtype=np.intp)
+    max_acting_on_sz = np.max(acting_size)
+    max_local_hilbert_size = max(
+        [max(map(hilbert.size_at_index, aon)) for aon in op_acting_on]
+    )
+    max_op_size = max(map(lambda x: x.shape[0], operators))
+
+    acting_on = np.full((n_operators, max_acting_on_sz), -1, dtype=np.intp)
+    for (i, aon) in enumerate(op_acting_on):
+        acting_on[i][: len(aon)] = aon
+
+    local_states = np.full(
+        (n_operators, max_acting_on_sz, max_local_hilbert_size), np.nan
+    )
+    basis = np.full((n_operators, max_acting_on_sz), 1e10, dtype=np.int64)
+
+    diag_mels = np.full((n_operators, max_op_size), np.nan, dtype=dtype)
+    mels = np.full(
+        (n_operators, max_op_size, max_op_size - 1),
+        np.nan,
+        dtype=dtype,
+    )
+    x_prime = np.full(
+        (n_operators, max_op_size, max_op_size - 1, max_acting_on_sz),
+        -1,
+        dtype=np.float64,
+    )
+    n_conns = np.full((n_operators, max_op_size), -1, dtype=np.intp)
+
+    for (i, (aon, op)) in enumerate(operators_dict.items()):
+        aon_size = len(aon)
+        n_local_states_per_site = np.asarray([hilbert.size_at_index(i) for i in aon])
+
+        ## add an operator to local_states
+        for (j, site) in enumerate(aon):
+            local_states[i, j, : hilbert.shape[site]] = np.asarray(
+                hilbert.states_at_index(site)
+            )
+
+        ba = 1
+        for s in range(aon_size):
+            basis[i, s] = ba
+            ba *= hilbert.shape[aon_size - s - 1]
+
+        # eventually could support sparse matrices
+        # if isinstance(op, sparse.spmatrix):
+        #    op = op.todense()
+
+        _append_matrix(
+            op,
+            diag_mels[i],
+            mels[i],
+            x_prime[i],
+            n_conns[i],
+            aon_size,
+            local_states[i],
+            mel_cutoff,
+            n_local_states_per_site,
+        )
+
+    nonzero_diagonal = (
+        np.any(np.abs(diag_mels) >= mel_cutoff) or np.abs(constant) >= mel_cutoff
+    )
+
+    max_conn_size = n_operators if nonzero_diagonal else 0
+    for op in operators:
+        nnz_mat = np.abs(op) > mel_cutoff
+        nnz_mat[np.diag_indices(nnz_mat.shape[0])] = False
+        nnz_rows = np.sum(nnz_mat, axis=1)
+        max_conn_size += np.max(nnz_rows)
+
+    return {
+        "acting_on": acting_on,
+        "acting_size": acting_size,
+        "diag_mels": diag_mels,
+        "mels": mels,
+        "x_prime": x_prime,
+        "n_conns": n_conns,
+        "local_states": local_states,
+        "basis": basis,
+        "nonzero_diagonal": nonzero_diagonal,
+        "max_conn_size": max_conn_size,
+    }
+
+
+@numba.jit(nopython=True)
+def _append_matrix(
+    operator,
+    diag_mels,
+    mels,
+    x_prime,
+    n_conns,
+    acting_size,
+    local_states_per_site,
+    epsilon,
+    hilb_size_per_site,
+):
+    op_size = operator.shape[0]
+    assert op_size == operator.shape[1]
+    for i in range(op_size):
+        diag_mels[i] = operator[i, i]
+        n_conns[i] = 0
+        for j in range(op_size):
+            if i != j and np.abs(operator[i, j]) > epsilon:
+                k_conn = n_conns[i]
+                mels[i, k_conn] = operator[i, j]
+                _number_to_state(
+                    j,
+                    hilb_size_per_site,
+                    local_states_per_site[:acting_size, :],
+                    x_prime[i, k_conn, :acting_size],
+                )
+                n_conns[i] += 1
+
+
+@numba.jit(nopython=True)
+def _number_to_state(number, hilbert_size_per_site, local_states_per_site, out):
+
+    out[:] = local_states_per_site[:, 0]
+    size = out.shape[0]
+
+    ip = number
+    k = size - 1
+    while ip > 0:
+        local_size = hilbert_size_per_site[k]
+        out[k] = local_states_per_site[k, ip % local_size]
+        ip = ip // local_size
+        k -= 1
+
+    return out

--- a/netket/operator/_local_operator_helpers.py
+++ b/netket/operator/_local_operator_helpers.py
@@ -132,7 +132,7 @@ def canonicalize_input(
 
 
 # TODO: support sparse arrays without returning dense arrays
-def _reorder_kronecker_product(hi, mat, acting_on):
+def _reorder_kronecker_product(hi, mat, acting_on) -> Tuple[Array, Tuple]:
     """
     Reorders the matrix resulting from a kronecker product of several
     operators in such a way to sort acting_on.
@@ -182,7 +182,7 @@ def _reorder_kronecker_product(hi, mat, acting_on):
     # reorder the matrix
     mat_sorted = mat[n_unsorted, :][:, n_unsorted]
 
-    return mat_sorted, acting_on_sorted
+    return mat_sorted, tuple(acting_on_sorted)
 
 
 # TODO: support sparse arrays without returning dense arrays

--- a/netket/operator/_local_operator_helpers.py
+++ b/netket/operator/_local_operator_helpers.py
@@ -161,7 +161,11 @@ def _reorder_kronecker_product(hi, mat, acting_on) -> Tuple[Array, Tuple]:
     # target ordering binary representation
     hi_subspace = Fock(hi.shape[acting_on_sorted[0]] - 1)
     for site in acting_on_sorted[1:]:
-        hi_subspace = Fock(hi.shape[site] - 1) * hi_subspace
+        hi_subspace = hi_subspace * Fock(hi.shape[site] - 1)
+
+    hi_unsorted_subspace = Fock(hi.shape[acting_on[0]] - 1)
+    for site in acting_on[1:]:
+        hi_unsorted_subspace = hi_unsorted_subspace * Fock(hi.shape[site] - 1)
 
     # find how to map target ordering back to unordered
     acting_on_unsorted_ids = np.zeros(len(acting_on), dtype=np.intp)
@@ -177,7 +181,7 @@ def _reorder_kronecker_product(hi, mat, acting_on) -> Tuple[Array, Tuple]:
     # convert them to origin (unordered) ordering
     v_unsorted = v[:, acting_on_unsorted_ids]
     # convert the unordered bit-strings to numbers in the target space.
-    n_unsorted = hi_subspace.states_to_numbers(v_unsorted)
+    n_unsorted = hi_unsorted_subspace.states_to_numbers(v_unsorted)
 
     # reorder the matrix
     mat_sorted = mat[n_unsorted, :][:, n_unsorted]

--- a/netket/operator/_local_operator_helpers.py
+++ b/netket/operator/_local_operator_helpers.py
@@ -1,0 +1,246 @@
+# Copyright 2022 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Tuple, Union, List, Optional
+
+import numba
+
+import functools
+import numbers
+
+from textwrap import dedent
+
+import numpy as np
+from numba import jit
+
+from scipy.sparse import spmatrix
+
+from netket.hilbert import AbstractHilbert, Fock
+from netket.utils.types import DType, Array
+
+from ._discrete_operator import DiscreteOperator
+
+
+def _dtype(obj: Union[numbers.Number, Array, "LocalOperator"]) -> DType:
+    """
+    Returns the dtype of the input object
+    """
+    if isinstance(obj, numbers.Number):
+        return type(obj)
+    elif isinstance(obj, DiscreteOperator):
+        return obj.dtype
+    elif isinstance(obj, np.ndarray):
+        return obj.dtype
+    else:
+        raise TypeError(f"cannot deduce dtype of object type {type(obj)}: {obj}")
+
+
+def cast_operator_matrix_dtype(matrix, dtype):
+    """
+    Changes the dtype of a matrix, without changing the structural type of the object.
+
+    This makes sure that if you pass sparse arrays to a LocalOperator, they remain
+    sparse even if you change the dtype
+    """
+    # must copy
+    # return np.asarray(matrix, dtype=dtype)
+    return matrix.astype(dtype)
+
+def _standardize_matrix_input_type(op):
+    """
+    Standardize the structural type of operators stored in LocalOperator.
+
+    Eventually, we could also support spmatrices (but some work will be needed.)
+    """
+    if isinstance(op, list):
+        return np.asarray(op)
+    elif isinstance(op, spmatrix):
+        return op.todense()
+    else:
+        return op
+
+def canonicalize_input(
+    hilbert: AbstractHilbert, operators, acting_on, constant, *, dtype=None
+):
+    """
+    Takes as inputs the inputs to the constructor of LocalOperator and canonicalizes
+    them by ensuring the following holds:
+     - acting_on is a list of list
+     - acting_on[i] are sorted
+     - operators is list of matrices
+     - all dtypes match
+
+    Args:
+        hilbert: The hilbert space
+
+    Returns:
+        List of operators, acting ons and dtypes.
+    """
+    # check if passing a single operator or a list of operators
+    if isinstance(acting_on, numbers.Number):
+        acting_on = [acting_on]
+
+    is_nested = any(hasattr(i, "__len__") for i in acting_on)
+    if not is_nested:
+        operators = [operators]
+        acting_on = [acting_on]
+
+    if all(len(aon) == 0 for aon in acting_on):
+        operators = []
+        acting_on = []
+    else:
+        if max(map(max, acting_on)) >= hilbert.size or min(map(min, acting_on)) < 0:
+            raise ValueError("An operator acts on an invalid set of sites.")
+
+    acting_on = [tuple(aon) for aon in acting_on]
+    # operators = [np.asarray(operator) for operator in operators]
+    operators = [_standardize_matrix_input_type(op) for op in operators]
+
+    # If we asked for a specific dtype, enforce it.
+    if dtype is None:
+        dtype = np.promote_types(np.float32, _dtype(constant))
+        dtype = functools.reduce(
+            lambda dt, op: np.promote_types(dt, op.dtype), operators, dtype
+        )
+    dtype = np.empty((), dtype=dtype).dtype
+
+    canonicalized_operators = []
+    canonicalized_acting_on = []
+    for (operator, acting_on) in zip(operators, acting_on):
+        if operator.dtype is not dtype:
+            operator = cast_operator_matrix_dtype(operator, dtype=dtype)
+
+        # re-sort the operator
+        operator, acting_on = _reorder_kronecker_product(hilbert, operator, acting_on)
+        canonicalized_operators.append(operator)
+        canonicalized_acting_on.append(acting_on)
+
+    return canonicalized_operators, canonicalized_acting_on, dtype
+
+
+# TODO: support sparse arrays without returning dense arrays
+def _reorder_kronecker_product(hi, mat, acting_on):
+    """
+    Reorders the matrix resulting from a kronecker product of several
+    operators in such a way to sort acting_on.
+
+    A conceptual example is the following:
+    if `mat = Â ⊗ B̂ ⊗ Ĉ` and `acting_on = [[2],[1],[3]`
+    you will get `result = B̂ ⊗ Â ⊗ Ĉ, [[1], [2], [3]].
+
+    However, essentially, A,B,C represent some operators acting on
+    thei sub-space acting_on[1], [2] and [3] of the hilbert space.
+
+    This function also handles any possible set of values in acting_on.
+
+    The inner logic uses the Fock.all_states(), number_to_state and
+    state_to_number to perform the re-ordering.
+    """
+    acting_on_sorted = np.sort(acting_on)
+    if np.array_equal(acting_on_sorted, acting_on):
+        return mat, acting_on
+
+    # could write custom binary <-> int logic instead of using Fock...
+    # Since i need to work with bit-strings (where instead of bits i
+    # have integers, in order to support arbitrary size spaces) this
+    # is exactly what hilbert.to_number() and viceversa do.
+
+    # target ordering binary representation
+    hi_subspace = Fock(hi.shape[acting_on_sorted[0]] - 1)
+    for site in acting_on_sorted[1:]:
+        hi_subspace = Fock(hi.shape[site] - 1) * hi_subspace
+
+    # find how to map target ordering back to unordered
+    acting_on_unsorted_ids = np.zeros(len(acting_on), dtype=np.intp)
+    for (i, site) in enumerate(acting_on):
+        acting_on_unsorted_ids[i] = np.argmax(site == acting_on_sorted)
+
+    # now it is valid that
+    # acting_on_sorted == acting_on[acting_on_unsorted_ids]
+
+    # generate n-bit strings in the target ordering
+    v = hi_subspace.all_states()
+
+    # convert them to origin (unordered) ordering
+    v_unsorted = v[:, acting_on_unsorted_ids]
+    # convert the unordered bit-strings to numbers in the target space.
+    n_unsorted = hi_subspace.states_to_numbers(v_unsorted)
+
+    # reorder the matrix
+    mat_sorted = mat[n_unsorted, :][:, n_unsorted]
+
+    return mat_sorted, acting_on_sorted
+
+
+# TODO: support sparse arrays without returning dense arrays
+def _multiply_operators(
+    hilbert, support_A: Tuple, A: "array", support_B: Tuple, B: "array", *, dtype
+) -> Tuple[Tuple, "array"]:
+    """
+    Returns the `Tuple[acting_on, Matrix]` representing the operator obtained by
+    multiplying the two input operators A and B. 
+    """
+    support_A = np.asarray(support_A)
+    support_B = np.asarray(support_B)
+
+    inters = np.intersect1d(support_A, support_B, return_indices=False)
+
+    if support_A.size == support_B.size and np.array_equal(support_A, support_B):
+        return tuple(support_A), A @ B
+    elif inters.size == 0:
+        # disjoint supports
+        support = tuple(np.concatenate([support_A, support_B]))
+        operator = np.kron(A, B)
+        operator, support = _reorder_kronecker_product(hilbert, operator, support)
+        return tuple(support), operator
+    else:
+        _support_A = list(support_A)
+        _support_B = list(support_B)
+        _A = A.copy()
+        _B = B.copy()
+
+        # expand _act to match _act_i
+        supp_B_min = min(support_B)
+        for site in support_A:
+            if site not in support_B:
+                I = np.eye(hilbert.shape[site], dtype=dtype)
+                if site < supp_B_min:
+                    _support_B = [site] + _support_B
+                    _B = np.kron(I, _B)
+                else:  # site > actmax
+                    _support_B = _support_B + [site]
+                    _B = np.kron(_B, I)
+
+        supp_A_min = min(support_A)
+        for site in support_B:
+            if site not in support_A:
+                I = np.eye(hilbert.shape[site], dtype=dtype)
+                if site < supp_A_min:
+                    _support_A = [site] + _support_A
+                    _A = np.kron(I, _A)
+                else:  #  site > actmax
+                    _support_A = _support_A + [site]
+                    _A = np.kron(_A, I)
+
+        # reorder
+        _A, _support_A = _reorder_kronecker_product(hilbert, _A, _support_A)
+        _B, _support_B = _reorder_kronecker_product(hilbert, _B, _support_B)
+
+        if len(_support_A) == len(_support_B) and np.array_equal(
+            _support_A, _support_B
+        ):
+            # back to the case of non-interesecting with same support
+            return tuple(_support_A), _A @ _B
+        else:
+            raise ValueError("Something failed")

--- a/netket/operator/_local_operator_helpers.py
+++ b/netket/operator/_local_operator_helpers.py
@@ -57,6 +57,7 @@ def cast_operator_matrix_dtype(matrix, dtype):
     # return np.asarray(matrix, dtype=dtype)
     return matrix.astype(dtype)
 
+
 def _standardize_matrix_input_type(op):
     """
     Standardize the structural type of operators stored in LocalOperator.
@@ -69,6 +70,7 @@ def _standardize_matrix_input_type(op):
         return op.todense()
     else:
         return op
+
 
 def canonicalize_input(
     hilbert: AbstractHilbert, operators, acting_on, constant, *, dtype=None
@@ -189,7 +191,7 @@ def _multiply_operators(
 ) -> Tuple[Tuple, "array"]:
     """
     Returns the `Tuple[acting_on, Matrix]` representing the operator obtained by
-    multiplying the two input operators A and B. 
+    multiplying the two input operators A and B.
     """
     support_A = np.asarray(support_A)
     support_B = np.asarray(support_B)

--- a/test/groundstate/test_vmc.py
+++ b/test/groundstate/test_vmc.py
@@ -35,7 +35,7 @@ def _setup_vmc(dtype=np.float32, sr=True):
 
     # Add custom observable
     X = [[0, 1], [1, 0]]
-    sx = nk.operator.LocalOperator(hi, [X] * L, [[i] for i in range(8)])
+    sx = nk.operator.LocalOperator(hi, [X] * L, [[i] for i in range(L)])
 
     if sr:
         sr_config = nk.optimizer.SR()

--- a/test/operator/test_local_operator.py
+++ b/test/operator/test_local_operator.py
@@ -458,13 +458,14 @@ def test_correct_minus():
     # they commute
     assert_same_matrices(op, opd)
 
+
 def test_operator():
     # check that heterogeneous hilbert spaces are ordered correctly #1106
     n_max = 5
     hi = nk.hilbert.Fock(n_max, N=1) * nk.hilbert.Qubit()
     a = nk.operator.boson.destroy(hi, 0)
     sp = nk.operator.spin.sigmap(hi, 1)
-    op1 = a*sp
-    op2 = sp*a
+    op1 = a * sp
+    op2 = sp * a
 
     assert_same_matrices(op1, op2)

--- a/test/operator/test_local_operator.py
+++ b/test/operator/test_local_operator.py
@@ -28,6 +28,7 @@ hi = nk.hilbert.CustomHilbert(local_states=[-1, 1], N=g.n_nodes)
 
 sy_sparse = sparse.csr_matrix(sy)
 
+
 def _loc(*args):
     return nk.operator.LocalOperator(hi, *args)
 

--- a/test/operator/test_local_operator.py
+++ b/test/operator/test_local_operator.py
@@ -10,6 +10,8 @@ import numpy as np
 import pytest
 from pytest import raises
 
+from scipy import sparse
+
 import jax
 
 herm_operators = {}
@@ -24,6 +26,7 @@ sp = [[0, 1], [0, 0]]
 g = nk.graph.Graph(edges=[[i, i + 1] for i in range(8)])
 hi = nk.hilbert.CustomHilbert(local_states=[-1, 1], N=g.n_nodes)
 
+sy_sparse = sparse.csr_matrix(sy)
 
 def _loc(*args):
     return nk.operator.LocalOperator(hi, *args)
@@ -35,9 +38,11 @@ szsz_hat = _loc(sz, [0]) @ _loc(sz, [1])
 szsz_hat += _loc(sz, [4]) @ _loc(sz, [5])
 szsz_hat += _loc(sz, [6]) @ _loc(sz, [8])
 szsz_hat += _loc(sz, [7]) @ _loc(sz, [0])
+sy_sparse_hat = _loc([sy_sparse] * 3, [[0], [1], [5]])
 
 herm_operators["sx (real op)"] = sx_hat
 herm_operators["sy"] = sy_hat
+herm_operators["sy_sparse"] = sy_sparse_hat
 
 herm_operators["Custom Hamiltonian"] = sx_hat + sy_hat + szsz_hat
 herm_operators["Custom Hamiltonian Prod"] = sx_hat * 1.5 + (2.0 * sy_hat)
@@ -52,9 +57,13 @@ generic_operators["sigma +/-"] = (sm_hat, sp_hat)
 def assert_same_matrices(matl, matr, eps=1.0e-6):
     if isinstance(matl, AbstractOperator):
         matl = matl.to_dense()
+    elif isinstance(matl, sparse.csr_matrix):
+        matl = matl.todense()
 
     if isinstance(matr, AbstractOperator):
         matr = matr.to_dense()
+    elif isinstance(matr, sparse.csr_matrix):
+        matr = matr.todense()
 
     np.testing.assert_allclose(matl, matr, atol=eps, rtol=eps)
 
@@ -348,7 +357,7 @@ def test_copy(op):
     op_copy = op.copy()
     assert op_copy is not op
     for o1, o2 in zip(op._operators, op_copy._operators):
-        assert o1 is not o2
+        # assert o1 is not o2
         assert_same_matrices(o1, o2)
     assert_same_matrices(op, op_copy)
 

--- a/test/operator/test_local_operator.py
+++ b/test/operator/test_local_operator.py
@@ -457,3 +457,14 @@ def test_correct_minus():
     assert_same_matrices(op, op2)
     # they commute
     assert_same_matrices(op, opd)
+
+def test_operator():
+    # check that heterogeneous hilbert spaces are ordered correctly #1106
+    n_max = 5
+    hi = nk.hilbert.Fock(n_max, N=1) * nk.hilbert.Qubit()
+    a = nk.operator.boson.destroy(hi, 0)
+    sp = nk.operator.spin.sigmap(hi, 1)
+    op1 = a*sp
+    op2 = sp*a
+
+    assert_same_matrices(op1, op2)

--- a/test/operator/test_operator.py
+++ b/test/operator/test_operator.py
@@ -543,7 +543,7 @@ def test_operator_on_subspace():
     assert nk.exact.lanczos_ed(h2)[0] == pytest.approx(-2.0)
 
     h12 = h1 + h2
-    assert sorted(h12.acting_on) == [[0, 1], [1, 2], [3, 4], [4, 5]]
+    assert sorted(h12.acting_on) == [(0, 1), (1, 2), (3, 4), (4, 5)]
     assert nk.exact.lanczos_ed(h12)[0] == pytest.approx(-4.0)
 
     h3 = nk.operator.GraphOperator(
@@ -551,7 +551,7 @@ def test_operator_on_subspace():
     )
     assert h3.acting_on_subspace == [0, 2, 4]
     assert nk.exact.lanczos_ed(h3)[0] == pytest.approx(-2.0)
-    assert h3.acting_on == [[0, 2], [2, 4]]
+    assert h3.acting_on == [(0, 2), (2, 4)]
 
     h4 = nk.operator.Heisenberg(hi, g, acting_on_subspace=0)
     assert h4.acting_on == h1.acting_on

--- a/test/operator/test_operator.py
+++ b/test/operator/test_operator.py
@@ -178,8 +178,6 @@ def test_lazy_hermitian(op):
     [pytest.param(op, id=name) for name, op in op_finite_size.items()],
 )
 def test_lazy_squared(op):
-    if isinstance(op, nk.operator.PauliStrings):
-        pytest.xfail(reason="Not Implemented")
 
     op2 = op.H @ op
     opd = op.to_dense()


### PR DESCRIPTION
This PR completely refactors the front-end logic of LocalOperator to match what happens in PauliString, that is:
 
- `LocalOperator` merely stores a list of operators and their `acting_on` when constructed and manipulated. Arrays/structures needed to perform` get_conn`, etc are constructed only when needed. This should alleviate slow-downs seen by users when trying to construct huge localoperators.'
  - This should make it easy in the future to separate the `LocalOperator` front-end code from the numba implementation and maybe write a jax implementation.
- The logic is now _simplified_, in the sense that all matrices are never modified in-place. This makes it more memory efficient in some cases because we never duplicate arrays anymore (provided you build directly the LocalOperator with the correct matrices), which is what @VolodyaCO wanted.
- The logic is simpler to follow, IMHO, because we modify a very simple data structure in only one place, and user data can onlhy be inputted at the constructor. Therefore we can skip a lot of data validation in the internal methods.

This PR also gets us 98% of the way towards supporting both sparse and dense amtrices inside of Localoperators (there's just a function or two that must be fixed) which has been a longstanding feature request.