### PR TITLE
fix sampling for pbc=False

### DIFF
--- a/Examples/Continuous/HO.py
+++ b/Examples/Continuous/HO.py
@@ -30,7 +30,7 @@ ha = ekin + 0.5 * pot
 
 model = nk.models.Gaussian(dtype=float)
 
-vs = nk.vqs.MCState(sab, model, n_samples=10**5, n_discard_per_chain=2000)
+vs = nk.vqs.MCState(sab, model, n_samples=10**4, n_discard_per_chain=2000)
 
 op = nk.optimizer.Sgd(0.01)
 sr = nk.optimizer.SR(diag_shift=0.01)

--- a/Examples/Continuous/HO.py
+++ b/Examples/Continuous/HO.py
@@ -22,7 +22,7 @@ def v(x):
 
 hilb = nk.hilbert.Particle(N=10, L=(jnp.inf, jnp.inf, jnp.inf), pbc=False)
 
-sab = nk.sampler.MetropolisGaussian(hilb, sigma=0.1, n_chains=16, n_sweeps=1)
+sab = nk.sampler.MetropolisGaussian(hilb, sigma=0.1, n_chains=16, n_sweeps=32)
 
 ekin = nk.operator.KineticEnergy(hilb, mass=1.0)
 pot = nk.operator.PotentialEnergy(hilb, v)
@@ -32,8 +32,8 @@ model = nk.models.Gaussian(dtype=float)
 
 vs = nk.vqs.MCState(sab, model, n_samples=10**4, n_discard_per_chain=2000)
 
-op = nk.optimizer.Sgd(0.01)
+op = nk.optimizer.Sgd(0.05)
 sr = nk.optimizer.SR(diag_shift=0.01)
 
 gs = nk.VMC(ha, op, sab, variational_state=vs, preconditioner=sr)
-gs.run(n_iter=500, out="HO_10_3d")
+gs.run(n_iter=100, out="HO_10_3d")

--- a/Examples/Continuous/Helium.py
+++ b/Examples/Continuous/Helium.py
@@ -18,6 +18,15 @@ import jax.numpy as jnp
 from optax._src import linear_algebra
 
 
+from optax._src import linear_algebra
+
+
+def mycb(step, logged_data, driver):
+    logged_data["acceptance"] = float(driver.state.sampler_state.acceptance)
+    logged_data["globalnorm"] = float(linear_algebra.global_norm(driver._loss_grad))
+    return True
+
+
 def minimum_distance(x, sdim):
     """Computes distances between particles using mimimum image convention"""
     n_particles = x.shape[0] // sdim
@@ -72,10 +81,10 @@ model = nk.models.DeepSetRelDistance(
     features_phi=(16, 16),
     features_rho=(16, 16, 1),
 )
-vs = nk.vqs.MCState(sab, model, n_samples=2 * 4096, n_discard_per_chain=128)
+vs = nk.vqs.MCState(sab, model, n_samples=4096, n_discard_per_chain=128)
 
-op = nk.optimizer.Sgd(0.001)
+op = nk.optimizer.Sgd(0.01)
 sr = nk.optimizer.SR(diag_shift=0.01)
 
 gs = nk.VMC(ha, op, sab, variational_state=vs, preconditioner=sr)
-gs.run(n_iter=500, out="Helium_10_1d")
+gs.run(n_iter=1000, callback=mycb, out="Helium_10_1d")

--- a/Examples/Continuous/Helium.py
+++ b/Examples/Continuous/Helium.py
@@ -15,18 +15,6 @@ import netket as nk
 import jax.numpy as jnp
 
 
-from optax._src import linear_algebra
-
-
-from optax._src import linear_algebra
-
-
-def mycb(step, logged_data, driver):
-    logged_data["acceptance"] = float(driver.state.sampler_state.acceptance)
-    logged_data["globalnorm"] = float(linear_algebra.global_norm(driver._loss_grad))
-    return True
-
-
 def minimum_distance(x, sdim):
     """Computes distances between particles using mimimum image convention"""
     n_particles = x.shape[0] // sdim
