### PR TITLE
[NFC] Clean-up some old workarounds in sampler, simplify some code, and add error checking

### DIFF
--- a/docs/advanced/custom_preconditioners.md
+++ b/docs/advanced/custom_preconditioners.md
@@ -27,7 +27,7 @@ The Callable must accept two (positional) inputs, where the first is the variati
 The output of the preconditioner must be the transformed gradient stored as a PyTree.
 
 This general API will allow you to implement any preconditioner and use it together with NetKet's variational optimization drivers.
-However, note that any performance optimisation (such as calling {func}`jax.jit` on the code) will be your responsability.
+However, note that any performance optimisation (such as calling {func}`jax.jit` on the code) will be your responsibility.
 
 ### The LinearPreconditioner interface
 

--- a/docs/advanced/custom_preconditioners.md
+++ b/docs/advanced/custom_preconditioners.md
@@ -26,7 +26,7 @@ def preconditioner(vstate: VariationalState, gradient: PyTree) -> PyTree:
 The Callable must accept two (positional) inputs, where the first is the variational state itself and the latter is the current gradient, stored as a PyTree.
 The output of the preconditioner must be the transformed gradient stored as a PyTree.
 
-This general API will allow you to implement any preconditioner and use it together with NetKet Variational Drivers.
+This general API will allow you to implement any preconditioner and use it together with NetKet's variational optimization drivers.
 However, note that any performance optimisation (such as calling {func}`jax.jit` on the code) will be your responsability.
 
 ### The LinearPreconditioner interface

--- a/docs/api/api-experimental.md
+++ b/docs/api/api-experimental.md
@@ -9,7 +9,7 @@
 In this page we present some experimental interfaces of NetKet.
 Those are not guaranteed to be API-stable, and might change without notice (other than the
 changelog) among minor releases.
-The {ref}`netket.experimental` modules mirrors the standard {ref}`netket` module structure,
+The {ref}`netket.experimental <api-experimental>` modules mirrors the standard {ref}`netket <api>` module structure,
 and we suggest to use it as follows:
 
 ```python
@@ -29,7 +29,7 @@ Until we will have verified this hypotesis and updated the tests in order not
 to fail, we provide the current implementation as-is, in the hope that some
 contributor might take up that work.
 
-The other experimental sampler is MetropolisSamplerPmap, which makes use of {ref}`jax.pmap`
+The other experimental sampler is MetropolisSamplerPmap, which makes use of {func}`jax.pmap`
 to use different GPUs/CPUs without having to use MPI. It should scale much better over
 several CPUs, but you have to start jax with a specific environment variable.
 

--- a/docs/api/drivers.md
+++ b/docs/api/drivers.md
@@ -6,6 +6,7 @@
 
 ```
 
+(drivers_abstract_classes)=
 ## Abstract classes
 
 Those are the abstract classes you can inherit from to implement your own driver
@@ -20,6 +21,7 @@ Those are the abstract classes you can inherit from to implement your own driver
    AbstractVariationalDriver
 ```
 
+(drivers_concrete)=
 ## Concrete drivers
 
 Those are the optimization drivers already implmented in Netket:

--- a/docs/api/operator.md
+++ b/docs/api/operator.md
@@ -39,7 +39,7 @@ Those classes cannot be directly instantiated, but you can inherit from one of t
 
 ## Concrete Classes
 
-Below you find a list of all concrete Operators that you can create on [DiscreteHilbert](netket.hilbert.DiscreteHilbert) spaces.
+Below you find a list of all concrete Operators that you can create on {class}`~netket.hilbert.DiscreteHilbert` spaces.
 
 ```{eval-rst}
 .. currentmodule:: netket.operator
@@ -72,7 +72,7 @@ In the experimental submodule there is also a class to represent fermionic opera
 
 ### Continuous space operators
 
-This is a list of operators that you can define on [ContinuousHilbert](netket.hilbert.ContinuousHilbert) spaces.
+This is a list of operators that you can define on {class}`~netket.hilbert.ContinuousHilbert` spaces.
 
 ```{eval-rst}
 .. currentmodule:: netket.operator
@@ -89,7 +89,7 @@ This is a list of operators that you can define on [ContinuousHilbert](netket.hi
 
 ## Pre-defined operators
 
-Those are easy-to-use constructors for a [LocalOperator](netket.operator.LocalOperator).
+Those are easy-to-use constructors for a {class}`~netket.operator.LocalOperator`.
 
 ```{eval-rst}
 .. currentmodule:: netket.operator
