### PR TITLE
Warn if user specifies `sigmay(dtype=realT)`

### DIFF
--- a/netket/operator/_abstract_operator.py
+++ b/netket/operator/_abstract_operator.py
@@ -111,4 +111,4 @@ class AbstractOperator(abc.ABC):
         return self.conjugate(concrete=False)
 
     def __repr__(self):
-        return f"{type(self).__name__}(hilbert={self.hilbert})"
+        return f"{type(self).__name__}(hilbert={self.hilbert}, dtype={self.dtype})"

--- a/netket/operator/spin.py
+++ b/netket/operator/spin.py
@@ -58,6 +58,20 @@ def sigmay(
     :return: a nk.operator.LocalOperator
     """
     import numpy as np
+    import netket.jax as nkjax
+
+    if not nkjax.is_complex_dtype(dtype):
+        import jax.numpy as jnp
+        import warnings
+
+        old_dtype = dtype
+        dtype = jnp.promote_types(complex, old_dtype)
+        warnings.warn(
+            np.ComplexWarning(
+                f"A complex dtype is required (dtype={old_dtype} specified). "
+                f"Promoting to dtype={dtype}."
+            )
+        )
 
     N = hilbert.size_at_index(site)
     S = (N - 1) / 2

--- a/test/operator/test_liouvillian.py
+++ b/test/operator/test_liouvillian.py
@@ -17,6 +17,7 @@ import numpy as np
 from scipy import sparse
 from scipy.sparse import linalg
 
+import pytest
 from pytest import approx
 
 from netket.operator import spin
@@ -116,3 +117,33 @@ def test_linear_operator():
     assert res_op2[-1] - dm.reshape((hi.n_states, hi.n_states)).trace() == approx(
         0.0, rel=1e-8, abs=1e-8
     )
+
+dtypes_r = [np.float32, np.float64]
+dtypes_c = [np.complex64, np.complex128]
+dtypes = dtypes_r + dtypes_c
+
+@pytest.mark.parametrize("dtype", dtypes)
+def test_dtype(dtype):
+    if not nk.jax.is_complex_dtype(dtype):
+        with pytest.warns(np.ComplexWarning):
+            lind = nk.operator.LocalLiouvillian(ha, j_ops, dtype=dtype)
+            dtype_c = nk.jax.dtype_complex(dtype)
+
+    else:
+        lind = nk.operator.LocalLiouvillian(ha, j_ops, dtype=dtype)
+        dtype_c = dtype
+
+    assert lind.dtype == dtype_c
+    assert lind.hamiltonian_nh.dtype == dtype_c
+    for op in lind.jump_operators:
+        assert op.dtype == dtype_c
+
+    for _dt in dtypes_r + [np.int8, np.int16]:
+        sigma = op.hilbert.numbers_to_states(np.array([0,1,2,3]))
+        sigma = np.array(sigma, dtype=_dt)
+        sigmap, mels = op.get_conn_padded(sigma)
+        assert sigmap.dtype == sigma.dtype
+        assert mels.dtype == lind.dtype
+
+
+

--- a/test/operator/test_liouvillian.py
+++ b/test/operator/test_liouvillian.py
@@ -118,9 +118,11 @@ def test_linear_operator():
         0.0, rel=1e-8, abs=1e-8
     )
 
+
 dtypes_r = [np.float32, np.float64]
 dtypes_c = [np.complex64, np.complex128]
 dtypes = dtypes_r + dtypes_c
+
 
 @pytest.mark.parametrize("dtype", dtypes)
 def test_dtype(dtype):
@@ -139,11 +141,8 @@ def test_dtype(dtype):
         assert op.dtype == dtype_c
 
     for _dt in dtypes_r + [np.int8, np.int16]:
-        sigma = op.hilbert.numbers_to_states(np.array([0,1,2,3]))
+        sigma = op.hilbert.numbers_to_states(np.array([0, 1, 2, 3]))
         sigma = np.array(sigma, dtype=_dt)
         sigmap, mels = op.get_conn_padded(sigma)
         assert sigmap.dtype == sigma.dtype
         assert mels.dtype == lind.dtype
-
-
-

--- a/test/operator/test_spin.py
+++ b/test/operator/test_spin.py
@@ -36,3 +36,20 @@ def test_pauli_algebra(S):
             assert_almost_equal(
                 (-1j * sx.to_dense() @ sy.to_dense() @ sz.to_dense()), Imat
             )
+
+def test_sigmay_is_complex():
+    hi = nk.hilbert.Spin(1//2) ** 3
+
+    with pytest.warns(np.ComplexWarning):
+        sy = spin.sigmay(hi, 0, dtype=np.float64)
+        assert sy.dtype == np.complex128
+
+    with pytest.warns(np.ComplexWarning):
+        sy = spin.sigmay(hi, 0, dtype=np.float32)
+        assert sy.dtype == np.complex64
+
+    sy = spin.sigmay(hi, 0, dtype=np.complex64)
+    assert sy.dtype == np.complex64
+
+    sy = spin.sigmay(hi, 0, dtype=np.complex128)
+    assert sy.dtype == np.complex128

--- a/test/operator/test_spin.py
+++ b/test/operator/test_spin.py
@@ -37,8 +37,9 @@ def test_pauli_algebra(S):
                 (-1j * sx.to_dense() @ sy.to_dense() @ sz.to_dense()), Imat
             )
 
+
 def test_sigmay_is_complex():
-    hi = nk.hilbert.Spin(1//2) ** 3
+    hi = nk.hilbert.Spin(1 // 2) ** 3
 
     with pytest.warns(np.ComplexWarning):
         sy = spin.sigmay(hi, 0, dtype=np.float64)


### PR DESCRIPTION
Sigmay and Liouvillian are complex by definition, so they cannot handle real dtypes.
Warn when this happens.