### PR TITLE
fixes for jax 0.3.3

### DIFF
--- a/netket/hilbert/random/tensor_hilbert.py
+++ b/netket/hilbert/random/tensor_hilbert.py
@@ -41,7 +41,9 @@ def _make_subfun(hilb, i, sub_hi):
         new_sub_state, old_val = flip_state_scalar(
             sub_hi, key, sub_state, index - hilb._cum_indices[i]
         )
-        new_state = state.at[hilb._cum_indices[i] : hilb._cum_sizes[i]].set(new_sub_state)
+        new_state = state.at[hilb._cum_indices[i] : hilb._cum_sizes[i]].set(
+            new_sub_state
+        )
         return new_state, old_val
 
     return subfun

--- a/netket/hilbert/random/tensor_hilbert.py
+++ b/netket/hilbert/random/tensor_hilbert.py
@@ -41,8 +41,7 @@ def _make_subfun(hilb, i, sub_hi):
         new_sub_state, old_val = flip_state_scalar(
             sub_hi, key, sub_state, index - hilb._cum_indices[i]
         )
-        idx = jax.ops.index[hilb._cum_indices[i] : hilb._cum_sizes[i]]
-        new_state = state.at[idx].set(new_sub_state)
+        new_state = state.at[hilb._cum_indices[i] : hilb._cum_sizes[i]].set(new_sub_state)
         return new_state, old_val
 
     return subfun

--- a/netket/nn/utils.py
+++ b/netket/nn/utils.py
@@ -78,7 +78,7 @@ def _to_array_rank(apply_fun, variables, σ_rank, n_states, normalize, allgather
 
     # last rank, get rid of fake elements
     if mpi.rank == mpi.n_nodes - 1 and n_fake_states > 0:
-        log_psi_local = log_psi_local.at[jax.ops.index[-n_fake_states:]].set(-jnp.inf)
+        log_psi_local = log_psi_local.at[-n_fake_states:].set(-jnp.inf)
 
     if normalize:
         # subtract logmax for better numerical stability


### PR DESCRIPTION
The latest jax released earlier today/yesterday broke some small things because it removed `jax.ops.index`.