### PR TITLE
Actually call _log_additional_data

### DIFF
--- a/netket/driver/abstract_variational_driver.py
+++ b/netket/driver/abstract_variational_driver.py
@@ -252,6 +252,7 @@ class AbstractVariationalDriver(abc.ABC):
             for step in self.iter(n_iter, step_size):
 
                 log_data = self.estimate(obs)
+                self._log_additional_data(log_data, step)
 
                 # if the cost-function is defined then report it in the progress bar
                 if self._loss_stats is not None:
@@ -313,6 +314,22 @@ class AbstractVariationalDriver(abc.ABC):
         self._optimizer_state, self.state.parameters = apply_gradient(
             self._optimizer.update, self._optimizer_state, dp, self.state.parameters
         )
+
+    def _log_additional_data(self, log_dict, step):
+        """
+        Method to be implemented in sub-classes of AbstractVariationalDriver to
+        log additional data at every step.
+        This method is called at every iteration when executing with `run`.
+
+        Args:
+            `log_dict`: The dictionary containing all logged data. It must be
+                modified in-place adding new keys.
+            `step`: the current step number.
+
+        Returns:
+            Nothing. The log dictionary should be modified in place.
+        """
+        pass  # pragma: no cover
 
 
 @partial(jax.jit, static_argnums=0)

--- a/netket/experimental/driver/tdvp.py
+++ b/netket/experimental/driver/tdvp.py
@@ -367,6 +367,7 @@ class TDVP(AbstractVariationalDriver):
 
             for step in self._iter(T, tstops=tstops, callback=update_progress_bar):
                 log_data = self.estimate(obs)
+                self._log_additional_data(log_data, step)
 
                 self._postfix = {"n": self.step_count}
                 # if the cost-function is defined then report it in the progress bar

--- a/netket/experimental/driver/tdvp.py
+++ b/netket/experimental/driver/tdvp.py
@@ -402,8 +402,8 @@ class TDVP(AbstractVariationalDriver):
 
         return loggers
 
-    def _log_additional_data(self, obs, step):
-        obs["t"] = self.t
+    def _log_additional_data(self, log_dict, step):
+        log_dict["t"] = self.t
 
     @property
     def _default_step_size(self):


### PR DESCRIPTION
I think this change got lost when @femtobit rebased my driver implementation for TDVP so.. here's it.
This actually makes the TDVP solver log the times (before, it was not working).

It's actually useful to log other stuff sometimes.
We should actually document it somewhere, but I'll leave the documentation effort for later.