### PR TITLE
Fix Squared Operator 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Fixed bug that prevented calling `.quantum_geometric_tensor` on `netket.vqs.ExactState`. [#1108](https://github.com/netket/netket/pull/1108)
 * Fixed bug where the gradient of `C->C` models (complex parameters, complex output) was computed incorrectly with `nk.vqs.ExactState`. [#1110](https://github.com/netket/netket/pull/1110)
 * Fixed bug where `QGTJacobianDense.state` and `QGTJacobianPyTree.state` would not correctly transform the starting point `x0` if `holomorphic=False`. [#1115](https://github.com/netket/netket/pull/1115)
+* The gradient of the expectation value obtained with `VarState.expect_and_grad` for `SquaredOperator`s was off by a factor of 2 in some cases, and wrong in others. This has now been fixed for models with real parameters. [#1065](https://github.com/netket/netket/pull/1065).
 
 ## NetKet 3.3.2 (🐛 Bug Fixes)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 * Fixed bug that prevented calling `.quantum_geometric_tensor` on `netket.vqs.ExactState`. [#1108](https://github.com/netket/netket/pull/1108)
 * Fixed bug where the gradient of `C->C` models (complex parameters, complex output) was computed incorrectly with `nk.vqs.ExactState`. [#1110](https://github.com/netket/netket/pull/1110)
 * Fixed bug where `QGTJacobianDense.state` and `QGTJacobianPyTree.state` would not correctly transform the starting point `x0` if `holomorphic=False`. [#1115](https://github.com/netket/netket/pull/1115)
-* The gradient of the expectation value obtained with `VarState.expect_and_grad` for `SquaredOperator`s was off by a factor of 2 in some cases, and wrong in others. This has now been fixed for models with real parameters. [#1065](https://github.com/netket/netket/pull/1065).
+* The gradient of the expectation value obtained with `VarState.expect_and_grad` for `SquaredOperator`s was off by a factor of 2 in some cases, and wrong in others. This has now been fixed. [#1065](https://github.com/netket/netket/pull/1065).
 
 ## NetKet 3.3.2 (🐛 Bug Fixes)
 

--- a/test/variational/finite_diff.py
+++ b/test/variational/finite_diff.py
@@ -1,0 +1,80 @@
+# Copyright 2021 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+import jax
+import jax.numpy as jnp
+
+import netket as nk
+
+
+def expval(par, vstate, H, real=False):
+    vstate.parameters = par
+    psi = vstate.to_array()
+    expval = psi.conj() @ (H @ psi)
+    if real:
+        expval = np.real(expval)
+
+    return expval
+
+
+def central_diff_grad(func, x, eps, *args, dtype=None):
+    if dtype is None:
+        dtype = x.dtype
+
+    grad = np.zeros(
+        len(x), dtype=nk.jax.maybe_promote_to_complex(x.dtype, func(x, *args).dtype)
+    )
+    epsd = np.zeros(len(x), dtype=dtype)
+    epsd[0] = eps
+    for i in range(len(x)):
+        assert not np.any(np.isnan(x + epsd))
+        grad_r = 0.5 * (func(x + epsd, *args) - func(x - epsd, *args))
+        if nk.jax.is_complex(x):
+            grad_i = 0.5 * (func(x + 1j * epsd, *args) - func(x - 1j * epsd, *args))
+            grad[i] = 0.5 * grad_r + 0.5j * grad_i
+        else:
+            # grad_i = 0.0
+            grad[i] = grad_r
+
+        assert not np.isnan(grad[i])
+        grad[i] /= eps
+        epsd = np.roll(epsd, 1)
+    return grad
+
+
+def same_derivatives(der_log, num_der_log, abs_eps=1.0e-6, rel_eps=1.0e-6):
+    assert der_log.shape == num_der_log.shape
+
+    np.testing.assert_allclose(
+        der_log.real, num_der_log.real, rtol=rel_eps, atol=abs_eps
+    )
+
+    # compute the distance between the two phases modulo 2pi
+    delta_der_log = der_log.imag - num_der_log.imag
+
+    # the distance is taken to be the minimum of the distance between
+    # (|A-B|mod 2Pi) and (|B-A| mod 2Pi)
+    delta_der_log_mod_1 = np.mod(delta_der_log, 2 * np.pi)
+    delta_der_log_mod_2 = np.mod(-delta_der_log, 2 * np.pi)
+    delta_der_log = np.minimum(delta_der_log_mod_1, delta_der_log_mod_2)
+
+    # Compare against pi and not 0 because otherwise rtol will fail always
+    np.testing.assert_allclose(
+        delta_der_log + np.pi,
+        np.pi,
+        rtol=rel_eps,
+        atol=abs_eps,
+    )

--- a/test/variational/finite_diff.py
+++ b/test/variational/finite_diff.py
@@ -55,7 +55,28 @@ def central_diff_grad(func, x, eps, *args, dtype=None):
     return grad
 
 
-def same_derivatives(der_log, num_der_log, abs_eps=1.0e-6, rel_eps=1.0e-6):
+def same_derivatives(der, num_der, abs_eps=1.0e-6, rel_eps=1.0e-6):
+    """
+    Checks that two complex-valued arrays are the same.
+
+    Same as `np.testing.assert_allclose` but checks the real 
+    and imaginary parts independently for better error reporting.
+    """
+    assert der.shape == num_der.shape
+
+    np.testing.assert_allclose(
+        der.real, num_der.real, rtol=rel_eps, atol=abs_eps
+    )
+
+    np.testing.assert_allclose(
+        der.imag, num_der.imag, rtol=rel_eps, atol=abs_eps
+    )
+
+
+def same_log_derivatives(der_log, num_der_log, abs_eps=1.0e-6, rel_eps=1.0e-6):
+    """
+    Checks that two log-derivatives are equivalent
+    """
     assert der_log.shape == num_der_log.shape
 
     np.testing.assert_allclose(

--- a/test/variational/finite_diff.py
+++ b/test/variational/finite_diff.py
@@ -59,18 +59,14 @@ def same_derivatives(der, num_der, abs_eps=1.0e-6, rel_eps=1.0e-6):
     """
     Checks that two complex-valued arrays are the same.
 
-    Same as `np.testing.assert_allclose` but checks the real 
+    Same as `np.testing.assert_allclose` but checks the real
     and imaginary parts independently for better error reporting.
     """
     assert der.shape == num_der.shape
 
-    np.testing.assert_allclose(
-        der.real, num_der.real, rtol=rel_eps, atol=abs_eps
-    )
+    np.testing.assert_allclose(der.real, num_der.real, rtol=rel_eps, atol=abs_eps)
 
-    np.testing.assert_allclose(
-        der.imag, num_der.imag, rtol=rel_eps, atol=abs_eps
-    )
+    np.testing.assert_allclose(der.imag, num_der.imag, rtol=rel_eps, atol=abs_eps)
 
 
 def same_log_derivatives(der_log, num_der_log, abs_eps=1.0e-6, rel_eps=1.0e-6):

--- a/test/variational/test_variational.py
+++ b/test/variational/test_variational.py
@@ -23,6 +23,7 @@ import jax
 import netket as nk
 from jax.nn.initializers import normal
 
+from .finite_diff import expval as _expval, central_diff_grad, same_derivatives
 from .. import common
 
 nk.config.update("NETKET_EXPERIMENTAL", True)
@@ -107,6 +108,11 @@ def test_deprecated_name():
         nk.variational.accabalubba
 
     assert dir(nk.vqs) == dir(nk.variational)
+
+
+def check_consistent(vstate, mpi_size):
+    assert vstate.n_samples == vstate.n_samples_per_rank * mpi_size
+    assert vstate.n_samples == vstate.chain_length * vstate.sampler.n_chains
 
 
 def test_n_samples_api(vstate, _mpi_size):
@@ -455,71 +461,3 @@ def test_expect_chunking(vstate, operator, n_chunks):
     jax.tree_multimap(
         partial(np.testing.assert_allclose, atol=1e-13), grad_nochunk, grad_chunk
     )
-
-
-###
-
-
-def _expval(par, vstate, H, real=False):
-    vstate.parameters = par
-    psi = vstate.to_array()
-    expval = psi.conj() @ (H @ psi)
-    if real:
-        expval = np.real(expval)
-
-    return expval
-
-
-def central_diff_grad(func, x, eps, *args, dtype=None):
-    if dtype is None:
-        dtype = x.dtype
-
-    grad = np.zeros(
-        len(x), dtype=nk.jax.maybe_promote_to_complex(x.dtype, func(x, *args).dtype)
-    )
-    epsd = np.zeros(len(x), dtype=dtype)
-    epsd[0] = eps
-    for i in range(len(x)):
-        assert not np.any(np.isnan(x + epsd))
-        grad_r = 0.5 * (func(x + epsd, *args) - func(x - epsd, *args))
-        if nk.jax.is_complex(x):
-            grad_i = 0.5 * (func(x + 1j * epsd, *args) - func(x - 1j * epsd, *args))
-            grad[i] = 0.5 * grad_r + 0.5j * grad_i
-        else:
-            # grad_i = 0.0
-            grad[i] = grad_r
-
-        assert not np.isnan(grad[i])
-        grad[i] /= eps
-        epsd = np.roll(epsd, 1)
-    return grad
-
-
-def same_derivatives(der_log, num_der_log, abs_eps=1.0e-6, rel_eps=1.0e-6):
-    assert der_log.shape == num_der_log.shape
-
-    np.testing.assert_allclose(
-        der_log.real, num_der_log.real, rtol=rel_eps, atol=abs_eps
-    )
-
-    # compute the distance between the two phases modulo 2pi
-    delta_der_log = der_log.imag - num_der_log.imag
-
-    # the distance is taken to be the minimum of the distance between
-    # (|A-B|mod 2Pi) and (|B-A| mod 2Pi)
-    delta_der_log_mod_1 = np.mod(delta_der_log, 2 * np.pi)
-    delta_der_log_mod_2 = np.mod(-delta_der_log, 2 * np.pi)
-    delta_der_log = np.minimum(delta_der_log_mod_1, delta_der_log_mod_2)
-
-    # Compare against pi and not 0 because otherwise rtol will fail always
-    np.testing.assert_allclose(
-        delta_der_log + np.pi,
-        np.pi,
-        rtol=rel_eps,
-        atol=abs_eps,
-    )
-
-
-def check_consistent(vstate, mpi_size):
-    assert vstate.n_samples == vstate.n_samples_per_rank * mpi_size
-    assert vstate.n_samples == vstate.chain_length * vstate.sampler.n_chains

--- a/test/variational/test_variational.py
+++ b/test/variational/test_variational.py
@@ -80,7 +80,7 @@ for i in range(H.hilbert.size):
     H += nk.operator.spin.sigmay(H.hilbert, i)
 
 operators["operator:(Hermitian Complex)"] = H
-operators["operator:(Hermitian Complex Squared)"] = H.H@H
+operators["operator:(Hermitian Complex Squared)"] = H.H @ H
 
 H = H.copy()
 for i in range(H.hilbert.size):

--- a/test/variational/test_variational.py
+++ b/test/variational/test_variational.py
@@ -80,12 +80,20 @@ for i in range(H.hilbert.size):
     H += nk.operator.spin.sigmay(H.hilbert, i)
 
 operators["operator:(Hermitian Complex)"] = H
+operators["operator:(Hermitian Complex Squared)"] = H.H@H
 
 H = H.copy()
 for i in range(H.hilbert.size):
     H += nk.operator.spin.sigmap(H.hilbert, i)
 
 operators["operator:(Non Hermitian)"] = H
+
+machines["model:(C->C)-nonholo"] = nk.models.ARNNDense(
+    layers=1,
+    features=2,
+    hilbert=hi,
+    dtype=complex,
+)
 
 
 @pytest.fixture(params=[pytest.param(ma, id=name) for name, ma in machines.items()])

--- a/test/variational/test_variational.py
+++ b/test/variational/test_variational.py
@@ -71,6 +71,9 @@ hi = nk.hilbert.Spin(s=0.5, N=L)
 H = nk.operator.Ising(hi, graph=g, h=1.0)
 operators["operator:(Hermitian Real)"] = H
 
+H2 = H @ H
+operators["operator:(Hermitian Real Squared)"] = H2
+
 H = nk.operator.Ising(hi, graph=g, h=1.0)
 for i in range(H.hilbert.size):
     H += nk.operator.spin.sigmay(H.hilbert, i)
@@ -403,9 +406,6 @@ def test_expect(vstate, operator):
     # Compute the expval and gradient with exact formula
     O_exact = expval_fun(pars, vstate, op_sparse)
     grad_exact = central_diff_grad(expval_fun, pars, 1.0e-5, vstate, op_sparse)
-
-    if not operator.is_hermitian:
-        grad_exact = jax.tree_map(lambda x: x * 2, grad_exact)
 
     # check the expectation values
     err = 5 * O_stat.error_of_mean


### PR DESCRIPTION
Cherry picked from  #1065 so that i separate the two changes in two different PRs.

Computing the gradient of operators that use `nkjax.expect` instead of the covariance formula (such as `SquaredOperator`) also had a wrong factor of 2 for C->C models.
This is due to the weird way that Jax handles complex differentiation.

This PR now fixes it, and a test is added to check the gradient wrt finite differences.

Also, this PR moves out into a common test file the finite difference functions so that they can be used for other tests.