### PR TITLE
Fix gradient of expectation value for exact state with complex parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 * The gradient obtained with `VarState.expect_and_grad` for models with real-parameters was off by a factor of $ 1/2 $ from the correct value. This has now been corrected. As a consequence, the correct gradient for real-parameter models is equal to the old times 2. If your model had real parameters you might need to change the learning rate and halve it. [#1069](https://github.com/netket/netket/pull/1069)
 * Support for coloured edges in `nk.graph.Grid`, removed in [#724](https://github.com/netket/netket/pull/724), is now restored. [#1074](https://github.com/netket/netket/pull/1074)
 * Fixed bug that prevented calling `.quantum_geometric_tensor` on `netket.vqs.ExactState`. [#1108](https://github.com/netket/netket/pull/1108)
-
+* Fixed bug where the gradient of `C->C` models (complex parameters, complex output) was computed incorrectly with `nk.vqs.ExactState`. [#1110](https://github.com/netket/netket/pull/1110)
 
 ## NetKet 3.3.2 (🐛 Bug Fixes)
 

--- a/netket/vqs/exact/expect.py
+++ b/netket/vqs/exact/expect.py
@@ -105,7 +105,7 @@ def _exp_grad(
     is_mutable = mutable is not False
 
     expval_O = (Ψ.conj() * OΨ).sum()
-    ΔOΨ = (OΨ - expval_O * Ψ.conj()) * Ψ
+    ΔOΨ = (OΨ - expval_O * Ψ).conj() * Ψ
 
     _, vjp_fun, *new_model_state = nkjax.vjp(
         lambda w: model_apply_fun({"params": w, **model_state}, σ, mutable=mutable),

--- a/test/variational/test_exact_state.py
+++ b/test/variational/test_exact_state.py
@@ -59,8 +59,8 @@ machines["model:(C->C)"] = RBM(
 machines["model:(C->C,α=5)"] = RBM(
     alpha=5,
     dtype=complex,
-    kernel_init=normal(stddev=1.0),
-    hidden_bias_init=normal(stddev=1.0),
+    kernel_init=normal(stddev=0.3),
+    hidden_bias_init=normal(stddev=0.3),
 )
 
 operators = {}

--- a/test/variational/test_exact_state.py
+++ b/test/variational/test_exact_state.py
@@ -194,8 +194,7 @@ def central_diff_grad(func, x, eps, *args, dtype=None):
     [(4, 100, 1), (6, 100, 2), (8, 100, 3)],
 )
 @pytest.mark.parametrize(
-    "machine",
-    machines.values(),
+    "machine", [pytest.param(ma, id=name) for name, ma in machines.items()]
 )
 def test_TFIM_energy_strictly_decreases(
     L, n_iterations, h, machine, abs_eps=1.0e-3, rel_eps=1.0e-4

--- a/test/variational/test_exact_state.py
+++ b/test/variational/test_exact_state.py
@@ -130,7 +130,9 @@ def test_qutip_conversion(vstate):
     np.testing.assert_allclose(q_obj.data.todense(), ket.reshape(q_obj.shape))
 
 
-@pytest.mark.parametrize("machine", [pytest.param(ma, id=name) for name, ma in machines.items()])
+@pytest.mark.parametrize(
+    "machine", [pytest.param(ma, id=name) for name, ma in machines.items()]
+)
 def test_derivatives_agree(machine):
     err = 1e-3
     g = nk.graph.Chain(length=8, pbc=True)

--- a/test/variational/test_exact_state.py
+++ b/test/variational/test_exact_state.py
@@ -14,8 +14,6 @@
 
 from functools import partial
 
-from itertools import product
-
 import pytest
 from pytest import approx, raises, warns
 

--- a/test/variational/test_exact_state.py
+++ b/test/variational/test_exact_state.py
@@ -56,7 +56,7 @@ machines["model:(C->C)"] = RBM(
     kernel_init=normal(stddev=0.1),
     hidden_bias_init=normal(stddev=0.1),
 )
-machines["model:(C->C) (alt)"] = RBM(
+machines["model:(C->C,α=5)"] = RBM(
     alpha=5,
     dtype=complex,
     kernel_init=normal(stddev=1.0),

--- a/test/variational/test_exact_state.py
+++ b/test/variational/test_exact_state.py
@@ -121,6 +121,7 @@ def test_qutip_conversion(vstate):
     assert q_obj.shape == (vstate.hilbert.n_states, 1)
     np.testing.assert_allclose(q_obj.data.todense(), ket.reshape(q_obj.shape))
 
+
 @pytest.mark.parametrize("dtype", [float, complex])
 def test_derivatives_agree(dtype):
     err = 1e-3
@@ -181,7 +182,10 @@ def central_diff_grad(func, x, eps, *args, dtype=None):
 
 
 @common.skipif_mpi
-@pytest.mark.parametrize("L,n_iterations,h,dtype", [(4, 100, 1, float), (4, 100, 1, complex), (6, 100, 2, float), (8, 100, 3, float)])
+@pytest.mark.parametrize(
+    "L,n_iterations,h,dtype",
+    [(4, 100, 1, float), (4, 100, 1, complex), (6, 100, 2, float), (8, 100, 3, float)],
+)
 def test_TFIM_energy_strictly_decreases(
     L, n_iterations, h, dtype, abs_eps=1.0e-3, rel_eps=1.0e-4
 ):

--- a/test/variational/test_exact_state.py
+++ b/test/variational/test_exact_state.py
@@ -133,7 +133,7 @@ def test_qutip_conversion(vstate):
 @pytest.mark.parametrize("machine", [pytest.param(ma, id=name) for name, ma in machines.items()])
 def test_derivatives_agree(machine):
     err = 1e-3
-    g = nk.graph.Hypercube(length=10, n_dim=1, pbc=True)
+    g = nk.graph.Chain(length=8, pbc=True)
     hi = nk.hilbert.Spin(s=1 / 2, N=g.n_nodes)
     ha = nk.operator.Ising(hilbert=hi, graph=g, h=1)
     vs = nk.vqs.ExactState(hi, machine)

--- a/test/variational/test_exact_state.py
+++ b/test/variational/test_exact_state.py
@@ -121,13 +121,13 @@ def test_qutip_conversion(vstate):
     assert q_obj.shape == (vstate.hilbert.n_states, 1)
     np.testing.assert_allclose(q_obj.data.todense(), ket.reshape(q_obj.shape))
 
-
-def test_derivatives_agree():
+@pytest.mark.parametrize("dtype", [float, complex])
+def test_derivatives_agree(dtype):
     err = 1e-3
     g = nk.graph.Hypercube(length=10, n_dim=1, pbc=True)
     hi = nk.hilbert.Spin(s=1 / 2, N=g.n_nodes)
     ha = nk.operator.Ising(hilbert=hi, graph=g, h=1)
-    ma = nk.models.RBM(alpha=10, dtype=float)
+    ma = nk.models.RBM(alpha=10, dtype=dtype)
     vs = nk.vqs.ExactState(hi, ma)
 
     _, grads_exact = vs.expect_and_grad(ha)
@@ -181,14 +181,14 @@ def central_diff_grad(func, x, eps, *args, dtype=None):
 
 
 @common.skipif_mpi
-@pytest.mark.parametrize("L,n_iterations,h", [(4, 100, 1), (6, 100, 2), (8, 100, 3)])
+@pytest.mark.parametrize("L,n_iterations,h,dtype", [(4, 100, 1, float), (4, 100, 1, complex), (6, 100, 2, float), (8, 100, 3, float)])
 def test_TFIM_energy_strictly_decreases(
-    L, n_iterations, h, abs_eps=1.0e-3, rel_eps=1.0e-4
+    L, n_iterations, h, dtype, abs_eps=1.0e-3, rel_eps=1.0e-4
 ):
     g = nk.graph.Hypercube(length=L, n_dim=1, pbc=True)
     hi = nk.hilbert.Spin(s=1 / 2, N=g.n_nodes)
     ha = nk.operator.Ising(hilbert=hi, graph=g, h=h)
-    ma = nk.models.RBM(alpha=10, dtype=float)
+    ma = nk.models.RBM(alpha=10, dtype=dtype)
     vs = nk.vqs.ExactState(hi, ma)
 
     op = nk.optimizer.Sgd(learning_rate=0.003)

--- a/test/variational/test_exact_state.py
+++ b/test/variational/test_exact_state.py
@@ -130,7 +130,7 @@ def test_qutip_conversion(vstate):
     np.testing.assert_allclose(q_obj.data.todense(), ket.reshape(q_obj.shape))
 
 
-@pytest.mark.parametrize("machine", machines.values())
+@pytest.mark.parametrize("machine", [pytest.param(ma, id=name) for name, ma in machines.items()])
 def test_derivatives_agree(machine):
     err = 1e-3
     g = nk.graph.Hypercube(length=10, n_dim=1, pbc=True)

--- a/test/variational/test_exact_state.py
+++ b/test/variational/test_exact_state.py
@@ -56,8 +56,8 @@ machines["model:(C->C)"] = RBM(
     kernel_init=normal(stddev=0.1),
     hidden_bias_init=normal(stddev=0.1),
 )
-machines["model:(C->C)"] = RBM(
-    alpha=10,
+machines["model:(C->C) (alt)"] = RBM(
+    alpha=5,
     dtype=complex,
     kernel_init=normal(stddev=1.0),
     hidden_bias_init=normal(stddev=1.0),


### PR DESCRIPTION
Hi all,
I noticed that there was a small error in the computation of the gradient of expectation values for the exact state when complex parameters are used in the model. This PR fixes that.

The issue can for example be seen with the following little script comparing the computed gradient with one obtained by numdifftools (yes, I know, it's a little bit strange to use numdifftools to verify the gradients in code based on jax but setting it up with numdifftools was just quicker than making the expectation value evaluation differentiable with jax).

```python
import netket as nk
import numpy as np
import numdifftools as nd
import jax
from jax.nn.initializers import normal

g = nk.graph.Chain(6)
hi = nk.hilbert.Spin(0.5, N=g.n_nodes, total_sz=0.0)
ha = nk.operator.Heisenberg(hi, g, sign_rule=False)
model = nk.models.RBM(dtype=complex, use_visible_bias=False, use_hidden_bias=False, kernel_init=normal(stddev=1.))

vs = nk.vqs.ExactState(hi, model=model, seed=jax.random.PRNGKey(123))
vs_sampled = nk.vqs.MCState(nk.sampler.MetropolisExchange(hi, graph=g), model=model, n_samples=1000000)

""" We are doing a little bit of reshaping and stacking to map the complex
parameters to a flattened array of real values (two times the total number of params). This way,
we can evaluate the gradient with numdifftool and compare."""

kernel_shape = vs.parameters["Dense"]["kernel"].shape
def calculate_expect(parameters):
    kernel = parameters[:len(parameters)//2] + 1.j*parameters[len(parameters)//2:]
    vs.parameters = {"Dense" : {"kernel" : kernel.reshape(kernel_shape)}}
    return vs.expect(ha).mean.real

def calculate_grad_flattened(parameters):
    kernel = parameters[:len(parameters)//2] + 1.j*parameters[len(parameters)//2:]
    vs.parameters = {"Dense" : {"kernel" : kernel.reshape(kernel_shape)}}
    grad_flattened = vs.expect_and_grad(ha)[1]["Dense"]["kernel"].flatten()
    return 2 * np.concatenate((grad_flattened.real, grad_flattened.imag))

""" Just to ensure that the sign definitions are in-line with the rest of NetKet,
we also compute a sampled expectation value."""
def calculate_grad_sampled_flattened(parameters):
    kernel = parameters[:len(parameters)//2] + 1.j*parameters[len(parameters)//2:]
    vs_sampled.parameters = {"Dense" : {"kernel" : kernel.reshape(kernel_shape)}}
    grad_flattened = vs_sampled.expect_and_grad(ha)[1]["Dense"]["kernel"].flatten()
    return 2 * np.concatenate((grad_flattened.real, grad_flattened.imag))

init_pars = vs.parameters["Dense"]["kernel"].flatten()
init_pars_split = np.concatenate((init_pars.real, init_pars.imag))

# gradient as calculated by NetKet
grad_nk = calculate_grad_flattened(init_pars_split)
grad_nk_sampled = calculate_grad_sampled_flattened(init_pars_split)

# Gradient computed by numdifftools
grad_nd = nd.Gradient(calculate_expect)(init_pars_split)

print(max(abs(grad_nd - grad_nk))) # returns large values without the fix in this PR
print(np.mean(abs(grad_nk_sampled - grad_nk)**2)) # returns large values without the fix in this PR
```

The script above just verifies the gradient by comparing the one obtained by calling `vs.expect_and_grad(ha)` with the numerical gradient of `vs.expect(ha)` as obtained with numdifftools.
WIthout the fix of this pull request, it can be seen that the gradients are wrong when complex parameters are used, i.e. there is a significant deviation between the different gradients (which then also results in weird behaviour in the optimization of the exact state with complex parameters).

Incidentally, I realised that the gradient with respect to complex parameters is defined differently in NetKet as compared to jax which might be a little bit confusing for people (happy to open an issue if this is wanted): NetKet gives the complex conjugated version of the gradient which jax would usually return (in the sense that if you do gradient descent with the jax gradients, you need to apply complex conjugation to the complex-valued gradients returned by jax, the NetKet version can directly be used for GD). This discrepancy will probably also lead to issues when using the interface to evaluate gradients for non-hermitian operators (which presumably has never really been tested for models with complex parameters?) as this just evaluates the gradient by jax-differentiating on the full expectation value evaluation. The fix in this PR explicitly assumes Hermitian operators but I guess this is fine as there is no clear definition how a gradient would be defined if the operator is non-hermitian and complex valued models are used (as this can give complex-valued expectation values).

I hope this all makes sense, let me know if you require further info.

Best wishes,
Yannic