@@ -87,4 +75,4 @@ op = nk.optimizer.Sgd(0.01)
 sr = nk.optimizer.SR(diag_shift=0.01)
 
 gs = nk.VMC(ha, op, sab, variational_state=vs, preconditioner=sr)
-gs.run(n_iter=1000, callback=mycb, out="Helium_10_1d")
+gs.run(n_iter=1000, out="Helium_10_1d")

--- a/netket/hilbert/particle.py
+++ b/netket/hilbert/particle.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from typing import Tuple, Union
-
+import jax.numpy as jnp
 from .continuous_hilbert import ContinuousHilbert
 
 
@@ -45,6 +45,12 @@ class Particle(ContinuousHilbert):
 
         if isinstance(pbc, bool):
             pbc = [pbc] * len(L)
+
+        if jnp.any(jnp.isinf(jnp.array(L) * jnp.array(pbc))):
+            raise TypeError(
+                "If you do have periodic boundary conditions the size of the box (L) "
+                "must be finite."
+            )
 
         self._N = N
 

--- a/netket/hilbert/particle.py
+++ b/netket/hilbert/particle.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from typing import Tuple, Union
-import jax.numpy as jnp
+import numpy as np
 from .continuous_hilbert import ContinuousHilbert
 
 
@@ -46,8 +46,8 @@ class Particle(ContinuousHilbert):
         if isinstance(pbc, bool):
             pbc = [pbc] * len(L)
 
