### PR TITLE
Add `DiscreteHilbert.states_to_local_indices` as it seems that it's used in multiple places

### DIFF
--- a/netket/hilbert/custom_hilbert.py
+++ b/netket/hilbert/custom_hilbert.py
@@ -16,6 +16,8 @@ from typing import Optional, List, Callable
 
 from numbers import Real
 
+import jax.numpy as jnp
+
 from netket.graph import AbstractGraph
 
 from .homogeneous import HomogeneousHilbert
@@ -56,6 +58,14 @@ class CustomHilbert(HomogeneousHilbert):
         N = graph_to_N_depwarn(N=N, graph=graph)
 
         super().__init__(local_states, N, constraint_fn)
+
+    def states_to_local_indices(self, x):
+        local_states = jnp.asarray(self.local_states)
+        local_states = local_states.reshape(tuple(1 for _ in range(x.ndim)) + (-1,))
+        x = x.reshape(x.shape + (1,))
+        x_idmap = x == local_states
+        idxs = jnp.arange(self.local_size).reshape(local_states.shape)
+        return jnp.sum(x_idmap * idxs, axis=-1)
 
     def __pow__(self, n):
         if self._has_constraint:

--- a/netket/hilbert/discrete_hilbert.py
+++ b/netket/hilbert/discrete_hilbert.py
@@ -17,6 +17,8 @@ from textwrap import dedent
 
 import numpy as np
 
+from netket.utils.types import Array
+
 from .abstract_hilbert import AbstractHilbert
 
 max_states = np.iinfo(np.int32).max
@@ -205,6 +207,27 @@ class DiscreteHilbert(AbstractHilbert):
         numbers = np.arange(0, self.n_states, dtype=np.int64)
 
         return self.numbers_to_states(numbers, out)
+
+    def states_to_local_indices(self, x: Array):
+        r"""Returns a tensor with the same shape of `x`, where all local
+        values are converted to indices in the range `0...self.shape[i]`.
+        This function is guaranteed to be jax-jittable.
+
+        For the `Fock` space this returns `x`, but for other hilbert spaces
+        such as `Spin` this returns an array of indices.
+
+        NOTE: This function is experimental. Use at your own risk.
+
+        Args:
+            x: a tensor containing samples from this hilbert space
+
+        Returns:
+            a tensor containing integer indices into the local hilbert
+        """
+        raise NotImplementedError(
+            "states_to_local_indices(self, x) is not "
+            f"implemented for Hilbert space {self} of type {type(self)}"
+        )
 
     @property
     def is_indexable(self) -> bool:

--- a/netket/hilbert/doubled_hilbert.py
+++ b/netket/hilbert/doubled_hilbert.py
@@ -142,6 +142,9 @@ class DoubledHilbert(DiscreteHilbert):
 
         return out
 
+    def states_to_local_indices(self, x):
+        return self.physical.states_to_local_indices(x)
+
     def __repr__(self):
         return "DoubledHilbert({})".format(self.physical)
 

--- a/netket/hilbert/fock.py
+++ b/netket/hilbert/fock.py
@@ -161,6 +161,9 @@ class Fock(HomogeneousHilbert):
         nmax = self._n_max if self._n_max < FOCK_MAX else "FOCK_MAX"
         return "Fock(n_max={}{}, N={})".format(nmax, n_particles, self._size)
 
+    def states_to_local_indices(self, x):
+        return x.astype(np.int32)
+
     @property
     def _attrs(self):
         return (self.size, self._n_max, self._constraint_fn)

--- a/netket/hilbert/qubit.py
+++ b/netket/hilbert/qubit.py
@@ -14,6 +14,8 @@
 
 from typing import Optional, Union, List
 
+import numpy as np
+
 from netket.graph import AbstractGraph
 
 from .homogeneous import HomogeneousHilbert
@@ -41,6 +43,9 @@ class Qubit(HomogeneousHilbert):
         N = graph_to_N_depwarn(N=N, graph=graph)
 
         super().__init__([0.0, 1.0], N)
+
+    def states_to_local_indices(self, x):
+        return x.astype(np.int32)
 
     def __pow__(self, n):
         return Qubit(self.size * n)

--- a/netket/hilbert/spin.py
+++ b/netket/hilbert/spin.py
@@ -146,6 +146,10 @@ class Spin(HomogeneousHilbert):
         else:
             return Spin(s=self._s, N=self.size - Nsites)
 
