### PR TITLE
Preconditioner schedules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 ### Breaking Changes
 * The gradient for models with real-parameter is now multiplied by 2. If your model had real parameters you might need to change the learning rate and halve it. Conceptually this is a bug-fix, as the value returned before was wrong (see Bug Fixes section below for additional details) [#1069](https://github.com/netket/netket/pull/1069)
 * In the statistics returned by `netket.stats.statistics`, the `.R_hat` diagnostic has been updated to be able to detect non-stationary chains via the split-Rhat diagnostic (see, e.g., Gelman et al., [Bayesian Data Analysis](http://www.stat.columbia.edu/~gelman/book/), 3rd edition). This changes (generally increases) the numerical values of `R_hat` for existing simulations, but should strictly improve its capabilities to detect MCMC convergence failure. [#1138](https://github.com/netket/netket/pull/1138)
-* Support for preconditioners that do not accept a `step_value` kwarg is deprecated. If you do not need this functionality in your custom preconditioner, add a dummy argument `step_value=None` to its calling sequence. [#1142](https://github.com/netket/netket/pull/1142)
+* Support for preconditioners that do not accept a `step_value` kwarg is deprecated. If you do not need this functionality in your custom preconditioner, add a dummy argument `step_value=None` to its calling sequence (adding a dummy `**kwargs` will not silence the error). [#1142](https://github.com/netket/netket/pull/1142)
 
 ### Internal Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,12 @@
 * `Lattice` supports specifying arbitrary edge content for each unit cell via the kwarg `custom_edges`. A generator for hexagonal lattices with coloured edges is implemented as `nk.graph.KitaevHoneycomb`. `nk.graph.Grid` again supports colouring edges by direction. [#1074](https://github.com/netket/netket/pull/1074)
 * Fermionic hilbert space (`nkx.hilbert.SpinOrbitalFermions`) and fermionic operators (`nkx.operator.fermion`) to treat systems with a finite number of Orbitals have been added to the experimental submodule. The operators are also integrated with [OpenFermion](https://quantumai.google/openfermion). Those functionalities are still in development and we would welcome feedback. [#1090](https://github.com/netket/netket/pull/1090)
 * It is now possible to change the integrator of a `TDVP` object without reconstructing it. [#1123](https://github.com/netket/netket/pull/1123)
+* Drivers call all preconditioners supplying an additional `step_value` argument, so parameters of custom preconditioners can be made dependent on training step etc. In particular, `nk.optimizer.SR` now accepts an optax schedule for `diag_shift`. [#1142](https://github.com/netket/netket/pull/1142)
 
 ### Breaking Changes
 * The gradient for models with real-parameter is now multiplied by 2. If your model had real parameters you might need to change the learning rate and halve it. Conceptually this is a bug-fix, as the value returned before was wrong (see Bug Fixes section below for additional details) [#1069](https://github.com/netket/netket/pull/1069)
 * In the statistics returned by `netket.stats.statistics`, the `.R_hat` diagnostic has been updated to be able to detect non-stationary chains via the split-Rhat diagnostic (see, e.g., Gelman et al., [Bayesian Data Analysis](http://www.stat.columbia.edu/~gelman/book/), 3rd edition). This changes (generally increases) the numerical values of `R_hat` for existing simulations, but should strictly improve its capabilities to detect MCMC convergence failure. [#1138](https://github.com/netket/netket/pull/1138)
+* Support for preconditioners that do not accept a `step_value` kwarg is deprecated. If you do not need this functionality in your custom preconditioner, add a dummy argument `step_value=None` to its calling sequence. [#1142](https://github.com/netket/netket/pull/1142)
 
 ### Internal Changes
 
@@ -25,7 +27,8 @@
 * Fixed bug that prevented calling `.quantum_geometric_tensor` on `netket.vqs.ExactState`. [#1108](https://github.com/netket/netket/pull/1108)
 * Fixed bug where the gradient of `C->C` models (complex parameters, complex output) was computed incorrectly with `nk.vqs.ExactState`. [#1110](https://github.com/netket/netket/pull/1110)
 * Fixed bug where `QGTJacobianDense.state` and `QGTJacobianPyTree.state` would not correctly transform the starting point `x0` if `holomorphic=False`. [#1115](https://github.com/netket/netket/pull/1115)
-* The gradient of the expectation value obtained with `VarState.expect_and_grad` for `SquaredOperator`s was off by a factor of 2 in some cases, and wrong in others. This has now been fixed. [#1065](https://github.com/netket/netket/pull/1065).
+* The gradient of the expectation value obtained with `VarState.expect_and_grad` for `SquaredOperator`s was off by a factor of 2 in some cases, and wrong in others. This has now been fixed. [#1065](https://github.com/netket/netket/pull/1065)
+* Real-parameter `GCNN` returned NaNs when used with real-valued characters, some of which is negative, as `logsumexp` uses real logarithms even if the result is negative. This is fixed by defining `nk.jax.logsumexp_cplx` that always returns a complex number and using it by default in `GCNN`. The old behaviour can be recovered using `complex_output=False`. [#1134](https://github.com/netket/netket/pull/1134)
 
 ## NetKet 3.3.2 (🐛 Bug Fixes)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,22 @@
 
 # Change Log
 
-## NetKet 3.4 (⚙️ In development)
+## NetKet 3.5 (⚙️ In development)
 
-[GitHub commits](https://github.com/netket/netket/compare/v3.3...master).
+[GitHub commits](https://github.com/netket/netket/compare/v3.4...master).
+
+### New features
+
+### Breaking Changes
+
+### Internal Changes
+
+### Bug Fixes
+
+
+## NetKet 3.4 (Special 🧱 edition)
+
+[GitHub commits](https://github.com/netket/netket/compare/v3.3...v3.4).
 
 ### New features
 * `Lattice` supports specifying arbitrary edge content for each unit cell via the kwarg `custom_edges`. A generator for hexagonal lattices with coloured edges is implemented as `nk.graph.KitaevHoneycomb`. `nk.graph.Grid` again supports colouring edges by direction. [#1074](https://github.com/netket/netket/pull/1074)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Anaconda-Server Badge](https://anaconda.org/conda-forge/netket/badges/version.svg)](https://anaconda.org/conda-forge/netket)
 [![Paper (v3)](https://img.shields.io/badge/paper%20%28v3%29-arXiv%3A2112.10526-B31B1B)](https://arxiv.org/abs/2112.10526)
 [![codecov](https://codecov.io/gh/netket/netket/branch/master/graph/badge.svg?token=gzcOlpO5lB)](https://codecov.io/gh/netket/netket)
-[![Slack](https://img.shields.io/badge/slack-chat-green.svg)](https://join.slack.com/t/mlquantum/shared_invite/zt-13nohbtt3-nWgz~faxWXjVnu0BCHWM7w) 
+[![Slack](https://img.shields.io/badge/slack-chat-green.svg)](https://join.slack.com/t/mlquantum/shared_invite/zt-16r1nfgoy-VkSghuNL1Co0mu3iYwOhuA) 
 
 NetKet is an open-source project delivering cutting-edge methods for the study
 of many-body quantum systems with artificial neural networks and machine learning techniques.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -156,7 +156,7 @@ html_context = {
         ),
         (
             '<i class="fab fa-slack" aria-hidden="true"></i>',
-            "https://join.slack.com/t/mlquantum/shared_invite/zt-13nohbtt3-nWgz~faxWXjVnu0BCHWM7w",
+            "https://join.slack.com/t/mlquantum/shared_invite/zt-16r1nfgoy-VkSghuNL1Co0mu3iYwOhuA",
             True,
         ),
     ],

--- a/netket/driver/steady_state.py
+++ b/netket/driver/steady_state.py
@@ -23,7 +23,7 @@ from netket.optimizer import (
     PreconditionerT,
 )
 
-from .vmc_common import info
+from .vmc_common import info, apply_preconditioner
 from .abstract_variational_driver import AbstractVariationalDriver
 
 
@@ -121,15 +121,7 @@ class SteadyState(AbstractVariationalDriver):
 
         # if it's the identity it does
         # self._dp = self._loss_grad
-        try:
-            self._dp = self.preconditioner(
-                self.state, self._loss_grad, step_value=self.step_count
-            )
-        except TypeError:
-            warn_deprecation(
-                "Preconditioners should accept an optional `step_value` argument."
-            )
-            self._dp = self.preconditioner(self.state, self._loss_grad)
+        apply_preconditioner(self)
 
         # If parameters are real, then take only real part of the gradient (if it's complex)
         self._dp = jax.tree_multimap(

--- a/netket/driver/steady_state.py
+++ b/netket/driver/steady_state.py
@@ -121,7 +121,9 @@ class SteadyState(AbstractVariationalDriver):
 
         # if it's the identity it does
         # self._dp = self._loss_grad
-        self._dp = self.preconditioner(self.state, self._loss_grad)
+        self._dp = self.preconditioner(
+            self.state, self._loss_grad, step_value=self.step_count
+        )
 
         # If parameters are real, then take only real part of the gradient (if it's complex)
         self._dp = jax.tree_multimap(

--- a/netket/driver/steady_state.py
+++ b/netket/driver/steady_state.py
@@ -121,9 +121,15 @@ class SteadyState(AbstractVariationalDriver):
 
         # if it's the identity it does
         # self._dp = self._loss_grad
-        self._dp = self.preconditioner(
-            self.state, self._loss_grad, step_value=self.step_count
-        )
+        try:
+            self._dp = self.preconditioner(
+                self.state, self._loss_grad, step_value=self.step_count
+            )
+        except TypeError:
+            warn_deprecation(
+                "Preconditioners should accept an optional `step_value` argument."
+            )
+            self._dp = self.preconditioner(self.state, self._loss_grad)
 
         # If parameters are real, then take only real part of the gradient (if it's complex)
         self._dp = jax.tree_multimap(

--- a/netket/driver/steady_state.py
+++ b/netket/driver/steady_state.py
@@ -23,7 +23,7 @@ from netket.optimizer import (
     PreconditionerT,
 )
 
-from .vmc_common import info, apply_preconditioner
+from .vmc_common import info, ensure_step_value
 from .abstract_variational_driver import AbstractVariationalDriver
 
 
@@ -100,7 +100,7 @@ class SteadyState(AbstractVariationalDriver):
         self._lind = lindbladian
         self._ldag_l = Squared(lindbladian)
 
-        self.preconditioner = preconditioner
+        self.preconditioner = ensure_step_value(preconditioner)
 
         self._dp = None
         self._S = None
@@ -121,7 +121,9 @@ class SteadyState(AbstractVariationalDriver):
 
         # if it's the identity it does
         # self._dp = self._loss_grad
-        apply_preconditioner(self)
+        self._dp = self.preconditioner(
+            self.state, self._loss_grad, step_value=self.step_count
+        )
 
         # If parameters are real, then take only real part of the gradient (if it's complex)
         self._dp = jax.tree_multimap(

--- a/netket/driver/vmc.py
+++ b/netket/driver/vmc.py
@@ -133,9 +133,15 @@ class VMC(AbstractVariationalDriver):
 
         # if it's the identity it does
         # self._dp = self._loss_grad
-        self._dp = self.preconditioner(
-            self.state, self._loss_grad, step_value=self.step_count
-        )
+        try:
+            self._dp = self.preconditioner(
+                self.state, self._loss_grad, step_value=self.step_count
+            )
+        except TypeError:
+            warn_deprecation(
+                "Preconditioners should accept an optional `step_value` argument."
+            )
+            self._dp = self.preconditioner(self.state, self._loss_grad)
 
         # If parameters are real, then take only real part of the gradient (if it's complex)
         self._dp = jax.tree_multimap(

--- a/netket/driver/vmc.py
+++ b/netket/driver/vmc.py
@@ -28,7 +28,7 @@ from netket.optimizer import (
 from netket.utils import warn_deprecation
 
 
-from .vmc_common import info, apply_preconditioner
+from .vmc_common import info, ensure_step_value
 from .abstract_variational_driver import AbstractVariationalDriver
 
 
@@ -112,7 +112,7 @@ class VMC(AbstractVariationalDriver):
 
         self._ham = hamiltonian.collect()  # type: AbstractOperator
 
-        self.preconditioner = preconditioner
+        self.preconditioner = ensure_step_value(preconditioner)
 
         self._dp = None  # type: PyTree
         self._S = None
@@ -133,7 +133,9 @@ class VMC(AbstractVariationalDriver):
 
         # if it's the identity it does
         # self._dp = self._loss_grad
-        apply_preconditioner(self)
+        self._dp = self.preconditioner(
+            self.state, self._loss_grad, step_value=self.step_count
+        )
 
         # If parameters are real, then take only real part of the gradient (if it's complex)
         self._dp = jax.tree_multimap(

--- a/netket/driver/vmc.py
+++ b/netket/driver/vmc.py
@@ -28,7 +28,7 @@ from netket.optimizer import (
 from netket.utils import warn_deprecation
 
 
-from .vmc_common import info
+from .vmc_common import info, apply_preconditioner
 from .abstract_variational_driver import AbstractVariationalDriver
 
 
@@ -133,15 +133,7 @@ class VMC(AbstractVariationalDriver):
 
         # if it's the identity it does
         # self._dp = self._loss_grad
-        try:
-            self._dp = self.preconditioner(
-                self.state, self._loss_grad, step_value=self.step_count
-            )
-        except TypeError:
-            warn_deprecation(
-                "Preconditioners should accept an optional `step_value` argument."
-            )
-            self._dp = self.preconditioner(self.state, self._loss_grad)
+        apply_preconditioner(self)
 
         # If parameters are real, then take only real part of the gradient (if it's complex)
         self._dp = jax.tree_multimap(

--- a/netket/driver/vmc.py
+++ b/netket/driver/vmc.py
@@ -133,7 +133,9 @@ class VMC(AbstractVariationalDriver):
 
         # if it's the identity it does
         # self._dp = self._loss_grad
-        self._dp = self.preconditioner(self.state, self._loss_grad)
+        self._dp = self.preconditioner(
+            self.state, self._loss_grad, step_value=self.step_count
+        )
 
         # If parameters are real, then take only real part of the gradient (if it's complex)
         self._dp = jax.tree_multimap(

--- a/netket/driver/vmc_common.py
+++ b/netket/driver/vmc_common.py
@@ -12,9 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from netket.utils import warn_deprecation
+
 
 def info(obj, depth=None):
     if hasattr(obj, "info") and callable(obj.info):
         return obj.info(depth)
     else:
         return str(obj)
+
+
+def apply_preconditioner(self):
+    try:
+        # Default: preconditioner accepts step_value
+        self._dp = self.preconditioner(
+            self.state, self._loss_grad, step_value=self.step_count
+        )
+    except TypeError:
+        # Not accepting step_value is deprecated but supported for now
+        warn_deprecation(
+            "Preconditioners should accept an optional `step_value` argument."
+        )
+        self._dp = self.preconditioner(self.state, self._loss_grad)

--- a/netket/optimizer/preconditioner.py
+++ b/netket/optimizer/preconditioner.py
@@ -68,7 +68,7 @@ class LinearPreconditioner:
         self.solver_restart = solver_restart
 
     def __call__(
-        self, vstate: VariationalState, gradient: PyTree, step_value: Number
+        self, vstate: VariationalState, gradient: PyTree, step_value: Number = None
     ) -> PyTree:
 
         self._lhs = self.lhs_constructor(vstate, step_value)

--- a/netket/optimizer/sr/api.py
+++ b/netket/optimizer/sr/api.py
@@ -20,6 +20,7 @@ from numbers import Number
 from netket.utils.numbers import is_scalar
 
 import jax
+from optax import constant_schedule
 
 from ..qgt import QGTAuto
 from ..preconditioner import LinearPreconditioner
@@ -178,7 +179,7 @@ def _SR(
         qgt = QGTAuto(solver)
 
     if isinstance(diag_shift, Number):
-        diag_shift = lambda _: diag_shift
+        diag_shift = constant_schedule(diag_shift)
 
     return SR(
         lambda vstate, step_value: qgt(

--- a/netket/optimizer/sr/api.py
+++ b/netket/optimizer/sr/api.py
@@ -18,6 +18,7 @@ from typing import Union, Callable
 from numbers import Number
 
 from netket.utils.numbers import is_scalar
+from netket.utils.types import PyTree
 
 import jax
 

--- a/test/driver/test_steadystate.py
+++ b/test/driver/test_steadystate.py
@@ -80,11 +80,11 @@ def test_estimate():
 
 
 def test_no_step_value():
-    lind, _, driver = _setup_ss(sr="no_step_value")
+    with pytest.warns(FutureWarning):
+        lind, _, driver = _setup_ss(sr="no_step_value")
 
     driver.estimate(lind.H @ lind)
-    with pytest.warns(FutureWarning):
-        driver.advance(1)
+    driver.advance(1)
     driver.estimate(lind.H @ lind)
 
 

--- a/test/optimizer/test_sr_api.py
+++ b/test/optimizer/test_sr_api.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import pytest
+from typing import Callable
 
 import netket as nk
 
@@ -37,3 +38,36 @@ def test_deprecated_sr():
 
     with pytest.warns(FutureWarning):
         nk.optimizer.sr.SRLazyGMRES()
+
+
+@pytest.mark.parametrize(
+    "diag_shift", [0.01, lambda _: 0.01, lambda x: 1 / x, "pytree"]
+)
+def test_diag_shift_schedule(diag_shift):
+    # construct a vstate
+    N = 5
+    hi = nk.hilbert.Spin(1 / 2, N)
+    vstate = nk.vqs.MCState(
+        nk.sampler.MetropolisLocal(hi),
+        nk.models.RBM(alpha=1),
+    )
+    vstate.init_parameters()
+    vstate.sample()
+
+    if isinstance(diag_shift, str):
+        sr = nk.optimizer.SR(diag_shift=vstate.parameters)
+        expected_diag_shift = lambda _: vstate.parameters
+    else:
+        sr = nk.optimizer.SR(diag_shift=diag_shift)
+        if isinstance(diag_shift, Callable):
+            expected_diag_shift = diag_shift
+        else:
+            expected_diag_shift = lambda _: diag_shift
+
+    for step_value in [10, 20.0]:
+        # ensure that this call is valid
+        grad = sr(vstate, vstate.parameters, step_value=step_value)
+
+        # check that the diag_shift passed to the QGT is correct
+        qgt = sr.lhs_constructor(vstate, step_value)
+        assert qgt.diag_shift == expected_diag_shift(step_value)


### PR DESCRIPTION
This PR implements the functionality discussed in #1077.
* `PreconditionerT = Callable[[VariationalState, PyTree, Number], PyTree]`, where the `Number` is a kwarg for `step_value` 
* `LHSConstructorT = Callable[[VariationalState, Number], LinearOperator]` ditto
* drivers pass `step_value` into the preconditioner, which is a breaking change for user-defined preconditioners, albeit one that is trivial to fix by adding a `step_value` kwarg doing nothing
* ~`SR` is changed to handle `diag_shift` schedules~ the `lhs_constructor` field of `SR` is changed to handle `step_value` through a simple lambda-expression (and internally convert a constant `diag_shift` into a schedule as well)

Pending issues:
* changing the t-VMC code to work with the new preconditioners (@femtobit I'll need some help around that interface)
* tests (what tests do we need?)