### PR TITLE
Implement split-Rhat diagnostic to detect non-stationary MCMC chains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Breaking Changes
 * The gradient for models with real-parameter is now multiplied by 2. If your model had real parameters you might need to change the learning rate and halve it. Conceptually this is a bug-fix, as the value returned before was wrong (see Bug Fixes section below for additional details) [#1069](https://github.com/netket/netket/pull/1069)
+* In the statistics returned by `netket.stats.statistics`, the `.R_hat` diagnostic has been updated to be able to detect non-stationary chains via the split-Rhat diagnostic (see, e.g., Gelman et al., [Bayesian Data Analysis](http://www.stat.columbia.edu/~gelman/book/), 3rd edition). This changes (generally increases) the numerical values of `R_hat` for existing simulations, but should strictly improve its capabilities to detect MCMC convergence failure. [#1138](https://github.com/netket/netket/pull/1138)
 
 ### Internal Changes
 

--- a/docs/api/api.md
+++ b/docs/api/api.md
@@ -21,6 +21,7 @@ hilbert
 operator
 exact
 sampler
+stats
 models
 nn
 jax

--- a/docs/api/stats.md
+++ b/docs/api/stats.md
@@ -1,0 +1,18 @@
+(netket_stats_api)=
+# netket.stats
+
+```{eval-rst}
+.. currentmodule:: netket.stats
+
+```
+## Stats
+
+MPI-compatible Monte Carlo statistics functions.
+
+```{eval-rst}
+.. autosummary::
+   :toctree: _generated/stats
+   :nosignatures:
+
+   statistics
+```

--- a/netket/stats/mc_stats.py
+++ b/netket/stats/mc_stats.py
@@ -133,18 +133,28 @@ def statistics(data, batch_size=32):
 
     Args:
         data (vector or matrix): The input data. It can be real or complex valued.
-                                * if a vector, it is assumed that this is a time
-                                  series of data (not necessarily independent).
-                                * if a matrix, it is assumed that that rows data[i]
-                                  contain independent time series.
+            * if a vector, it is assumed that this is a time series of data (not necessarily independent);
+            * if a matrix, it is assumed that that rows :code:`data[i]` contain independent time series.
 
     Returns:
-       Stats: A dictionary-compatible class containing the average (mean),
-             the variance (variance),
-             the error of the mean (error_of_mean), and an estimate of the
-             autocorrelation time (tau_corr). In addition to accessing the elements with the standard
-             dict sintax (e.g. res['mean']), one can also access them directly with the dot operator
-             (e.g. res.mean).
+       Stats: A dictionary-compatible class containing the
+             average (:code:`.mean`, :code:`["Mean"]`),
+             variance (:code:`.variance`, :code:`["Variance"]`),
+             the Monte Carlo standard error of the mean (:code:`error_of_mean`, :code:`["Sigma"]`),
+             an estimate of the autocorrelation time (:code:`tau_corr`, :code:`["TauCorr"]`), and the
+             Gelman-Rubin split-Rhat diagnostic (:code:`.R_hat`, :code:`["R_hat"]`).
+
+             These properties can be accessed both the attribute and the dictionary-style syntax
+             (both indicated above).
+
+             The split-Rhat diagnostic is based on comparing intra-chain and inter-chain
+             statistics of the sample and is thus only available for 2d-array inputs where
+             the rows are independently sampled MCMC chains. In an ideal MCMC samples,
+             R_hat should be 1.0. If it deviates from this value too much, this indicates
+             MCMC convergence issues. Thresholds such as R_hat > 1.1 or even R_hat > 1.01 have
+             been suggested in the literature for when to discard a sample. (See, e.g.,
+             Gelman et al., `Bayesian Data Analysis <http://www.stat.columbia.edu/~gelman/book/>`_,
+             or Vehtari et al., `arXiv:1903.08008 <https://arxiv.org/abs/1903.08008>`_.)
     """
     return _statistics(data, batch_size)
 

--- a/netket/utils/config_flags.py
+++ b/netket/utils/config_flags.py
@@ -125,3 +125,18 @@ config.define(
     ),
     runtime=False,
 )
+
+config.define(
+    "NETKET_USE_PLAIN_RHAT",
+    bool,
+    default=False,
+    help=dedent(
+        """
+        By default, NetKet uses the split-R̂ Gelman-Rubin diagnostic in `netket.stats.statistics`,
+        which detects non-stationarity in the MCMC chains (in addition to the classes of
+        chain-mixing failures detected by plain R) since version 3.4.
+        Enabling this flag restores the previous behavior of using plain (non-split) Rhat.
+        """
+    ),
+    runtime=True,
+)

--- a/test/mpi/test_stats_ops.py
+++ b/test/mpi/test_stats_ops.py
@@ -19,14 +19,14 @@ def reference_stats(data):
     M_full = M_par * M_loc
     data_ = data.reshape(M_full, N)
 
-    chain_means = np.mean(data_, axis=1)
-    chain_vars = np.var(data_, axis=1, ddof=0)
-
     mean_full = np.mean(data)
     var_full = np.var(data, ddof=0)
 
-    var_mean = np.mean(chain_vars)
-    var_between = N * np.var(chain_means, ddof=0)
+    data_split = data_.reshape(2 * M_full, N // 2)
+    split_chain_means = np.mean(data_split, axis=1)
+    split_chain_vars = np.var(data_split, axis=1, ddof=0)
+    var_mean = np.mean(split_chain_vars)
+    var_between = N * np.var(split_chain_means, ddof=0)
 
     R_hat = np.sqrt((N - 1) / N + var_between / (N * var_mean))
 

--- a/test/stats/test_stats.py
+++ b/test/stats/test_stats.py
@@ -82,13 +82,8 @@ def _test_stats_mean_std(hi, ham, ma, n_chains):
 
     assert stats.mean == pytest.approx(np.mean(eloc))
     if n_chains > 1:
-
         # variance == average sample variance over chains
         assert stats.variance == pytest.approx(np.var(eloc))
-        # R estimate
-        B_over_n = stats.error_of_mean**2
-        W = stats.variance
-        assert stats.R_hat == pytest.approx(np.sqrt(1.0 + B_over_n / W), abs=1e-3)
 
 
 @common.skipif_mpi
@@ -194,6 +189,7 @@ def test_decimal_format():
     assert str(Stats(1.0, 0.12, 0.5, R_hat=1.01)) == "1.00 ± 0.12 [σ²=0.50, R̂=1.0100]"
 
 
+@common.skipif_mpi
 def test_R_hat():
     # detect disagreeing chains
     x = np.array(

--- a/test/stats/test_stats.py
+++ b/test/stats/test_stats.py
@@ -192,3 +192,36 @@ def test_decimal_format():
 
     assert str(Stats(1.0, 0.12, 0.5)) == "1.00 ± 0.12 [σ²=0.50]"
     assert str(Stats(1.0, 0.12, 0.5, R_hat=1.01)) == "1.00 ± 0.12 [σ²=0.50, R̂=1.0100]"
+
+
+def test_R_hat():
+    # detect disagreeing chains
+    x = np.array(
+        [
+            [1.0, 1.0, 1.0],
+            [1.1, 1.1, 1.1],
+        ]
+    )
+    assert statistics(x).R_hat > 1.01
+
+    # detect non-stationary chains
+    x = np.array(
+        [
+            [1.0, 1.5, 2.0],
+            [2.0, 1.5, 1.0],
+        ]
+    )
+    assert statistics(x).R_hat > 1.01
+
+    # detect "stuck" chains
+    x = np.array(
+        [
+            np.random.normal(size=1000),
+            np.random.normal(size=1000),
+        ]
+    )
+    # not stuck -> good R_hat:
+    assert statistics(x).R_hat <= 1.01
+    # stuck -> bad  R_hat:
+    x[1, 100:] = 1.0
+    assert statistics(x).R_hat > 1.01


### PR DESCRIPTION
This PR introduces a flag to compute the split-R_hat diagnostic instead of the plain R_hat currently used. Split-R_hat is able to additionally detect non-stationarity within single chains.

See, e.g., [Vehtari et al. (arXiv:1903.08008)](https://arxiv.org/abs/1903.08008) for a modern discussion of this diagnostic (that paper points out some failure types that split-Rhat does not cover either and proposes an improved version, but let's do one step at a time here).

Here is a very simple example featuring two (identical) linearly increasing and thus non-stationary chains:
```python
# stats_example.py
import netket as nk
import numpy as np

r = np.arange(100, dtype=float)
x = np.array([r, r])
print(nk.stats.statistics(x))
```
which gives these results (split-Rhat is currently enabled by the `NETKET_USE_SPLIT_RHAT` flag in this PR):
```bash
$ python3 stats_example.py
49.5 ± 3.5 [σ²=833.2, R̂=0.9950]
$ NETKET_USE_SPLIT_RHAT=1 python3 stats_example.py
49.5 ± 3.5 [σ²=833.2, R̂=1.3191]
```
The non-split Rhat is happy (with `R^ ≈ 1.0`) because the chains do have identical mean and variance, whereas the split-chain version correctly identifies the failed MC convergence (`R^ >> 1.01`).

There are some open questions regarding this PR:

- Should split-Rhat be enabled by default? It makes Rhat strictly more useful, I would say, but this change will alter the vaules of Rhat for basically any VMC run then.
- If we decide it should be enabled by default, do we need the flag to optionally restore the old behavior?
- Do we care about the overhead of one more MPI call? (Its probably not a performance issue, but I haven't done any benchmarking yet.)
- In cases where there is an odd number of samples per chain, I discard one sample per chain to get an even split (which makes the code much simpler). I think this is fine, unless in pathological cases where there are _very_ few samples per chain (in which case the stationarity of the chains isn't a sensible property anyways).