-        if jnp.any(jnp.isinf(jnp.array(L) * jnp.array(pbc))):
-            raise TypeError(
+        if np.any(np.isinf(np.array(L) * np.array(pbc))):
+            raise ValueError(
                 "If you do have periodic boundary conditions the size of the box (L) "
                 "must be finite."
             )

--- a/netket/hilbert/random/particle.py
+++ b/netket/hilbert/random/particle.py
@@ -50,8 +50,7 @@ def random_state(hilb: Particle, key, batches: int, *, dtype):
     noise = gaussian * width
     uniform = jnp.tile(jnp.linspace(0.0, min_modulus, hilb.size), (batches, 1))
 
-    select = np.equal(boundary, False)
-    rs = jnp.where(select, gaussian, (uniform + noise) % modulus)
+    rs = jnp.where(np.equal(boundary, False), gaussian, (uniform + noise) % modulus)
 
     return jnp.asarray(rs, dtype=dtype)
 

--- a/netket/hilbert/random/particle.py
+++ b/netket/hilbert/random/particle.py
@@ -39,6 +39,7 @@ def random_state(hilb: Particle, key, batches: int, *, dtype):
     gaussian = jax.random.normal(
         key, shape=(batches, hilb.size), dtype=nkjax.dtype_real(dtype)
     )
+
     width = min_modulus / (4.0 * hilb.n_particles)
     # The width gives the noise level. In the periodic case the
     # particles are evenly distributed between 0 and min(L). The
@@ -50,7 +51,7 @@ def random_state(hilb: Particle, key, batches: int, *, dtype):
     uniform = jnp.tile(jnp.linspace(0.0, min_modulus, hilb.size), (batches, 1))
 
     select = np.equal(boundary, False)
-    rs = select * gaussian + np.logical_not(select) * ((uniform + noise) % modulus)
+    rs = jnp.where(select, gaussian, (uniform + noise) % modulus)
 
     return jnp.asarray(rs, dtype=dtype)
 

--- a/netket/models/deepset.py
+++ b/netket/models/deepset.py
@@ -147,7 +147,7 @@ class DeepSetRelDistance(nn.Module):
         if self.cusp_exponent is not None:
             cusp = -0.5 * jnp.sum(param / dis**self.cusp_exponent, axis=-1)
 
-        y = (2 * d / L[jnp.newaxis, :]) ** 2
+        y = (d / L[jnp.newaxis, :]) ** 2
 
         """ The phi transformation """
         for layer in self.phi:

--- a/netket/models/deepset.py
+++ b/netket/models/deepset.py
@@ -32,7 +32,7 @@ class DeepSetRelDistance(nn.Module):
     that is suitable for the simulation of periodic systems.
     Additionally one can add a cusp condition by specifying the
     asymptotic exponent.
-    For helium the Ansatz reads:
+    For helium the Ansatz reads (https://arxiv.org/abs/2112.11957):
 
     .. math ::
 

--- a/netket/models/deepset.py
+++ b/netket/models/deepset.py
@@ -82,7 +82,7 @@ class DeepSetRelDistance(nn.Module):
 
         if not all(self.hilbert.pbc):
             raise ValueError(
-                "The DeepSetRelDistance modeel only works with "
+                "The DeepSetRelDistance model only works with "
                 "hilbert spaces with periodic boundary conditions "
                 "among all directions."
             )
@@ -147,7 +147,7 @@ class DeepSetRelDistance(nn.Module):
         if self.cusp_exponent is not None:
             cusp = -0.5 * jnp.sum(param / dis**self.cusp_exponent, axis=-1)
 
-        y = (d / L[jnp.newaxis, :]) ** 2
+        y = (2 * d / L[jnp.newaxis, :]) ** 2
 
         """ The phi transformation """
         for layer in self.phi:

--- a/netket/sampler/rules/continuous_gaussian.py
+++ b/netket/sampler/rules/continuous_gaussian.py
@@ -50,8 +50,8 @@ class GaussianRule(MetropolisRule):
         ) * jnp.asarray(rule.sigma, dtype=r.dtype)
 
         opt_1 = np.equal(boundary, False)
-        opt_2 = np.logical_not(opt_1)
-        rp = opt_1 * (r + prop) + opt_2 * ((r + prop) % modulus)
+        rp = jnp.where(opt_1, (r + prop), (r + prop) % modulus)
+
         return rp, None
 
     def __repr__(self):

--- a/netket/sampler/rules/continuous_gaussian.py
+++ b/netket/sampler/rules/continuous_gaussian.py
@@ -49,8 +49,7 @@ class GaussianRule(MetropolisRule):
             key, shape=(n_chains, hilb.size), dtype=r.dtype
         ) * jnp.asarray(rule.sigma, dtype=r.dtype)
 
-        opt_1 = np.equal(boundary, False)
-        rp = jnp.where(opt_1, (r + prop), (r + prop) % modulus)
+        rp = jnp.where(np.equal(boundary, False), (r + prop), (r + prop) % modulus)
 
         return rp, None
 

--- a/test/hilbert/test_hilbert.py
+++ b/test/hilbert/test_hilbert.py
@@ -217,7 +217,7 @@ def test_random_states_particle(hi: Particle):
 
 def test_particle_fail():
     with pytest.raises(ValueError):
-        _ = Particle(N=5, L=(jnp.inf, 2.0), periodic=True)
+        _ = Particle(N=5, L=(jnp.inf, 2.0), pbc=True)
 
 
 @pytest.mark.parametrize("hi", discrete_hilbert_params)

--- a/test/hilbert/test_hilbert.py
+++ b/test/hilbert/test_hilbert.py
@@ -216,7 +216,7 @@ def test_random_states_particle(hi: Particle):
 
 
 def test_particle_fail():
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         _ = Particle(N=5, L=(jnp.inf, 2.0), periodic=True)
 
 

--- a/test/hilbert/test_hilbert.py
+++ b/test/hilbert/test_hilbert.py
@@ -124,6 +124,7 @@ hilberts["ContinuousSpaceHilbert"] = nk.hilbert.Particle(
     N=5, L=(np.inf, 10.0), pbc=(False, True)
 )
 
