### PR TITLE
print loss stats at each step in TDVP

### DIFF
--- a/netket/experimental/driver/tdvp.py
+++ b/netket/experimental/driver/tdvp.py
@@ -362,6 +362,12 @@ class TDVP(AbstractVariationalDriver):
 
                 pbar.n = np.asarray(self._integrator.t)
                 self._postfix["n"] = self.step_count
+                self._postfix.update(
+                    {
+                        self._loss_name: str(self._loss_stats),
+                    }
+                )
+
                 pbar.set_postfix(self._postfix)
                 pbar.refresh()
 


### PR DESCRIPTION
We are already updating the progress bar at every substep, so we might as well print the expectation value as well.
It can help detect when NaNs are encountered