### PR TITLE
Upgrade `black` to v22.3.0 in `.pre-commit-config.yaml`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
     - id: black
 


### PR DESCRIPTION
This fixes a broken dependency. It's done in #1146 for the CI config, but not for the `pre-commit` config.