+
 all_hilbert_params = [pytest.param(hi, id=name) for name, hi in hilberts.items()]
 discrete_hilbert_params = [
     pytest.param(hi, id=name)
@@ -212,6 +213,11 @@ def test_random_states_particle(hi: Particle):
     assert jnp.sum(
         jnp.where(jnp.equal(boundary, True), state < extension, 0)
     ) == jnp.sum(jnp.where(jnp.equal(boundary, True), 1, 0))
+
+
+def test_particle_fail():
+    with pytest.raises(TypeError):
+        _ = Particle(N=5, L=(jnp.inf, 2.0), periodic=True)
 
 
 @pytest.mark.parametrize("hi", discrete_hilbert_params)

--- a/test/sampler/test_sampler.py
+++ b/test/sampler/test_sampler.py
@@ -306,8 +306,10 @@ def test_correct_sampling(sampler_c, model_and_weights, set_pdf_power):
         assert pval > 0.01 or np.max(pvalues) > 0.01
 
     elif isinstance(hi, Particle):
+        # TODO: Find periodic distribution that can be exactly sampled and do the same test.
+
         ma, w = model_and_weights(hi, sampler)
-        n_samples = 75000
+        n_samples = 5000
         n_discard = 2 * 1024
         n_rep = 6
         pvalues = np.zeros(n_rep)

--- a/test/sampler/test_sampler.py
+++ b/test/sampler/test_sampler.py
@@ -104,9 +104,9 @@ samplers["Autoregressive: Fock"] = nk.sampler.ARDirectSampler(hib_u)
 
 
 # Hilbert space and sampler for particles
-hi_particles = nk.hilbert.Particle(N=3, L=(np.inf,), pbc=(False,))
+hi_particles = nk.hilbert.Particle(N=3, L=(jnp.inf,), pbc=False)
 samplers["Metropolis(Gaussian): Gaussian"] = nk.sampler.MetropolisGaussian(
-    hi_particles, sigma=1.0, n_sweeps=hi_particles.size * 4
+    hi_particles, sigma=1.0, n_sweeps=hi_particles.size * 10
 )
 
 
@@ -307,8 +307,8 @@ def test_correct_sampling(sampler_c, model_and_weights, set_pdf_power):
 
     elif isinstance(hi, Particle):
         ma, w = model_and_weights(hi, sampler)
-        n_samples = 5000
-        n_discard = 2000
+        n_samples = 75000
+        n_discard = 2 * 1024
         n_rep = 6
         pvalues = np.zeros(n_rep)
 
@@ -327,7 +327,10 @@ def test_correct_sampling(sampler_c, model_and_weights, set_pdf_power):
                 hi.size,
             )
             samples, sampler_state = sampler.sample(
-                ma, w, state=sampler_state, chain_length=n_samples
+                ma,
+                w,
+                state=sampler_state,
+                chain_length=n_samples,
             )
 
             assert samples.shape == (n_samples, sampler.n_chains, hi.size)
@@ -341,7 +344,7 @@ def test_correct_sampling(sampler_c, model_and_weights, set_pdf_power):
                     * np.dot(w["params"]["kernel"].T, w["params"]["kernel"])
                 ),
             )
-            exact_samples = dist.rvs(size=samples.shape[0] * sampler.n_chains)
+            exact_samples = dist.rvs(size=samples.shape[0])
 
             counts, bins = np.histogramdd(samples, bins=10)
             counts_exact, _ = np.histogramdd(exact_samples, bins=bins)
@@ -351,6 +354,7 @@ def test_correct_sampling(sampler_c, model_and_weights, set_pdf_power):
             )
 
         s, pval = combine_pvalues(pvalues, method="fisher")
+
         assert pval > 0.01 or np.max(pvalues) > 0.01
 
 


### PR DESCRIPTION
This fixes a bug where the`random_state` in the Hilbertspace and the proposal in the sampler return NaN for `L=jnp.inf` (and `pbc=false`), and consequently (fixes) the Harmonic Oscillator example.