### PR TITLE
Use get_conn_flattened for our local energy expectation kernels

### DIFF
--- a/netket/jax/__init__.py
+++ b/netket/jax/__init__.py
@@ -34,6 +34,7 @@ from .utils import (
     mpi_split,
     PRNGKey,
     PRNGSeq,
+    complex,
 )
 
 from ._vjp import vjp

--- a/netket/jax/__init__.py
+++ b/netket/jax/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from netket.utils import HashablePartial
+from netket.utils import HashablePartial, Static
 
 from .utils import (
     tree_ravel,

--- a/netket/jax/__init__.py
+++ b/netket/jax/__init__.py
@@ -41,6 +41,7 @@ from ._vjp import vjp
 from ._grad import grad, value_and_grad
 
 from ._expect import expect
+from ._segment import segment_sumdiffexp
 
 from ._chunk_utils import chunk, unchunk
 from ._scanmap import scan_reduce, scan_append, scan_append_reduce, scanmap

--- a/netket/jax/_segment.py
+++ b/netket/jax/_segment.py
@@ -35,11 +35,6 @@ def segment_sumdiffexp(A_nz, B=None, *, row_lengths, H_nz=None):
         sections: a keyword argument expressing the length of every row of the matrix A.
         H: an optional kewyrod argumnet that must be a vector with the same structure as `vecA`.
     """
-    return _segment_sumdiffexp(A_nz, B, H_nz, row_lengths)
-
-
-@partial(jax.custom_jvp, nondiff_argnums=(3,))
-def _segment_sumdiffexp(A_nz, B, H_nz, row_lengths):
 
     if A_nz.ndim != 1:
         raise ValueError(
@@ -76,28 +71,3 @@ def _segment_sumdiffexp(A_nz, B, H_nz, row_lengths):
     )
 
     return result
-
-
-@_segment_sumdiffexp.defjvp
-def _segment_sumdiffexp_jvp(row_lengths, primals, tangents):
-    print(f"extra {row_lengths}")
-    A_nz, B, H_nz = primals
-    A_nz_dot, B_dot, H_nz_dot = tangents
-
-    primal_out = _segment_sumdiffexp(A_nz, B, H_nz, row_lengths)
-    dR_dH_dH = _segment_sumdiffexp(A_nz, B, H_nz_dot, row_lengths)
-    dR_dA_dA = _segment_sumdiffexp(A_nz, B, H_nz * A_nz_dot, row_lengths)
-    dR_dB = -_segment_sumdiffexp(A_nz, B, H_nz, row_lengths)
-    print(f"{primal_out = }")
-    print(f"{dR_dH_dH = }")
-    print(f"{dR_dA_dA =}")
-    print(f"{dR_dB =}")
-    print(f"{A_nz_dot =}")
-    print(f"{B_dot =}")
-    print(f"{H_nz_dot =}")
-    tangent_out = dR_dH_dH + dR_dA_dA + dR_dB * B_dot
-    tangent_out = dR_dB * B_dot
-
-    print(f"{tangent_out = }")
-
-    return primal_out, tangent_out

--- a/netket/jax/_segment.py
+++ b/netket/jax/_segment.py
@@ -1,0 +1,103 @@
+# Copyright 2022 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Callable, Tuple
+from functools import partial
+
+import jax
+from jax import numpy as jnp
+import numpy as np
+
+from netket.utils.types import PyTree
+
+
+def segment_sumdiffexp(A_nz, B=None, *, row_lengths, H_nz=None):
+    r"""
+    computes
+    $$
+    \sum_{j=0}^{s[i]} H_{i,j}\exp[A_{i,j} - B_i]
+    $$
+
+    Args:
+        vecA: a vector containing all non-zero entries in the matrix `A`.
+        B: a vector containing all entries `B`
+        sections: a keyword argument expressing the length of every row of the matrix A.
+        H: an optional kewyrod argumnet that must be a vector with the same structure as `vecA`.
+    """
+    return _segment_sumdiffexp(A_nz, B, H_nz, row_lengths)
+
+
+@partial(jax.custom_jvp, nondiff_argnums=(3,))
+def _segment_sumdiffexp(A_nz, B, H_nz, row_lengths):
+
+    if A_nz.ndim != 1:
+        raise ValueError(
+            "The first argument `A_nz` must be a vector of nonzero entries."
+        )
+    if H_nz is None:
+        H_nz = 1
+    elif H_nz.shape != A_nz.shape:
+        raise ValueError(
+            "The optional argument `H_nz` must have the same shape as `A_nz`."
+        )
+
+    N_rows = row_lengths.shape[0]
+    n_nonzero = A_nz.size
+
+    if B is None:
+        B_ext = 1
+    elif B.shape[0] == row_lengths.shape[0]:
+        B_ext = jnp.repeat(B, row_lengths, total_repeat_length=n_nonzero)
+    else:
+        raise ValueError(
+            "The second argument `B` must be a vector with the same length as `row_lengths`."
+        )
+
+    # compute the matrix elements in vector form
+    values = H_nz * jnp.exp(A_nz - B_ext)
+
+    # Construct the indices necessary to perform the segment_sum
+    indices = jnp.repeat(jnp.arange(N_rows), row_lengths, total_repeat_length=n_nonzero)
+
+    # sum contiguous blocks of `values` according to `indices`
+    result = jax.ops.segment_sum(
+        values, indices, num_segments=N_rows, indices_are_sorted=True
+    )
+
+    return result
+
+
+@_segment_sumdiffexp.defjvp
+def _segment_sumdiffexp_jvp(row_lengths, primals, tangents):
+    print(f"extra {row_lengths}")
+    A_nz, B, H_nz = primals
+    A_nz_dot, B_dot, H_nz_dot = tangents
+
+    primal_out = _segment_sumdiffexp(A_nz, B, H_nz, row_lengths)
+    dR_dH_dH = _segment_sumdiffexp(A_nz, B, H_nz_dot, row_lengths)
+    dR_dA_dA = _segment_sumdiffexp(A_nz, B, H_nz * A_nz_dot, row_lengths)
+    dR_dB = -_segment_sumdiffexp(A_nz, B, H_nz, row_lengths)
+    print(f"{primal_out = }")
+    print(f"{dR_dH_dH = }")
+    print(f"{dR_dA_dA =}")
+    print(f"{dR_dB =}")
+    print(f"{A_nz_dot =}")
+    print(f"{B_dot =}")
+    print(f"{H_nz_dot =}")
+    tangent_out = dR_dH_dH + dR_dA_dA + dR_dB * B_dot
+    tangent_out = dR_dB * B_dot
+
+    print(f"{tangent_out = }")
+
+    return primal_out, tangent_out

--- a/netket/utils/__init__.py
+++ b/netket/utils/__init__.py
@@ -21,6 +21,7 @@ from . import types
 from . import float
 
 from .array import HashableArray
+from .static import Static
 from .partial import HashablePartial
 from .jax import get_afun_if_module, wrap_afun, wrap_to_support_scalar
 from .optional_deps import tensorboard_available

--- a/netket/utils/static.py
+++ b/netket/utils/static.py
@@ -1,0 +1,28 @@
+# Copyright 2021 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any
+
+from netket.utils import struct
+
+
+@struct.dataclass(cache_hash=True)
+class Static:
+    """
+    This class wraps an hashable class to make it a Static Argument for a
+    jax compiled function.
+    """
+
+    value: Any = struct.field(pytree_node=False)
+    """The wrapped object."""

--- a/netket/vqs/mc/mc_mixed_state/expect.py
+++ b/netket/vqs/mc/mc_mixed_state/expect.py
@@ -44,7 +44,7 @@ def get_local_kernel_arguments(  # noqa: F811
 
     secs = np.zeros(σr.shape[0], dtype=np.intp)
     σp, mels = Ô.get_conn_flattened(σr, sections=secs)
-    return σ, (σp, mels, secs, nkjax.Static(int(secs[-1])))
+    return σ, (σp, mels, secs)
 
 
 @dispatch
@@ -57,7 +57,7 @@ def get_local_kernel_arguments(  # noqa: F811
 
     secs = np.zeros(σr.shape[0], dtype=np.intp)
     σp, mels = Ô.get_conn_flattened(σr, sections=secs)
-    return σ, (σp, mels, secs, nkjax.Static(int(secs[-1])))
+    return σ, (σp, mels, secs)
 
 
 @dispatch

--- a/netket/vqs/mc/mc_mixed_state/expect_chunked.py
+++ b/netket/vqs/mc/mc_mixed_state/expect_chunked.py
@@ -30,11 +30,11 @@ from .state import MCMixedState
 def get_local_kernel(  # noqa: F811
     vstate: MCMixedState, Ô: Squared[AbstractSuperOperator], chunk_size: int
 ):
-    return kernels.local_value_squared_kernel_chunked
+    return kernels.local_value_squared_kernel_flattened_chunked
 
 
 @dispatch
 def get_local_kernel(  # noqa: F811
     vstate: MCMixedState, Ô: DiscreteOperator, chunk_size: int
 ):
-    return kernels.local_value_op_op_cost_chunked
+    return kernels.local_value_op_op_kernel_flattened

--- a/netket/vqs/mc/mc_mixed_state/expect_chunked.py
+++ b/netket/vqs/mc/mc_mixed_state/expect_chunked.py
@@ -27,6 +27,11 @@ from .state import MCMixedState
 
 # Dispatches to select what expect-kernel to use
 @dispatch
+def get_local_kernel(vstate: MCMixedState, Ô: AbstractSuperOperator):  # noqa: F811
+    return kernels.local_value_kernel_flattened_chunked
+
+
+@dispatch
 def get_local_kernel(  # noqa: F811
     vstate: MCMixedState, Ô: Squared[AbstractSuperOperator], chunk_size: int
 ):

--- a/netket/vqs/mc/mc_state/expect.py
+++ b/netket/vqs/mc/mc_state/expect.py
@@ -50,7 +50,7 @@ def get_local_kernel_arguments(vstate: MCState, Ô: DiscreteOperator):  # noqa:
 
     secs = np.zeros(σr.shape[0], dtype=np.intp)
     σp, mels = Ô.get_conn_flattened(σr, sections=secs)
-    return σ, (σp, mels, secs, nkjax.Static(int(secs[-1])))
+    return σ, (σp, mels, secs)
 
 
 @dispatch

--- a/netket/vqs/mc/mc_state/expect.py
+++ b/netket/vqs/mc/mc_state/expect.py
@@ -42,15 +42,6 @@ from .state import MCState
 
 
 @dispatch
-def get_local_kernel_arguments(vstate: MCState, Ô: Squared):  # noqa: F811
-    return get_local_kernel_arguments(vstate, Ô.parent)
-
-@dispatch
-def get_local_kernel(vstate: MCState, Ô: Squared):  # noqa: F811
-    return kernels.local_value_squared_kernel_flattened
-
-
-@dispatch
 def get_local_kernel_arguments(vstate: MCState, Ô: DiscreteOperator):  # noqa: F811
     check_hilbert(vstate.hilbert, Ô.hilbert)
 
@@ -64,7 +55,17 @@ def get_local_kernel_arguments(vstate: MCState, Ô: DiscreteOperator):  # noqa:
 
 @dispatch
 def get_local_kernel(vstate: MCState, Ô: DiscreteOperator):  # noqa: F811
-    return kernels.local_value_kernel_flattened
+    return kernels.local_value_kernel_flattened_chunked
+
+
+@dispatch
+def get_local_kernel_arguments(vstate: MCState, Ô: Squared):  # noqa: F811
+    return get_local_kernel_arguments(vstate, Ô.parent)
+
+
+@dispatch
+def get_local_kernel(vstate: MCState, Ô: Squared):  # noqa: F811
+    return kernels.local_value_squared_kernel_flattened
 
 
 @dispatch

--- a/netket/vqs/mc/mc_state/expect_chunked.py
+++ b/netket/vqs/mc/mc_state/expect_chunked.py
@@ -45,14 +45,14 @@ from .state import MCState
 # Dispatches to select what expect-kernel to use
 @dispatch
 def get_local_kernel(vstate: MCState, Ô: Squared, chunk_size: int):  # noqa: F811
-    return kernels.local_value_squared_kernel_chunked
+    return kernels.local_value_squared_kernel_flattened_chunked
 
 
 @dispatch
 def get_local_kernel(  # noqa: F811
     vstate: MCState, Ô: DiscreteOperator, chunk_size: int
 ):
-    return kernels.local_value_kernel_chunked
+    return kernels.local_value_kernel_flattened_chunked
 
 
 def _local_continuous_kernel(kernel, logpsi, pars, σ, args, *, chunk_size=None):

--- a/test/utils/test_frameworks.py
+++ b/test/utils/test_frameworks.py
@@ -36,6 +36,7 @@ def test_jax_framework_works_without_haiku():
 
 
 def test_haiku_framework():
+    pytest.importorskip("haiku")
     import haiku as hk
 
     def apply(x):


### PR DESCRIPTION
**Please give me feedback**

Right now local kernels use `get_conn_padded` which pad the number of connected elements per sample to the maximum number of connected elements among all the samples.

This leads to some wasted compute power.

This PR improves the situation by using `get_conn_flattened` to get the connected elements on discrete operators.
The downside is that the local-energy code becomes considerably more convoluted. The upside is that this gives a net x% speedup where x is the number of 0 matrix elements you have in your operators.

While for Ising and simple hamiltonians this gives no bonus (and in fact, yields a small ~1-5% slowdown in Ising 20 spins, vanishingly small on 60 spins), this gives me a 20% speedup in some dissipative things I'm running.
And I guess @jwnys might be interested too?

Still WIP, but I'd like some feedback on this 

Note: this code path is only taken if chunking is disabled. I still have to update the chunked code.