### PR TITLE
Use colors to signal bad sampling

### DIFF
--- a/netket/utils/display/__init__.py
+++ b/netket/utils/display/__init__.py
@@ -1,0 +1,18 @@
+# Copyright 2022 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .repr import rich_repr
+from .repr import color_good_bad
+
+from .progress import TimerColumn, ProgressSpeedColumn, StatsDisplayColumn

--- a/netket/utils/display/progress.py
+++ b/netket/utils/display/progress.py
@@ -1,0 +1,88 @@
+# Copyright 2022 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from datetime import timedelta
+
+from rich.markdown import Text
+
+from rich.progress import ProgressColumn
+
+
+class TimerColumn(ProgressColumn):
+    """Renders estimated time remaining."""
+
+    # Only refresh twice a second to prevent jitter
+    max_refresh = 0.5
+
+    def render(self, task) -> Text:
+        """Show time elapsed and remaining."""
+        elapsed = task.finished_time if task.finished else task.elapsed
+        remaining = task.time_remaining
+
+        if elapsed is None:
+            elapsed = 0
+        delta = timedelta(seconds=int(elapsed))
+
+        if remaining is None:
+            remaining_delta = "?"
+        else:
+            remaining_delta = timedelta(seconds=int(remaining))
+
+        elapsed_txt = Text(str(delta), style="progress.elapsed")
+        reimaining_txt = Text(str(remaining_delta), style="progress.remaining")
+
+        if not task.finished:
+            elapsed_txt.append(">")
+            elapsed_txt.append(reimaining_txt)
+
+        return elapsed_txt
+
+
+class ProgressSpeedColumn(ProgressColumn):
+    """Renders human readable transfer speed."""
+
+    def render(self, task) -> Text:
+        """Show data transfer speed."""
+        speed = task.finished_speed or task.speed
+        if speed is None:
+            return Text("?", style="progress.data.speed")
+
+        if speed >= 10:
+            return Text(f"{speed:>3.1f}it/s", style="progress.data.speed")
+        else:
+            speedm1 = speed**-1
+            return Text(f"{speedm1:>3.1f}s/it", style="progress.data.speed")
+
+
+class StatsDisplayColumn(ProgressColumn):
+    """Renders human readable transfer speed."""
+
+    def render(self, task) -> Text:
+        """Show data transfer speed."""
+        loss_name = task.fields.get("loss_name", "")
+        loss_stats = task.fields.get("loss_stats", "")
+
+        if loss_stats is not None:
+            if hasattr(loss_stats, "__rich__"):
+                loss_data_text = loss_stats.__rich__()
+            else:
+                loss_data_text = loss_stats.__repr__()
+            if loss_data_text is not None:
+                res = Text(f"{loss_name} = ")
+                res.append(loss_data_text)
+            else:
+                res = Text()
+            return res
+        else:
+            return Text()

--- a/netket/utils/display/repr.py
+++ b/netket/utils/display/repr.py
@@ -1,0 +1,76 @@
+# Copyright 2022 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, Dict, Iterable
+
+
+import rich
+from rich.color import Color
+
+
+import colorsys
+
+
+def color_good_bad(value: float):
+    """
+    Returns a rgb color interpolated between
+    green if value=0 and red if value=1
+    """
+    # hue: 0 -> red, 0.4->green
+    h = (1 - value) * 0.4
+    # luminance
+    l = 0.9
+    # saturation
+    s = 0.9
+
+    r, g, b = colorsys.hsv_to_rgb(h, l, s)
+    # hsb to rgb
+    return Color.from_rgb(r * 255, g * 255, b * 255)
+
+
+def __repr_from_rich__(self):
+    """
+    default __repr__ that calls __rich__
+    """
+    console = rich.get_console()
+    with console.capture() as capture:
+        console.print(self, end="")
+    return capture.get()
+
+
+def _repr_mimebundle_from_rich_(
+    self, include: Iterable[str], exclude: Iterable[str], **kwargs: Any
+) -> Dict[str, str]:
+    from rich.jupyter import _render_segments
+
+    console = rich.get_console()
+    segments = list(console.render(self, console.options))  # type: ignore
+    html = _render_segments(segments)
+    text = console._render_buffer(segments)
+    data = {"text/plain": text, "text/html": html}
+    if include:
+        data = {k: v for (k, v) in data.items() if k in include}
+    if exclude:
+        data = {k: v for (k, v) in data.items() if k not in exclude}
+    return data
+
+
+def rich_repr(clz):
+    """
+    Class decorator setting the repr method to use
+    `rich`.
+    """
+    setattr(clz, "__repr__", __repr_from_rich__)
+    setattr(clz, "_repr_mimebundle_", _repr_mimebundle_from_rich_)
+    return clz


### PR DESCRIPTION
This was a little weekend's experimentation. 

I don't have the time to finish this now but would love some feedback on it...

The idea is to prevent users to completely ignore when sampling is going bad. We currently have 2 metrics: `variational_state.sampler_state.acceptance` (which is displayed in the repr of variational state) and `R_hat` of the energy.

I tried using [rich](https://github.com/Textualize/rich#readme) to interpolate between green (`R_hat==1`)  and red (`(1-R_hat)>>0`). Similar coloring is used for `sampler_state.acceptance`.
The color curve is a sigmoid, and was just chosen pretty much arbitrarily.  I chose `rich` because it's the only python package that supports arbitrary colors (and not only 16 colors) that i could find. 
This works in python repl and in jupyter notebooks. 

Interestingly, rich also has advanced support for progress bars with crazy displays so we could use it to also display additional data during training. In this PR there is an experimental progress bar with rich.

You can see the result here (the progress bar normally displays correctly and not on a new line, but the recorder does not like progress bars..)
[![asciicast](https://asciinema.org/a/hWGiJzJvJAJTxl0y6kljbrBd8.svg)](https://asciinema.org/a/hWGiJzJvJAJTxl0y6kljbrBd8)

Ideally i'd like an opinion on colors. On what curve to use for R_hat/acceptance (when should the value turn redd-ish) and what stuff we could add to the progress bar diplay. And if you like that or not. And what can we do for color-blind people.

Also, this should be tested with MPI and slurm, as i don't know if they will work nicely togethre (i think they should... but to be tested).
