### PR TITLE
Change `tree_multimap` to `tree_map` for jax 0.3.5

### DIFF
--- a/netket/driver/steady_state.py
+++ b/netket/driver/steady_state.py
@@ -124,7 +124,7 @@ class SteadyState(AbstractVariationalDriver):
         self._dp = self.preconditioner(self.state, self._loss_grad)
 
         # If parameters are real, then take only real part of the gradient (if it's complex)
-        self._dp = jax.tree_multimap(
+        self._dp = jax.tree_map(
             lambda x, target: (x if jnp.iscomplexobj(target) else x.real),
             self._dp,
             self.state.parameters,

--- a/netket/driver/vmc.py
+++ b/netket/driver/vmc.py
@@ -136,7 +136,7 @@ class VMC(AbstractVariationalDriver):
         self._dp = self.preconditioner(self.state, self._loss_grad)
 
         # If parameters are real, then take only real part of the gradient (if it's complex)
-        self._dp = jax.tree_multimap(
+        self._dp = jax.tree_map(
             lambda x, target: (x if jnp.iscomplexobj(target) else x.real),
             self._dp,
             self.state.parameters,

--- a/netket/experimental/dynamics/_rk_tableau.py
+++ b/netket/experimental/dynamics/_rk_tableau.py
@@ -115,9 +115,9 @@ class TableauRKExplicit:
         k = expand_dim(y_t, self.stages)
         for l in range(self.stages):
             dy_l = jax.tree_map(lambda k: jnp.tensordot(self.a[l], k, axes=1), k)
-            y_l = jax.tree_multimap(lambda y_t, dy_l: y_t + dt * dy_l, y_t, dy_l)
+            y_l = jax.tree_map(lambda y_t, dy_l: y_t + dt * dy_l, y_t, dy_l)
             k_l = f(times[l], y_l, stage=l)
-            k = jax.tree_multimap(lambda k, k_l: k.at[l].set(k_l), k, k_l)
+            k = jax.tree_map(lambda k, k_l: k.at[l].set(k_l), k, k_l)
 
         return k
 
@@ -132,7 +132,7 @@ class TableauRKExplicit:
         k = self._compute_slopes(f, t, dt, y_t)
 
         b = self.b[0] if self.b.ndim == 2 else self.b
-        y_tp1 = jax.tree_multimap(
+        y_tp1 = jax.tree_map(
             lambda y_t, k: y_t + dt * jnp.tensordot(b, k, axes=1), y_t, k
         )
 
@@ -154,7 +154,7 @@ class TableauRKExplicit:
 
         k = self._compute_slopes(f, t, dt, y_t)
 
-        y_tp1 = jax.tree_multimap(
+        y_tp1 = jax.tree_map(
             lambda y_t, k: y_t + dt * jnp.tensordot(self.b[0], k, axes=1), y_t, k
         )
         db = self.b[0] - self.b[1]

--- a/netket/jax/_grad.py
+++ b/netket/jax/_grad.py
@@ -187,9 +187,7 @@ def value_and_grad(
                         )(*args, **kwargs)
 
                     out = out_r + 1j * out_j
-                    grad = jax.tree_multimap(
-                        lambda re, im: re + 1j * im, grad_r, grad_j
-                    )
+                    grad = jax.tree_map(lambda re, im: re + 1j * im, grad_r, grad_j)
 
                     if has_aux:
                         return out, grad, aux

--- a/netket/jax/_scanmap.py
+++ b/netket/jax/_scanmap.py
@@ -8,7 +8,7 @@ from functools import partial, wraps
 
 from netket.utils import module_version
 
-_tree_add = partial(jax.tree_multimap, jax.lax.add)
+_tree_add = partial(jax.tree_map, jax.lax.add)
 _tree_zeros_like = partial(jax.tree_map, lambda x: jnp.zeros(x.shape, dtype=x.dtype))
 
 
@@ -93,7 +93,7 @@ def scan_append_reduce(f, x, append_cond, op=_tree_add):
         y_op = _get_op_part(y)
         y_append = _get_append_part(y)
         # select here to avoid the user having to specify the zero element for op
-        y_reduce = jax.tree_multimap(
+        y_reduce = jax.tree_map(
             partial(jax.lax.select, is_first), y_op, op(y_carry, y_op)
         )
         return (False, y_reduce), y_append

--- a/netket/jax/_vjp.py
+++ b/netket/jax/_vjp.py
@@ -19,7 +19,7 @@ import jax
 from jax import numpy as jnp
 from jax.tree_util import (
     tree_map,
-    tree_multimap,
+    tree_map,
 )
 
 
@@ -74,9 +74,9 @@ def vjp_rr(
             out_r = _vjp_fun(jnp.asarray(ȳ.real, dtype=primals_out.dtype))
             out_i = _vjp_fun(jnp.asarray(ȳ.imag, dtype=primals_out.dtype))
             if conjugate:
-                out = tree_multimap(lambda re, im: re - 1j * im, out_r, out_i)
+                out = tree_map(lambda re, im: re - 1j * im, out_r, out_i)
             else:
-                out = tree_multimap(lambda re, im: re + 1j * im, out_r, out_i)
+                out = tree_map(lambda re, im: re + 1j * im, out_r, out_i)
 
         return out
 
@@ -124,13 +124,13 @@ def vjp_rc(
         vr_jj = vjp_j_fun(jnp.asarray(ȳ_r, dtype=vals_j.dtype))
         vj_jj = vjp_j_fun(jnp.asarray(ȳ_j, dtype=vals_j.dtype))
 
-        r = tree_multimap(
+        r = tree_map(
             lambda re, im: re + 1j * im,
             vr_jr,
             vj_jr,
         )
-        i = tree_multimap(lambda re, im: re + 1j * im, vr_jj, vj_jj)
-        out = tree_multimap(lambda re, im: re + 1j * im, r, i)
+        i = tree_map(lambda re, im: re + 1j * im, vr_jj, vj_jj)
+        out = tree_map(lambda re, im: re + 1j * im, r, i)
 
         if conjugate:
             out = tree_map(jnp.conjugate, out)

--- a/netket/jax/utils.py
+++ b/netket/jax/utils.py
@@ -191,7 +191,7 @@ def tree_dot(a: PyTree, b: PyTree) -> Scalar:
     """
     return jax.tree_util.tree_reduce(
         jax.numpy.add,
-        jax.tree_map(jax.numpy.sum, jax.tree_multimap(jax.numpy.multiply, a, b)),
+        jax.tree_map(jax.numpy.sum, jax.tree_map(jax.numpy.multiply, a, b)),
     )
 
 
@@ -209,7 +209,7 @@ def tree_cast(x: PyTree, target: PyTree) -> PyTree:
     """
     # astype alone would also work, however that raises ComplexWarning when casting complex to real
     # therefore the real is taken first where needed
-    return jax.tree_multimap(
+    return jax.tree_map(
         lambda x, target: (x if jnp.iscomplexobj(target) else x.real).astype(
             target.dtype
         ),
@@ -230,9 +230,9 @@ def tree_axpy(a: Scalar, x: PyTree, y: PyTree) -> PyTree:
         where the leaves of x are first scaled with a.
     """
     if is_scalar(a):
-        return jax.tree_multimap(lambda x_, y_: a * x_ + y_, x, y)
+        return jax.tree_map(lambda x_, y_: a * x_ + y_, x, y)
     else:
-        return jax.tree_multimap(lambda a_, x_, y_: a_ * x_ + y_, a, x, y)
+        return jax.tree_map(lambda a_, x_, y_: a_ * x_ + y_, a, x, y)
 
 
 def _to_real(x):

--- a/netket/optimizer/qgt/common.py
+++ b/netket/optimizer/qgt/common.py
@@ -48,4 +48,4 @@ def check_valid_vector_type(x: PyTree, target: PyTree):
                 )
             )
 
-    jax.tree_multimap(check, x, target)
+    jax.tree_map(check, x, target)

--- a/netket/optimizer/qgt/qgt_jacobian_dense_logic.py
+++ b/netket/optimizer/qgt/qgt_jacobian_dense_logic.py
@@ -149,7 +149,7 @@ def _jacobian_cplx(
 
 @partial(wraps(_jacobian_cplx))
 def jacobian_cplx(
-    forward_fn, params, samples, _build_fn=partial(jax.tree_multimap, jax.lax.complex)
+    forward_fn, params, samples, _build_fn=partial(jax.tree_map, jax.lax.complex)
 ):
     return _jacobian_cplx(forward_fn, params, samples, _build_fn)
 

--- a/netket/optimizer/qgt/qgt_jacobian_pytree.py
+++ b/netket/optimizer/qgt/qgt_jacobian_pytree.py
@@ -208,12 +208,12 @@ def _matmul(
     check_valid_vector_type(self.params, vec)
 
     if self.scale is not None:
-        vec = jax.tree_multimap(jnp.multiply, vec, self.scale)
+        vec = jax.tree_map(jnp.multiply, vec, self.scale)
 
     result = mat_vec(vec, self.O, self.diag_shift)
 
     if self.scale is not None:
-        result = jax.tree_multimap(jnp.multiply, result, self.scale)
+        result = jax.tree_map(jnp.multiply, result, self.scale)
 
     # Reassemble real-imaginary split as needed
     if reassemble is not None:
@@ -240,9 +240,9 @@ def _solve(
     check_valid_vector_type(self.params, y)
 
     if self.scale is not None:
-        y = jax.tree_multimap(jnp.divide, y, self.scale)
+        y = jax.tree_map(jnp.divide, y, self.scale)
         if x0 is not None:
-            x0 = jax.tree_multimap(jnp.multiply, x0, self.scale)
+            x0 = jax.tree_map(jnp.multiply, x0, self.scale)
 
     # to pass the object LinearOperator itself down
     # but avoid rescaling, we pass down an object with
@@ -253,7 +253,7 @@ def _solve(
     out, info = solve_fun(unscaled_self, y, x0=x0)
 
     if self.scale is not None:
-        out = jax.tree_multimap(jnp.divide, out, self.scale)
+        out = jax.tree_map(jnp.divide, out, self.scale)
 
     # Reassemble real-imaginary split as needed
     if self.mode != "holomorphic":

--- a/netket/optimizer/qgt/qgt_jacobian_pytree_logic.py
+++ b/netket/optimizer/qgt/qgt_jacobian_pytree_logic.py
@@ -80,7 +80,7 @@ def jacobian_cplx(
     params: PyTree,
     samples: Array,
     chunk_size: int = None,
-    _build_fn: Callable = partial(jax.tree_multimap, jax.lax.complex),
+    _build_fn: Callable = partial(jax.tree_map, jax.lax.complex),
 ) -> PyTree:
     """Calculates Jacobian entries by vmapping grad.
     Assumes the function is R→C, backpropagates 1 and -1j
@@ -148,7 +148,7 @@ def stack_jacobian_tuple(centered_oks_re_im):
     Args:
         centered_oks_re_im : a tuple (ΔOᵣ, ΔOᵢ) of two PyTrees representing the real and imag part of ΔOⱼₖ
     """
-    return jax.tree_multimap(
+    return jax.tree_map(
         lambda re, im: jnp.concatenate([re, im], axis=0), *centered_oks_re_im
     )
 
@@ -166,7 +166,7 @@ def _rescale(centered_oks):
         ** 0.5,
         centered_oks,
     )
-    centered_oks = jax.tree_multimap(jnp.divide, centered_oks, scale)
+    centered_oks = jax.tree_map(jnp.divide, centered_oks, scale)
     scale = jax.tree_map(partial(jnp.squeeze, axis=0), scale)
     return centered_oks, scale
 
@@ -176,7 +176,7 @@ def _jvp(oks: PyTree, v: PyTree) -> Array:
     Compute the matrix-vector product between the pytree jacobian oks and the pytree vector v
     """
     td = lambda x, y: jnp.tensordot(x, y, axes=y.ndim)
-    return jax.tree_util.tree_reduce(jnp.add, jax.tree_multimap(td, oks, v))
+    return jax.tree_util.tree_reduce(jnp.add, jax.tree_map(td, oks, v))
 
 
 def _vjp(oks: PyTree, w: Array) -> PyTree:
@@ -294,7 +294,7 @@ def prepare_centered_oks(
     else:
         oks = jacobian_fun(f, params, samples)
         oks_mean = jax.tree_map(partial(sum, axis=0), _multiply_by_pdf(oks, pdf))
-        centered_oks = jax.tree_multimap(lambda x, y: x - y, oks, oks_mean)
+        centered_oks = jax.tree_map(lambda x, y: x - y, oks, oks_mean)
 
         centered_oks = _multiply_by_pdf(centered_oks, jnp.sqrt(pdf))
     if rescale_shift:

--- a/netket/vqs/exact/expect.py
+++ b/netket/vqs/exact/expect.py
@@ -116,7 +116,7 @@ def _exp_grad(
 
     Ō_grad = vjp_fun(ΔOΨ)[0]
 
-    Ō_grad = jax.tree_multimap(
+    Ō_grad = jax.tree_map(
         lambda x, target: (x if jnp.iscomplexobj(target) else 2 * x.real).astype(
             target.dtype
         ),

--- a/netket/vqs/mc/mc_state/expect_grad.py
+++ b/netket/vqs/mc/mc_state/expect_grad.py
@@ -154,7 +154,7 @@ def grad_expect_hermitian(
     )
     Ō_grad = vjp_fun(jnp.conjugate(O_loc) / n_samples)[0]
 
-    Ō_grad = jax.tree_multimap(
+    Ō_grad = jax.tree_map(
         lambda x, target: (x if jnp.iscomplexobj(target) else 2 * x.real).astype(
             target.dtype
         ),
@@ -208,7 +208,7 @@ def grad_expect_operator_kernel(
 
     # This term below is needed otherwise it does not match the value obtained by
     # (ha@ha).collect(). I'm unsure of why it is needed.
-    Ō_pars_grad = jax.tree_multimap(
+    Ō_pars_grad = jax.tree_map(
         lambda x, target: x / 2 if jnp.iscomplexobj(target) else x,
         Ō_pars_grad,
         parameters,

--- a/netket/vqs/mc/mc_state/expect_grad_chunked.py
+++ b/netket/vqs/mc/mc_state/expect_grad_chunked.py
@@ -149,7 +149,7 @@ def grad_expect_hermitian_chunked(
         (jnp.conjugate(O_loc) / n_samples),
     )[0]
 
-    Ō_grad = jax.tree_multimap(
+    Ō_grad = jax.tree_map(
         lambda x, target: (x if jnp.iscomplexobj(target) else 2 * x.real).astype(
             target.dtype
         ),

--- a/test/groundstate/test_vmc.py
+++ b/test/groundstate/test_vmc.py
@@ -106,7 +106,7 @@ def test_vmc_functions():
     def check_shape(a, b):
         assert a.shape == b.shape
 
-    jax.tree_multimap(check_shape, grads, ma.parameters)
+    jax.tree_map(check_shape, grads, ma.parameters)
     grads, _ = nk.jax.tree_ravel(grads)
 
     assert np.mean(np.abs(grads) ** 2) == approx(0.0, abs=1e-8)

--- a/test/optimizer/test_qgt_itersolve.py
+++ b/test/optimizer/test_qgt_itersolve.py
@@ -122,7 +122,7 @@ def test_qgt_solve(qgt, vstate, solver, _mpi_size, _mpi_rank):
     S = qgt(vstate)
     x, _ = S.solve(solver, vstate.parameters)
 
-    jax.tree_multimap(
+    jax.tree_map(
         partial(testing.assert_allclose, rtol=solvers_tol[solver]),
         S @ x,
         vstate.parameters,
@@ -142,7 +142,7 @@ def test_qgt_solve(qgt, vstate, solver, _mpi_size, _mpi_rank):
             S = qgt(vstate)
             x_all, _ = S.solve(solver, vstate.parameters)
 
-            jax.tree_multimap(
+            jax.tree_map(
                 lambda a, b: np.testing.assert_allclose(a, b, rtol=0.00045), x, x_all
             )
 
@@ -178,16 +178,14 @@ def test_qgt_matmul(qgt, vstate, _mpi_size, _mpi_rank):
     def check_same_dtype(x, y):
         assert x.dtype == y.dtype
 
-    jax.tree_multimap(check_same_dtype, x, y)
+    jax.tree_map(check_same_dtype, x, y)
 
     # test multiplication by dense gives same result...
     y_dense, unravel = nk.jax.tree_ravel(y)
     x_dense = S @ y_dense
     x_dense_unravelled = unravel(x_dense)
 
-    jax.tree_multimap(
-        lambda a, b: np.testing.assert_allclose(a, b), x, x_dense_unravelled
-    )
+    jax.tree_map(lambda a, b: np.testing.assert_allclose(a, b), x, x_dense_unravelled)
 
     if _mpi_size > 1:
         # other check
@@ -203,7 +201,7 @@ def test_qgt_matmul(qgt, vstate, _mpi_size, _mpi_rank):
             S = qgt(vstate)
             x_all = S @ y
 
-            jax.tree_multimap(lambda a, b: np.testing.assert_allclose(a, b), x, x_all)
+            jax.tree_map(lambda a, b: np.testing.assert_allclose(a, b), x, x_all)
 
 
 @pytest.mark.parametrize(
@@ -272,4 +270,4 @@ def test_qgt_pytree_diag_shift(qgt, vstate):
     )
     S = S.replace(diag_shift=diag_shift_tree)
     res = S @ v
-    jax.tree_multimap(lambda a, b: np.testing.assert_allclose(a, b), res, expected)
+    jax.tree_map(lambda a, b: np.testing.assert_allclose(a, b), res, expected)

--- a/test/optimizer/test_qgt_logic.py
+++ b/test/optimizer/test_qgt_logic.py
@@ -67,7 +67,7 @@ def reassemble_complex(x, target, fun=tree_toreal_flat):
 
 
 def tree_allclose(t1, t2):
-    t = jax.tree_multimap(jnp.allclose, t1, t2)
+    t = jax.tree_map(jnp.allclose, t1, t2)
     return all(jax.tree_util.tree_flatten(t)[0])
 
 
@@ -80,7 +80,7 @@ def random_split_like_tree(rng_key, target=None, treedef=None):
 
 def tree_random_normal_like(rng_key, target):
     keys_tree = random_split_like_tree(rng_key, target)
-    return jax.tree_multimap(
+    return jax.tree_map(
         lambda l, k: jax.random.normal(k, l.shape, l.dtype),
         target,
         keys_tree,

--- a/test/variational/test_exact_state.py
+++ b/test/variational/test_exact_state.py
@@ -94,7 +94,7 @@ def test_init_parameters(vstate):
     def _f(x, y):
         np.testing.assert_allclose(x, y)
 
-    jax.tree_multimap(_f, pars, pars2)
+    jax.tree_map(_f, pars, pars2)
 
 
 @common.skipif_mpi

--- a/test/variational/test_experimental.py
+++ b/test/variational/test_experimental.py
@@ -66,9 +66,7 @@ def test_variables_from_file(vstate, tmp_path):
         vstate2.variables = nkx.vqs.variables_from_file(name, vstate2.variables)
 
         # check
-        jax.tree_multimap(
-            np.testing.assert_allclose, vstate.parameters, vstate2.parameters
-        )
+        jax.tree_map(np.testing.assert_allclose, vstate.parameters, vstate2.parameters)
 
 
 def test_variables_from_tar(vstate, tmp_path):
@@ -89,7 +87,7 @@ def test_variables_from_tar(vstate, tmp_path):
             vstate2.variables = nkx.vqs.variables_from_tar(name, vstate2.variables, j)
 
             # check
-            jax.tree_multimap(
+            jax.tree_map(
                 np.testing.assert_allclose, vstate.parameters, vstate2.parameters
             )
 

--- a/test/variational/test_variational.py
+++ b/test/variational/test_variational.py
@@ -308,7 +308,7 @@ def test_serialization(vstate):
 
     vstate = serialization.from_bytes(vstate, bdata)
 
-    jax.tree_multimap(np.testing.assert_allclose, vstate.parameters, old_params)
+    jax.tree_map(np.testing.assert_allclose, vstate.parameters, old_params)
     np.testing.assert_allclose(vstate.samples, old_samples)
     assert vstate.n_samples == old_nsamples
     assert vstate.n_discard_per_chain == old_ndiscard
@@ -324,7 +324,7 @@ def test_init_parameters(vstate):
     def _f(x, y):
         np.testing.assert_allclose(x, y)
 
-    jax.tree_multimap(_f, pars, pars2)
+    jax.tree_map(_f, pars, pars2)
 
 
 @common.skipif_mpi
@@ -457,7 +457,7 @@ def test_expect_chunking(vstate, operator, n_chunks):
     vstate.chunk_size = chunk_size
     eval_chunk = vstate.expect(operator)
 
-    jax.tree_multimap(
+    jax.tree_map(
         partial(np.testing.assert_allclose, atol=1e-13), eval_nochunk, eval_chunk
     )
 
@@ -466,6 +466,6 @@ def test_expect_chunking(vstate, operator, n_chunks):
     vstate.chunk_size = chunk_size
     grad_chunk = vstate.grad(operator)
 
-    jax.tree_multimap(
+    jax.tree_map(
         partial(np.testing.assert_allclose, atol=1e-13), grad_nochunk, grad_chunk
     )

--- a/test/variational/test_variational_mixed.py
+++ b/test/variational/test_variational_mixed.py
@@ -251,9 +251,7 @@ def test_serialization(vstate):
 
     vstate_new = serialization.from_bytes(vstate_new, bdata)
 
-    jax.tree_multimap(
-        np.testing.assert_allclose, vstate.parameters, vstate_new.parameters
-    )
+    jax.tree_map(np.testing.assert_allclose, vstate.parameters, vstate_new.parameters)
     np.testing.assert_allclose(vstate.samples, vstate_new.samples)
     np.testing.assert_allclose(vstate.diagonal.samples, vstate_new.diagonal.samples)
     assert vstate.n_samples == vstate_new.n_samples
@@ -303,7 +301,7 @@ def test_expect_chunking(vstate, operator, n_chunks):
     vstate.diagonal.chunk_size = chunk_size_diag
     eval_chunk = vstate.expect(operator)
 
-    jax.tree_multimap(
+    jax.tree_map(
         partial(np.testing.assert_allclose, atol=1e-13), eval_nochunk, eval_chunk
     )
 
@@ -324,7 +322,7 @@ def test_expect_grad_chunking(vstate, n_chunks):
     vstate.diagonal.chunk_size = chunk_size_diag
     grad_chunk = vstate.grad(operator)
 
-    jax.tree_multimap(
+    jax.tree_map(
         partial(np.testing.assert_allclose, atol=1e-13), grad_nochunk, grad_chunk
     )
 


### PR DESCRIPTION
As `tree_multimap` is deprecated in jax 0.3.5 . There are still some deprecation warnings caused by optax, and they already did a PR to fix them (deepmind/optax#330).