### PR TITLE
Bump minimum jax version to 0.2.25

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,12 +19,12 @@ BASE_DEPENDENCIES = [
     "plum-dispatch~=1.5.1",
     "numba>=0.52, <0.57",
     "igraph~=0.9.8",
-    "jax>=0.2.23, <0.4",
+    "jax>=0.2.25, <0.4",
     "jaxlib>=0.1.72",
     "flax>=0.3.5, <0.5",
     "orjson~=3.4",
     "optax>=0.1.1, <0.2",
-    "numba4jax>=0.0.3, <0.1",
+    "numba4jax>=0.0.10, <0.1",
 ]
 
 setup(


### PR DESCRIPTION
Increase the minimum required jax version to fix CI crashes.