### PR TITLE
Allow adding an operator and it's (lazy) transpose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### Bug Fixes
 * Several _type promotion_ bugs that would end up promoting single-precision models to double-precision have been squashed. Those involved `nk.operator.Ising` and `nk.operator.BoseHubbard`[#1180](https://github.com/netket/netket/pull/1180), `nkx.TDVP` [#1186](https://github.com/netket/netket/pull/1186) and continuous-space samplers and operators [#1187](https://github.com/netket/netket/pull/1187).
 * Fixed bug [#1192](https://github.com/netket/netket/pull/1192) that affected most operators (`nk.operator.LocalOperator`) constructed on non-homogeneous hilbert spaces. This bug was first introduced in version 3.3.4 and affects all subsequent versions until [NEXT BUGFIX RELEASE]. [#1193](https://github.com/netket/netket/pull/1193)
+* It is now possible to add an operator and it's lazy transpose/hermitian conjugate [#1194](https://github.com/netket/netket/pull/1194)
 
 ## NetKet 3.4.1 (BugFixes & DepWarns)
 

--- a/netket/operator/_local_operator_helpers.py
+++ b/netket/operator/_local_operator_helpers.py
@@ -24,8 +24,7 @@ from scipy.sparse import spmatrix
 from netket.hilbert import AbstractHilbert, Fock
 from netket.utils.types import DType, Array
 
-from ._abstract_operator import AbstractOperator
-from ._discrete_operator import DiscreteOperator
+from ._discrete_operator import AbstractOperator, DiscreteOperator
 
 
 def _dtype(obj: Union[numbers.Number, Array, AbstractOperator]) -> DType:
@@ -34,7 +33,7 @@ def _dtype(obj: Union[numbers.Number, Array, AbstractOperator]) -> DType:
     """
     if isinstance(obj, numbers.Number):
         return type(obj)
-    elif isinstance(obj, DiscreteOperator):
+    elif isinstance(obj, AbstractOperator):
         return obj.dtype
     elif isinstance(obj, np.ndarray):
         return obj.dtype

--- a/test/operator/test_local_operator.py
+++ b/test/operator/test_local_operator.py
@@ -489,8 +489,8 @@ def test_inhomogeneous_hilb_issue_1192():
 
     assert_same_matrices(c0 @ d2, c0.to_dense() @ d2.to_dense())
 
-def test_add_transpose():
-    hi = nk.hilbert.Fock(n_max=3) 
-    c0 = bcreate(hi, 0)
-    assert_same_matrices(c0+c0.H, c0.to_dense() + c0.H.to_dense())
 
+def test_add_transpose():
+    hi = nk.hilbert.Fock(n_max=3)
+    c0 = bcreate(hi, 0)
+    assert_same_matrices(c0 + c0.H, c0.to_dense() + c0.H.to_dense())

--- a/test/operator/test_local_operator.py
+++ b/test/operator/test_local_operator.py
@@ -488,3 +488,9 @@ def test_inhomogeneous_hilb_issue_1192():
     d2 = bdestroy(hi, 2)
 
     assert_same_matrices(c0 @ d2, c0.to_dense() @ d2.to_dense())
+
+def test_add_transpose():
+    hi = nk.hilbert.Fock(n_max=3) 
+    c0 = bcreate(hi, 0)
+    assert_same_matrices(c0+c0.H, c0.to_dense() + c0.H.to_dense())
+


### PR DESCRIPTION
From the recently opened issue I noticed that right now neteket complains if you try to add an operator and its lazy transpose/hermitian.

The issue arises because he does not know that he can take the `obj.dtype` of those types... I fixed it now.

```
>>> a+a.H
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/filippovicentini/Dropbox/Ricerca/Codes/Python/netket/netket/operator/_local_operator.py", line 241, in __add__
    op = self.copy(dtype=np.promote_types(self.dtype, _dtype(other)))
  File "/Users/filippovicentini/Dropbox/Ricerca/Codes/Python/netket/netket/operator/_local_operator_helpers.py", line 42, in _dtype
    raise TypeError(f"cannot deduce dtype of object type {type(obj)}: {obj}")
TypeError: cannot deduce dtype of object type <class 'netket.operator._lazy.Adjoint[<class 'netket.operator._local_operator.LocalOperator'>]'>: Adjoint(LocalOperator(dim=1, acting_on=[(0,)], constant=0.0, dtype=float64))
```

This is now addressed