### PR TITLE
Fix inline math directive in docstrings

### DIFF
--- a/netket/experimental/sampler/metropolis_pmap.py
+++ b/netket/experimental/sampler/metropolis_pmap.py
@@ -70,7 +70,7 @@ class MetropolisSamplerPmap(MetropolisSampler):
 
         A(s \rightarrow s^\prime) = \mathrm{min} \left( 1,\frac{P(s^\prime)}{P(s)} e^{L(s,s^\prime)} \right) ,
 
-    where the probability being sampled from is :math:`P(s)=|M(s)|^p. Here :math:`M(s)` is a
+    where the probability being sampled from is :math:`P(s)=|M(s)|^p`. Here :math:`M(s)` is a
     user-provided function (the machine), :math:`p` is also user-provided with default value :math:`p=2`,
     and :math:`L(s,s^\prime)` is a suitable correcting factor computed by the transition kernel.
 

--- a/netket/experimental/sampler/metropolis_pt.py
+++ b/netket/experimental/sampler/metropolis_pt.py
@@ -67,7 +67,7 @@ The move is accepted with probability
 .. math::
     A(s\rightarrow s^\prime) = \mathrm{min}\left (1,\frac{P(s^\prime)}{P(s)} e^{L(s,s^\prime)} \right),
 
-where the probability being sampled from is :math:`P(s)=|M(s)|^p. Here :math:`M(s)` is a
+where the probability being sampled from is :math:`P(s)=|M(s)|^p`. Here :math:`M(s)` is a
 user-provided function (the machine), :math:`p` is also user-provided with default value :math:`p=2`,
 and :math:`L(s,s^\prime)` is a suitable correcting factor computed by the transition kernel.
 

--- a/netket/optimizer/__init__.py
+++ b/netket/optimizer/__init__.py
@@ -95,7 +95,7 @@ def AdaGrad(
     initial_accumulator_value: float = 0.1,
 ):
     r"""AdaGrad Optimizer.
-        In many cases, in Sgd the learning rate :math`\eta` should
+        In many cases, in Sgd the learning rate :math:`\eta` should
         decay as a function of training iteration to prevent overshooting
         as the optimum is approached. AdaGrad is an adaptive learning
         rate algorithm that automatically scales the learning rate with a sum

--- a/netket/sampler/metropolis.py
+++ b/netket/sampler/metropolis.py
@@ -514,7 +514,7 @@ def MetropolisExchange(
     numbers, thus global quantities such as the sum of the local quantum numbers
     are conserved during the sampling.
     This scheme should be used then only when sampling in a
-    region where :math:`\sum_i s_i = \mathrm{constant} ` is needed,
+    region where :math:`\sum_i s_i = \mathrm{constant}` is needed,
     otherwise the sampling would be strongly not ergodic.
 
     Args:


### PR DESCRIPTION
I noticed some math in the API was not rendering correctly so this PR fixes those inline math directives in docstrings.