### PR TITLE
Deprecate .dtype from all layers and modules, switch to .param_dtype

### DIFF
--- a/Examples/Continuous/HO.py
+++ b/Examples/Continuous/HO.py
@@ -28,7 +28,7 @@ ekin = nk.operator.KineticEnergy(hilb, mass=1.0)
 pot = nk.operator.PotentialEnergy(hilb, v)
 ha = ekin + 0.5 * pot
 
-model = nk.models.Gaussian(dtype=float)
+model = nk.models.Gaussian(param_dtype=float)
 
 vs = nk.vqs.MCState(sab, model, n_samples=10**4, n_discard_per_chain=2000)
 

--- a/Examples/Dynamics/ising1d.py
+++ b/Examples/Dynamics/ising1d.py
@@ -29,7 +29,7 @@ hi = nk.hilbert.Spin(s=1 / 2, N=g.n_nodes)
 ha = nk.operator.Ising(hilbert=hi, graph=g, h=1.0)
 
 # RBM Spin Machine
-ma = nk.models.RBM(alpha=1, use_visible_bias=True, dtype=complex)
+ma = nk.models.RBM(alpha=1, use_visible_bias=True, param_dtype=complex)
 
 # Metropolis Local Sampling
 sa = nk.sampler.MetropolisHamiltonian(hi, ha, n_chains=16)

--- a/Examples/Fermions/fermi_hubbard.py
+++ b/Examples/Fermions/fermi_hubbard.py
@@ -58,7 +58,7 @@ sa = nk.sampler.MetropolisExchange(hi, graph=disj_graph, n_chains=16)
 
 # since the hilbert basis is a set of occupation numbers, we can take a general RBM
 # we take complex parameters, since it learns sign structures more easily, and for even fermion number, the wave function might be complex
-ma = nk.models.RBM(alpha=1, dtype=complex, use_visible_bias=False)
+ma = nk.models.RBM(alpha=1, param_dtype=complex, use_visible_bias=False)
 vs = nk.vqs.MCState(sa, ma, n_discard_per_chain=100, n_samples=512)
 
 # we will use sgd with Stochastic Reconfiguration

