### PR TITLE
Fixing documentation links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ It is a Python library built on [JAX](https://github.com/google/jax).
 
 ## Installation and Usage
 
-Netket runs on MacOS and Linux. We reccomend to install NetKet using `pip`, but it can also be installed with `conda`.
+NetKet runs on MacOS and Linux. We recommend to install NetKet using `pip`, but it can also be installed with `conda`.
 It is often necessary to first update `pip` to a recent release (`>=20.3`) in order for upper compatibility bounds to be considered and avoid a broken installation.
-For instructions on how to install the latest stable/beta release of NetKet see the [Getting Started](https://www.netket.org/docs/getting_started.html) section of our website or run the following command (Apple M1 users, follow that link for more instructions):
+For instructions on how to install the latest stable/beta release of NetKet see the [Get Started](https://www.netket.org/get_started/) page of our website or run the following command (Apple M1 users, follow that link for more instructions):
 
 ```sh
 pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ of many-body quantum systems with artificial neural networks and machine learnin
 It is a Python library built on [JAX](https://github.com/google/jax).
 
 - **Homepage:** <https://www.netket.org>
-- **Citing:** <https://www.netket.org/citing>
-- **Documentation:** <https://www.netket.org/documentation>
-- **Tutorials:** <https://www.netket.org/tutorials>
+- **Citing:** <https://www.netket.org/cite/>
+- **Documentation:** <https://netket.readthedocs.io/en/latest/index.html>
+- **Tutorials:** <https://netket.readthedocs.io/en/latest/tutorials/gs-ising.htmls>
 - **Examples:** <https://github.com/netket/netket/tree/master/Examples>
 - **Source code:** <https://github.com/netket/netket>
 
@@ -94,7 +94,7 @@ If you want MPI support, please follow the discussion in [mpi4jax](https://githu
 
 ## Getting Started
 
-To get started with NetKet, we reccomend you give a look to our [tutorials](https://www.netket.org/tutorials), by running them on your computer.
+To get started with NetKet, we recommend you give a look at our [tutorials page](https://netket.readthedocs.io/en/latest/tutorials/gs-ising.htmls), by running them on your computer or on [Google Colaboratory](https://colab.research.google.com).
 There are also many example scripts that you can download, run and edit that showcase some use-cases of NetKet, although they are not commented.
 
 If you want to get in touch with us, feel free to open an issue or a discussion here on GitHub, or to join the MLQuantum slack group where several people involved with NetKet hang out. To join the slack channel just accept [this invitation](https://join.slack.com/t/mlquantum/shared_invite/zt-13nohbtt3-nWgz~faxWXjVnu0BCHWM7w)

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ can be slightly out of date compared to PyPi.
 To check what is the latest version released on both distributions you can inspect the badges at the top of this readme.
 
 ### Extra dependencies
-When installing netket with pip, you can pass the following extra variants as square brakets. You can install several of them by separating them with a comma.
+When installing `netket` with pip, you can pass the following extra variants as square brakets. You can install several of them by separating them with a comma.
  - `"[dev]"`: installs development-related dependencies such as black, pytest and testing dependencies
  - `"[mpi]"`: Installs `mpi4py` to enable multi-process parallelism. Requires a working MPI compiler in your path
  - `"[extra]"`: Installs `tensorboardx` to enable logging to tensorboard, and openfermion to convert the QubitOperators.


### PR DESCRIPTION
This PR solves #1125 

The changes are in the bullet list at the beginning of the README and the `Get Started` and `Tutorials` link in the rest of the file.
I also fixed some typos and spelled `NetKet` uniformly with the right capital letters.