### PR TITLE
Allow returning local estimators from `expect` and `expect_and_grad`

### DIFF
--- a/netket/vqs/base.py
+++ b/netket/vqs/base.py
@@ -291,7 +291,7 @@ class VariationalMixedState(VariationalState):
 
 
 @dispatch.abstract
-def expect(vstate: VariationalState, operator: AbstractOperator):
+def expect(vstate: VariationalState, operator: AbstractOperator, **kwargs):
     """
     Computes the expectation value of the given operator over the
     variational state.


### PR DESCRIPTION
This PR introduces an (experimental) option `_return_estimators` for `MCState.expect` and `MCState.expect_and_grad`, which optionally returns the local estimators `O_loc(s) = <s|O|ψ>/<s|ψ>` and not just their statistics.

This is necessary for implementing #1140 and potentially other VMC regularization methods or preconditioners and also can be useful for debugging purposes (e.g., to check MCMC chain properties beyond those contained in `statistics`).