### PR TITLE
enforce correct dtype promotion in qgt

### DIFF
--- a/netket/optimizer/qgt/qgt_jacobian_dense_logic.py
+++ b/netket/optimizer/qgt/qgt_jacobian_dense_logic.py
@@ -14,10 +14,12 @@
 
 from typing import Callable, Optional, Tuple
 from functools import partial, wraps
+import math
 
-import numpy as np
 import jax
 from jax import numpy as jnp
+
+import numpy as np
 
 from netket.stats import subtract_mean
 from netket.utils.types import PyTree, Array
@@ -289,9 +291,9 @@ def prepare_centered_oks(
     )
 
     n_samp = samples.shape[0] * mpi.n_nodes
-    centered_oks = subtract_mean(jacobians, axis=0) / np.sqrt(
-        n_samp, dtype=jacobians.dtype
-    )
+    centered_oks = subtract_mean(jacobians, axis=0) / math.sqrt(
+        n_samp
+    )  # maintain weak type!
 
     centered_oks = centered_oks.reshape(-1, centered_oks.shape[-1])
 

--- a/netket/optimizer/qgt/qgt_jacobian_pytree_logic.py
+++ b/netket/optimizer/qgt/qgt_jacobian_pytree_logic.py
@@ -14,7 +14,7 @@
 
 from typing import Optional
 from functools import partial
-from netket.jax import compose, vmap_chunked
+import math
 
 import jax
 import jax.flatten_util
@@ -24,10 +24,15 @@ import numpy as np
 
 from netket.stats import subtract_mean, sum
 from netket.utils import mpi
-
 from netket.utils.types import Array, Callable, PyTree, Scalar
-
-from netket.jax import tree_cast, tree_conj, tree_axpy, tree_to_real
+from netket.jax import (
+    tree_cast,
+    tree_conj,
+    tree_axpy,
+    tree_to_real,
+    compose,
+    vmap_chunked,
+)
 
 
 # TODO better name and move it somewhere sensible
@@ -114,7 +119,8 @@ def _divide_by_sqrt_n_samp(oks, samples):
     divide Oⱼₖ by √n
     """
     n_samp = samples.shape[0] * mpi.n_nodes  # MPI
-    return jax.tree_map(lambda x: x / np.sqrt(n_samp, dtype=x.dtype), oks)
+    sqrt_n = math.sqrt(n_samp)  # enforce weak type
+    return jax.tree_map(lambda x: x / sqrt_n, oks)
 
 
 def _multiply_by_pdf(oks, pdf):

--- a/test/optimizer/test_qgt_logic.py
+++ b/test/optimizer/test_qgt_logic.py
@@ -71,6 +71,13 @@ def tree_allclose(t1, t2):
     return all(jax.tree_util.tree_flatten(t)[0])
 
 
+def tree_samedtypes(t1, t2):
+    def _same_dtypes(x, y):
+        assert x.dtype == y.dtype
+
+    jax.tree_map(_same_dtypes, t1, t2)
+
+
 def random_split_like_tree(rng_key, target=None, treedef=None):
     if treedef is None:
         treedef = jax.tree_structure(target)
@@ -244,6 +251,7 @@ def test_matvec(e, jit, chunk_size):
         e.S_real @ e.v_real_flat + diag_shift * e.v_real_flat, target=e.target
     )
     assert tree_allclose(actual, expected)
+    tree_samedtypes(actual, expected)
 
 
 @pytest.mark.parametrize("holomorphic", [True, False])
@@ -286,6 +294,7 @@ def test_matvec_linear_transpose(e, jit, chunk_size):
     )
     # (expected,) = jax.linear_transpose(lambda v_: reassemble_complex(S_real @ tree_toreal_flat(v_), target=e.target), v)(v)
     assert tree_allclose(actual, expected)
+    tree_samedtypes(actual, expected)
 
 
 # TODO separate test for prepare_centered_oks
@@ -315,6 +324,7 @@ def test_matvec_treemv(e, jit, holomorphic, pardtype, outdtype, chunk_size):
     actual = mv(e.v, centered_oks)
     expected = reassemble_complex(e.S_real @ e.v_real_flat, target=e.target)
     assert tree_allclose(actual, expected)
+    tree_samedtypes(actual, expected)
 
 
 # TODO separate test for prepare_centered_oks
@@ -359,6 +369,7 @@ def test_matvec_treemv_modes(e, jit, holomorphic, pardtype, outdtype):
         e.S_real @ e.v_real_flat + diag_shift * e.v_real_flat, target=e.target
     )
     assert tree_allclose(actual, expected)
+    tree_samedtypes(actual, expected)
 
 
 @pytest.mark.parametrize("holomorphic", [True])
@@ -383,6 +394,7 @@ def test_scale_invariant_regularization(e, outdtype, pardtype):
     actual = mv(e.v, centered_oks_scaled)
     expected = reassemble_complex(e.S_real_scaled @ e.v_real_flat, target=e.target)
     assert tree_allclose(actual, expected)
+    tree_samedtypes(actual, expected)
 
 
 # TODO test with MPI

--- a/test/optimizer/test_qgt_logic.py
+++ b/test/optimizer/test_qgt_logic.py
@@ -74,6 +74,7 @@ def tree_allclose(t1, t2):
 def tree_samedtypes(t1, t2):
     def _same_dtypes(x, y):
         assert x.dtype == y.dtype
+        assert x.weak_type == y.weak_type
 
     jax.tree_map(_same_dtypes, t1, t2)
 


### PR DESCRIPTION
numpy.sqrt() was not a weak type and was promoting float32 networks to float64 in some cases.

@inailuig if you have some time at some point I'd love if you could contribute a test for this