+    def states_to_local_indices(self, x):
+        numbers = (x + self.local_size - 1) / 2
+        return numbers.astype(np.int32)
+
     def __repr__(self):
         total_sz = (
             ", total_sz={}".format(self._total_sz) if self._total_sz is not None else ""

--- a/netket/hilbert/tensor_hilbert.py
+++ b/netket/hilbert/tensor_hilbert.py
@@ -15,6 +15,7 @@
 from typing import Optional, List, Union
 
 import numpy as np
+import jax.numpy as jnp
 
 from .discrete_hilbert import DiscreteHilbert, _is_indexable
 
@@ -144,6 +145,16 @@ class TensorHilbert(DiscreteHilbert):
             )
             out += temp * dim
 
+        return out
+
+    def states_to_local_indices(self, x):
+        out = jnp.empty_like(x, dtype=jnp.int32)
+        for (i, hilb_i) in enumerate(self._hilbert_spaces):
+            out = out.at[..., self._cum_indices[i] : self._cum_sizes[i]].set(
+                hilb_i.states_to_local_indices(
+                    x[..., self._cum_indices[i] : self._cum_sizes[i]]
+                )
+            )
         return out
 
     def __repr__(self):

--- a/netket/models/autoreg.py
+++ b/netket/models/autoreg.py
@@ -317,7 +317,7 @@ def _call(model: AbstractARNN, inputs: Array) -> Array:
     if inputs.ndim == 1:
         inputs = jnp.expand_dims(inputs, axis=0)
 
-    idx = _local_states_to_numbers(model.hilbert, inputs)
+    idx = model.hilbert.states_to_local_indices(inputs)
     idx = jnp.expand_dims(idx, axis=-1)
 
     log_psi = _conditionals_log_psi(model, inputs)
@@ -335,25 +335,3 @@ def _reshape_inputs(model: ARNNConv2D, inputs: Array) -> Array:  # noqa: F811
 @dispatch
 def _reshape_inputs(model: Any, inputs: Array) -> Array:  # noqa: F811
     return inputs
-
-
-@dispatch
-def _local_states_to_numbers(hilbert: Spin, x: Array) -> Array:  # noqa: F811
-    numbers = (x + hilbert.local_size - 1) / 2
-    numbers = jnp.asarray(numbers, jnp.int32)
-    return numbers
-
-
-@dispatch
-def _local_states_to_numbers(  # noqa: F811
-    hilbert: Union[Fock, Qubit], x: Array
-) -> Array:
-    numbers = jnp.asarray(x, jnp.int32)
-    return numbers
-
-
-@dispatch
-def _local_states_to_numbers(hilbert: Any, x: Array) -> Array:  # noqa: F811
-    raise NotImplementedError(
-        f"_local_states_to_numbers is not implemented for hilbert {type(hilbert)}."
-    )

--- a/test/hilbert/test_hilbert.py
+++ b/test/hilbert/test_hilbert.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import itertools
+from functools import partial
 import netket as nk
 import numpy as np
 import pytest
@@ -323,6 +324,28 @@ def test_hilbert_index_discrete(hi: DiscreteHilbert):
         op.to_dense()
     with pytest.raises(RuntimeError):
         op.to_sparse()
+
+
+@partial(jax.jit, static_argnums=0)
+def _states_to_local_indices_jit(hilb, x):
+    return hilb.states_to_local_indices(x)
+
+
+@pytest.mark.parametrize("hi", discrete_hilbert_params)
+def test_states_to_local_indices(hi):
+    if isinstance(hi, nkx.hilbert.SpinOrbitalFermions):
+        pytest.xfail()
+
+    x = hi.random_state(jax.random.PRNGKey(3), (200))
+    idxs = hi.states_to_local_indices(x)
+    idxs_jit = _states_to_local_indices_jit(hi, x)
+
+    np.testing.assert_allclose(idxs, idxs_jit)
+
+    # check that the index is correct
+    for s in range(hi.size):
+        local_states = np.asarray(hi.states_at_index(s))
+        np.testing.assert_allclose(local_states[idxs[..., s]], x[..., s])
 
 
 def test_state_iteration():


### PR DESCRIPTION
This function convert every local degree of freedom which might be a whatever number to an integer index from 0 to ... Max.

This function already exists inside `nk.models.autoregressive` because it's needed there, and it cannot easily be extended for fermonic stuff. 
Moreover, this function came up as something that would be useful to implement #1209 concisely, so... here is it.

