### PR TITLE
Use numpy isclose comparison in hermiticity check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 
 ### Bug Fixes
 * Fixed bug where a `nk.operator.LocalOperator` representing the identity would lead to a crash. [#1197](https://github.com/netket/netket/pull/1197)
-
+* Use np.isclose to allow for some tolerance in checking the hermicity of a `nkx.operator.FermionOperator2nd` [#1233](https://github.com/netket/netket/pull/1233)
 
 ## NetKet 3.4.2 (BugFixes & DepWarns again)
 

--- a/netket/experimental/operator/_fermions_2nd.py
+++ b/netket/experimental/operator/_fermions_2nd.py
@@ -682,8 +682,8 @@ def dict_compare(d1, d2):
     d2_keys = set(d2.keys())
     if d1_keys != d2_keys:
         return False
-    shared_keys = d1_keys.intersection(d2_keys)
-    return all(np.isclose(d1[o], d2[o]) for o in shared_keys)
+    # We checked that d1 and d2 have the same keys. Now check the values.
+    return all(np.isclose(d1[o], d2[o]) for o in d1_keys)
 
 
 def _order_fun(term: List[List[int]], weight: Union[float, complex] = 1.0):

--- a/netket/experimental/operator/_fermions_2nd.py
+++ b/netket/experimental/operator/_fermions_2nd.py
@@ -676,25 +676,14 @@ def _check_hermitian(
     return is_hermitian
 
 
-def dict_compare(d1, d2, rtol=1e-05, atol=1e-08, equal_nan=False):
+def dict_compare(d1, d2):
     """Compare two dicts and return True if their keys and values are all the same (up to some tolerance)"""
     d1_keys = set(d1.keys())
     d2_keys = set(d2.keys())
+    if d1_keys != d2_keys:
+        return False
     shared_keys = d1_keys.intersection(d2_keys)
-    added = d1_keys - d2_keys
-    if len(added) != 0:
-        return False
-    removed = d2_keys - d1_keys
-    if len(removed) != 0:
-        return False
-    modified = {
-        o: (d1[o], d2[o])
-        for o in shared_keys
-        if not np.isclose(d1[o], d2[o], rtol=rtol, atol=atol, equal_nan=equal_nan)
-    }
-    if len(modified) != 0:
-        return False
-    return True
+    return not any((not np.isclose(d1[o], d2[o])) for o in shared_keys)
 
 
 def _order_fun(term: List[List[int]], weight: Union[float, complex] = 1.0):

--- a/netket/experimental/operator/_fermions_2nd.py
+++ b/netket/experimental/operator/_fermions_2nd.py
@@ -669,8 +669,32 @@ def _check_hermitian(
     # check if hermitian by comparing the dictionaries
     dict_normal = dict(dict_normal)
     dict_hc_normal = dict(dict_hc_normal)
-    is_hermitian = dict_normal == dict_hc_normal
+
+    # compare dict up to a tolerance
+    is_hermitian = dict_compare(dict_normal, dict_hc_normal)
+
     return is_hermitian
+
+
+def dict_compare(d1, d2, rtol=1e-05, atol=1e-08, equal_nan=False):
+    """Compare two dicts and return True if their keys and values are all the same (up to some tolerance)"""
+    d1_keys = set(d1.keys())
+    d2_keys = set(d2.keys())
+    shared_keys = d1_keys.intersection(d2_keys)
+    added = d1_keys - d2_keys
+    if len(added) != 0:
+        return False
+    removed = d2_keys - d1_keys
+    if len(removed) != 0:
+        return False
+    modified = {
+        o: (d1[o], d2[o])
+        for o in shared_keys
+        if not np.isclose(d1[o], d2[o], rtol=rtol, atol=atol, equal_nan=equal_nan)
+    }
+    if len(modified) != 0:
+        return False
+    return True
 
 
 def _order_fun(term: List[List[int]], weight: Union[float, complex] = 1.0):

--- a/netket/experimental/operator/_fermions_2nd.py
+++ b/netket/experimental/operator/_fermions_2nd.py
@@ -683,7 +683,7 @@ def dict_compare(d1, d2):
     if d1_keys != d2_keys:
         return False
     shared_keys = d1_keys.intersection(d2_keys)
-    return not any((not np.isclose(d1[o], d2[o])) for o in shared_keys)
+    return all(np.isclose(d1[o], d2[o]) for o in shared_keys)
 
 
 def _order_fun(term: List[List[int]], weight: Union[float, complex] = 1.0):

--- a/test/operator/test_fermions.py
+++ b/test/operator/test_fermions.py
@@ -61,6 +61,15 @@ op_ferm["ordering"] = (
     True,
 )
 
+op_ferm["float_round"] = (
+    nkx.operator.FermionOperator2nd(
+        hi,
+        terms=("0^ 1", "1^ 0"),
+        weights=(0.15438015086600768 + 0j, 0.15438015086600765 + 0j),
+    ),
+    True,
+)
+
 
 @pytest.mark.parametrize(
     "op_ferm, is_hermitian",


### PR DESCRIPTION
Hermiticity check was too strong, but uses numpy.isclose now with some tolerance.