### PR TITLE
support identity LocalOperator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Breaking Changes
 
 ### Bug Fixes
+* Fixed bug where a `nk.operator.LocalOperator` representing the identity would lead to a crash. [#1197](https://github.com/netket/netket/pull/1197)
 
 
 ## NetKet 3.4.2 (BugFixes & DepWarns again)

--- a/test/operator/test_local_operator.py
+++ b/test/operator/test_local_operator.py
@@ -494,3 +494,15 @@ def test_add_transpose():
     hi = nk.hilbert.Fock(n_max=3)
     c0 = bcreate(hi, 0)
     assert_same_matrices(c0 + c0.H, c0.to_dense() + c0.H.to_dense())
+
+
+def test_identity():
+    hi = nk.hilbert.Fock(n_max=3)
+    I = nk.operator.LocalOperator(hi, constant=1)
+    
+    assert_same_matrices(I, np.eye(hi.n_states))
+
+    X = bcreate(hi, 0)
+    assert_same_matrices(I@X, X)
+
+

--- a/test/operator/test_local_operator.py
+++ b/test/operator/test_local_operator.py
@@ -499,10 +499,8 @@ def test_add_transpose():
 def test_identity():
     hi = nk.hilbert.Fock(n_max=3)
     I = nk.operator.LocalOperator(hi, constant=1)
-    
+
     assert_same_matrices(I, np.eye(hi.n_states))
 
     X = bcreate(hi, 0)
-    assert_same_matrices(I@X, X)
-
-
+    assert_same_matrices(I @ X, X)


### PR DESCRIPTION
LocalOperator crashes if it has no operators (so it's the identity) unless one builds it on purpose with matrices full of zeros, which is not needed.

This supports 'empty' local operators with only a diagonal constant