### PR TITLE
Add MCState.local_estimators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### New features
 
+* The method `MCState.local_estimators` has been added, which returns the local estimators `O_loc(s) = 〈s|O|ψ〉 / 〈s|ψ〉` (which are known as local energies if `O` is the Hamiltonian). [#1179](https://github.com/netket/netket/pull/1179)
+
 ### Breaking Changes
 
 

--- a/netket/vqs/mc/mc_state/state.py
+++ b/netket/vqs/mc/mc_state/state.py
@@ -550,7 +550,9 @@ class MCState(VariationalState):
         """
         return jit_evaluate(self._apply_fun, self.variables, σ)
 
-    def local_estimators(self, op: AbstractOperator, *, chunk_size: int = None):
+    def local_estimators(
+        self, op: AbstractOperator, *, chunk_size: Optional[int] = None
+    ):
         r"""
         Compute the local estimators for the operator :code:`op` (also known as local energies
         when :code:`op` is the Hamiltonian) at the current configuration samples :code:`self.samples`.
@@ -572,27 +574,7 @@ class MCState(VariationalState):
             chunk_size: Suggested maximum size of the chunks used in forward and backward evaluations
                 of the model. (Default: :code:`self.chunk_size`)
         """
-        s, extra_args = get_local_kernel_arguments(self, op)
-
-        shape = s.shape
-        if jnp.ndim(s) != 2:
-            s = s.reshape((-1, shape[-1]))
-
-        def logpsi(w, s):
-            return self._apply_fun({"params": w, **self.model_state}, s)
-
-        if chunk_size is not None or self.chunk_size is not None:
-            if chunk_size is None:
-                chunk_size = self.chunk_size
-            kernel = get_local_kernel(self, op, chunk_size)
-        else:
-            kernel = get_local_kernel(self, op)
-
-        O_loc = kernel(logpsi, self.parameters, s, extra_args)
-
-        # transpose O_loc so it matches the (n_chains, n_samples_per_chain) shape
-        # expected by netket.stats.statistics.
-        return O_loc.reshape(shape[:-1]).T
+        return local_estimators(self, op, chunk_size=chunk_size)
 
     # override to use chunks
     def expect(self, Ô: AbstractOperator) -> Stats:
@@ -687,6 +669,36 @@ class MCState(VariationalState):
             + "sampler = {}, ".format(self.sampler)
             + "n_samples = {})".format(self.n_samples)
         )
+
+
+@partial(jax.jit, static_argnames=("kernel", "apply_fun", "shape"))
+def _local_estimators_kernel(kernel, apply_fun, shape, variables, samples, extra_args):
+    O_loc = kernel(apply_fun, variables, samples, extra_args)
+
+    # transpose O_loc so it matches the (n_chains, n_samples_per_chain) shape
+    # expected by netket.stats.statistics.
+    return O_loc.reshape(shape).T
+
+
+def local_estimators(
+    state: MCState, op: AbstractOperator, *, chunk_size: Optional[int]
+):
+    s, extra_args = get_local_kernel_arguments(state, op)
+
+    shape = s.shape
+    if jnp.ndim(s) != 2:
+        s = s.reshape((-1, shape[-1]))
+
+    if chunk_size is not None or state.chunk_size is not None:
+        if chunk_size is None:
+            chunk_size = state.chunk_size
+        kernel = get_local_kernel(state, op, chunk_size)
+    else:
+        kernel = get_local_kernel(state, op)
+
+    return _local_estimators_kernel(
+        kernel, state._apply_fun, shape[:-1], state.variables, s, extra_args
+    )
 
 
 # serialization

--- a/netket/vqs/mc/mc_state/state.py
+++ b/netket/vqs/mc/mc_state/state.py
@@ -572,7 +572,7 @@ class MCState(VariationalState):
             chunk_size: Suggested maximum size of the chunks used in forward and backward evaluations
                 of the model. (Default: :code:`self.chunk_size`)
         """
-        s, (sp, mels) = get_local_kernel_arguments(self, op)
+        s, extra_args = get_local_kernel_arguments(self, op)
 
         shape = s.shape
         if jnp.ndim(s) != 2:
@@ -588,7 +588,7 @@ class MCState(VariationalState):
         else:
             kernel = get_local_kernel(self, op)
 
-        O_loc = kernel(logpsi, self.parameters, s, (sp, mels))
+        O_loc = kernel(logpsi, self.parameters, s, extra_args)
 
         # transpose O_loc so it matches the (n_chains, n_samples_per_chain) shape
         # expected by netket.stats.statistics.

--- a/netket/vqs/mc/mc_state/state.py
+++ b/netket/vqs/mc/mc_state/state.py
@@ -689,12 +689,13 @@ def local_estimators(
     if jnp.ndim(s) != 2:
         s = s.reshape((-1, shape[-1]))
 
-    if chunk_size is not None or state.chunk_size is not None:
-        if chunk_size is None:
-            chunk_size = state.chunk_size
-        kernel = get_local_kernel(state, op, chunk_size)
-    else:
+    if chunk_size is None:
+        chunk_size = state.chunk_size  # state.chunk_size can still be None
+
+    if chunk_size is None:
         kernel = get_local_kernel(state, op)
+    else:
+        kernel = get_local_kernel(state, op, chunk_size)
 
     return _local_estimators_kernel(
         kernel, state._apply_fun, shape[:-1], state.variables, s, extra_args

--- a/test/variational/test_variational.py
+++ b/test/variational/test_variational.py
@@ -429,6 +429,40 @@ def test_expect(vstate, operator):
     same_derivatives(O_grad, grad_exact, abs_eps=err, rel_eps=err)
 
 
+@common.skipif_mpi
+@pytest.mark.parametrize(
+    "operator",
+    [
+        pytest.param(
+            op,
+            id=name,
+        )
+        for name, op in operators.items()
+    ],
+)
+def test_local_estimators(vstate, operator):
+    def assert_stats_equal(st1, st2):
+        assert st1.mean == pytest.approx(st2.mean)
+        assert st1.variance == pytest.approx(st2.variance)
+        assert st1.error_of_mean == pytest.approx(st2.error_of_mean)
+
+    def inner_test():
+        print(vstate.samples.shape)
+        oloc = vstate.local_estimators(operator)
+        print(oloc.shape)
+        assert oloc.shape == (vstate.sampler.n_chains, vstate.n_samples)
+
+        stats1 = nk.stats.statistics(oloc)
+        stats2 = vstate.expect(operator)
+        assert_stats_equal(stats1, stats2)
+
+    # no chunking
+    inner_test()
+    # chunking
+    vstate.chunk_size = 2
+    inner_test()
+
+
 # Have a different test because the above is marked as xfail.
 # This only checks that the code runs.
 def test_expect_grad_nonhermitian_works(vstate):


### PR DESCRIPTION
This PR adds an `MCState.local_estimators` method, addressing point 2 of #1178 (and superseding the previous PR #1154).
```python3
O_loc = vstate.local_estimators(operator)
print(O_loc.shape) # -> (n_chains, n_samples)
```

It only supports computing the estimate for the current `vstate.samples`. That is a restriction because of the way the interface described in https://netket.readthedocs.io/en/latest/advanced/custom_operators.html allows extending operators in a way that depends on the `VariationalState`, making it non-trivial to decouple that logic. Doing it this way should ensure that the same code path is used to compute the local estimators that is also used for `expect`.