### PR TITLE
Add FFT-based computation of the autocorrelation time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * New method {meth}`~nk.utils.group.Permutation.apply_to_id` can be used to apply a permutation (or a permutation group) to one or more lattice indices. [#1293](https://github.com/netket/netket/issues/1293)
 * It is now possible to disable MPI by setting the environment variable `NETKET_MPI`. This is useful in cases where mpi4py crashes upon load [#1254](https://github.com/netket/netket/issues/1254).
 * The new function {func}`nk.nn.binary_encoding` can be used to encode a set of samples according to the binary shape defined by an Hilbert space. It should be used similarly to {func}`flax.linen.one_hot` and works with non homogeneous Hilbert spaces [#1209](https://github.com/netket/netket/issues/1209).
+* A new technique to estimate the correlation time in markov-chains, based on the full FFT transform of the input data, has been added to the {func}`nk.stats.statistics` function. This new technique is not used by default, but can be turned on by setting the `NETKET_EXPERIMENTAL_FFT_AUTOCORRELATION` environment variable to 1. In the future we might turn this on by default [#1150](https://github.com/netket/netket/issues/1150).
 
 ### Dependencies
 * NetKet now requires at least Flax v0.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 * New method {meth}`~nk.utils.group.Permutation.apply_to_id` can be used to apply a permutation (or a permutation group) to one or more lattice indices. [#1293](https://github.com/netket/netket/issues/1293)
 * It is now possible to disable MPI by setting the environment variable `NETKET_MPI`. This is useful in cases where mpi4py crashes upon load [#1254](https://github.com/netket/netket/issues/1254).
 * The new function {func}`nk.nn.binary_encoding` can be used to encode a set of samples according to the binary shape defined by an Hilbert space. It should be used similarly to {func}`flax.linen.one_hot` and works with non homogeneous Hilbert spaces [#1209](https://github.com/netket/netket/issues/1209).
-* A new technique to estimate the correlation time in markov-chains, based on the full FFT transform of the input data, has been added to the {func}`nk.stats.statistics` function. This new technique is not used by default, but can be turned on by setting the `NETKET_EXPERIMENTAL_FFT_AUTOCORRELATION` environment variable to 1. In the future we might turn this on by default [#1150](https://github.com/netket/netket/issues/1150).
+* A new method to estimate the correlation time in Markov chain Monte Carlo (MCMC) sampling has been added to the {func}`nk.stats.statistics` function, which uses the full FFT transform of the input data. The new method is not enabled by default, but can be turned on by setting the `NETKET_EXPERIMENTAL_FFT_AUTOCORRELATION` environment variable to `1`. In the future we might turn this on by default [#1150](https://github.com/netket/netket/issues/1150).
 
 ### Dependencies
 * NetKet now requires at least Flax v0.5

--- a/netket/stats/_autocorr.py
+++ b/netket/stats/_autocorr.py
@@ -64,7 +64,7 @@ def auto_window(taus, c):
 def integrated_time(x, c=5):
     """Estimate the integrated autocorrelation time of a time series.
     This estimate uses the iterative procedure described on page 16 of
-    `Sokal's notes <https://www.semanticscholar.org/paper/Monte-Carlo-Methods-in-Statistical-Mechanics%3A-and-Sokal/0bfe9e3db30605fe2d4d26e1a288a5e2997e7225>`_ 
+    `Sokal's notes <https://www.semanticscholar.org/paper/Monte-Carlo-Methods-in-Statistical-Mechanics%3A-and-Sokal/0bfe9e3db30605fe2d4d26e1a288a5e2997e7225>`_
     to determine a reasonable window size.
     Args:
         x: The time series.

--- a/netket/stats/_autocorr.py
+++ b/netket/stats/_autocorr.py
@@ -1,0 +1,83 @@
+"""
+This code has been taken and modified from emcee (https://github.com/dfm/emcee/),
+version 3.1.1.
+
+The original copyright notice is reproduced below:
+
+    Copyright (c) 2010-2021 Daniel Foreman-Mackey & contributors.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+"""
+
+import jax.numpy as jnp
+from jax import lax
+
+
+def next_pow_two(n):
+    """Returns the next power of two greater than or equal to `n`"""
+    i = 1
+    while i < n:
+        i = i << 1
+    return i
+
+
+def autocorr_1d(x):
+    """Estimate the normalized autocorrelation function of a 1-D series
+    Args:
+        x: The series as a 1-D numpy array.
+    Returns:
+        array: The autocorrelation function of the time series.
+    """
+    x = jnp.atleast_1d(x)
+    if len(x.shape) != 1:
+        raise ValueError("invalid dimensions for 1D autocorrelation function")
+    n = next_pow_two(len(x))
+
+    # Compute the FFT and then (from that) the auto-correlation function
+    f = jnp.fft.fft(x - jnp.mean(x), n=2 * n)
+    acf = jnp.fft.ifft(f * jnp.conjugate(f))[: len(x)].real
+    acf /= acf[0]
+    return acf
+
+
+def auto_window(taus, c):
+    m = jnp.arange(len(taus)) < c * taus
+    return lax.cond(jnp.any(m), lambda: jnp.argmin(m), lambda: len(taus) - 1)
+
+
+def integrated_time(x, c=5):
+    """Estimate the integrated autocorrelation time of a time series.
+    This estimate uses the iterative procedure described on page 16 of
+    `Sokal's notes <https://www.semanticscholar.org/paper/Monte-Carlo-Methods-in-Statistical-Mechanics%3A-and-Sokal/0bfe9e3db30605fe2d4d26e1a288a5e2997e7225>`_ 
+    to determine a reasonable window size.
+    Args:
+        x: The time series.
+        c (Optional[float]): The step size for the window search. (default:
+            ``5``)
+    Returns:
+        float or array: An estimate of the integrated autocorrelation time of
+            the time series ``x``.
+    """
+    if x.ndim != 1:
+        raise ValueError("invalid shape")
+
+    f = autocorr_1d(x)
+    taus = 2.0 * jnp.cumsum(f) - 1.0
+    window = auto_window(taus, c)
+    return taus[window]

--- a/netket/stats/mc_stats.py
+++ b/netket/stats/mc_stats.py
@@ -84,7 +84,8 @@ class Stats:
             ext = ", R̂={:.4f}".format(self.R_hat)
         else:
             ext = ""
-        ext += ", τ={:.1f}<{:.1f}".format(self.tau_corr, self.tau_corr_max)
+        if not (math.isnan(self.tau_corr) and math.isnan(self.tau_corr_max)):
+            ext += ", τ={:.1f}<{:.1f}".format(self.tau_corr, self.tau_corr_max)
         return "{} ± {} [σ²={}{}]".format(mean, err, var, ext)
 
     # Alias accessors

--- a/netket/stats/mc_stats.py
+++ b/netket/stats/mc_stats.py
@@ -64,7 +64,7 @@ class Stats:
     variance: float = _NaN
     """Estimation of the variance of the data."""
     tau_corr: float = _NaN
-    """Estimate of the correlation time (in adimensional units relating to `steps`).
+    """Estimate of the autocorrelation time (in dimensionless units of number of steps).
 
     This value is estimated with a blocking algorithm by default, but the result is known
     to be unreliable. A more precise estimator based on the FFT transform can be used by
@@ -87,10 +87,10 @@ class Stats:
     """
     tau_corr_max: float = _NaN
     """
-    Estimation of the maximum correlation time among all markov chains.
+    Estimate of the maximum autocorrelation time among all Markov chains.
 
     This value is only computed if the environment variable
-    `NETKET_EXPERIMENTAL_FFT_AUTOCORRELATION` is `True`.
+    `NETKET_EXPERIMENTAL_FFT_AUTOCORRELATION` is set.
     """
 
     def to_dict(self):
@@ -113,12 +113,9 @@ class Stats:
             ext = ", R̂={:.4f}".format(self.R_hat)
         else:
             ext = ""
-        if not config.FLAGS["NETKET_EXPERIMENTAL_FFT_AUTOCORRELATION"]:
-            if not math.isnan(self.tau_corr):
-                ext += ", τ={:.1f}".format(self.tau_corr)
-        elif not (math.isnan(self.tau_corr) and math.isnan(self.tau_corr_max)):
-            ext += ", τ={:.1f}<{:.1f}".format(self.tau_corr, self.tau_corr_max)
-
+        if config.FLAGS["NETKET_EXPERIMENTAL_FFT_AUTOCORRELATION"]:
+            if not (math.isnan(self.tau_corr) and math.isnan(self.tau_corr_max)):
+                ext += ", τ={:.1f}<{:.1f}".format(self.tau_corr, self.tau_corr_max)
         return "{} ± {} [σ²={}{}]".format(mean, err, var, ext)
 
     # Alias accessors

--- a/netket/stats/mc_stats.py
+++ b/netket/stats/mc_stats.py
@@ -13,23 +13,18 @@
 # limitations under the License.
 
 import math
-
 from typing import Union
 
-from functools import partial
-
-from flax import struct
 import jax
+import numpy as np
 from jax import numpy as jnp
 
-import numpy as np
-
-from netket import jax as nkjax
-from netket.utils import config
+from netket.utils import config, mpi, struct
 
 from . import mean as _mean
 from . import var as _var
 from . import total_size as _total_size
+from ._autocorr import integrated_time
 
 
 def _format_decimal(value, std, var):
@@ -60,6 +55,7 @@ class Stats:
     error_of_mean: float = _NaN
     variance: float = _NaN
     tau_corr: float = _NaN
+    tau_corr_max: float = _NaN
     R_hat: float = _NaN
 
     def to_dict(self):
@@ -69,6 +65,7 @@ class Stats:
         jsd["Sigma"] = self.error_of_mean.item()
         jsd["R_hat"] = self.R_hat.item()
         jsd["TauCorr"] = self.tau_corr.item()
+        jsd["TauCorrMax"] = self.tau_corr_max.item()
         return jsd
 
     def to_compound(self):
@@ -80,6 +77,7 @@ class Stats:
             ext = ", R̂={:.4f}".format(self.R_hat)
         else:
             ext = ""
+        ext += ", τ={:.1f}<{:.1f}".format(self.tau_corr, self.tau_corr_max)
         return "{} ± {} [σ²={}{}]".format(mean, err, var, ext)
 
     # Alias accessors
@@ -94,10 +92,18 @@ class Stats:
             return self.R_hat
         elif name in ("tau_corr", "TauCorr"):
             return self.tau_corr
+        elif name in ("tau_corr_max", "TauCorrMax"):
+            return self.tau_corr_max
         else:
             raise AttributeError(
                 "'Stats' object object has no attribute '{}'".format(name)
             )
+
+    def real(self):
+        return self.replace(mean=np.real(self.mean))
+
+    def imag(self):
+        return self.replace(mean=np.imag(self.mean))
 
 
 def _get_blocks(data, block_size):
@@ -123,8 +129,35 @@ def _batch_variance(data):
     return _var(b_means), ts
 
 
-# this is not batch_size maybe?
-def statistics(data, batch_size=32):
+def _split_R_hat(data, W):
+    N = data.shape[-1]
+    if not config.FLAGS["NETKET_USE_PLAIN_RHAT"]:
+        # compute split-chain batch variance
+        local_batch_size = data.shape[0]
+        if N % 2 == 0:
+            # split each chain in the middle,
+            # like [[1 2 3 4]] -> [[1 2][3 4]]
+            batch_var, _ = _batch_variance(
+                data.reshape(2 * local_batch_size, N // 2)
+            )
+        else:
+            # drop the last sample of each chain for an even split,
+            # like [[1 2 3 4 5]] -> [[1 2][3 4]]
+            batch_var, _ = _batch_variance(
+                data[:, :-1].reshape(2 * local_batch_size, N // 2)
+            )
+
+    # V_loc = _np.var(data, axis=-1, ddof=0)
+    # W_loc = _np.mean(V_loc)
+    # W = _mean(W_loc)
+    # # This approximation seems to hold well enough for larger n_samples
+    return jnp.sqrt((N - 1) / N + batch_var / W)
+
+
+BLOCK_SIZE = 32
+
+
+def statistics(data):
     r"""
     Returns statistics of a given array (or matrix, see below) containing a stream of data.
     This is particularly useful to analyze Markov Chain data, but it can be used
@@ -137,30 +170,31 @@ def statistics(data, batch_size=32):
             * if a matrix, it is assumed that that rows :code:`data[i]` contain independent time series.
 
     Returns:
-       Stats: A dictionary-compatible class containing the
-             average (:code:`.mean`, :code:`["Mean"]`),
-             variance (:code:`.variance`, :code:`["Variance"]`),
-             the Monte Carlo standard error of the mean (:code:`error_of_mean`, :code:`["Sigma"]`),
-             an estimate of the autocorrelation time (:code:`tau_corr`, :code:`["TauCorr"]`), and the
-             Gelman-Rubin split-Rhat diagnostic (:code:`.R_hat`, :code:`["R_hat"]`).
+       Stats:
+        A dictionary-compatible class containing the
+        average (:code:`.mean`, :code:`["Mean"]`),
+        variance (:code:`.variance`, :code:`["Variance"]`),
+        the Monte Carlo standard error of the mean (:code:`error_of_mean`, :code:`["Sigma"]`),
+        an estimate of the autocorrelation time (:code:`tau_corr`, :code:`["TauCorr"]`), and the
+        Gelman-Rubin split-Rhat diagnostic (:code:`.R_hat`, :code:`["R_hat"]`).
 
-             These properties can be accessed both the attribute and the dictionary-style syntax
-             (both indicated above).
+        These properties can be accessed both the attribute and the dictionary-style syntax
+        (both indicated above).
 
-             The split-Rhat diagnostic is based on comparing intra-chain and inter-chain
-             statistics of the sample and is thus only available for 2d-array inputs where
-             the rows are independently sampled MCMC chains. In an ideal MCMC samples,
-             R_hat should be 1.0. If it deviates from this value too much, this indicates
-             MCMC convergence issues. Thresholds such as R_hat > 1.1 or even R_hat > 1.01 have
-             been suggested in the literature for when to discard a sample. (See, e.g.,
-             Gelman et al., `Bayesian Data Analysis <http://www.stat.columbia.edu/~gelman/book/>`_,
-             or Vehtari et al., `arXiv:1903.08008 <https://arxiv.org/abs/1903.08008>`_.)
+        The split-Rhat diagnostic is based on comparing intra-chain and inter-chain
+        statistics of the sample and is thus only available for 2d-array inputs where
+        the rows are independently sampled MCMC chains. In an ideal MCMC samples,
+        R_hat should be 1.0. If it deviates from this value too much, this indicates
+        MCMC convergence issues. Thresholds such as R_hat > 1.1 or even R_hat > 1.01 have
+        been suggested in the literature for when to discard a sample. (See, e.g.,
+        Gelman et al., `Bayesian Data Analysis <http://www.stat.columbia.edu/~gelman/book/>`_,
+        or Vehtari et al., `arXiv:1903.08008 <https://arxiv.org/abs/1903.08008>`_.)
     """
-    return _statistics(data, batch_size)
+    return _statistics(data)
 
 
-@partial(jax.jit, static_argnums=1)
-def _statistics(data, batch_size):
+@jax.jit
+def _statistics(data):
     data = jnp.atleast_1d(data)
     if data.ndim == 1:
         data = data.reshape((1, -1))
@@ -171,102 +205,20 @@ def _statistics(data, batch_size):
     mean = _mean(data)
     variance = _var(data)
 
-    ts = _total_size(data)
-
-    bare_var = variance
+    taus = jax.vmap(integrated_time)(data)
+    tau_avg = mpi.mpi_mean_jax(taus)
+    tau_max = mpi.mpi_max_jax(taus)
 
     batch_var, n_batches = _batch_variance(data)
-
-    l_block = max(1, data.shape[1] // batch_size)
-
-    block_var, n_blocks = _block_variance(data, l_block)
-
-    tau_batch = ((ts / n_batches) * batch_var / bare_var - 1) * 0.5
-    tau_block = ((ts / n_blocks) * block_var / bare_var - 1) * 0.5
-
-    batch_good = (tau_batch < 6 * data.shape[1]) * (n_batches >= batch_size)
-    block_good = (tau_block < 6 * l_block) * (n_blocks >= batch_size)
-
-    stat_dtype = nkjax.dtype_real(data.dtype)
-
-    # if batch_good:
-    #    error_of_mean = jnp.sqrt(batch_var / n_batches)
-    #    tau_corr = jnp.max(0, tau_batch)
-    # elif block_good:
-    #    error_of_mean = jnp.sqrt(block_var / n_blocks)
-    #    tau_corr = jnp.max(0, tau_block)
-    # else:
-    #    error_of_mean = jnp.nan
-    #    tau_corr = jnp.nan
-    # jax style
-
-    def batch_good_err(args):
-        batch_var, tau_batch, *_ = args
-        error_of_mean = jnp.sqrt(batch_var / n_batches)
-        tau_corr = jnp.clip(tau_batch, 0)
-        return jnp.asarray(error_of_mean, dtype=stat_dtype), jnp.asarray(
-            tau_corr, dtype=stat_dtype
-        )
-
-    def block_good_err(args):
-        _, _, block_var, tau_block = args
-        error_of_mean = jnp.sqrt(block_var / n_blocks)
-        tau_corr = jnp.clip(tau_block, 0)
-        return jnp.asarray(error_of_mean, dtype=stat_dtype), jnp.asarray(
-            tau_corr, dtype=stat_dtype
-        )
-
-    def nan_err(args):
-        return jnp.asarray(jnp.nan, dtype=stat_dtype), jnp.asarray(
-            jnp.nan, dtype=stat_dtype
-        )
-
-    def batch_not_good(args):
-        batch_var, tau_batch, block_var, tau_block, block_good = args
-        return jax.lax.cond(
-            block_good,
-            block_good_err,
-            nan_err,
-            (batch_var, tau_batch, block_var, tau_block),
-        )
-
-    error_of_mean, tau_corr = jax.lax.cond(
-        batch_good,
-        batch_good_err,
-        batch_not_good,
-        (batch_var, tau_batch, block_var, tau_block, block_good),
-    )
-
     if n_batches > 1:
-        N = data.shape[-1]
-
-        if not config.FLAGS["NETKET_USE_PLAIN_RHAT"]:
-            # compute split-chain batch variance
-            local_batch_size = data.shape[0]
-            if N % 2 == 0:
-                # split each chain in the middle,
-                # like [[1 2 3 4]] -> [[1 2][3 4]]
-                batch_var, _ = _batch_variance(
-                    data.reshape(2 * local_batch_size, N // 2)
-                )
-            else:
-                # drop the last sample of each chain for an even split,
-                # like [[1 2 3 4 5]] -> [[1 2][3 4]]
-                batch_var, _ = _batch_variance(
-                    data[:, :-1].reshape(2 * local_batch_size, N // 2)
-                )
-
-        # V_loc = _np.var(data, axis=-1, ddof=0)
-        # W_loc = _np.mean(V_loc)
-        # W = _mean(W_loc)
-        # # This approximation seems to hold well enough for larger n_samples
-        W = variance
-
-        R_hat = jnp.sqrt((N - 1) / N + batch_var / W)
+        error_of_mean = jnp.sqrt(batch_var / n_batches)
+        R_hat = _split_R_hat(data, variance)
     else:
+        l_block = max(1, data.shape[1] // BLOCK_SIZE)
+        block_var, n_blocks = _block_variance(data, l_block)
+        error_of_mean = jnp.sqrt(block_var / n_blocks)
         R_hat = jnp.nan
 
-    res = Stats(mean, error_of_mean, variance, tau_corr, R_hat)
+    res = Stats(mean, error_of_mean, variance, tau_avg, tau_max, R_hat)
 
     return res
-    ##

--- a/netket/stats/mc_stats.py
+++ b/netket/stats/mc_stats.py
@@ -137,9 +137,7 @@ def _split_R_hat(data, W):
         if N % 2 == 0:
             # split each chain in the middle,
             # like [[1 2 3 4]] -> [[1 2][3 4]]
-            batch_var, _ = _batch_variance(
-                data.reshape(2 * local_batch_size, N // 2)
-            )
+            batch_var, _ = _batch_variance(data.reshape(2 * local_batch_size, N // 2))
         else:
             # drop the last sample of each chain for an even split,
             # like [[1 2 3 4 5]] -> [[1 2][3 4]]

--- a/netket/stats/mc_stats.py
+++ b/netket/stats/mc_stats.py
@@ -55,15 +55,43 @@ def _maybe_item(x):
 
 @struct.dataclass
 class Stats:
-    """A dict-compatible class containing the result of the statistics function."""
+    """A dict-compatible pytree containing the result of the statistics function."""
 
     mean: Union[float, complex] = _NaN
-    """The mean value"""
+    """The mean value."""
     error_of_mean: float = _NaN
+    """Estimate of the error of the mean."""
     variance: float = _NaN
+    """Estimation of the variance of the data."""
     tau_corr: float = _NaN
+    """Estimate of the correlation time (in adimensional units relating to `steps`).
+
+    This value is estimated with a blocking algorithm by default, but the result is known
+    to be unreliable. A more precise estimator based on the FFT transform can be used by
+    setting the environment variable `NETKET_EXPERIMENTAL_FFT_AUTOCORRELATION=1`. This
+    estimator is more computationally expensive, but overall the added cost should be
+    negligible.
+    """
     R_hat: float = _NaN
+    """
+    Estimator of the split-Rhat convergence estimator.
+
+    The split-Rhat diagnostic is based on comparing intra-chain and inter-chain
+    statistics of the sample and is thus only available for 2d-array inputs where
+    the rows are independently sampled MCMC chains. In an ideal MCMC samples,
+    R_hat should be 1.0. If it deviates from this value too much, this indicates
+    MCMC convergence issues. Thresholds such as R_hat > 1.1 or even R_hat > 1.01 have
+    been suggested in the literature for when to discard a sample. (See, e.g.,
+    Gelman et al., `Bayesian Data Analysis <http://www.stat.columbia.edu/~gelman/book/>`_,
+    or Vehtari et al., `arXiv:1903.08008 <https://arxiv.org/abs/1903.08008>`_.)
+    """
     tau_corr_max: float = _NaN
+    """
+    Estimation of the maximum correlation time among all markov chains.
+
+    This value is only computed if the environment variable
+    `NETKET_EXPERIMENTAL_FFT_AUTOCORRELATION` is `True`.
+    """
 
     def to_dict(self):
         jsd = {}

--- a/netket/stats/mc_stats.py
+++ b/netket/stats/mc_stats.py
@@ -85,7 +85,10 @@ class Stats:
             ext = ", R̂={:.4f}".format(self.R_hat)
         else:
             ext = ""
-        if not (math.isnan(self.tau_corr) and math.isnan(self.tau_corr_max)):
+        if not config.FLAGS["NETKET_EXPERIMENTAL_FFT_AUTOCORRELATION"]:
+            if not math.isnan(self.tau_corr):
+                ext += ", τ={:.1f}".format(self.tau_corr)
+        elif not (math.isnan(self.tau_corr) and math.isnan(self.tau_corr_max)):
             ext += ", τ={:.1f}<{:.1f}".format(self.tau_corr, self.tau_corr_max)
 
         return "{} ± {} [σ²={}{}]".format(mean, err, var, ext)

--- a/netket/stats/mc_stats_old.py
+++ b/netket/stats/mc_stats_old.py
@@ -1,0 +1,199 @@
+# Copyright 2021 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import partial
+
+import jax
+from jax import numpy as jnp
+
+import numpy as np
+
+from netket import jax as nkjax
+from netket.utils import config
+
+from . import mean as _mean
+from . import var as _var
+from . import total_size as _total_size
+from .mc_stats import Stats
+
+
+def _get_blocks(data, block_size):
+    chain_length = data.shape[1]
+
+    n_blocks = int(np.floor(chain_length / float(block_size)))
+
+    return data[:, 0 : n_blocks * block_size].reshape((-1, block_size)).mean(axis=1)
+
+
+def _block_variance(data, l):
+    blocks = _get_blocks(data, l)
+    ts = _total_size(blocks)
+    if ts > 0:
+        return _var(blocks), ts
+    else:
+        return jnp.nan, 0
+
+
+def _batch_variance(data):
+    b_means = data.mean(axis=1)
+    ts = _total_size(b_means)
+    return _var(b_means), ts
+
+
+# this is not batch_size maybe?
+def statistics(data, batch_size=32):
+    r"""
+    Returns statistics of a given array (or matrix, see below) containing a stream of data.
+    This is particularly useful to analyze Markov Chain data, but it can be used
+    also for other type of time series.
+    Assumes same shape on all MPI processes.
+
+    Args:
+        data (vector or matrix): The input data. It can be real or complex valued.
+            * if a vector, it is assumed that this is a time series of data (not necessarily independent);
+            * if a matrix, it is assumed that that rows :code:`data[i]` contain independent time series.
+
+    Returns:
+       Stats: A dictionary-compatible class containing the
+             average (:code:`.mean`, :code:`["Mean"]`),
+             variance (:code:`.variance`, :code:`["Variance"]`),
+             the Monte Carlo standard error of the mean (:code:`error_of_mean`, :code:`["Sigma"]`),
+             an estimate of the autocorrelation time (:code:`tau_corr`, :code:`["TauCorr"]`), and the
+             Gelman-Rubin split-Rhat diagnostic (:code:`.R_hat`, :code:`["R_hat"]`).
+
+             These properties can be accessed both the attribute and the dictionary-style syntax
+             (both indicated above).
+
+             The split-Rhat diagnostic is based on comparing intra-chain and inter-chain
+             statistics of the sample and is thus only available for 2d-array inputs where
+             the rows are independently sampled MCMC chains. In an ideal MCMC samples,
+             R_hat should be 1.0. If it deviates from this value too much, this indicates
+             MCMC convergence issues. Thresholds such as R_hat > 1.1 or even R_hat > 1.01 have
+             been suggested in the literature for when to discard a sample. (See, e.g.,
+             Gelman et al., `Bayesian Data Analysis <http://www.stat.columbia.edu/~gelman/book/>`_,
+             or Vehtari et al., `arXiv:1903.08008 <https://arxiv.org/abs/1903.08008>`_.)
+    """
+    return _statistics(data, batch_size)
+
+
+@partial(jax.jit, static_argnums=1)
+def _statistics(data, batch_size):
+    data = jnp.atleast_1d(data)
+    if data.ndim == 1:
+        data = data.reshape((1, -1))
+
+    if data.ndim > 2:
+        raise NotImplementedError("Statistics are implemented only for ndim<=2")
+
+    mean = _mean(data)
+    variance = _var(data)
+
+    ts = _total_size(data)
+
+    bare_var = variance
+
+    batch_var, n_batches = _batch_variance(data)
+
+    l_block = max(1, data.shape[1] // batch_size)
+
+    block_var, n_blocks = _block_variance(data, l_block)
+
+    tau_batch = ((ts / n_batches) * batch_var / bare_var - 1) * 0.5
+    tau_block = ((ts / n_blocks) * block_var / bare_var - 1) * 0.5
+
+    batch_good = (tau_batch < 6 * data.shape[1]) * (n_batches >= batch_size)
+    block_good = (tau_block < 6 * l_block) * (n_blocks >= batch_size)
+
+    stat_dtype = nkjax.dtype_real(data.dtype)
+
+    # if batch_good:
+    #    error_of_mean = jnp.sqrt(batch_var / n_batches)
+    #    tau_corr = jnp.max(0, tau_batch)
+    # elif block_good:
+    #    error_of_mean = jnp.sqrt(block_var / n_blocks)
+    #    tau_corr = jnp.max(0, tau_block)
+    # else:
+    #    error_of_mean = jnp.nan
+    #    tau_corr = jnp.nan
+    # jax style
+
+    def batch_good_err(args):
+        batch_var, tau_batch, *_ = args
+        error_of_mean = jnp.sqrt(batch_var / n_batches)
+        tau_corr = jnp.clip(tau_batch, 0)
+        return jnp.asarray(error_of_mean, dtype=stat_dtype), jnp.asarray(
+            tau_corr, dtype=stat_dtype
+        )
+
+    def block_good_err(args):
+        _, _, block_var, tau_block = args
+        error_of_mean = jnp.sqrt(block_var / n_blocks)
+        tau_corr = jnp.clip(tau_block, 0)
+        return jnp.asarray(error_of_mean, dtype=stat_dtype), jnp.asarray(
+            tau_corr, dtype=stat_dtype
+        )
+
+    def nan_err(args):
+        return jnp.asarray(jnp.nan, dtype=stat_dtype), jnp.asarray(
+            jnp.nan, dtype=stat_dtype
+        )
+
+    def batch_not_good(args):
+        batch_var, tau_batch, block_var, tau_block, block_good = args
+        return jax.lax.cond(
+            block_good,
+            block_good_err,
+            nan_err,
+            (batch_var, tau_batch, block_var, tau_block),
+        )
+
+    error_of_mean, tau_corr = jax.lax.cond(
+        batch_good,
+        batch_good_err,
+        batch_not_good,
+        (batch_var, tau_batch, block_var, tau_block, block_good),
+    )
+
+    if n_batches > 1:
+        N = data.shape[-1]
+
+        if not config.FLAGS["NETKET_USE_PLAIN_RHAT"]:
+            # compute split-chain batch variance
+            local_batch_size = data.shape[0]
+            if N % 2 == 0:
+                # split each chain in the middle,
+                # like [[1 2 3 4]] -> [[1 2][3 4]]
+                batch_var, _ = _batch_variance(
+                    data.reshape(2 * local_batch_size, N // 2)
+                )
+            else:
+                # drop the last sample of each chain for an even split,
+                # like [[1 2 3 4 5]] -> [[1 2][3 4]]
+                batch_var, _ = _batch_variance(
+                    data[:, :-1].reshape(2 * local_batch_size, N // 2)
+                )
+
+        # V_loc = _np.var(data, axis=-1, ddof=0)
+        # W_loc = _np.mean(V_loc)
+        # W = _mean(W_loc)
+        # # This approximation seems to hold well enough for larger n_samples
+        W = variance
+
+        R_hat = jnp.sqrt((N - 1) / N + batch_var / W)
+    else:
+        R_hat = jnp.nan
+
+    res = Stats(mean, error_of_mean, variance, tau_corr, R_hat)
+
+    return res

--- a/netket/utils/config_flags.py
+++ b/netket/utils/config_flags.py
@@ -154,6 +154,23 @@ config.define(
     runtime=True,
 )
 
+config.define(
+    "NETKET_EXPERIMENTAL_FFT_AUTOCORRELATION",
+    bool,
+    default=False,
+    help=dedent(
+        """
+        The integrated autocorrelation time $\tau_c$ is computed separately for each chain $c$.
+        To summarize it for the user, `Stats.tau_corr` is changed to contain the average over all
+        chains and a new field `Stats.tau_corr_max` is added containing the maximum autocorrelation
+        among all chains (which helps to identify outliers). Using the average $\tau$ over all chains
+        seems like a good choice as it results in a low-variance estimate
+        (see [here](https://emcee.readthedocs.io/en/stable/tutorials/autocorr/#autocorr) for a good
+        discussion).
+        """
+    ),
+    runtime=True,
+)
 
 config.define(
     "NETKET_SPHINX_BUILD",

--- a/test/common.py
+++ b/test/common.py
@@ -94,6 +94,28 @@ class netket_disable_mpi:
         nk.utils.mpi.primitives.n_nodes = self._orig_nodes
 
 
+class netket_experimental_fft_autocorrelation:
+    """
+    Temporarily enables the experimental fft autocorrelation logic
+
+    Example:
+
+    >>> with netket_experimental_fft_autocorrelation(True):
+    >>>     run_code
+
+    """
+
+    def __init__(self, val):
+        self._value = val
+
+    def __enter__(self):
+        self._orig_value = nk.config.FLAGS["NETKET_EXPERIMENTAL_FFT_AUTOCORRELATION"]
+        nk.config.update("NETKET_EXPERIMENTAL_FFT_AUTOCORRELATION", self._value)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        nk.config.update("NETKET_EXPERIMENTAL_FFT_AUTOCORRELATION", self._orig_value)
+
+
 def hash_for_seed(obj):
     """
     Hash any object into an int that can be used in `np.random.seed`, and does not change between Python sessions.

--- a/test/stats/test_stats.py
+++ b/test/stats/test_stats.py
@@ -93,7 +93,9 @@ def test_stats_mean_std():
         _test_stats_mean_std(hi, ham, ma, bs)
 
 
-def _test_tau_corr(batch_size, sig_corr):
+@pytest.mark.parametrize("batch_size", [1, 2, 4, 8, 16, 32])
+@pytest.mark.parametrize("sig_corr", [0.5])
+def test_tau_corr(batch_size, sig_corr):
     def next_pow_two(n):
         i = 1
         while i < n:
@@ -117,7 +119,6 @@ def _test_tau_corr(batch_size, sig_corr):
 
         return acf
 
-    @jit
     def gen_data(n_samples, log_f, dx, seed=1234):
         np.random.seed(seed)
         # Generates data with a simple markov chain
@@ -133,14 +134,13 @@ def _test_tau_corr(batch_size, sig_corr):
             x_old = x[i]
         return x
 
-    @jit
     def log_f(x):
         return -(x**2.0) / 2.0
 
     def func_corr(x, tau):
         return np.exp(-x / (tau))
 
-    n_samples = 8000000 // batch_size
+    n_samples = 2**20 // batch_size
 
     data = np.empty((batch_size, n_samples))
     tau_fit = np.empty((batch_size))
@@ -151,25 +151,19 @@ def _test_tau_corr(batch_size, sig_corr):
         popt, pcov = curve_fit(func_corr, np.arange(40), autoc[0:40])
         tau_fit[i] = popt[0]
 
-    tau_fit_m = tau_fit.mean()
+    tau_fit_mean = 1 + 2 * tau_fit.mean()
+    tau_fit_max = 1 + 2 * tau_fit.max()
 
     stats = statistics(data)
 
     assert np.mean(data) == pytest.approx(stats.mean)
     assert np.var(data) == pytest.approx(stats.variance)
 
-    assert tau_fit_m == pytest.approx(stats.tau_corr, rel=1, abs=3)
+    assert tau_fit_mean == pytest.approx(stats.tau_corr, rel=0.5, abs=0.5)
+    assert tau_fit_max == pytest.approx(stats.tau_corr_max, rel=0.5, abs=0.5)
 
-    eom_fit = np.sqrt(np.var(data) * tau_fit_m / float(n_samples * batch_size))
-
-    print(stats.error_of_mean, eom_fit)
-    assert eom_fit == pytest.approx(stats.error_of_mean, rel=0.6)
-
-
-def test_tau_corr():
-    sig_corr = 0.5
-    for bs in (1, 2, 32, 64):
-        _test_tau_corr(bs, sig_corr)
+    eom_fit = np.sqrt(np.var(data) * tau_fit_mean / float(n_samples * batch_size))
+    assert eom_fit == pytest.approx(stats.error_of_mean, rel=0.5)
 
 
 def test_decimal_format():


### PR DESCRIPTION
This PR improves our estimate of the autocorrelation time in `netket.stats.statistics` by importing code from [`emcee`](https://github.com/dfm/emcee) which computes it via FFT.

The integrated autocorrelation time $\tau_c$ is computed separately for each chain $c$. To summarize it for the user, `Stats.tau_corr` is changed to contain the average over all chains and a new field `Stats.tau_corr_max` is added containing the maximum autocorrelation among all chains (which helps to identify outliers). Using the average $\tau$ over all chains seems like a good choice as it results in a low-variance estimate (see [here](https://emcee.readthedocs.io/en/stable/tutorials/autocorr/#autocorr) for a good discussion).

### Definition of tau_corr

Note that I've encountered two definitions of the autocorrelation time in the literature:

1. The statistics convention, where the effective sample size is $N_{\mathrm{eff}} = \frac{N}{\tau}$. Here, $\tau=1$ is the minimum and achieved for an uncorrelated chain. (Because samples $\tau = 1$ steps apart are uncorrelated in a correlation-free chain.) See [emcee](https://emcee.readthedocs.io/en/stable/tutorials/autocorr/#autocorr) or [Vehtari et al. (2021)](https://doi.org/10.1214/20-BA1221).
2. The convention $N_{\mathrm{eff}} = \frac{N}{1 + 2\tau'}$ which is use e.g. by [Ambegaokar and Troyer (2009)](https://arxiv.org/pdf/0906.0943.pdf) and might be more common in (parts of) physics. Here, an uncorrelated chain has $\tau' = 0.$

This PR chooses the first convention because a) it is useful to be able to estimate the effective sample size at a glance (in this convention, if $\tau=2$ we know that we have about half the effective samples compared to the total sample size) and b) the estimate can be a bit noisy for shorter chains and thus fluctuate around $\tau = 1$ or $\tau' = 0$ for mostly uncorrelated chains. In the second convention, this can result in slightly negative values which are somewhat ugly.

### Effect on runtime

Note also that the FFT-based computation slows down `statistics` between 5x to 20x for sample sizes between 1000 and 100000 on CPU. However, when testing the performance of this PR in VMC applications, the overhead was essentially unnoticeable as computing the stats is an almost negligible contribution to overall runtime compared to MC sampling. I believe the increased diagnostic value of the FFT estimate and avoidance of issues such as #1149, which this PR fixes, are easily worth it.

### Block-based estimates

This PR also changes the `statistics` code to only use block-based statistics (instead of the chain based ones) if there is only a single chain (like in autoregressive applications). This simplifies the logic (since in the case of multiple chains, the previous block-based estimates could be harder to interpret as they ignored per-chain information) but there might be a statistical impact if someone runs, say, two chains. (Maybe it would be ideal for two chains to combine block and chain based information, but that would be more complicated than the current code.) IMHO, the version of this PR is a reasonable tradeoff and the chain-based stats do give usable results even with two chains. If we decide so, we can always further improve "low-n_chain statistics" in a later PR.