### PR TITLE
Stop when loss is NaN

### DIFF
--- a/netket/callbacks/__init__.py
+++ b/netket/callbacks/__init__.py
@@ -14,6 +14,7 @@
 
 from .earlystopping import EarlyStopping
 from .timeout import Timeout
+from .invalidlossstopping import InvalidLossStopping
 
 from netket.utils import _hide_submodules
 

--- a/netket/callbacks/invalidlossstopping.py
+++ b/netket/callbacks/invalidlossstopping.py
@@ -1,0 +1,43 @@
+# Copyright 2020, 2021 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass
+class InvalidLossStopping:
+    """A simple callback to stop NetKet if there are no more improvements in the training.
+    based on `driver._loss_name`."""
+
+    monitor: str = "mean"
+    """Loss statistic to monitor. Should be one of 'mean', 'variance', 'sigma'."""
+
+    def __call__(self, step, log_data, driver):
+        """
+        A boolean function that determines whether or not to stop training.
+
+        Args:
+            step: An integer corresponding to the step (iteration or epoch) in training.
+            log_data: A dictionary containing log data for training.
+            driver: A NetKet variational driver.
+
+        Returns:
+            A boolean. If True, training continues, else, it does not.
+        """
+        loss = np.real(getattr(log_data[driver._loss_name], self.monitor))
+        if np.isnan(loss):
+            return False
+        return True

--- a/netket/driver/abstract_variational_driver.py
+++ b/netket/driver/abstract_variational_driver.py
@@ -23,6 +23,7 @@ from jax.tree_util import tree_map
 
 from netket.logging import JsonLog
 from netket.utils import mpi
+from netket.callbacks import InvalidLossStopping
 
 
 def _to_iterable(maybe_iterable):
@@ -190,7 +191,7 @@ class AbstractVariationalDriver(abc.ABC):
         save_params_every=50,  # for default logger
         write_every=50,  # for default logger
         step_size=1,  # for default logger
-        callback=lambda *x: True,
+        callback=InvalidLossStopping,
     ):
         """
         Executes the Monte Carlo Variational optimization, updating the weights of the network

--- a/netket/driver/abstract_variational_driver.py
+++ b/netket/driver/abstract_variational_driver.py
@@ -251,9 +251,9 @@ class AbstractVariationalDriver(abc.ABC):
         callback_stop = False
 
         if stop_on_invalid_loss and all(
-            not isinstance(cb, InvalidLossStopping) for cb in callback
+            not isinstance(cb, InvalidLossStopping) for cb in callbacks
         ):
-            callback.append(InvalidLossStopping())
+            callbacks = callbacks + (InvalidLossStopping(),)
 
         with tqdm(total=n_iter, disable=not show_progress) as pbar:
             old_step = self.step_count


### PR DESCRIPTION
Closes #1222

This PR includes the `InvalidLossStopping` callback. As mentioned in #1222, I once saw energy going to NaN and back to being finite. Thus, we might want to not have this as default. I was thinking, however, that we can have a "default" callback that checks for NaNs in the loss value, and if it sees NaNs, it raises a warning, telling the user that they might want to include this callback.

Seems too cumbersome, though. What do you think about it?