### PR TITLE
use float() with tqdm instead of `np.asarray`

### DIFF
--- a/netket/experimental/driver/tdvp.py
+++ b/netket/experimental/driver/tdvp.py
@@ -311,7 +311,7 @@ class TDVP(AbstractVariationalDriver):
         callback_stop = False
 
         with tqdm(
-            total=float(self.t + T),
+            total=np.asarray(self.t + T),
             disable=not show_progress,
             unit_scale=True,
         ) as pbar:
@@ -326,7 +326,7 @@ class TDVP(AbstractVariationalDriver):
                     first_step = False
                     pbar.unpause()
 
-                pbar.n = float(self._integrator.t)
+                pbar.n = np.asarray(self._integrator.t)
                 self._postfix["n"] = self.step_count
                 pbar.set_postfix(self._postfix)
                 pbar.refresh()

--- a/netket/experimental/driver/tdvp.py
+++ b/netket/experimental/driver/tdvp.py
@@ -311,7 +311,7 @@ class TDVP(AbstractVariationalDriver):
         callback_stop = False
 
         with tqdm(
-            total=self.t + T,
+            total=float(self.t + T),
             disable=not show_progress,
             unit_scale=True,
         ) as pbar:

--- a/netket/experimental/driver/tdvp.py
+++ b/netket/experimental/driver/tdvp.py
@@ -326,7 +326,7 @@ class TDVP(AbstractVariationalDriver):
                     first_step = False
                     pbar.unpause()
 
-                pbar.n = np.asarray(self._integrator.t)
+                pbar.n = float(self._integrator.t)
                 self._postfix["n"] = self.step_count
                 pbar.set_postfix(self._postfix)
                 pbar.refresh()

--- a/test/dynamics/test_driver.py
+++ b/test/dynamics/test_driver.py
@@ -231,6 +231,7 @@ def test_repr_and_info():
     assert "integrator" in info
     assert "RK23" in info
 
+
 def test_run_twice():
     # 1100
     ha, vstate, _ = _setup_system(L=2)

--- a/test/dynamics/test_driver.py
+++ b/test/dynamics/test_driver.py
@@ -230,3 +230,15 @@ def test_repr_and_info():
     assert "generator" in info
     assert "integrator" in info
     assert "RK23" in info
+
+def test_run_twice():
+    # 1100
+    ha, vstate, _ = _setup_system(L=2)
+    driver = nkx.TDVP(
+        ha,
+        vstate,
+        nkx.dynamics.RK23(dt=0.01),
+    )
+    driver.run(0.03)
+    driver.run(0.03)
+    np.testing.assert_allclose(driver.t, 0.06)


### PR DESCRIPTION
~Sometimes np.asarray returns a devicearray (why? no idea)~

EDIT: I found why: if you `.run()` twice a `TDVP` driver, the first time `driver.t` is a float, while the second time it is a `devicearray` so it was breaking tqdm.