### PR TITLE
Fix PauliStrings when openfermion has constant term

### DIFF
--- a/netket/operator/_pauli_strings.py
+++ b/netket/operator/_pauli_strings.py
@@ -252,13 +252,7 @@ class PauliStrings(DiscreteOperator):
             # no warning, just overwrite
             n_qubits = hilbert.size
         if n_qubits is None:
-            # we always start counting from 0, so we only determine the maximum location
-            n_qubits = (
-                max(
-                    max(term[0] for term in op) for op in of_qubit_operator.terms.keys()
-                )
-                + 1
-            )
+            n_qubits = _count_of_locations(of_qubit_operator)
         for operator, weight in of_qubit_operator.terms.items():  # gives dict
             s = ["I"] * n_qubits
             for loc, op in operator:
@@ -491,6 +485,19 @@ class PauliStrings(DiscreteOperator):
             )
 
         return jit(nopython=True)(gccf_fun)
+
+
+def _count_of_locations(of_qubit_operator):
+    # we always start counting from 0, so we only determine the maximum location
+    def max_or_default(x):
+        x = list(x)
+        return max(x) if len(x) > 0 else -1  # -1 is default
+
+    n_qubits = max_or_default(
+        max_or_default(term[0] for term in op) for op in of_qubit_operator.terms.keys()
+    )
+    n_qubits += 1
+    return n_qubits
 
 
 @jit(nopython=True)

--- a/netket/operator/_pauli_strings.py
+++ b/netket/operator/_pauli_strings.py
@@ -493,10 +493,9 @@ def _count_of_locations(of_qubit_operator):
         x = list(x)
         return max(x) if len(x) > 0 else -1  # -1 is default
 
-    n_qubits = max_or_default(
+    n_qubits = 1 + max_or_default(
         max_or_default(term[0] for term in op) for op in of_qubit_operator.terms.keys()
     )
-    n_qubits += 1
     return n_qubits
 
 

--- a/netket/operator/_pauli_strings.py
+++ b/netket/operator/_pauli_strings.py
@@ -488,6 +488,12 @@ class PauliStrings(DiscreteOperator):
 
 
 def _count_of_locations(of_qubit_operator):
+    """Obtain the number of qubits in the openfermion QubitOperator. Openfermion builds operators from terms that store operators locations.
+    Args:
+        of_qubit_operator (openfermion.QubitOperator, openfermion.FermionOperator)
+    Returns:
+        n_qubits (int): number of qubits in the operator, which we can use to create a suitable hilbert space
+    """
     # we always start counting from 0, so we only determine the maximum location
     def max_or_default(x):
         x = list(x)

--- a/test/operator/test_operator.py
+++ b/test/operator/test_operator.py
@@ -418,7 +418,10 @@ def test_openfermion_conversion():
     pytest.importorskip("openfermion")
     from openfermion.ops import QubitOperator
 
-    of_qubit_operator = 0.5 * QubitOperator("X0 X3") + 0.3 * QubitOperator("Z0")
+    # first term is a constant
+    of_qubit_operator = (
+        QubitOperator("") + 0.5 * QubitOperator("X0 X3") + 0.3 * QubitOperator("Z0")
+    )
 
     # no extra info given
     ps = nk.operator.PauliStrings.from_openfermion(of_qubit_operator)


### PR DESCRIPTION
Small bug fix: when openfermion has a constant term, the conversion failed at counting the number of fermions.
Will also need this function for the fermion2nd implementation, for example.
Added a test with a constant term.