### PR TITLE
Significantly speed up superoperators

### DIFF
--- a/netket/operator/_local_operator_compile_helpers.py
+++ b/netket/operator/_local_operator_compile_helpers.py
@@ -110,7 +110,7 @@ def pack_internals(
         np.any(np.abs(diag_mels) >= mel_cutoff) or np.abs(constant) >= mel_cutoff
     )
 
-    max_conn_size = n_operators if nonzero_diagonal else 0
+    max_conn_size = 1 if nonzero_diagonal else 0
     for op in operators:
         nnz_mat = np.abs(op) > mel_cutoff
         nnz_mat[np.diag_indices(nnz_mat.shape[0])] = False


### PR DESCRIPTION
Super-operators use the `op.max_conn_size` to estimate the maximum size of super operators.

Right now this size is over-estimated because the diagonal terms of all operators only contribute 1 connected element (since they don't flip any spin), not `n_operators`.
I think originally this was not how it was implemented, but at some point I made it so that all diagonal contributions are stored in the same connected element but evidently forgot to update this `max_conn_size` accordingly.

(Tests already check that this value is correct, so if tests pass, it's good)