--- a/Examples/HeisenbergJ1J2/heisenbergJ1J2.py
+++ b/Examples/HeisenbergJ1J2/heisenbergJ1J2.py
@@ -17,7 +17,7 @@ machine = nk.models.GCNN(
     parity=1,
     layers=4,
     features=4,
-    dtype=complex,
+    param_dtype=complex,
 )
 sampler = nk.sampler.MetropolisExchange(
     hilbert=hi,
@@ -50,7 +50,7 @@ machine = nk.models.GCNN(
     parity=-1,
     layers=4,
     features=4,
-    dtype=complex,
+    param_dtype=complex,
 )
 vstate = nk.vqs.MCState(
     sampler=sampler,

--- a/Examples/Ising1d/ising1d.py
+++ b/Examples/Ising1d/ising1d.py
@@ -26,7 +26,7 @@ hi = nk.hilbert.Spin(s=1 / 2, N=g.n_nodes)
 ha = nk.operator.Ising(hilbert=hi, graph=g, h=1.0)
 
 # RBM Spin Machine
-ma = nk.models.RBM(alpha=1, use_visible_bias=True, dtype=float)
+ma = nk.models.RBM(alpha=1, use_visible_bias=True, param_dtype=float)
 
 # Metropolis Local Sampling
 sa = nk.sampler.MetropolisLocal(hi, n_chains=16, reset_chains=False)

--- a/Examples/Ising1d/ising1d_jastrow.py
+++ b/Examples/Ising1d/ising1d_jastrow.py
@@ -27,7 +27,7 @@ hi = nk.hilbert.Spin(s=1 / 2, N=g.n_nodes)
 ha = nk.operator.Ising(hilbert=hi, graph=g, h=0.0)
 
 # RBM Spin Machine
-ma = nk.models.Jastrow(dtype=np.float64)
+ma = nk.models.Jastrow(param_dtype=np.float64)
 
 # Metropolis Local Sampling
 sa = nk.sampler.MetropolisLocal(hi, n_chains=16)

--- a/Examples/Ising1d/ising1d_sr.py
+++ b/Examples/Ising1d/ising1d_sr.py
@@ -25,7 +25,7 @@ hi = nk.hilbert.Spin(s=1 / 2, N=g.n_nodes)
 ha = nk.operator.Ising(hilbert=hi, graph=g, h=1.0)
 
 # RBM Spin Machine
-ma = nk.models.RBM(alpha=1, dtype=float)
+ma = nk.models.RBM(alpha=1, param_dtype=float)
 
 # Metropolis Local Sampling
 sa = nk.sampler.MetropolisLocal(hi, n_chains=16)

--- a/Examples/Ising1d/ising1d_sr_chol.py
+++ b/Examples/Ising1d/ising1d_sr_chol.py
@@ -25,7 +25,7 @@ hi = nk.hilbert.Spin(s=1 / 2, N=g.n_nodes)
 ha = nk.operator.Ising(hilbert=hi, graph=g, h=1.0)
 
 # RBM Spin Machine
-ma = nk.models.RBM(alpha=1, dtype=float)
+ma = nk.models.RBM(alpha=1, param_dtype=float)
 
 # Metropolis Local Sampling
 sa = nk.sampler.MetropolisLocal(hi, n_chains=16)

--- a/Examples/Ising2d/ising2d.py
+++ b/Examples/Ising2d/ising2d.py
@@ -24,7 +24,7 @@ hi = nk.hilbert.Spin(s=1 / 2, N=g.n_nodes)
 ha = nk.operator.Ising(hilbert=hi, graph=g, h=3.0)
 
 # RBM Spin Machine
-ma = nk.models.RBM(alpha=1, use_visible_bias=True, dtype=float)
+ma = nk.models.RBM(alpha=1, use_visible_bias=True, param_dtype=float)
 
 # Metropolis Local Sampling
 sa = nk.sampler.MetropolisLocal(hi, n_chains=16)

--- a/docs/api/models.md
+++ b/docs/api/models.md
@@ -29,6 +29,6 @@ neural quantum states.
    ARNNConv2D
    FastARNNConv1D
    FastARNNConv2D
-   DeepSetRelDistance
+   DeepSet
 
 ```

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,3 +1,7 @@
+# -- Set env variables to correctly detect sphinx in NetKet
+import os
+
+os.environ["NETKET_SPHINX_BUILD"] = "1"
 import netket as nk
 
 # -- Project information -----------------------------------------------------

--- a/docs/docs/install.md
+++ b/docs/docs/install.md
@@ -194,7 +194,7 @@ The [operator sub-module](netket_operator_api) contains several pre-built hamilt
 See the [Operators](operator.md) documentation for more informations.
 
 ```python
-ma = nk.models.RBM(alpha=1, dtype=float)
+ma = nk.models.RBM(alpha=1, param_dtype=float)
 
 sa = nk.sampler.MetropolisLocal(hi, n_chains=16)
 ```

--- a/docs/docs/sampler.ipynb
+++ b/docs/docs/sampler.ipynb
@@ -184,7 +184,7 @@
     "hilbert = nk.hilbert.Spin(0.5, 4)\n",
     "\n",
     "# We define our variational ansatz\n",
-    "log_pdf = nk.models.RBM(dtype=float)\n",
+    "log_pdf = nk.models.RBM(param_dtype=float)\n",
     "\n",
     "# and we initialize it's parameters\n",
     "param_seed = jax.random.PRNGKey(0)\n",

--- a/docs/docs/sr.md
+++ b/docs/docs/sr.md
@@ -13,7 +13,7 @@ This can be expanded to second order in an infinitesimal parameter change $\delt
 In NetKet you can obtain (an approximation of) the quantum geometric tensor of a variational state by calling {attr}`~netket.vqs.VariationalState.quantum_geometric_tensor`.
 
 ```python
-ma = nk.models.RBM(alpha=1, dtype=float)
+ma = nk.models.RBM(alpha=1, param_dtype=float)
 sa = nk.sampler.MetropolisLocal(nk.hilbert.Spin(0.5, 16), n_chains=16)
 vs = nk.vqs.MCState(sa, ma)
 

--- a/docs/docs/varstate.md
+++ b/docs/docs/varstate.md
@@ -61,7 +61,7 @@ hilbert = nk.hilbert.Spin(0.5)**10
 
 sampler = nk.sampler.MetropolisLocal(hilbert)
 
-model = nk.models.RBM(alpha=1, dtype=float, kernel_init=nk.nn.initializers.normal(stddev=0.01))
+model = nk.models.RBM(alpha=1, param_dtype=float, kernel_init=nn.initializers.normal(stddev=0.01))
 
 vstate = nk.vqs.MCState(sampler, model, n_samples=500)
 ```

--- a/docs/tutorials/gs-heisenberg.ipynb
+++ b/docs/tutorials/gs-heisenberg.ipynb
@@ -685,10 +685,10 @@
     }
    ],
    "source": [
-    "class Model(nk.nn.Module):\n",
-    "    @nk.nn.compact\n",
+    "class Model(nn.Module):\n",
+    "    @nn.compact\n",
     "    def __call__(self, x):\n",
-    "        x = nk.nn.Dense(features=2*x.shape[-1], dtype=np.complex128, kernel_init=nk.nn.initializers.normal(stddev=0.1), bias_init=nk.nn.initializers.normal(stddev=0.1))(x)\n",
+    "        x = nn.Dense(features=2*x.shape[-1], param_dtype=np.complex128, kernel_init=nn.initializers.normal(stddev=0.1), bias_init=nn.initializers.normal(stddev=0.1))(x)\n",
     "        x = nk.nn.activation.log_cosh(x)\n",
     "        return jax.numpy.sum(x, axis=-1)\n",
     "    \n",
@@ -798,12 +798,12 @@
     }
    ],
    "source": [
-    "class Model2(nk.nn.Module):\n",
-    "    @nk.nn.compact\n",
+    "class Model2(nn.Module):\n",
+    "    @nn.compact\n",
     "    def __call__(self, x):\n",
-    "        x = nk.nn.Dense(features=2*x.shape[-1], dtype=np.complex128, kernel_init=nk.nn.initializers.normal(stddev=0.1), bias_init=nk.nn.initializers.normal(stddev=0.1))(x)\n",
+    "        x = nn.Dense(features=2*x.shape[-1], param_dtype=np.complex128, kernel_init=nn.initializers.normal(stddev=0.1), bias_init=nn.initializers.normal(stddev=0.1))(x)\n",
     "        x = nk.nn.activation.log_cosh(x)\n",
-    "        x = nk.nn.Dense(features=x.shape[-1], dtype=np.complex128, kernel_init=nk.nn.initializers.normal(stddev=0.1), bias_init=nk.nn.initializers.normal(stddev=0.1))(x)\n",
+    "        x = nn.Dense(features=x.shape[-1], param_dtype=np.complex128, kernel_init=nn.initializers.normal(stddev=0.1), bias_init=nn.initializers.normal(stddev=0.1))(x)\n",
     "        x = nk.nn.activation.log_cosh(x)\n",
     "        return jax.numpy.sum(x, axis=-1)\n",
     "    \n",

--- a/docs/tutorials/gs-ising.ipynb
+++ b/docs/tutorials/gs-ising.ipynb
@@ -970,26 +970,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a72882a6-57e8-4462-a333-24a500e71020",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "markdown",
-   "id": "76a17a81-31cd-44c7-8e5a-d7d8743df8c7",
-   "metadata": {},
-   "source": [
-    "*Warning*: Flax has a bug with its layers, where they drop the imaginary part\n",
-    "of complex numbers if the layer has real weights.\n",
-    "This is not a problem in the above example, but if you try to work on more complex\n",
-    "problems where you work with complex numbers you should rather use the equivalent \n",
-    "`nk.nn.Dense` which contains a fix for this bug."
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "f29016f4",
    "metadata": {},

--- a/netket/models/__init__.py
+++ b/netket/models/__init__.py
@@ -19,9 +19,21 @@ from .mps import MPSPeriodic
 from .gaussian import Gaussian
 from .deepset import DeepSetRelDistance
 from .ndm import NDM
-from .autoreg import AbstractARNN, ARNNDense, ARNNConv1D, ARNNConv2D
-from .fast_autoreg import FastARNNDense, FastARNNConv1D, FastARNNConv2D
+from .autoreg import AbstractARNN, ARNNDense, ARNNConv1D, ARNNConv2D as _ARNNConv2D
+from .fast_autoreg import (
+    FastARNNDense,
+    FastARNNConv1D,
+    FastARNNConv2D as _FastARNNConv2D,
+)
 from .utils import update_GCNN_parity
+
+
+# TODO: remove dtype deprecation
+from netket.utils import deprecate_dtype as _deprecate_dtype
+
+ARNNConv2D = _deprecate_dtype(_ARNNConv2D)
+FastARNNConv2D = _deprecate_dtype(_FastARNNConv2D)
+
 
 from netket.utils import _hide_submodules
 

--- a/netket/models/autoreg.py
+++ b/netket/models/autoreg.py
@@ -27,6 +27,7 @@ from netket.hilbert.homogeneous import HomogeneousHilbert
 from netket.nn import MaskedConv1D, MaskedConv2D, MaskedDense1D
 from netket.nn.masked_linear import default_kernel_init
 from netket.utils.types import Array, DType, NNInitFunc
+from netket.utils import deprecate_dtype
 
 
 class AbstractARNN(nn.Module):
@@ -97,6 +98,7 @@ class AbstractARNN(nn.Module):
         """
 
 
+@deprecate_dtype
 class ARNNDense(AbstractARNN):
     """Autoregressive neural network with dense layers."""
 
@@ -109,7 +111,7 @@ class ARNNDense(AbstractARNN):
     """the nonlinear activation function between hidden layers (default: selu)."""
     use_bias: bool = True
     """whether to add a bias to the output (default: True)."""
-    dtype: DType = jnp.float64
+    param_dtype: DType = jnp.float64
     """the dtype of the computation (default: float64)."""
     precision: Any = None
     """numerical precision of the computation, see `jax.lax.Precision` for details."""
@@ -133,7 +135,7 @@ class ARNNDense(AbstractARNN):
                 features=features[i],
                 exclusive=(i == 0),
                 use_bias=self.use_bias,
-                dtype=self.dtype,
+                param_dtype=self.param_dtype,
                 precision=self.precision,
                 kernel_init=self.kernel_init,
                 bias_init=self.bias_init,
@@ -148,6 +150,7 @@ class ARNNDense(AbstractARNN):
         return _call(self, inputs)
 
 
+@deprecate_dtype
 class ARNNConv1D(AbstractARNN):
     """Autoregressive neural network with 1D convolution layers."""
 
@@ -164,7 +167,7 @@ class ARNNConv1D(AbstractARNN):
     """the nonlinear activation function between hidden layers (default: selu)."""
     use_bias: bool = True
     """whether to add a bias to the output (default: True)."""
-    dtype: DType = jnp.float64
+    param_dtype: DType = jnp.float64
     """the dtype of the computation (default: float64)."""
     precision: Any = None
     """numerical precision of the computation, see `jax.lax.Precision` for details."""
@@ -190,7 +193,7 @@ class ARNNConv1D(AbstractARNN):
                 kernel_dilation=self.kernel_dilation,
                 exclusive=(i == 0),
                 use_bias=self.use_bias,
-                dtype=self.dtype,
+                param_dtype=self.param_dtype,
                 precision=self.precision,
                 kernel_init=self.kernel_init,
                 bias_init=self.bias_init,
@@ -222,7 +225,7 @@ class ARNNConv2D(AbstractARNN):
     """the nonlinear activation function between hidden layers (default: selu)."""
     use_bias: bool = True
     """whether to add a bias to the output (default: True)."""
-    dtype: DType = jnp.float64
+    param_dtype: DType = jnp.float64
     """the dtype of the computation (default: float64)."""
     precision: Any = None
     """numerical precision of the computation, see `jax.lax.Precision` for details."""
@@ -251,7 +254,7 @@ class ARNNConv2D(AbstractARNN):
                 kernel_dilation=self.kernel_dilation,
                 exclusive=(i == 0),
                 use_bias=self.use_bias,
-                dtype=self.dtype,
+                param_dtype=self.param_dtype,
                 precision=self.precision,
                 kernel_init=self.kernel_init,
                 bias_init=self.bias_init,

--- a/netket/models/deepset.py
+++ b/netket/models/deepset.py
@@ -10,6 +10,7 @@ from jax.nn.initializers import (
     lecun_normal,
 )
 
+from netket.utils import deprecate_dtype
 from netket.hilbert import ContinuousHilbert
 
 
@@ -21,6 +22,7 @@ def check_features_length(features, n_layers, name):
         )
 
 
+@deprecate_dtype
 class DeepSetRelDistance(nn.Module):
     r"""Implements an equivariant version of the DeepSets architecture
     given by (https://arxiv.org/abs/1703.06114)
@@ -59,7 +61,7 @@ class DeepSetRelDistance(nn.Module):
     cusp_exponent: Optional[int] = None
     """exponent of Katos cusp condition"""
 
-    dtype: Any = jnp.float64
+    param_dtype: Any = jnp.float64
     """The dtype of the weights."""
 
     activation: Any = jax.nn.gelu
@@ -104,7 +106,7 @@ class DeepSetRelDistance(nn.Module):
             nn.Dense(
                 feat,
                 use_bias=self.use_bias,
-                param_dtype=self.dtype,
+                param_dtype=self.param_dtype,
                 kernel_init=self.kernel_init,
                 bias_init=self.bias_init,
             )
@@ -115,7 +117,7 @@ class DeepSetRelDistance(nn.Module):
             nn.Dense(
                 feat,
                 use_bias=self.use_bias,
-                param_dtype=self.dtype,
+                param_dtype=self.param_dtype,
                 kernel_init=self.kernel_init,
                 bias_init=self.bias_init,
             )
@@ -135,7 +137,7 @@ class DeepSetRelDistance(nn.Module):
     @nn.compact
     def __call__(self, x):
         sha = x.shape
-        param = self.param("cusp", self.params_init, (1,), self.dtype)
+        param = self.param("cusp", self.params_init, (1,), self.param_dtype)
 
         L = jnp.array(self.hilbert.extent)
         sdim = L.size

--- a/netket/models/equivariant.py
+++ b/netket/models/equivariant.py
@@ -22,7 +22,7 @@ from flax import linen as nn
 from jax.nn.initializers import zeros, lecun_normal
 from jax.scipy.special import logsumexp
 
-from netket.utils import HashableArray, warn_deprecation
+from netket.utils import HashableArray, warn_deprecation, deprecate_dtype
 from netket.utils.types import NNInitFunc
 from netket.utils.group import PermutationGroup
 from netket.graph import Graph, Lattice
@@ -44,6 +44,7 @@ def identity(x):
     return x
 
 
+@deprecate_dtype
 class GCNN_FFT(nn.Module):
     r"""Implements a GCNN using a fast fourier transform over the translation group.
 
@@ -69,7 +70,7 @@ class GCNN_FFT(nn.Module):
     all layers will have the same number of features."""
     characters: HashableArray
     """Array specifying the characters of the desired symmetry representation"""
-    dtype: Any = float
+    param_dtype: Any = float
     """The dtype of the weights."""
     activation: Any = reim_selu
     """The nonlinear activation function between hidden layers."""
@@ -97,7 +98,7 @@ class GCNN_FFT(nn.Module):
             space_group=self.symmetries,
             shape=self.shape,
             features=self.features[0],
-            dtype=self.dtype,
+            param_dtype=self.param_dtype,
             use_bias=self.use_bias,
             kernel_init=self.kernel_init,
             bias_init=self.bias_init,
@@ -110,7 +111,7 @@ class GCNN_FFT(nn.Module):
                 shape=self.shape,
                 features=self.features[layer + 1],
                 use_bias=self.use_bias,
-                dtype=self.dtype,
+                param_dtype=self.param_dtype,
                 precision=self.precision,
                 kernel_init=self.kernel_init,
                 bias_init=self.bias_init,
@@ -141,6 +142,7 @@ class GCNN_FFT(nn.Module):
             return x
 
 
+@deprecate_dtype
 class GCNN_Irrep(nn.Module):
     r"""Implements a GCNN by projecting onto irreducible
     representations of the group. The projection onto
@@ -181,7 +183,7 @@ class GCNN_Irrep(nn.Module):
     all layers will have the same number of features."""
     characters: HashableArray
     """Array specifying the characters of the desired symmetry representation"""
-    dtype: Any = np.float64
+    param_dtype: Any = np.float64
     """The dtype of the weights."""
     activation: Any = reim_selu
     """The nonlinear activation function between hidden layers."""
@@ -208,7 +210,7 @@ class GCNN_Irrep(nn.Module):
         self.dense_symm = DenseSymmMatrix(
             symmetries=self.symmetries,
             features=self.features[0],
-            dtype=self.dtype,
+            param_dtype=self.param_dtype,
             use_bias=self.use_bias,
             kernel_init=self.kernel_init,
             bias_init=self.bias_init,
@@ -220,7 +222,7 @@ class GCNN_Irrep(nn.Module):
                 irreps=self.irreps,
                 features=self.features[layer + 1],
                 use_bias=self.use_bias,
-                dtype=self.dtype,
+                param_dtype=self.param_dtype,
                 precision=self.precision,
                 kernel_init=self.kernel_init,
                 bias_init=self.bias_init,
@@ -251,6 +253,7 @@ class GCNN_Irrep(nn.Module):
             return x
 
 
+@deprecate_dtype
 class GCNN_Parity_FFT(nn.Module):
     r"""Implements a GCNN using a fast fourier transform over the translation group.
     The group convolution can be written in terms of translational convolutions with
@@ -278,7 +281,7 @@ class GCNN_Parity_FFT(nn.Module):
     """Array specifying the characters of the desired symmetry representation"""
     parity: int
     """Integer specifying the eigenvalue with respect to parity"""
-    dtype: Any = np.float64
+    param_dtype: Any = np.float64
     """The dtype of the weights."""
     activation: Any = reim_selu
     """The nonlinear activation function between hidden layers."""
@@ -320,7 +323,7 @@ class GCNN_Parity_FFT(nn.Module):
             space_group=self.symmetries,
             shape=self.shape,
             features=self.features[0],
-            dtype=self.dtype,
+            param_dtype=self.param_dtype,
             use_bias=self.use_bias,
             kernel_init=self.kernel_init,
             bias_init=self.bias_init,
@@ -333,7 +336,7 @@ class GCNN_Parity_FFT(nn.Module):
                 shape=self.shape,
                 features=self.features[layer + 1],
                 use_bias=self.use_bias,
-                dtype=self.dtype,
+                param_dtype=self.param_dtype,
                 precision=self.precision,
                 kernel_init=self.kernel_init,
                 bias_init=self.bias_init,
@@ -348,7 +351,7 @@ class GCNN_Parity_FFT(nn.Module):
                 features=self.features[layer + 1],
                 # this would bias the same outputs as self.equivariant
                 use_bias=self.extra_bias and self.use_bias,
-                dtype=self.dtype,
+                param_dtype=self.param_dtype,
                 precision=self.precision,
                 kernel_init=self.kernel_init,
                 bias_init=self.bias_init,
@@ -408,6 +411,7 @@ class GCNN_Parity_FFT(nn.Module):
             return x
 
 
+@deprecate_dtype
 class GCNN_Parity_Irrep(nn.Module):
     r"""Implements a GCNN by projecting onto irreducible
     representations of the group. The projection onto
@@ -453,7 +457,7 @@ class GCNN_Parity_Irrep(nn.Module):
     """Array specifying the characters of the desired symmetry representation"""
     parity: int
     """Integer specifying the eigenvalue with respect to parity"""
-    dtype: Any = np.float64
+    param_dtype: Any = np.float64
     """The dtype of the weights."""
     activation: Any = reim_selu
     """The nonlinear activation function between hidden layers."""
@@ -494,7 +498,7 @@ class GCNN_Parity_Irrep(nn.Module):
         self.dense_symm = DenseSymmMatrix(
             symmetries=self.symmetries,
             features=self.features[0],
-            dtype=self.dtype,
+            param_dtype=self.param_dtype,
             use_bias=self.use_bias,
             kernel_init=self.kernel_init,
             bias_init=self.bias_init,
@@ -506,7 +510,7 @@ class GCNN_Parity_Irrep(nn.Module):
                 irreps=self.irreps,
                 features=self.features[layer + 1],
                 use_bias=self.use_bias,
-                dtype=self.dtype,
+                param_dtype=self.param_dtype,
                 precision=self.precision,
                 kernel_init=self.kernel_init,
                 bias_init=self.bias_init,
@@ -520,7 +524,7 @@ class GCNN_Parity_Irrep(nn.Module):
                 features=self.features[layer + 1],
                 # this would bias the same outputs as self.equivariant
                 use_bias=self.extra_bias and self.use_bias,
-                dtype=self.dtype,
+                param_dtype=self.param_dtype,
                 precision=self.precision,
                 kernel_init=self.kernel_init,
                 bias_init=self.bias_init,
@@ -580,6 +584,7 @@ class GCNN_Parity_Irrep(nn.Module):
             return x
 
 
+@deprecate_dtype
 def GCNN(
     symmetries=None,
     product_table=None,
@@ -591,7 +596,7 @@ def GCNN(
     features=None,
     characters=None,
     parity=None,
-    dtype=np.float64,
+    param_dtype=np.float64,
     complex_output=True,
     **kwargs,
 ):
@@ -632,7 +637,7 @@ def GCNN(
         characters: Array specifying the characters of the desired symmetry representation.
         parity: Optional argument with value +/-1 that specifies the eigenvalue
             with respect to parity (only use on two level systems).
-        dtype: The dtype of the weights.
+        param_dtype: The dtype of the weights.
         activation: The nonlinear activation function between hidden layers. Defaults to
             :func:`nk.nn.activation.reim_selu` .
         output_activation: The nonlinear activation before the output.
@@ -704,7 +709,7 @@ def GCNN(
     else:
         if (
             not is_complex(characters)
-            and not is_complex_dtype(dtype)
+            and not is_complex_dtype(param_dtype)
             and not complex_output
             and jnp.any(characters < 0)
         ):
@@ -727,7 +732,7 @@ def GCNN(
                 characters=characters,
                 shape=shape,
                 parity=parity,
-                dtype=dtype,
+                param_dtype=param_dtype,
                 complex_output=complex_output,
                 **kwargs,
             )
@@ -739,7 +744,7 @@ def GCNN(
                 features=features,
                 characters=characters,
                 shape=shape,
-                dtype=dtype,
+                param_dtype=param_dtype,
                 complex_output=complex_output,
                 **kwargs,
             )
@@ -757,7 +762,7 @@ def GCNN(
                 features=features,
                 characters=characters,
                 parity=parity,
-                dtype=dtype,
+                param_dtype=param_dtype,
                 complex_output=complex_output,
                 **kwargs,
             )
@@ -768,7 +773,7 @@ def GCNN(
                 layers=layers,
                 features=features,
                 characters=characters,
-                dtype=dtype,
+                param_dtype=param_dtype,
                 complex_output=complex_output,
                 **kwargs,
             )

--- a/netket/models/fast_autoreg.py
+++ b/netket/models/fast_autoreg.py
@@ -30,8 +30,10 @@ from netket.models.autoreg import (
 from netket.nn import FastMaskedConv1D, FastMaskedConv2D, FastMaskedDense1D
 from netket.nn.masked_linear import default_kernel_init
 from netket.utils.types import Array, DType, NNInitFunc
+from netket.utils import deprecate_dtype
 
 
+@deprecate_dtype
 class FastARNNDense(AbstractARNN):
     """
     Fast autoregressive neural network with dense layers.
@@ -51,7 +53,7 @@ class FastARNNDense(AbstractARNN):
     """the nonlinear activation function between hidden layers (default: selu)."""
     use_bias: bool = True
     """whether to add a bias to the output (default: True)."""
-    dtype: DType = jnp.float64
+    param_dtype: DType = jnp.float64
     """the dtype of the computation (default: float64)."""
     precision: Any = None
     """numerical precision of the computation, see `jax.lax.Precision` for details."""
@@ -76,7 +78,7 @@ class FastARNNDense(AbstractARNN):
                 features=features[i],
                 exclusive=(i == 0),
                 use_bias=self.use_bias,
-                dtype=self.dtype,
+                param_dtype=self.param_dtype,
                 precision=self.precision,
                 kernel_init=self.kernel_init,
                 bias_init=self.bias_init,
@@ -94,6 +96,7 @@ class FastARNNDense(AbstractARNN):
         return _call(self, inputs)
 
 
+@deprecate_dtype
 class FastARNNConv1D(AbstractARNN):
     """
     Fast autoregressive neural network with 1D convolution layers.
@@ -114,7 +117,7 @@ class FastARNNConv1D(AbstractARNN):
     """the nonlinear activation function between hidden layers (default: selu)."""
     use_bias: bool = True
     """whether to add a bias to the output (default: True)."""
-    dtype: DType = jnp.float64
+    param_dtype: DType = jnp.float64
     """the dtype of the computation (default: float64)."""
     precision: Any = None
     """numerical precision of the computation, see `jax.lax.Precision` for details."""
@@ -140,7 +143,7 @@ class FastARNNConv1D(AbstractARNN):
                 kernel_dilation=self.kernel_dilation,
                 exclusive=(i == 0),
                 use_bias=self.use_bias,
-                dtype=self.dtype,
+                param_dtype=self.param_dtype,
                 precision=self.precision,
                 kernel_init=self.kernel_init,
                 bias_init=self.bias_init,
@@ -179,7 +182,7 @@ class FastARNNConv2D(AbstractARNN):
     """the nonlinear activation function between hidden layers (default: selu)."""
     use_bias: bool = True
     """whether to add a bias to the output (default: True)."""
-    dtype: DType = jnp.float64
+    param_dtype: DType = jnp.float64
     """the dtype of the computation (default: float64)."""
     precision: Any = None
     """numerical precision of the computation, see `jax.lax.Precision` for details."""
@@ -209,7 +212,7 @@ class FastARNNConv2D(AbstractARNN):
                 kernel_dilation=self.kernel_dilation,
                 exclusive=(i == 0),
                 use_bias=self.use_bias,
-                dtype=self.dtype,
+                param_dtype=self.param_dtype,
                 precision=self.precision,
                 kernel_init=self.kernel_init,
                 bias_init=self.bias_init,

--- a/netket/models/mps.py
+++ b/netket/models/mps.py
@@ -22,11 +22,13 @@ from jax import numpy as jnp
 import numpy as np
 from jax.nn.initializers import normal
 
+from netket.utils import deprecate_dtype
 from netket.graph import AbstractGraph, Chain
 from netket.hilbert import AbstractHilbert
 from netket.utils.types import NNInitFunc
 
 
+@deprecate_dtype
 class MPSPeriodic(nn.Module):
     r"""
     A periodic Matrix Product State (MPS) for a quantum state of discrete
@@ -60,7 +62,7 @@ class MPSPeriodic(nn.Module):
         stddev=0.01
     )  # default standard deviation equals 1e-2
     """the initializer for the MPS weights."""
-    dtype: Any = np.complex64
+    param_dtype: Any = np.complex64
     """complex or float, whether the variational parameters of the MPS are real or complex."""
 
     def setup(self):
@@ -113,11 +115,11 @@ class MPSPeriodic(nn.Module):
         # define diagonal tensors with correct unit cell shape
         if self.diag:
             iden_tensors = jnp.ones(
-                (self._symperiod, phys_dim, self.bond_dim), dtype=self.dtype
+                (self._symperiod, phys_dim, self.bond_dim), dtype=self.param_dtype
             )
         else:
             iden_tensors = jnp.repeat(
-                jnp.eye(self.bond_dim, dtype=self.dtype)[jnp.newaxis, :, :],
+                jnp.eye(self.bond_dim, dtype=self.param_dtype)[jnp.newaxis, :, :],
                 self._symperiod * phys_dim,
                 axis=0,
             )
@@ -126,7 +128,7 @@ class MPSPeriodic(nn.Module):
             )
 
         self.kernel = (
-            self.param("kernel", self.kernel_init, unit_cell_shape, self.dtype)
+            self.param("kernel", self.kernel_init, unit_cell_shape, self.param_dtype)
             + iden_tensors
         )
 

--- a/netket/models/ndm.py
+++ b/netket/models/ndm.py
@@ -21,6 +21,7 @@ from jax import numpy as jnp
 from flax import linen as nn
 from jax.nn.initializers import zeros, normal
 
+from netket.utils import deprecate_dtype
 from netket.utils.types import NNInitFunc
 from netket import jax as nkjax
 from netket import nn as nknn
@@ -34,7 +35,7 @@ class PureRBM(nn.Module):
     indices with the same RBM.
     """
 
-    dtype: Any = np.float64
+    param_dtype: Any = np.float64
     """The dtype of the weights."""
     activation: Any = nknn.log_cosh
     """The nonlinear activation function."""
@@ -59,7 +60,7 @@ class PureRBM(nn.Module):
         W = nn.Dense(
             name="Dense",
             features=int(self.alpha * σr.shape[-1]),
-            param_dtype=self.dtype,
+            param_dtype=self.param_dtype,
             use_bias=self.use_hidden_bias,
             kernel_init=self.kernel_init,
             bias_init=self.hidden_bias_init,
@@ -75,7 +76,10 @@ class PureRBM(nn.Module):
 
         if self.use_visible_bias:
             v_bias = self.param(
-                "visible_bias", self.visible_bias_init, (σr.shape[-1],), self.dtype
+                "visible_bias",
+                self.visible_bias_init,
+                (σr.shape[-1],),
+                self.param_dtype,
             )
             if symmetric:
                 out_bias = jnp.dot(σr + σc, v_bias)
@@ -93,7 +97,7 @@ class MixedRBM(nn.Module):
     indices with the same RBM.
     """
 
-    dtype: Any = np.float64
+    param_dtype: Any = np.float64
     """The dtype of the weights."""
     activation: Any = nknn.log_cosh
     """The nonlinear activation function."""
@@ -114,7 +118,7 @@ class MixedRBM(nn.Module):
         U_S = nn.Dense(
             name="Symm",
             features=int(self.alpha * σr.shape[-1]),
-            param_dtype=self.dtype,
+            param_dtype=self.param_dtype,
             use_bias=False,
             kernel_init=self.kernel_init,
             precision=self.precision,
@@ -122,7 +126,7 @@ class MixedRBM(nn.Module):
         U_A = nn.Dense(
             name="ASymm",
             features=int(self.alpha * σr.shape[-1]),
-            param_dtype=self.dtype,
+            param_dtype=self.param_dtype,
             use_bias=False,
             kernel_init=self.kernel_init,
             precision=self.precision,
@@ -134,7 +138,7 @@ class MixedRBM(nn.Module):
                 "bias",
                 self.bias_init,
                 (int(self.alpha * σr.shape[-1]),),
-                nkjax.dtype_real(self.dtype),
+                nkjax.dtype_real(self.param_dtype),
             )
             y = y + bias
 
@@ -142,6 +146,7 @@ class MixedRBM(nn.Module):
         return y.sum(axis=-1)
 
 
+@deprecate_dtype
 class NDM(nn.Module):
     """
     Encodes a Positive-Definite Neural Density Matrix using the ansatz from Torlai and
@@ -152,7 +157,7 @@ class NDM(nn.Module):
     given in Vicentini et Al, PRL 122, 250503 (2019).
     """
 
-    dtype: Any = np.float64
+    param_dtype: Any = np.float64
     """The dtype of the weights."""
     activation: Any = nknn.log_cosh
     """The nonlinear activation function."""
@@ -188,7 +193,7 @@ class NDM(nn.Module):
             name="PureSymm",
             alpha=self.alpha,
             activation=self.activation,
-            dtype=self.dtype,
+            param_dtype=self.param_dtype,
             use_hidden_bias=self.use_hidden_bias,
             use_visible_bias=self.use_visible_bias,
             visible_bias_init=self.visible_bias_init,
@@ -201,7 +206,7 @@ class NDM(nn.Module):
             name="PureASymm",
             alpha=self.alpha,
             activation=self.activation,
-            dtype=self.dtype,
+            param_dtype=self.param_dtype,
             use_hidden_bias=self.use_hidden_bias,
             use_visible_bias=self.use_visible_bias,
             visible_bias_init=self.visible_bias_init,
@@ -213,7 +218,7 @@ class NDM(nn.Module):
         Π = MixedRBM(
             name="Mixed",
             alpha=self.beta,
-            dtype=self.dtype,
+            param_dtype=self.param_dtype,
             use_bias=self.use_ancilla_bias,
             activation=self.activation,
             kernel_init=self.kernel_init,

--- a/netket/models/rbm.py
+++ b/netket/models/rbm.py
@@ -21,7 +21,7 @@ from jax import numpy as jnp
 from flax import linen as nn
 from jax.nn.initializers import normal
 
-from netket.utils import HashableArray
+from netket.utils import HashableArray, deprecate_dtype
 from netket.utils.types import NNInitFunc
 from netket.utils.group import PermutationGroup
 from netket import nn as nknn
@@ -29,8 +29,9 @@ from netket import nn as nknn
 default_kernel_init = normal(stddev=0.01)
 
 
+@deprecate_dtype
 class RBM(nn.Module):
-    """A restricted boltzman Machine, equivalent to a 2-layer FFNN with a
+    r"""A restricted boltzman Machine, equivalent to a 2-layer FFNN with a
     nonlinear activation function in between.
     """
 
@@ -78,6 +79,7 @@ class RBM(nn.Module):
             return x
 
 
+@deprecate_dtype
 class RBMModPhase(nn.Module):
     r"""
     A fully connected Restricted Boltzmann Machine (RBM) with real-valued parameters.
@@ -139,6 +141,7 @@ class RBMModPhase(nn.Module):
         return re + 1j * im
 
 
+@deprecate_dtype
 class RBMMultiVal(nn.Module):
     """
     A fully connected Restricted Boltzmann Machine (see :ref:`netket.models.RBM`) suitable for large local hilbert spaces.

--- a/netket/models/rbm.py
+++ b/netket/models/rbm.py
@@ -35,7 +35,7 @@ class RBM(nn.Module):
     nonlinear activation function in between.
     """
 
-    dtype: Any = np.float64
+    param_dtype: Any = np.float64
     """The dtype of the weights."""
     activation: Any = nknn.log_cosh
     """The nonlinear activation function."""
@@ -60,7 +60,7 @@ class RBM(nn.Module):
         x = nn.Dense(
             name="Dense",
             features=int(self.alpha * input.shape[-1]),
-            param_dtype=self.dtype,
+            param_dtype=self.param_dtype,
             precision=self.precision,
             use_bias=self.use_hidden_bias,
             kernel_init=self.kernel_init,
@@ -71,7 +71,10 @@ class RBM(nn.Module):
 
         if self.use_visible_bias:
             v_bias = self.param(
-                "visible_bias", self.visible_bias_init, (input.shape[-1],), self.dtype
+                "visible_bias",
+                self.visible_bias_init,
+                (input.shape[-1],),
+                self.param_dtype,
             )
             out_bias = jnp.dot(input, v_bias)
             return x + out_bias
@@ -98,7 +101,7 @@ class RBMModPhase(nn.Module):
     for arbitrary local quantum numbers :math:`s_i`.
     """
 
-    dtype: Any = np.float64
+    param_dtype: Any = np.float64
     """The dtype of the weights."""
     activation: Any = nknn.log_cosh
     """The nonlinear activation function."""
@@ -118,7 +121,7 @@ class RBMModPhase(nn.Module):
     def __call__(self, x):
         re = nn.Dense(
             features=int(self.alpha * x.shape[-1]),
-            param_dtype=self.dtype,
+            param_dtype=self.param_dtype,
             use_bias=self.use_hidden_bias,
             precision=self.precision,
             kernel_init=self.kernel_init,
@@ -129,7 +132,7 @@ class RBMModPhase(nn.Module):
 
         im = nn.Dense(
             features=int(self.alpha * x.shape[-1]),
-            param_dtype=self.dtype,
+            param_dtype=self.param_dtype,
             use_bias=self.use_hidden_bias,
             precision=self.precision,
             kernel_init=self.kernel_init,
@@ -152,7 +155,7 @@ class RBMMultiVal(nn.Module):
 
     n_classes: int
     """The number of classes in the one-hot encoding"""
-    dtype: Any = np.float64
+    param_dtype: Any = np.float64
     """The dtype of the weights."""
     activation: Any = nknn.log_cosh
     """The nonlinear activation function."""
@@ -174,7 +177,7 @@ class RBMMultiVal(nn.Module):
 
     def setup(self):
         self.RBM = RBM(
-            dtype=self.dtype,
+            param_dtype=self.param_dtype,
             activation=self.activation,
             alpha=self.alpha,
             use_hidden_bias=self.use_hidden_bias,
@@ -203,7 +206,7 @@ class RBMSymm(nn.Module):
     """A group of symmetry operations (or array of permutation indices) over which the layer should be invariant.
     Numpy/Jax arrays must be wrapped into an :class:`netket.utils.HashableArray`.
     """
-    dtype: Any = np.float64
+    param_dtype: Any = np.float64
     """The dtype of the weights."""
     activation: Any = nknn.log_cosh
     """The nonlinear activation function."""
@@ -242,7 +245,7 @@ class RBMSymm(nn.Module):
             mode="matrix",
             symmetries=self.symmetries,
             features=self.features,
-            dtype=self.dtype,
+            param_dtype=self.param_dtype,
             use_bias=self.use_hidden_bias,
             kernel_init=self.kernel_init,
             bias_init=self.hidden_bias_init,
@@ -255,7 +258,7 @@ class RBMSymm(nn.Module):
 
         if self.use_visible_bias:
             v_bias = self.param(
-                "visible_bias", self.visible_bias_init, (1,), self.dtype
+                "visible_bias", self.visible_bias_init, (1,), self.param_dtype
             )
             out_bias = v_bias[0] * jnp.sum(x_in, axis=-1)
             return x + out_bias

--- a/netket/nn/deprecation.py
+++ b/netket/nn/deprecation.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from textwrap import dedent
-from functools import wraps, partial
+from functools import wraps
 
 import warnings
 
@@ -40,14 +40,14 @@ def _warning_string(module_name):
          1) Flax has fixed their issues with complex numbers, so we encourage you to use flax directly
          instead of `netket.nn`
 
-         2) The meaning of `module.dtype` in Flax is different than in NetKet! 
+         2) The meaning of `module.dtype` in Flax is different than in NetKet!
             - `param_dtype` specifies the type of parameters to be used. In most cases you will want to
                             specify this one. For example, to use complex parameters you should use
                             `param_dtype=complex`.
                             By default it is `jnp.float32`.
 
-            - `dtype`       is an optional specification stating the precision of the calculation, and 
-                            it has no impact unless you are working on a GPU or TPU. For example, by 
+            - `dtype`       is an optional specification stating the precision of the calculation, and
+                            it has no impact unless you are working on a GPU or TPU. For example, by
                             specifying `param_dtype=jnp.float64` and `dtype=jnp.float32`, you will store
                             parameters in double precision, but perform calculations in single precision.
 
@@ -63,9 +63,9 @@ def deprecated_module(original_module, module_name):
         if "param_dtype" in kwargs:
 
             err_msg = f"""
-                    *************************************************************************          
-                    Use `flax.linen.{module_name}` instead of `netket.nn.{module_name}`. 
-                    *************************************************************************            
+                    *************************************************************************
+                    Use `flax.linen.{module_name}` instead of `netket.nn.{module_name}`.
+                    *************************************************************************
 
             You are specifying `param_dtype` so you should be good.
             """
@@ -90,9 +90,9 @@ def deprecated_function(original_function, function_name):
     @wraps(original_function)
     def call_deprecated_function(*args, **kwargs):
         wrn_msg = f"""
-                *************************************************************************          
-                Use `flax.linen.{function_name}` instead of `netket.nn.{function_name}`. 
-                *************************************************************************            
+                *************************************************************************
+                Use `flax.linen.{function_name}` instead of `netket.nn.{function_name}`.
+                *************************************************************************
         """
 
         warnings.warn(dedent(wrn_msg), category=FutureWarning, stacklevel=3)

--- a/netket/nn/fast_masked_linear.py
+++ b/netket/nn/fast_masked_linear.py
@@ -16,6 +16,8 @@ from typing import Any, Tuple
 
 import flax
 from flax import linen as nn
+from flax.linen.dtypes import promote_dtype
+
 from jax import lax
 from jax import numpy as jnp
 from jax.nn.initializers import zeros
@@ -28,8 +30,10 @@ from netket.nn.masked_linear import (
     wrap_kernel_init,
 )
 from netket.utils.types import Array, DType, NNInitFunc
+from netket.utils import deprecate_dtype
 
 
+@deprecate_dtype
 class FastMaskedDense1D(nn.Module):
     """
     1D linear transformation module with mask for fast autoregressive NN.
@@ -48,7 +52,7 @@ class FastMaskedDense1D(nn.Module):
     """True if an output element does not depend on the input element at the same index."""
     use_bias: bool = True
     """whether to add a bias to the output (default: True)."""
-    dtype: DType = jnp.float64
+    param_dtype: DType = jnp.float64
     """the dtype of the computation (default: float64)."""
     precision: Any = None
     """numerical precision of the computation, see `jax.lax.Precision` for details."""
@@ -69,17 +73,39 @@ class FastMaskedDense1D(nn.Module):
         Returns:
           The output site with dimensions (batch, features).
         """
-        dtype = jnp.promote_types(inputs.dtype, self.dtype)
-
-        inputs = jnp.asarray(inputs, dtype)
-
-        is_single_input = False
         if inputs.ndim == 1:
             is_single_input = True
             inputs = jnp.expand_dims(inputs, axis=0)
+        else:
+            is_single_input = False
 
         batch, in_features = inputs.shape
         size = self.size
+
+        if self.use_bias:
+            bias = self.param(
+                "bias", self.bias_init, (size, self.features), self.param_dtype
+            )
+        else:
+            bias = None
+
+        # The construction of `mask` will be optimized to a constant by JIT
+        mask = jnp.ones((size, size), dtype=self.param_dtype)
+        mask = jnp.triu(mask, self.exclusive)
+        mask = jnp.kron(
+            mask, jnp.ones((in_features, self.features), dtype=self.param_dtype)
+        )
+
+        kernel = self.param(
+            "kernel",
+            wrap_kernel_init(self.kernel_init, mask),
+            (size * in_features, size * self.features),
+            self.param_dtype,
+        )
+
+        inputs, kernel, mask, bias = promote_dtype(
+            inputs, kernel, mask, bias, dtype=None
+        )
 
         # Number of input sites depended by the output site at the index
         size_i = index + 1
@@ -100,26 +126,10 @@ class FastMaskedDense1D(nn.Module):
                 lambda _: _cache.value,
                 None,
             )
-
         cache = _cache.value
-        cache = jnp.asarray(cache, dtype)
 
         cache_i = cache[:, :size_i, :]
         cache_i = cache_i.reshape((batch, size_i * in_features))
-
-        # The construction of `mask` will be optimized to a constant by JIT
-        mask = jnp.ones((size, size), dtype=self.dtype)
-        mask = jnp.triu(mask, self.exclusive)
-        mask = jnp.kron(mask, jnp.ones((in_features, self.features), dtype=self.dtype))
-
-        kernel = self.param(
-            "kernel",
-            wrap_kernel_init(self.kernel_init, mask),
-            (size * in_features, size * self.features),
-            self.dtype,
-        )
-        mask = jnp.asarray(mask, dtype)
-        kernel = jnp.asarray(kernel, dtype)
 
         mask_i = mask.reshape((size, in_features, size, self.features))
         mask_i = mask_i[:size_i, :, index, :]
@@ -132,12 +142,7 @@ class FastMaskedDense1D(nn.Module):
         y_i = lax.dot(cache_i, mask_i * kernel_i, precision=self.precision)
 
         if self.use_bias:
-            bias = self.param("bias", self.bias_init, (size, self.features), self.dtype)
-            bias = jnp.asarray(bias, dtype)
-
-            bias_i = bias[index, :]
-
-            y_i = y_i + bias_i
+            y_i = y_i + bias[index, :]
 
         assert y_i.shape[1] == self.features
 
@@ -159,6 +164,7 @@ class FastMaskedDense1D(nn.Module):
         return MaskedDense1D.__call__(self, inputs)
 
 
+@deprecate_dtype
 class FastMaskedConv1D(nn.Module):
     """
     1D convolution module with mask for fast autoregressive NN.
@@ -181,7 +187,7 @@ class FastMaskedConv1D(nn.Module):
     """if specified, divides the input features into groups (default: 1)."""
     use_bias: bool = True
     """whether to add a bias to the output (default: True)."""
-    dtype: DType = jnp.float64
+    param_dtype: DType = jnp.float64
     """the dtype of the computation (default: float64)."""
     precision: Any = None
     """numerical precision of the computation, see `jax.lax.Precision` for details."""
@@ -202,21 +208,34 @@ class FastMaskedConv1D(nn.Module):
         Returns:
           The next output site with dimensions (batch, features).
         """
-        dtype = jnp.promote_types(inputs.dtype, self.dtype)
-
-        inputs = jnp.asarray(inputs, dtype)
-
         kernel_size = self.kernel_size - self.exclusive
         dilation = self.kernel_dilation
 
-        is_single_input = False
         if inputs.ndim == 1:
             is_single_input = True
             inputs = jnp.expand_dims(inputs, axis=0)
+        else:
+            is_single_input = False
 
         batch, in_features = inputs.shape
         assert in_features % self.feature_group_count == 0
         cache_size = kernel_size * dilation - (not self.exclusive) * (dilation - 1)
+
+        kernel_shape = (
+            kernel_size,
+            in_features // self.feature_group_count,
+            self.features,
+        )
+        kernel = self.param("kernel", self.kernel_init, kernel_shape, self.param_dtype)
+
+        if self.use_bias:
+            bias = self.param(
+                "bias", self.bias_init, (self.features,), self.param_dtype
+            )
+        else:
+            bias = None
+
+        inputs, kernel, bias = promote_dtype(inputs, kernel, bias, dtype=None)
 
         # Initialize the cache with zeros, and the RNG key is None
         # `cache.dtype` must be the same as `inputs.dtype` (no promotion)
@@ -243,15 +262,6 @@ class FastMaskedConv1D(nn.Module):
             )
 
         cache = _cache.value
-        cache = jnp.asarray(cache, dtype)
-
-        kernel_shape = (
-            kernel_size,
-            in_features // self.feature_group_count,
-            self.features,
-        )
-        kernel = self.param("kernel", self.kernel_init, kernel_shape, self.dtype)
-        kernel = jnp.asarray(kernel, dtype)
 
         if self.exclusive and dilation > 1:
             cache = cache[:, : -(dilation - 1), :]
@@ -270,8 +280,6 @@ class FastMaskedConv1D(nn.Module):
         )
 
         if self.use_bias:
-            bias = self.param("bias", self.bias_init, (self.features,), self.dtype)
-            bias = jnp.asarray(bias, dtype)
             y_i = y_i + bias
 
         y_i = y_i.squeeze(axis=1)
@@ -294,6 +302,7 @@ class FastMaskedConv1D(nn.Module):
         return MaskedConv1D.__call__(self, inputs)
 
 
+@deprecate_dtype
 class FastMaskedConv2D(nn.Module):
     """
     2D convolution module with mask for fast autoregressive NN.
@@ -316,7 +325,7 @@ class FastMaskedConv2D(nn.Module):
     """if specified, divides the input features into groups (default: 1)."""
     use_bias: bool = True
     """whether to add a bias to the output (default: True)."""
-    dtype: DType = jnp.float64
+    param_dtype: DType = jnp.float64
     """the dtype of the computation (default: float64)."""
     precision: Any = None
     """numerical precision of the computation, see `jax.lax.Precision` for details."""
@@ -327,7 +336,7 @@ class FastMaskedConv2D(nn.Module):
 
     def setup(self):
         kernel_h, kernel_w = self.kernel_size
-        mask = jnp.ones((kernel_h, kernel_w, 1, 1), dtype=self.dtype)
+        mask = jnp.ones((kernel_h, kernel_w, 1, 1), dtype=self.param_dtype)
         mask = mask.at[-1, kernel_w // 2 + (not self.exclusive) :].set(0)
         self.mask = mask
 
@@ -343,10 +352,6 @@ class FastMaskedConv2D(nn.Module):
         Returns:
           The next output site with dimensions (batch, features).
         """
-        dtype = jnp.promote_types(inputs.dtype, self.dtype)
-
-        inputs = jnp.asarray(inputs, dtype)
-
         L = self.L
         index_w = index % L
 
@@ -354,15 +359,36 @@ class FastMaskedConv2D(nn.Module):
         dilation_h, dilation_w = self.kernel_dilation
         ones = (1, 1)
 
-        is_single_input = False
         if inputs.ndim == 1:
             is_single_input = True
             inputs = jnp.expand_dims(inputs, axis=0)
+        else:
+            is_single_input = False
 
         batch, in_features = inputs.shape
         assert in_features % self.feature_group_count == 0
         recep_h = (kernel_h - 1) * dilation_h + 1
         recep_w = (kernel_w - 1) * dilation_w + 1
+
+        if self.use_bias:
+            bias = self.param(
+                "bias", self.bias_init, (self.features,), self.param_dtype
+            )
+        else:
+            bias = None
+
+        kernel_shape = self.kernel_size + (
+            in_features // self.feature_group_count,
+            self.features,
+        )
+        kernel = self.param(
+            "kernel",
+            wrap_kernel_init(self.kernel_init, self.mask),
+            kernel_shape,
+            self.param_dtype,
+        )
+
+        inputs, kernel, bias = promote_dtype(inputs, kernel, bias, dtype=None)
 
         # Initialize the cache with zeros, and the RNG key is None
         # `cache.dtype` must be the same as `inputs.dtype` (no promotion)
@@ -420,19 +446,6 @@ class FastMaskedConv2D(nn.Module):
             )
 
         cache = _cache.value
-        cache = jnp.asarray(cache, dtype)
-
-        kernel_shape = self.kernel_size + (
-            in_features // self.feature_group_count,
-            self.features,
-        )
-        kernel = self.param(
-            "kernel",
-            wrap_kernel_init(self.kernel_init, self.mask),
-            kernel_shape,
-            self.dtype,
-        )
-        kernel = jnp.asarray(kernel, dtype)
 
         # Zero padding
         cache = jnp.pad(
@@ -464,8 +477,6 @@ class FastMaskedConv2D(nn.Module):
         )
 
         if self.use_bias:
-            bias = self.param("bias", self.bias_init, (self.features,), self.dtype)
-            bias = jnp.asarray(bias, dtype)
             y_i = y_i + bias
 
         y_i = y_i.squeeze(axis=(1, 2))

--- a/netket/optimizer/__init__.py
+++ b/netket/optimizer/__init__.py
@@ -68,7 +68,7 @@ def Momentum(learning_rate: float, beta: float = 0.9, nesterov: bool = False):
         :math:`G(\mathbf{p})`, the updates for the parameter :math:`p_k` and
         corresponding component of the momentum :math:`m_k` are
 
-        .. math:: 
+        .. math::
 
             m^\prime_k &= \beta m_k + (1-\beta)G_k(\mathbf{p})\\
             p^\prime_k &= \eta m^\prime_

--- a/netket/utils/__init__.py
+++ b/netket/utils/__init__.py
@@ -27,7 +27,12 @@ from .optional_deps import tensorboard_available
 from .seed import random_seed
 from .summation import KahanSum
 
-from .deprecation import warn_deprecation, deprecated, deprecated_new_name
+from .deprecation import (
+    warn_deprecation,
+    deprecated,
+    deprecated_new_name,
+    deprecate_dtype,
+)
 from .moduletools import _hide_submodules, rename_class, auto_export as _auto_export
 from .version_check import module_version
 

--- a/netket/utils/_dependencies_check.py
+++ b/netket/utils/_dependencies_check.py
@@ -30,7 +30,7 @@ def create_msg(pkg_name, cur_version, desired_version, extra_msg=""):
         f"""
 
         ##########################################################################################
-        
+
         {pkg_name} version {cur_version} (< {desired_version}) is too old and incompatible with NetKet.
         Please update `{pkg_name}` by running the command:
 
@@ -52,16 +52,16 @@ def create_msg(pkg_name, cur_version, desired_version, extra_msg=""):
 
 if not module_version("optax") >= (0, 1, 1):
     cur_version = version_string("optax")
-    extra = f"""Reason: Optax is NetKet's provider of optimisers. Versions before 0.1.1 did not
-                support complex numbers and silently returned wrong values, especially when
-                using optimisers involving the norm of the gradient such as `Adam`.
-                As recent versions of optax correctly work with complex numbers, please upgrade.
-                """
+    extra = """Reason: Optax is NetKet's provider of optimisers. Versions before 0.1.1 did not
+               support complex numbers and silently returned wrong values, especially when
+               using optimisers involving the norm of the gradient such as `Adam`.
+               As recent versions of optax correctly work with complex numbers, please upgrade.
+               """
     raise ImportError(create_msg("optax", cur_version, "0.1.1", extra))
 
 if not module_version("flax") >= (0, 5, 0):
     cur_version = version_string("flax")
-    extra = f"""Reason: Flax is NetKet's default neural-network library. Versions before 0.5 had
-                a bug and did not properly support complex numbers.
-                """
+    extra = """Reason: Flax is NetKet's default neural-network library. Versions before 0.5 had
+               a bug and did not properly support complex numbers.
+               """
     raise ImportError(create_msg("flax", cur_version, "0.5", extra))

--- a/netket/utils/config_flags.py
+++ b/netket/utils/config_flags.py
@@ -140,3 +140,16 @@ config.define(
     ),
     runtime=True,
 )
+
+
+config.define(
+    "NETKET_SPHINX_BUILD",
+    bool,
+    default=False,
+    help=dedent(
+        """
+        Set to True when building documentation with Sphinx. Disables some decorators.
+        """
+    ),
+    runtime=True,
+)

--- a/netket/utils/deprecation.py
+++ b/netket/utils/deprecation.py
@@ -106,14 +106,6 @@ def deprecate_dtype(clz):
     # this env variable set by us sphinx's conf.py, and we do not apply the
     # deecorator if that's the case.
     if config.FLAGS["NETKET_SPHINX_BUILD"]:
-        if hasattr(clz, "__init__"):
-            if clz.__init__.__doc__ is not None and clz.__init__.__doc__ != "":
-                clz.__init__.__doc__ = clz.__init__.__doc__ + _dep_msg
-            else:
-                clz.__doc__ = clz.__doc__ + _dep_msg
-        else:
-            clz.__doc__ = clz.__doc__ + _dep_msg
-
         return clz
 
     # If it is a class, then add the deprecated dtype attribute returning

--- a/netket/utils/deprecation.py
+++ b/netket/utils/deprecation.py
@@ -80,11 +80,11 @@ def deprecated_new_name(message):
 _dep_msg = f"""
 
 **DEPRECATION_WARNING:**
-    The `dtype` argument to Neural-Network layers and models is deprecated
+    The `dtype` argument to neural-network layers and models is deprecated
     throughout NetKet to maintain consistency with new releases of flax. 
     Please use `param_dtype` instead.
 
-    This warning will eventually turn into an error.  
+    This warning will become an error in a future version of NetKet.  
 
 """
 

--- a/netket/utils/deprecation.py
+++ b/netket/utils/deprecation.py
@@ -15,7 +15,6 @@
 import warnings
 import functools
 import inspect
-import typing
 
 from textwrap import dedent
 
@@ -77,14 +76,14 @@ def deprecated_new_name(message):
     return deprecated_decorator
 
 
-_dep_msg = f"""
+_dep_msg = """
 
 **DEPRECATION_WARNING:**
     The `dtype` argument to neural-network layers and models is deprecated
-    throughout NetKet to maintain consistency with new releases of flax. 
+    throughout NetKet to maintain consistency with new releases of flax.
     Please use `param_dtype` instead.
 
-    This warning will become an error in a future version of NetKet.  
+    This warning will become an error in a future version of NetKet.
 
 """
 

--- a/netket/utils/deprecation.py
+++ b/netket/utils/deprecation.py
@@ -15,8 +15,11 @@
 import warnings
 import functools
 import inspect
+import typing
 
 from textwrap import dedent
+
+from .config_flags import config
 
 
 def deprecated(reason=None, func_name=None):
@@ -72,3 +75,70 @@ def deprecated_new_name(message):
         return deprecated_func
 
     return deprecated_decorator
+
+
+_dep_msg = f"""
+
+**DEPRECATION_WARNING:**
+    The `dtype` argument to Neural-Network layers and models is deprecated
+    throughout NetKet to maintain consistency with new releases of flax. 
+    Please use `param_dtype` instead.
+
+    This warning will eventually turn into an error.  
+
+"""
+
+
+def _dtype_deprecated(self):
+    warn_deprecation(_dep_msg)
+    return self.param_dtype
+
+
+def deprecate_dtype(clz):
+    """
+    Decorator taking a class or a function returning an instance of a class
+    and replacing the `dtype` argument with `param_dtype`.
+
+    This decorator also adds a deprecated field `dtype` to the class, which
+    returns `param_dtype`.
+    """
+    # Sphinx is terrible at understanding wrappers of classses, so we detect
+    # this env variable set by us sphinx's conf.py, and we do not apply the
+    # deecorator if that's the case.
+    if config.FLAGS["NETKET_SPHINX_BUILD"]:
+        if hasattr(clz, "__init__"):
+            if clz.__init__.__doc__ is not None and clz.__init__.__doc__ != "":
+                clz.__init__.__doc__ = clz.__init__.__doc__ + _dep_msg
+            else:
+                clz.__doc__ = clz.__doc__ + _dep_msg
+        else:
+            clz.__doc__ = clz.__doc__ + _dep_msg
+
+        return clz
+
+    # If it is a class, then add the deprecated dtype attribute returning
+    # `param.dtype`
+    # else, if this is a function returning a class, it will be set later
+    # on.
+    if inspect.isclass(clz):
+        lazy = False
+        if not hasattr(clz, "dtype"):
+            clz.dtype = property(_dtype_deprecated)
+    else:
+        lazy = True
+
+    @functools.wraps(clz)
+    def helper(*args, **kws):
+        # deprecated dtype argument
+        if "dtype" in kws.keys():
+            warn_deprecation(_dep_msg)
+            dtype = kws.pop("dtype")
+            kws["param_dtype"] = dtype
+        res = clz(*args, **kws)
+        if lazy:
+            _clz = type(res)
+            if not hasattr(_clz, "dtype"):
+                _clz.dtype = property(_dtype_deprecated)
+        return res
+
+    return helper

--- a/test/models/test_rbm.py
+++ b/test/models/test_rbm.py
@@ -114,3 +114,11 @@ def test_RBMMultiVal(use_hidden_bias, use_visible_bias):
         ma,
     )
     vmc.advance(1)
+
+
+def test_deprecated_dtype():
+    with pytest.warns(FutureWarning):
+        module = nk.models.RBM(dtype=complex)
+
+    with pytest.warns(FutureWarning):
+        assert module.dtype == module.param_dtype

--- a/test/nn/test_deprecated.py
+++ b/test/nn/test_deprecated.py
@@ -40,6 +40,7 @@ def test_deprecated_layers():
 
     assert module == module2
 
+
 def test_deprecated_dtype_layers():
     g = nk.graph.Square(3)
     with pytest.warns(FutureWarning):

--- a/test/nn/test_deprecated.py
+++ b/test/nn/test_deprecated.py
@@ -39,3 +39,17 @@ def test_deprecated_layers():
     module2 = nn.Dense(features=3, param_dtype=complex)
 
     assert module == module2
+
+def test_deprecated_dtype_layers():
+    g = nk.graph.Square(3)
+    with pytest.warns(FutureWarning):
+        module = nknn.DenseSymm(g, features=2, dtype=complex)
+
+    with pytest.warns(FutureWarning):
+        assert module.dtype == module.param_dtype
+
+    with pytest.warns(FutureWarning):
+        module = nknn.DenseEquivariant(g, features=2, dtype=complex)
+
+    with pytest.warns(FutureWarning):
+        assert module.dtype == module.param_dtype

--- a/test/optimizer/test_qgt_itersolve.py
+++ b/test/optimizer/test_qgt_itersolve.py
@@ -84,10 +84,10 @@ RBMModPhase = partial(
 )
 
 models = {
-    "RBM[dtype=float64]": partial(RBM, dtype=np.dtype("float64")),
-    "RBM[dtype=float32]": partial(RBM, dtype=np.dtype("float32")),
-    "RBM[dtype=complex128]": partial(RBM, dtype=np.dtype("complex128")),
-    "RBMModPhase[dtype=float64]": partial(RBMModPhase, dtype=np.dtype("float64")),
+    "RBM[dtype=float64]": partial(RBM, param_dtype=np.dtype("float64")),
+    "RBM[dtype=float32]": partial(RBM, param_dtype=np.dtype("float32")),
+    "RBM[dtype=complex128]": partial(RBM, param_dtype=np.dtype("complex128")),
+    "RBMModPhase[dtype=float64]": partial(RBMModPhase, param_dtype=np.dtype("float64")),
 }
 
 
@@ -253,7 +253,7 @@ def test_qgt_dense(qgt, vstate, _mpi_size, _mpi_rank):
     assert Sd.ndim == 2
     if hasattr(S, "mode"):
         if S.mode == "complex" and np.issubdtype(
-            vstate.model.dtype, np.complexfloating
+            vstate.model.param_dtype, np.complexfloating
         ):
             assert Sd.shape == (2 * vstate.n_parameters, 2 * vstate.n_parameters)
         else:

--- a/test/variational/test_experimental.py
+++ b/test/variational/test_experimental.py
@@ -41,7 +41,7 @@ def vstate(request):
 
     ma = nk.models.RBM(
         alpha=1,
-        dtype=float,
+        param_dtype=float,
         hidden_bias_init=normal(),
         visible_bias_init=normal(),
     )

--- a/test/variational/test_variational_mixed.py
+++ b/test/variational/test_variational_mixed.py
@@ -376,7 +376,7 @@ def _skip_expect_exact_hotfix(vstate, operator):
     info = sys.version_info
     is_python_37 = info.major == 3 and info.minor == 7
 
-    is_crashing_test = operator is LdagL and isinstance(vstate._model, nk.models.NDM)
+    is_crashing_test = operator is LdagL and type(vstate.model).__name__ == "NDM"
 
     is_ci = common._is_true(os.environ.get("CI", False))
 


### PR DESCRIPTION
This is to be consistent with the new flax. It's annoying, but it's for the better.

It will be mildly annoying for users by trying to be loud, but we don't break code because everything is properly deprecated.

I kind-of-like it as I prefer `RBMModPhase(param_dtype=float32)`to `RBMModPhase(dtype=float32)` to use single-precision.

Based on top of #1198