### PR TITLE
Fix bug with initial point in iterative solvers and QGTJacobian(holomorphic=False)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Support for coloured edges in `nk.graph.Grid`, removed in [#724](https://github.com/netket/netket/pull/724), is now restored. [#1074](https://github.com/netket/netket/pull/1074)
 * Fixed bug that prevented calling `.quantum_geometric_tensor` on `netket.vqs.ExactState`. [#1108](https://github.com/netket/netket/pull/1108)
 * Fixed bug where the gradient of `C->C` models (complex parameters, complex output) was computed incorrectly with `nk.vqs.ExactState`. [#1110](https://github.com/netket/netket/pull/1110)
+* Fixed bug where `QGTJacobianDense.state` and `QGTJacobianPyTree.state` would not correctly transform the starting point `x0` if `holomorphic=False`. 
 
 ## NetKet 3.3.2 (🐛 Bug Fixes)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 * Support for coloured edges in `nk.graph.Grid`, removed in [#724](https://github.com/netket/netket/pull/724), is now restored. [#1074](https://github.com/netket/netket/pull/1074)
 * Fixed bug that prevented calling `.quantum_geometric_tensor` on `netket.vqs.ExactState`. [#1108](https://github.com/netket/netket/pull/1108)
 * Fixed bug where the gradient of `C->C` models (complex parameters, complex output) was computed incorrectly with `nk.vqs.ExactState`. [#1110](https://github.com/netket/netket/pull/1110)
-* Fixed bug where `QGTJacobianDense.state` and `QGTJacobianPyTree.state` would not correctly transform the starting point `x0` if `holomorphic=False`. 
+* Fixed bug where `QGTJacobianDense.state` and `QGTJacobianPyTree.state` would not correctly transform the starting point `x0` if `holomorphic=False`. [#1115](https://github.com/netket/netket/pull/1115)
 
 ## NetKet 3.3.2 (🐛 Bug Fixes)
 

--- a/netket/optimizer/qgt/qgt_jacobian_dense.py
+++ b/netket/optimizer/qgt/qgt_jacobian_dense.py
@@ -216,7 +216,7 @@ def _solve(
         x0, _ = nkjax.tree_ravel(x0)
         if self.mode != "holomorphic":
             x0, _ = vec_to_real(x0)
-            
+
         if self.scale is not None:
             x0 = x0 * self.scale
 

--- a/netket/optimizer/qgt/qgt_jacobian_dense.py
+++ b/netket/optimizer/qgt/qgt_jacobian_dense.py
@@ -214,6 +214,9 @@ def _solve(
 
     if x0 is not None:
         x0, _ = nkjax.tree_ravel(x0)
+        if self.mode != "holomorphic":
+            x0, _ = vec_to_real(x0)
+            
         if self.scale is not None:
             x0 = x0 * self.scale
 

--- a/netket/optimizer/qgt/qgt_jacobian_pytree.py
+++ b/netket/optimizer/qgt/qgt_jacobian_pytree.py
@@ -234,6 +234,8 @@ def _solve(
     # Real-imaginary split RHS in R→R and R→C modes
     if self.mode != "holomorphic":
         y, reassemble = nkjax.tree_to_real(y)
+        if x0 is not None:
+            x0, _ = nkjax.tree_to_real(x0)
 
     check_valid_vector_type(self.params, y)
 

--- a/test/optimizer/test_qgt_itersolve.py
+++ b/test/optimizer/test_qgt_itersolve.py
@@ -17,6 +17,7 @@ import pytest
 from functools import partial
 
 import jax
+import jax.numpy as jnp
 import numpy as np
 from numpy import testing
 import jax.flatten_util
@@ -139,6 +140,20 @@ def test_qgt_solve(qgt, vstate, solver, _mpi_size, _mpi_rank):
             x_all, _ = S.solve(solver, vstate.parameters)
 
             jax.tree_multimap(lambda a, b: np.testing.assert_allclose(a, b), x, x_all)
+
+
+@pytest.mark.skipif_mpi
+@pytest.mark.parametrize(
+    "qgt",
+    [pytest.param(sr, id=name) for name, sr in QGT_objects.items()],
+)
+@pytest.mark.parametrize("chunk_size", [None])
+def test_qgt_solve_with_x0(qgt, vstate):
+    solver = jax.scipy.sparse.linalg.gmres
+    x0 = jax.tree_map(jnp.zeros_like, vstate.parameters)
+
+    S = qgt(vstate)
+    x, _ = S.solve(solver, vstate.parameters, x0=x0)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The QGT where not splitting the real/imaginary part of the initial point as well.

The test in this PR does not pass on current master:

```python

qgt = functools.partial(<function QGTJacobianDense at 0x13e53b430>, rescale_shift=True, diag_shift=0.01)
vstate = MCState(
  hilbert = Spin(s=1/2, N=5),
  sampler = MetropolisSampler(rule = LocalRule(), n_chains = 16, n_sweeps = 5, ...lisSamplerState(# accepted = 13029/13040 (99.91564417177914%), rng state=[1337081576 4230717147]),
  n_parameters = 35)

    @pytest.mark.skipif_mpi
    @pytest.mark.parametrize(
        "qgt",
        [pytest.param(sr, id=name) for name, sr in QGT_objects.items()],
    )
    @pytest.mark.parametrize("chunk_size", [None])
    def test_qgt_solve_with_x0(qgt, vstate):
        solver = jax.scipy.sparse.linalg.gmres
        x0 = jax.tree_map(jnp.zeros_like, vstate.parameters)

        S = qgt(vstate)
>       x, _ = S.solve(solver, vstate.parameters, x0=x0)

test/optimizer/test_qgt_itersolve.py:156:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
netket/optimizer/linear_operator.py:100: in solve
    return self._solve(jax.tree_util.Partial(solve_fun), y, x0=x0, **kwargs)
netket/optimizer/qgt/qgt_jacobian_dense.py:148: in _solve
    return _solve(self, solve_fun, y, x0=x0)
netket/optimizer/qgt/qgt_jacobian_dense.py:218: in _solve
    x0 = x0 * self.scale
../../../../../Documents/pythonenvs/netket_env/lib/python3.9/site-packages/jax/_src/numpy/lax_numpy.py:6715: in deferring_binary_op
    return binary_op(self, other)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

x1 = Traced<ShapedArray(complex128[35])>with<DynamicJaxprTrace(level=0/2)>
x2 = Traced<ShapedArray(complex128[70])>with<DynamicJaxprTrace(level=0/2)>

    def fn(x1, x2):
      x1, x2 = _promote_args(numpy_fn.__name__, x1, x2)
>     return lax_fn(x1, x2) if x1.dtype != bool_ else bool_lax_fn(x1, x2)
E     TypeError: mul got incompatible shapes for broadcasting: (35,), (70,).

../../../../../Documents/pythonenvs/netket_env/lib/python3.9/site-packages/jax/_src/numpy/lax_numpy.py:700: TypeError
================================================================= warnings summary ==================================================================
```