### PR TITLE
When operators have lower precision, return samples of lower precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 ### New features
 
 ### Breaking Changes
+* `nk.operator.Ising`, `nk.operator.BoseHubbard` and `nk.operator.LocalLiouvillian` now return connected samples with the same precision (`dtype`) as the input samples. This allows to preserve low precision along the computation when using those operators.[#1180](https://github.com/netket/netket/pull/1180)
+* `nkx.TDVP` now updates the expectation value displaied in the progress bar at every time-step. [#1182](https://github.com/netket/netket/pull/1182)
 
 
 ## NetKet 3.4.1 (BugFixes & DepWarns)

--- a/test/operator/test_operator.py
+++ b/test/operator/test_operator.py
@@ -224,6 +224,13 @@ def test_get_conn_numpy_closure(op):
     "op", [pytest.param(op, id=name) for name, op in operators.items()]
 )
 @pytest.mark.parametrize(
+    "dtype",
+    [
+        pytest.param(np.float32, id="float32"),
+        pytest.param(np.float64, id="float64"),
+    ],
+)
+@pytest.mark.parametrize(
     "shape",
     [
         pytest.param(s, id=f"shape={s}")
@@ -237,15 +244,17 @@ def test_get_conn_numpy_closure(op):
         ]
     ],
 )
-def test_get_conn_padded(op, shape):
+def test_get_conn_padded(op, shape, dtype):
     hi = op.hilbert
 
-    v = hi.random_state(jax.random.PRNGKey(0), shape)
+    v = hi.random_state(jax.random.PRNGKey(0), shape, dtype=dtype)
 
     vp, mels = op.get_conn_padded(v)
 
     assert vp.ndim == v.ndim + 1
     assert mels.ndim == v.ndim
+    assert vp.dtype == v.dtype
+    assert mels.dtype == op.dtype
 
     vp_f, mels_f = op.get_conn_padded(v.reshape(-1, hi.size))
     np.testing.assert_allclose(vp_f, vp.reshape(-1, *vp.shape[-2:]))


### PR DESCRIPTION
Ising and BoseHubbard (and Lindblad) did not respect this.
Therefore when computing local-energies with single precision models using those operators, jax would go back to double precision