### PR TITLE
Vectorise `test_gcnn_equivariance`

### DIFF
--- a/test/models/test_gcnn.py
+++ b/test/models/test_gcnn.py
@@ -55,6 +55,8 @@ def test_gcnn_equivariance(parity, symmetries, lattice, mode):
     pars = ma.init(nk.jax.PRNGKey(), hi.random_state(nk.jax.PRNGKey(), 1))
 
     v = hi.random_state(jax.random.PRNGKey(0), 3)
+    # vals = [ma.apply(pars, v[..., p]) for p in np.asarray(perms)]
+    # code below implements the commented line above, but is vectorised    
     v = v[..., np.asarray(perms)].transpose(1, 0, 2)
     v = v.reshape(len(perms) * 3, g.n_nodes)
     vals = ma.apply(pars, v).reshape(len(perms), 3)

--- a/test/models/test_gcnn.py
+++ b/test/models/test_gcnn.py
@@ -55,7 +55,9 @@ def test_gcnn_equivariance(parity, symmetries, lattice, mode):
     pars = ma.init(nk.jax.PRNGKey(), hi.random_state(nk.jax.PRNGKey(), 1))
 
     v = hi.random_state(jax.random.PRNGKey(0), 3)
-    vals = [ma.apply(pars, v[..., p]) for p in np.asarray(perms)]
+    v = jnp.asarray([v[..., p] for p in np.asarray(perms)])
+    v = v.reshape(len(perms) * 3, g.n_nodes)
+    vals = ma.apply(pars, v).reshape(len(perms), 3)
 
     for val in vals:
         assert jnp.allclose(val, vals[0])

--- a/test/models/test_gcnn.py
+++ b/test/models/test_gcnn.py
@@ -55,7 +55,7 @@ def test_gcnn_equivariance(parity, symmetries, lattice, mode):
     pars = ma.init(nk.jax.PRNGKey(), hi.random_state(nk.jax.PRNGKey(), 1))
 
     v = hi.random_state(jax.random.PRNGKey(0), 3)
-    v = jnp.asarray([v[..., p] for p in np.asarray(perms)])
+    v = v[..., np.asarray(perms)].transpose(1, 0, 2)
     v = v.reshape(len(perms) * 3, g.n_nodes)
     vals = ma.apply(pars, v).reshape(len(perms), 3)
 

--- a/test/models/test_gcnn.py
+++ b/test/models/test_gcnn.py
@@ -56,7 +56,7 @@ def test_gcnn_equivariance(parity, symmetries, lattice, mode):
 
     v = hi.random_state(jax.random.PRNGKey(0), 3)
     # vals = [ma.apply(pars, v[..., p]) for p in np.asarray(perms)]
-    # code below implements the commented line above, but is vectorised    
+    # code below implements the commented line above, but is vectorised
     v = v[..., np.asarray(perms)].transpose(1, 0, 2)
     v = v.reshape(len(perms) * 3, g.n_nodes)
     vals = ma.apply(pars, v).reshape(len(perms), 3)


### PR DESCRIPTION
This PR merges the symmetry-related input spin configurations in `test_gcnn_equivariance` into a single array so they can be pulled through the GCNN in a single call, as suggested in #1171. On my laptop, this leads to a factor of ~3 speedup.

I don't think there's a similar quick fix for `test_gcnn`, the long runtimes there probably have to do with jitting everything you need for VMC.