### PR TITLE
tdvp: allow changing solver without reconstructing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### New features
 * `Lattice` supports specifying arbitrary edge content for each unit cell via the kwarg `custom_edges`. A generator for hexagonal lattices with coloured edges is implemented as `nk.graph.KitaevHoneycomb`. `nk.graph.Grid` again supports colouring edges by direction. [#1074](https://github.com/netket/netket/pull/1074)
 * Fermionic hilbert space (`nkx.hilbert.SpinOrbitalFermions`) and fermionic operators (`nkx.operator.fermion`) to treat systems with a finite number of Orbitals have been added to the experimental submodule. The operators are also integrated with [OpenFermion](https://quantumai.google/openfermion). Those functionalities are still in development and we would welcome feedback. [#1090](https://github.com/netket/netket/pull/1090)
+* It is now possible to change the integrator of a `TDVP` object without reconstructing it. [#1123](https://github.com/netket/netket/pull/1123)
 
 ### Breaking Changes
 * The gradient for models with real-parameter is now multiplied by 2. If your model had real parameters you might need to change the learning rate and halve it. Conceptually this is a bug-fix, as the value returned before was wrong (see Bug Fixes section below for additional details) [#1069](https://github.com/netket/netket/pull/1069)

--- a/netket/experimental/driver/tdvp.py
+++ b/netket/experimental/driver/tdvp.py
@@ -128,6 +128,7 @@ class TDVP(AbstractVariationalDriver):
         self._dw = None  # type: PyTree
         self._last_qgt = None
         self._integrator = None
+        self._integrator_constructor = None
 
         self._odefun = HashablePartial(odefun_host_callback, self.state, self)
 
@@ -150,6 +151,8 @@ class TDVP(AbstractVariationalDriver):
             t0 = self.t0
         else:
             t0 = self.t
+
+        self._integrator_constructor = integrator
 
         self._integrator = integrator(
             self._odefun,
@@ -200,6 +203,9 @@ class TDVP(AbstractVariationalDriver):
                 "error_norm must be a callable or one of 'euclidean', 'qgt', 'maximum',"
                 f" but {error_norm} was passed."
             )
+
+        if self.integrator is not None:
+            self.integrator.norm = self._error_norm
 
     def advance(self, T: float):
         """

--- a/test/dynamics/test_driver.py
+++ b/test/dynamics/test_driver.py
@@ -259,3 +259,28 @@ def test_change_integrator():
 
     driver.run(0.1)
     np.testing.assert_allclose(driver.t, 0.13)
+
+
+def test_change_norm():
+    ha, vstate, _ = _setup_system(L=2)
+    driver = nkx.TDVP(
+        ha,
+        vstate,
+        nkx.dynamics.RK23(dt=0.01, adaptive=False),
+    )
+    driver.run(0.03)
+
+    def norm(x):
+        return 0.0
+
+    driver.error_norm = norm
+    driver.run(0.02)
+
+    driver.error_norm = "qgt"
+    driver.run(0.02)
+
+    driver.error_norm = "maximum"
+    driver.run(0.02)
+
+    with pytest.raises(ValueError):
+        driver.error_norm = "assd"

--- a/test/dynamics/test_driver.py
+++ b/test/dynamics/test_driver.py
@@ -240,3 +240,22 @@ def test_run_twice():
     driver.run(0.03)
     driver.run(0.03)
     np.testing.assert_allclose(driver.t, 0.06)
+
+
+def test_change_integrator():
+    ha, vstate, _ = _setup_system(L=2)
+    driver = nkx.TDVP(
+        ha,
+        vstate,
+        nkx.dynamics.RK23(dt=0.01, adaptive=False),
+    )
+    driver.run(0.03)
+    np.testing.assert_allclose(driver.t, 0.03)
+
+    integrator = nkx.dynamics.Euler(dt=0.05)
+    driver.integrator = integrator
+    np.testing.assert_allclose(driver.t, 0.03)
+    np.testing.assert_allclose(driver.dt, 0.05)
+
+    driver.run(0.1)
+    np.testing.assert_allclose(driver.t, 0.13)


### PR DESCRIPTION
Useful to change the dt in the midst of the integration