@@ -110,7 +110,7 @@ Those are easy-to-use constructors for a [LocalOperator](netket.operator.LocalOp
 
 ```
 
-In the experimental submodule there are also easy-to-use constructors for common [FermionOperator2nd](netket.experimental.operator.FermionOperator2nd).
+In the experimental submodule there are also easy-to-use constructors for common {class}`~netket.experimental.operator.FermionOperator2nd`.
 
 ```{eval-rst}
 .. currentmodule:: netket

--- a/docs/docs/drivers.md
+++ b/docs/docs/drivers.md
@@ -16,7 +16,7 @@ may wish.
 
 There are two objects both drivers above need in order to be constructed:
 
-- The {class}`~netket.operator.AbstractOperator` defining the problem we wish to solve, such as the Hamiltonian for which we want to find the ground state or the Lindbladian for which we want to find the Steady-State.
+- The {class}`~netket.operator.AbstractOperator` defining the problem we wish to solve, such as the Hamiltonian for which we want to find the ground state or the Lindbladian for which we want to find the steady state.
 - The [Optimizer](netket_optimizer_api) to use in order to update the weights among iterations.
 
 Those are respectively the first and second argument of the constructor.

--- a/docs/docs/drivers.md
+++ b/docs/docs/drivers.md
@@ -1,7 +1,7 @@
 # The Drivers API
 
 In this section we will briefly describe the capabilities of the drivers API.
-This page assumes that you have already read and are familiar witht the [Variational State interface](varstate).
+This page assumes that you have already read and are familiar with the [`VariationalState` interface](varstate).
 
 In Netket there are two drivers, even though you can define your own; those are:
 

--- a/docs/docs/drivers.md
+++ b/docs/docs/drivers.md
@@ -80,6 +80,6 @@ run(n_iter, out=None, obs=None, callback=None, step_size=None)
 
   The first argument is the step number, the second argument is the dictionary holding data that will be logged, and it can be modified by the callback, and the third is the driver itself, which can be used to access the current state or any other quantity.
   The output of the callback must be a boolean, which signals whever to continue the optimisation or not. When any one of the callbacks return {code}`False`, the optimisation will be stopped.
-  Netket comes with a few built-in callbacks, listed [in the API](netket_callbacks_api)`, but you can also implement your own.
+  NetKet comes with a few built-in callbacks, listed [in the API docs](netket_callbacks_api)`, but you can also implement your own.
 
 - {code}`step_size`: Data will be logged and callbacks will be called every {code}`step_size` optimisation steps. Useful if your callbacks have a high computational cost. If unspecified, logs at every step.

--- a/docs/docs/drivers.md
+++ b/docs/docs/drivers.md
@@ -1,8 +1,7 @@
 # The Drivers API
 
 In this section we will briefly describe the capabilities of the drivers API.
-This page assumes that you have already read and are familiar witht the {ref}`Variational
-State interface <variational_state>`.
+This page assumes that you have already read and are familiar witht the [Variational State interface](varstate).
 
 In Netket there are two drivers, even though you can define your own; those are:
 
@@ -17,8 +16,8 @@ may wish.
 
 There are two objects both drivers above need in order to be constructed:
 
-- The {class}`netket.operator.AbstractOperator` defining the problem we wish to solve, such as the Hamiltonian for which we want to find the ground state or the Lindbladian for which we want to find the Steady-State.
-- The {ref}`Optimizer <optimizer-api>` to use in order to update the weights among iterations.
+- The {class}`~netket.operator.AbstractOperator` defining the problem we wish to solve, such as the Hamiltonian for which we want to find the ground state or the Lindbladian for which we want to find the Steady-State.
+- The [Optimizer](netket_optimizer_api) to use in order to update the weights among iterations.
 
 Those are respectively the first and second argument of the constructor.
 
@@ -72,7 +71,7 @@ run(n_iter, out=None, obs=None, callback=None, step_size=None)
 
   - {code}`string`: A default Json logger will be created, serializing data to the specified filename.
 
-  - {code}`Logger`: a logger, or iterable of loggers, respecting the standard loging interface. The available loggers are listed {ref}`here <logging-api>`.
+  - {code}`Logger`: a logger, or iterable of loggers, respecting the standard loging interface. The available loggers are listed [here](netket_logging_api).
 
   - The {code}`callbacks` can be used to pass callbacks to the optimisation driver. Callbacks must be callables with the signature
     .. code:: python
@@ -81,6 +80,6 @@ run(n_iter, out=None, obs=None, callback=None, step_size=None)
 
   The first argument is the step number, the second argument is the dictionary holding data that will be logged, and it can be modified by the callback, and the third is the driver itself, which can be used to access the current state or any other quantity.
   The output of the callback must be a boolean, which signals whever to continue the optimisation or not. When any one of the callbacks return {code}`False`, the optimisation will be stopped.
-  Netket comes with a few built-in callbacks, listed {ref}`in the API <callbacks-api>`, but you can also implement your own.
+  Netket comes with a few built-in callbacks, listed [in the API](netket_callbacks_api)`, but you can also implement your own.
 
 - {code}`step_size`: Data will be logged and callbacks will be called every {code}`step_size` optimisation steps. Useful if your callbacks have a high computational cost. If unspecified, logs at every step.

--- a/docs/docs/operator.md
+++ b/docs/docs/operator.md
@@ -5,9 +5,9 @@
 .. currentmodule:: netket.operator
 ```
 
-The [Operator](`netket.operator`) module defines the common interfaces used to interact with quantum operators and super-operators, as well as several concrete implementations of different operators such as {ref}`netket.hilbert.LocalOperator`, {ref}`netket.hilbert.Ising` and others.
+The [Operator](netket_operator_api) module defines the common interfaces used to interact with quantum operators and super-operators, as well as several concrete implementations of different operators such as {class}`LocalOperator`, {class}`Ising` and others.
 
-NetKet's operators are all sub-classes of the abstract class {ref}`netket.hilbert.AbstractOperator`, which defines a small set of API respected by all implementations. 
+NetKet's operators are all sub-classes of the abstract class {class}`AbstractOperator`, which defines a small set of API respected by all implementations. 
 The inheritance diagram for the class hierarchy of the Operators included with NetKet is shown below (you can click on the nodes in the graph to go to their API documentation page). 
 Dashed nodes represent abstract classes that cannot be instantiated, while the others are concrete and they can be instantiated.
 
@@ -18,22 +18,22 @@ Dashed nodes represent abstract classes that cannot be instantiated, while the o
 
 ```
 
-Similarly to Hilbert spaces, there are two large classes of operators: {ref}`DiscreteOperator` and {ref}`ContinuousOperator`. 
+Similarly to Hilbert spaces, there are two large classes of operators: {class}`DiscreteOperator` and {class}`ContinuousOperator`. 
 Evidently the formers will only work with Discrete Hilbert spaces, while the latters will only work with continuous Hilbert spaces.
 
 The main function of operators in NetKet is to define the logic and some values used to compute expectation values over a variational state.
 Functions implemented by operators are either needed to compute expectation values, or are nice utilities useful to manipulate or inspect the operators but are not needed by the Monte-Carlo logic interacting with the variational states.
 
-All {ref}`AbstractOperator`s act on a well defined hilbert space that can be accessed through the {attr}`~netket.hilbert.AbstractOperator.hilbert` attribute.
-It is also possible to check if the operator is hermitian through the boolean property {attr}`~netket.hilbert.AbstractOperator.is_hermitian`.
+All {class}`AbstractOperator`s act on a well defined hilbert space that can be accessed through the {attr}`~AbstractOperator.hilbert` attribute.
+It is also possible to check if the operator is hermitian through the boolean property {attr}`~AbstractOperator.is_hermitian`.
 There are only two other operations defined on all operator types: it is possible to take the conjugate or conjugate-transpose of an operator by accessing the methods
-{meth}`~netket.hilbert.AbstractOperator.conj` and {attr}`~netket.hilbert.AbstractOperator.transpose`. 
+{meth}`~AbstractOperator.conj` and {attr}`~AbstractOperator.transpose`. 
 Those will usually return lazy wrappers.
-Finally, it is also possible to call {meth}`~netket.hilbert.AbstractOperator.collect` to get rid of any possible lazy wrapper.
+Finally, it is also possible to call {meth}`~AbstractOperator.collect` to get rid of any possible lazy wrapper.
 
 The bare-minimum requirement when defining a custom operator is to define it's hilbert space. 
 Most likely you will also want to define the `expect` and/or the `expect_and_grad` method to compute the expectation value of such operator over a certain Variational State. 
-Contrary to more standard Pythonic code, those methods are not defined as class-functions in your custom operator class, but you have to use multiple dispatch ({ref}`netket.utils.dispatch.dispatch`) to define those methods on a specific signature such as `expect(vstate: MCState, O: MyCustomOperator)`. 
+Contrary to more standard Pythonic code, those methods are not defined as class-functions in your custom operator class, but you have to use multiple dispatch ({func}`netket.utils.dispatch.dispatch`) to define those methods on a specific signature such as `expect(vstate: MCState, O: MyCustomOperator)`. 
 This is needed because the way you compute expectation values and/or gradients might not only change depending on the exact operator, but depends also on the type of variational state that you are working with.
 To learn more about multiple dispatch, check {ref}`this section <multiple-dispatch>`
 

--- a/docs/docs/sr.md
+++ b/docs/docs/sr.md
@@ -90,7 +90,7 @@ The QGT is positive definite, therefore it can be inverted and the solution is f
 \end{equation}
 where bold fonts are used for vectors.
 A complication is given by the fact that the QGT is determined by Monte Carlo sampling and it might have several eigenvalues that are zero or very small, leading to numerical stability issues when inverting the matrix or in the resulting dynamics.
-The linear system can be solved with several methods. For the models with many parameters and to achieve the best performance, iterative solvers such as those found in `jax.scipy.sparse.linalg`, such as {ref}`jax.scipy.sparse.linalg.cg` {ref}`jax.scipy.sparse.linalg.gmres` are the best choice. 
+The linear system can be solved with several methods. For the models with many parameters and to achieve the best performance, iterative solvers such as those found in [jax.scipy.sparse.linalg](https://jax.readthedocs.io/en/latest/jax.scipy.html#module-jax.scipy.sparse.linalg), such as {func}`jax.scipy.sparse.linalg.cg` {func}`jax.scipy.sparse.linalg.gmres` are the best choice. 
 Do note that to stabilize those algorithms it is often needed to add a small ($10^{-5} - 10^{-2}$) shift to the diagonal of the QGT. 
 This can be set with the keyword argument `diag_shift`.
 Those methods, combined with our lazy representations of the QGT, never instantiate the full matrix and therefore achieve a great performance.

--- a/netket/models/autoreg.py
+++ b/netket/models/autoreg.py
@@ -35,7 +35,7 @@ class AbstractARNN(nn.Module):
 
     Subclasses must implement the methods `__call__` and `conditionals`.
     They can also override `_conditional` to implement the caching for fast autoregressive sampling.
-    See :ref:`netket.nn.FastARNNConv1D` for example.
+    See :class:`netket.nn.FastARNNConv1D` for example.
 
     They must also implement the field `machine_pow`,
     which specifies the exponent to normalize the outputs of `__call__`.

--- a/netket/models/equivariant.py
+++ b/netket/models/equivariant.py
@@ -46,6 +46,7 @@ def identity(x):
 
 class GCNN_FFT(nn.Module):
     r"""Implements a GCNN using a fast fourier transform over the translation group.
+
     The group convolution can be written in terms of translational convolutions with
     symmetry transformed filters as desribed in ` Cohen et. *al* <http://proceedings.mlr.press/v48/cohenc16.pdf>`_
     The translational convolutions are then implemented with Fast Fourier Transforms.
@@ -632,12 +633,12 @@ def GCNN(
             with respect to parity (only use on two level systems).
         dtype: The dtype of the weights.
         activation: The nonlinear activation function between hidden layers. Defaults to
-            :ref:`nk.nn.activation.reim_selu`.
+            :func:`nk.nn.activation.reim_selu` .
         output_activation: The nonlinear activation before the output.
         equal_amplitudes: If True forces all basis states to have equal amplitude
             by setting :math:`\Re(\psi) = 0`.
         use_bias: If True uses a bias in all layers.
-        precision: Numerical precision of the computation see `jax.lax.Precision`for details.
+        precision: Numerical precision of the computation see {class}`jax.lax.Precision` for details.
         kernel_init: Initializer for the kernels of all layers. Defaults to
             `lecun_normal(in_axis=1, out_axis=0)` which guarantees the correct variance of the
             output.

--- a/netket/models/fast_autoreg.py
+++ b/netket/models/fast_autoreg.py
@@ -36,7 +36,7 @@ class FastARNNDense(AbstractARNN):
     """
     Fast autoregressive neural network with dense layers.
 
-    See :ref:`netket.nn.FastMaskedConv1D` for a brief explanation of fast autoregressive sampling.
+    See :class:`netket.nn.FastMaskedConv1D` for a brief explanation of fast autoregressive sampling.
 
     TODO: FastMaskedDense1D does not support JIT yet, because it involves slicing the cached inputs
     and the weights with a dynamic shape.
@@ -98,7 +98,7 @@ class FastARNNConv1D(AbstractARNN):
     """
     Fast autoregressive neural network with 1D convolution layers.
 
-    See :ref:`netket.nn.FastMaskedConv1D` for a brief explanation of fast autoregressive sampling.
+    See :class:`netket.nn.FastMaskedConv1D` for a brief explanation of fast autoregressive sampling.
     """
 
     layers: int
@@ -162,7 +162,7 @@ class FastARNNConv2D(AbstractARNN):
     """
     Fast autoregressive neural network with 2D convolution layers.
 
-    See :ref:`netket.nn.FastMaskedConv1D` for a brief explanation of fast autoregressive sampling.
+    See :class:`netket.nn.FastMaskedConv1D` for a brief explanation of fast autoregressive sampling.
     """
 
     layers: int

--- a/netket/nn/fast_masked_linear.py
+++ b/netket/nn/fast_masked_linear.py
@@ -34,7 +34,7 @@ class FastMaskedDense1D(nn.Module):
     """
     1D linear transformation module with mask for fast autoregressive NN.
 
-    See :ref:`netket.nn.FastMaskedConv1D` for a brief explanation of fast autoregressive sampling.
+    See :class:`netket.nn.FastMaskedConv1D` for a brief explanation of fast autoregressive sampling.
 
     TODO: FastMaskedDense1D does not support JIT yet, because it involves slicing the cached inputs
     and the weights with a dynamic shape.
@@ -298,7 +298,7 @@ class FastMaskedConv2D(nn.Module):
     """
     2D convolution module with mask for fast autoregressive NN.
 
-    See :ref:`netket.nn.FastMaskedConv1D` for a brief explanation of fast autoregressive sampling.
+    See :class:`netket.nn.FastMaskedConv1D` for a brief explanation of fast autoregressive sampling.
     """
 
     L: int
@@ -306,7 +306,7 @@ class FastMaskedConv2D(nn.Module):
     features: int
     """number of convolution filters."""
     kernel_size: Tuple[int, int]
-    """shape of the convolutional kernel `(h, w)`. Typically, `h = w // 2 + 1`."""
+    """shape of the convolutional kernel `(h, w)`. Typically, :math:`h = w // 2 + 1`."""
     kernel_dilation: Tuple[int, int]
     """a sequence of 2 integers, giving the dilation factor to
     apply in each spatial dimension of the convolution kernel."""

--- a/netket/sampler/autoreg.py
+++ b/netket/sampler/autoreg.py
@@ -49,9 +49,6 @@ class ARDirectSamplerState(SamplerState):
     key: PRNGKeyT
     """state of the random number generator."""
 
-    def __repr__(self):
-        return f"{type(self).__name__}(rng state={self.key})"
-
 
 @struct.dataclass
 class ARDirectSampler(Sampler):

--- a/netket/sampler/base.py
+++ b/netket/sampler/base.py
@@ -53,7 +53,7 @@ class Sampler(abc.ABC):
     hilbert: AbstractHilbert = struct.field(pytree_node=False)
     """The Hilbert space to sample."""
 
-    n_chains_per_rank: int = struct.field(pytree_node=False, default=None)
+    n_chains_per_rank: int = struct.field(pytree_node=False, default=None, repr=False)
     """Number of independent chains on every MPI rank."""
 
     machine_pow: int = struct.field(default=2)

--- a/netket/sampler/base.py
+++ b/netket/sampler/base.py
@@ -31,15 +31,11 @@ fancy = []
 
 
 @struct.dataclass
-class SamplerState:
+class SamplerState(abc.ABC):
     """
     Base class holding the state of a sampler.
     """
 
-    pass
-
-
-def autodoc(clz):
     pass
 
 

--- a/netket/sampler/exact.py
+++ b/netket/sampler/exact.py
@@ -126,20 +126,3 @@ class ExactSampler(Sampler):
         )
 
         return samples, state.replace(rng=new_rng)
-
-    def __repr__(sampler):
-        return (
-            "ExactSampler("
-            + "\n  hilbert = {},".format(sampler.hilbert)
-            + "\n  n_chains_per_rank = {},".format(sampler.n_chains_per_rank)
-            + "\n  machine_power = {},".format(sampler.machine_pow)
-            + "\n  dtype = {})".format(sampler.dtype)
-        )
-
-    def __str__(sampler):
-        return (
-            "ExactSampler("
-            + "n_chains_per_rank = {}, ".format(sampler.n_chains_per_rank)
-            + "machine_power = {}, ".format(sampler.machine_pow)
-            + "dtype = {})".format(sampler.dtype)
-        )

--- a/netket/sampler/metropolis.py
+++ b/netket/sampler/metropolis.py
@@ -228,7 +228,7 @@ class MetropolisSampler(Sampler):
     reset_chains: bool = struct.field(pytree_node=False, default=False)
     """If True, resets the chain state when `reset` is called on every new sampling."""
 
-    def __pre_init__(self, hilbert, rule, **kwargs):
+    def __pre_init__(self, hilbert: AbstractHilbert, rule: MetropolisRule, **kwargs):
         """
         Constructs a Metropolis Sampler.
 
@@ -244,6 +244,13 @@ class MetropolisSampler(Sampler):
             machine_pow: The power to which the machine should be exponentiated to generate the pdf (default = 2).
             dtype: The dtype of the states sampled (default = np.float64).
         """
+        # Validate the inputs
+        if not isinstance(rule, MetropolisRule):
+            raise TypeError(
+                f"The second positional argument, rule, must be a MetropolisRule but "
+                f"`type(rule)={type(rule)}`."
+            )
+
         if "n_chains" not in kwargs and "n_chains_per_rank" not in kwargs:
             kwargs["n_chains_per_rank"] = 16
 
@@ -263,9 +270,6 @@ class MetropolisSampler(Sampler):
 
     def __post_init__(self):
         super().__post_init__()
-        # Validate the inputs
-        if not isinstance(self.rule, MetropolisRule):
-            raise TypeError("rule must be a MetropolisRule.")
 
         if not isinstance(self.reset_chains, bool):
             raise TypeError("reset_chains must be a boolean.")

--- a/netket/sampler/metropolis.py
+++ b/netket/sampler/metropolis.py
@@ -14,6 +14,7 @@
 
 from functools import partial
 from typing import Any, Callable, Optional, Tuple, Union
+import abc
 
 import jax
 from flax import linen as nn
@@ -31,7 +32,7 @@ from .base import Sampler, SamplerState
 
 
 @struct.dataclass
-class MetropolisRule:
+class MetropolisRule(abc.ABC):
     """
     Base class for transition rules of Metropolis, such as Local, Exchange, Hamiltonian
     and several others.
@@ -84,6 +85,7 @@ class MetropolisRule:
         """
         return sampler_state.rule_state
 
+    @abc.abstractmethod
     def transition(
         rule,
         sampler: "MetropolisSampler",
@@ -94,7 +96,7 @@ class MetropolisRule:
         σ: jnp.ndarray,
     ) -> Tuple[jnp.ndarray, Optional[jnp.ndarray]]:
 
-        raise NotImplementedError
+        pass
 
     def random_state(
         rule,

--- a/netket/sampler/metropolis.py
+++ b/netket/sampler/metropolis.py
@@ -20,7 +20,7 @@ import jax
 from flax import linen as nn
 from jax import numpy as jnp
 
-from netket.hilbert import ContinuousHilbert
+from netket.hilbert import AbstractHilbert, ContinuousHilbert
 
 from netket.utils import mpi, wrap_afun
 from netket.utils.types import PyTree, PRNGKeyT
@@ -29,98 +29,7 @@ from netket.utils.deprecation import deprecated, warn_deprecation
 from netket.utils import struct
 
 from .base import Sampler, SamplerState
-
-
-@struct.dataclass
-class MetropolisRule(abc.ABC):
-    """
-    Base class for transition rules of Metropolis, such as Local, Exchange, Hamiltonian
-    and several others.
-    """
-
-    def init_state(
-        rule,
-        sampler: "MetropolisSampler",
-        machine: nn.Module,
-        params: PyTree,
-        key: PRNGKeyT,
-    ) -> Optional[Any]:
-        """
-        Initialises the optional internal state of the Metropolis sampler transition
-        rule.
-
-        The provided key is unique and does not need to be splitted.
-
-        It should return an immutable data structure.
-
-        Arguments:
-            sampler: The Metropolis sampler.
-            machine: A Flax module with the forward pass of the log-pdf.
-            params: The PyTree of parameters of the model.
-            key: A Jax PRNGKey.
-
-        Returns:
-            An optional state.
-        """
-        return None
-
-    def reset(
-        rule,
-        sampler: "MetropolisSampler",
-        machine: nn.Module,
-        params: PyTree,
-        sampler_state: SamplerState,
-    ) -> Optional[Any]:
-        """
-        Resets the internal state of the Metropolis Sampler Transition Rule.
-
-        Arguments:
-            sampler: The Metropolis sampler.
-            machine: A Flax module with the forward pass of the log-pdf.
-            params: The PyTree of parameters of the model.
-            sampler_state: The current state of the sampler. Should not modify it.
-
-        Returns:
-           A new, resetted, state of the rule. This returns the same type of :py:meth:`sampler_state.rule_state` and might be `None`.
-        """
-        return sampler_state.rule_state
-
-    @abc.abstractmethod
-    def transition(
-        rule,
-        sampler: "MetropolisSampler",
-        machine: nn.Module,
-        parameters: PyTree,
-        state: SamplerState,
-        key: PRNGKeyT,
-        σ: jnp.ndarray,
-    ) -> Tuple[jnp.ndarray, Optional[jnp.ndarray]]:
-
-        pass
-
-    def random_state(
-        rule,
-        sampler: "MetropolisSampler",
-        machine: nn.Module,
-        parameters: PyTree,
-        state: SamplerState,
-        key: PRNGKeyT,
-    ):
-        """
-        Generates a random state compatible with this rule.
-
-        By default this calls :func:`netket.hilbert.random.random_state`.
-
-        Arguments:
-            sampler: The Metropolis sampler.
-            machine: A Flax module with the forward pass of the log-pdf.
-            parameters: The PyTree of parameters of the model.
-            state: The current state of the sampler. Should not modify it.
-            key: The PRNGKey to use to generate the random state.
-        """
-        return sampler.hilbert.random_state(
-            key, size=sampler.n_batches, dtype=sampler.dtype
-        )
+from .rules import MetropolisRule
 
 
 @struct.dataclass

--- a/netket/sampler/rules/__init__.py
+++ b/netket/sampler/rules/__init__.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from .base import MetropolisRule
+
 from .local import LocalRule
 from .exchange import ExchangeRule
 from .hamiltonian import HamiltonianRule

--- a/netket/sampler/rules/base.py
+++ b/netket/sampler/rules/base.py
@@ -92,9 +92,10 @@ class MetropolisRule(abc.ABC):
     ) -> Tuple[jnp.ndarray, Optional[jnp.ndarray]]:
         r"""
         Proposes a new configuration set of configurations $\sigma'$ starting from the current
-        chain configurations $\sigma$.
+        chain configurations :math:`\sigma`.
 
-        The new configurations $\sigma'$ should be a matrix with the same dimension as $\sigma$.
+        The new configurations :math:`\sigma'` should be a matrix with the same dimension as
+        :math:`\sigma`.
 
         This function should return a tuple. where the first element are the new configurations
         $\sigma'$ and the second element is either `None` or an array of length `σ.shape[0]`
@@ -110,7 +111,7 @@ class MetropolisRule(abc.ABC):
             σ: The current configurations stored in a 2D matrix.
 
         Returns:
-           A tuple containing the new configurations $\sigma'$ and the optional vector of
+           A tuple containing the new configurations :math:`\sigma'` and the optional vector of
            log corrections to the transition probability.
         """
         pass

--- a/netket/sampler/rules/base.py
+++ b/netket/sampler/rules/base.py
@@ -1,0 +1,115 @@
+# Copyright 2021 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, Optional, Tuple
+import abc
+
+from flax import linen as nn
+from jax import numpy as jnp
+
+from netket.utils.types import PyTree, PRNGKeyT
+
+from netket.utils import struct
+
+
+@struct.dataclass
+class MetropolisRule(abc.ABC):
+    """
+    Base class for transition rules of Metropolis, such as Local, Exchange, Hamiltonian
+    and several others.
+    """
+
+    def init_state(
+        rule,
+        sampler: "MetropolisSampler",  # noqa: F821
+        machine: nn.Module,
+        params: PyTree,
+        key: PRNGKeyT,
+    ) -> Optional[Any]:
+        """
+        Initialises the optional internal state of the Metropolis sampler transition
+        rule.
+
+        The provided key is unique and does not need to be splitted.
+
+        It should return an immutable data structure.
+
+        Arguments:
+            sampler: The Metropolis sampler.
+            machine: A Flax module with the forward pass of the log-pdf.
+            params: The PyTree of parameters of the model.
+            key: A Jax PRNGKey.
+
+        Returns:
+            An optional state.
+        """
+        return None
+
+    def reset(
+        rule,
+        sampler: "MetropolisSampler",  # noqa: F821
+        machine: nn.Module,
+        params: PyTree,
+        sampler_state: "SamplerState",  # noqa: F821
+    ) -> Optional[Any]:
+        """
+        Resets the internal state of the Metropolis Sampler Transition Rule.
+
+        Arguments:
+            sampler: The Metropolis sampler.
+            machine: A Flax module with the forward pass of the log-pdf.
+            params: The PyTree of parameters of the model.
+            sampler_state: The current state of the sampler. Should not modify it.
+
+        Returns:
+           A new, resetted, state of the rule. This returns the same type of :py:meth:`sampler_state.rule_state` and might be `None`.
+        """
+        return sampler_state.rule_state
+
+    @abc.abstractmethod
+    def transition(
+        rule,
+        sampler: "MetropolisSampler",  # noqa: F821
+        machine: nn.Module,
+        parameters: PyTree,
+        state: "SamplerState",  # noqa: F821
+        key: PRNGKeyT,
+        σ: jnp.ndarray,
+    ) -> Tuple[jnp.ndarray, Optional[jnp.ndarray]]:
+
+        pass
+
+    def random_state(
+        rule,
+        sampler: "MetropolisSampler",  # noqa: F821
+        machine: nn.Module,
+        parameters: PyTree,
+        state: "SamplerState",  # noqa: F821
+        key: PRNGKeyT,
+    ):
+        """
+        Generates a random state compatible with this rule.
+
+        By default this calls :func:`netket.hilbert.random.random_state`.
+
+        Arguments:
+            sampler: The Metropolis sampler.
+            machine: A Flax module with the forward pass of the log-pdf.
+            parameters: The PyTree of parameters of the model.
+            state: The current state of the sampler. Should not modify it.
+            key: The PRNGKey to use to generate the random state.
+        """
+        return sampler.hilbert.random_state(
+            key, size=sampler.n_batches, dtype=sampler.dtype
+        )

--- a/netket/sampler/rules/continuous_gaussian.py
+++ b/netket/sampler/rules/continuous_gaussian.py
@@ -28,7 +28,12 @@ class GaussianRule(MetropolisRule):
     New proposals of particle positions are generated according to a
     Gaussian distribution of width sigma.
     """
+
     sigma: float = 1.0
+    """
+    The variance of the gaussian distribution centered around the current
+    configuration, used to propose new configurations. 
+    """
 
     def transition(rule, sampler, machine, parameters, state, key, r):
         if jnp.issubdtype(r.dtype, jnp.complexfloating):

--- a/netket/sampler/rules/continuous_gaussian.py
+++ b/netket/sampler/rules/continuous_gaussian.py
@@ -17,7 +17,7 @@ import numpy as np
 
 from flax import struct
 
-from ..metropolis import MetropolisRule
+from .base import MetropolisRule
 
 
 @struct.dataclass

--- a/netket/sampler/rules/custom_numpy.py
+++ b/netket/sampler/rules/custom_numpy.py
@@ -21,8 +21,7 @@ from flax import struct
 
 from netket.operator import AbstractOperator
 
-
-from ..metropolis import MetropolisRule
+from .base import MetropolisRule
 
 
 @struct.dataclass

--- a/netket/sampler/rules/exchange.py
+++ b/netket/sampler/rules/exchange.py
@@ -21,7 +21,8 @@ from jax import numpy as jnp
 from flax import struct
 
 from netket.graph import AbstractGraph
-from ..metropolis import MetropolisRule
+
+from .base import MetropolisRule
 
 
 @struct.dataclass

--- a/netket/sampler/rules/hamiltonian.py
+++ b/netket/sampler/rules/hamiltonian.py
@@ -23,7 +23,7 @@ from numba4jax import njit4jax
 
 from netket.operator import AbstractOperator
 
-from ..metropolis import MetropolisRule
+from .base import MetropolisRule
 
 
 @struct.dataclass

--- a/netket/sampler/rules/hamiltonian_numpy.py
+++ b/netket/sampler/rules/hamiltonian_numpy.py
@@ -21,8 +21,7 @@ from flax import struct
 
 from netket.operator import AbstractOperator
 
-
-from ..metropolis import MetropolisRule
+from .base import MetropolisRule
 
 
 @struct.dataclass

--- a/netket/sampler/rules/local.py
+++ b/netket/sampler/rules/local.py
@@ -18,7 +18,7 @@ from flax import struct
 
 from netket.hilbert.random import flip_state
 
-from ..metropolis import MetropolisRule
+from .base import MetropolisRule
 
 
 @struct.dataclass

--- a/netket/sampler/rules/local_numpy.py
+++ b/netket/sampler/rules/local_numpy.py
@@ -17,7 +17,7 @@ from numba import jit
 import numpy as np
 from flax import struct
 
-from ..metropolis import MetropolisRule
+from .base import MetropolisRule
 
 
 @struct.dataclass


### PR DESCRIPTION
This PR does the following minor changes: 
  - removes the jit function trampolines used by samplers to jit the code, as it's no longer needed thanks to improvements in jax caching mechanism, making the code easier to read 
  - remove some custom `__repr__` definitions for samplers, in favour of using `show_repr=False` on `n_chains` of the samplers. This cuts some more LOCs.
  - Makes `MetropolisRule` an abstract base class (it was raising errors anyway, and this makes it nicer in generated docs).
 
The following major changes:
 - move `nk.sampler.MetropolisRule` abstract base class to `nk.sampler.rules.MetropolisRule`. In a later PR I'd like to deprecate the original binding. part of the reason is to make the `metropolis.py` file a bit smaller.
 - Add some error checking code to `MetropolisSampler`, so that if one defines a custom rule or uses a model that returns the wrong shapes, it gives a more comprehensible error instead of imperscrutabili jax errors.
