### PR TITLE
enforce correct dtype promotion in qgt implementations

### DIFF
--- a/netket/optimizer/qgt/qgt_jacobian_dense_logic.py
+++ b/netket/optimizer/qgt/qgt_jacobian_dense_logic.py
@@ -287,9 +287,8 @@ def prepare_centered_oks(
     )
 
     n_samp = samples.shape[0] * mpi.n_nodes
-    centered_oks = subtract_mean(jacobians, axis=0) / np.sqrt(
-        n_samp, dtype=jacobians.dtype
-    )
+    sqrt_n_samp = float(np.sqrt(n_samp, dtype=jacobians.dtype))  # enforce weak type
+    centered_oks = subtract_mean(jacobians, axis=0) / sqrt_n_samp
 
     centered_oks = centered_oks.reshape(-1, centered_oks.shape[-1])
 

--- a/netket/optimizer/qgt/qgt_jacobian_dense_logic.py
+++ b/netket/optimizer/qgt/qgt_jacobian_dense_logic.py
@@ -14,10 +14,12 @@
 
 from typing import Callable, Optional, Tuple
 from functools import partial, wraps
+import math
 
-import numpy as np
 import jax
 from jax import numpy as jnp
+
+import numpy as np
 
 from netket.stats import subtract_mean
 from netket.utils.types import PyTree, Array
@@ -287,8 +289,9 @@ def prepare_centered_oks(
     )
 
     n_samp = samples.shape[0] * mpi.n_nodes
-    sqrt_n_samp = float(np.sqrt(n_samp, dtype=jacobians.dtype))  # enforce weak type
-    centered_oks = subtract_mean(jacobians, axis=0) / sqrt_n_samp
+    centered_oks = subtract_mean(jacobians, axis=0) / math.sqrt(
+        n_samp
+    )  # maintain weak type!
 
     centered_oks = centered_oks.reshape(-1, centered_oks.shape[-1])
 

--- a/netket/optimizer/qgt/qgt_jacobian_pytree_logic.py
+++ b/netket/optimizer/qgt/qgt_jacobian_pytree_logic.py
@@ -14,7 +14,7 @@
 
 from typing import Optional
 from functools import partial
-from netket.jax import compose, vmap_chunked
+import math
 
 import jax
 import jax.flatten_util
@@ -24,10 +24,15 @@ import numpy as np
 
 from netket.stats import subtract_mean, sum
 from netket.utils import mpi
-
 from netket.utils.types import Array, Callable, PyTree, Scalar
-
-from netket.jax import tree_cast, tree_conj, tree_axpy, tree_to_real
+from netket.jax import (
+    tree_cast,
+    tree_conj,
+    tree_axpy,
+    tree_to_real,
+    compose,
+    vmap_chunked,
+)
 
 
 # TODO better name and move it somewhere sensible
@@ -114,7 +119,7 @@ def _divide_by_sqrt_n_samp(oks, samples):
     divide Oⱼₖ by √n
     """
     n_samp = samples.shape[0] * mpi.n_nodes  # MPI
-    sqrt_n = float(np.sqrt(n_samp))  # enforce weak type
+    sqrt_n = math.sqrt(n_samp)  # enforce weak type
     return jax.tree_map(lambda x: x / sqrt_n, oks)
 
 

--- a/netket/optimizer/qgt/qgt_jacobian_pytree_logic.py
+++ b/netket/optimizer/qgt/qgt_jacobian_pytree_logic.py
@@ -114,7 +114,8 @@ def _divide_by_sqrt_n_samp(oks, samples):
     divide Oⱼₖ by √n
     """
     n_samp = samples.shape[0] * mpi.n_nodes  # MPI
-    return jax.tree_map(lambda x: x / np.sqrt(n_samp, dtype=x.dtype), oks)
+    sqrt_n = float(np.sqrt(n_samp, dtype=x.dtype))  # enforce weak type
+    return jax.tree_map(lambda x: x / sqrt_n, oks)
 
 
 def _multiply_by_pdf(oks, pdf):

--- a/netket/optimizer/qgt/qgt_jacobian_pytree_logic.py
+++ b/netket/optimizer/qgt/qgt_jacobian_pytree_logic.py
@@ -114,7 +114,7 @@ def _divide_by_sqrt_n_samp(oks, samples):
     divide Oⱼₖ by √n
     """
     n_samp = samples.shape[0] * mpi.n_nodes  # MPI
-    sqrt_n = float(np.sqrt(n_samp, dtype=x.dtype))  # enforce weak type
+    sqrt_n = float(np.sqrt(n_samp))  # enforce weak type
     return jax.tree_map(lambda x: x / sqrt_n, oks)
 
 


### PR DESCRIPTION
numpy.sqrt() was not a weak type and was promoting float32 neetworks to float64.
This was an issue on `QGTJacobian***`

(This came up because I'm trying to run netket at single precision on gpu to get a speed bump and lower memory requirements).

@inailuig can I ask you to add a test for this?