### PR TITLE
Fix tevo with real parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,16 @@
 
 ### Breaking Changes
 
+
+## NetKet 3.4.1 (BugFixes & DepWarns)
+
 ### Internal Changes
+* Several deprecation warnings related to `jax.tree_util.tree_multimap` being deprecated have been resolved by changing those calls to `jax.tree_util.tree_map`. Jax should feel more tranquillo now. [#1156](https://github.com/netket/netket/pull/1156)
 
 ### Bug Fixes
+* `TDVP` now supports model with real parameters such as `RBMModPhase`. [#1139](https://github.com/netket/netket/pull/1139)
+* An error is now raised when user attempts to construct a `LocalOperator` with a matrix of the wrong size (bug [#1157](https://github.com/netket/netket/pull/1157). [#1158](https://github.com/netket/netket/pull/1158)
+* A bug where `QGTJacobian` could not be used with models in single precision has been addressed (bug [#1153](https://github.com/netket/netket/pull/1153). [#1155](https://github.com/netket/netket/pull/1155)
 
 
 ## NetKet 3.4 (Special 🧱 edition)

--- a/netket/experimental/driver/tdvp.py
+++ b/netket/experimental/driver/tdvp.py
@@ -514,6 +514,14 @@ def odefun(state: MCState, driver: TDVP, t, w, *, stage=0):  # noqa: F811
 
     initial_dw = None if driver.linear_solver_restart else driver._dw
     driver._dw, _ = qgt.solve(driver.linear_solver, driver._loss_grad, x0=initial_dw)
+
+    # If parameters are real, then take only real part of the gradient (if it's complex)
+    driver._dw = jax.tree_multimap(
+        lambda x, target: (x if jnp.iscomplexobj(target) else x.real),
+        driver._dw,
+        state.parameters,
+    )
+
     return driver._dw
 
 

--- a/test/dynamics/test_driver.py
+++ b/test/dynamics/test_driver.py
@@ -26,14 +26,16 @@ import netket.experimental as nkx
 SEED = 214748364
 
 
-def _setup_system(L, *, dtype=np.complex128):
+def _setup_system(L, *, model=None, dtype=np.complex128):
     g = nk.graph.Chain(length=L)
     hi = nk.hilbert.Spin(s=0.5, N=g.n_nodes)
 
-    ma = nk.models.RBM(alpha=1, dtype=dtype)
+    if model is None:
+        model = nk.models.RBM(alpha=1, dtype=dtype)
+
     sa = nk.sampler.ExactSampler(hilbert=hi)
 
-    vs = nk.vqs.MCState(sa, ma, n_samples=1000, seed=SEED)
+    vs = nk.vqs.MCState(sa, model, n_samples=1000, seed=SEED)
 
     ha = nk.operator.Ising(hi, graph=g, h=1.0)
 
@@ -68,11 +70,16 @@ adaptive_step_integrators = [
 ]
 all_integrators = fixed_step_integrators + adaptive_step_integrators
 
+nqs_models = [
+    pytest.param(nk.models.RBM(alpha=1, dtype=np.complex128), id="RBM(complex128)"),
+    pytest.param(nk.models.RBMModPhase(alpha=1, dtype=np.float64), id="RBMModPhase(float64)"),
+]
 
+@pytest.mark.parametrize("model", nqs_models)
 @pytest.mark.parametrize("integrator", fixed_step_integrators)
 @pytest.mark.parametrize("propagation_type", ["real", "imag"])
-def test_one_fixed_step(integrator, propagation_type):
-    ha, vstate, _ = _setup_system(L=2)
+def test_one_fixed_step(model, integrator, propagation_type):
+    ha, vstate, _ = _setup_system(L=2, model=model)
     te = nkx.TDVP(
         ha,
         vstate,

--- a/test/dynamics/test_driver.py
+++ b/test/dynamics/test_driver.py
@@ -72,8 +72,11 @@ all_integrators = fixed_step_integrators + adaptive_step_integrators
 
 nqs_models = [
     pytest.param(nk.models.RBM(alpha=1, dtype=np.complex128), id="RBM(complex128)"),
-    pytest.param(nk.models.RBMModPhase(alpha=1, dtype=np.float64), id="RBMModPhase(float64)"),
+    pytest.param(
+        nk.models.RBMModPhase(alpha=1, dtype=np.float64), id="RBMModPhase(float64)"
+    ),
 ]
+
 
 @pytest.mark.parametrize("model", nqs_models)
 @pytest.mark.parametrize("integrator", fixed_step_integrators)


### PR DESCRIPTION
If you run `Examples/Dyanamics/Ising1d.py` with `RBMModPhase` Ansatz which has real parameters but complex output, TDVP breaks down because the gradient is complex but we need to take the real part.

I don't have the time, but if somebody could take this and add a test would be great.

cc @femtobit 