### PR TITLE
Improve serialization of variational states

### DIFF
--- a/netket/vqs/mc/mc_mixed_state/state.py
+++ b/netket/vqs/mc/mc_mixed_state/state.py
@@ -289,10 +289,11 @@ class MCMixedState(VariationalMixedState, MCState):
 def serialize_MCMixedState(vstate):
     state_dict = {
         "variables": serialization.to_state_dict(vstate.variables),
-        "sampler_state": serialization.to_state_dict(vstate.sampler_state),
+        "sampler_state": serialization.to_state_dict(vstate._sampler_state_previous),
         "diagonal": serialization.to_state_dict(vstate.diagonal),
         "n_samples": vstate.n_samples,
         "n_discard_per_chain": vstate.n_discard_per_chain,
+        "chunk_size": vstate.chunk_size,
     }
     return state_dict
 
@@ -316,6 +317,7 @@ def deserialize_MCMixedState(vstate, state_dict):
     )
     new_vstate.n_samples = state_dict["n_samples"]
     new_vstate.n_discard_per_chain = state_dict["n_discard_per_chain"]
+    new_vstate.chunk_size = state_dict["chunk_size"]
 
     return new_vstate
 

--- a/test/variational/test_variational_mixed.py
+++ b/test/variational/test_variational_mixed.py
@@ -243,6 +243,8 @@ def test_deprecations(vstate):
 def test_serialization(vstate):
     from flax import serialization
 
+    vstate.chunk_size = 12345
+
     bdata = serialization.to_bytes(vstate)
 
     vstate_new = nk.vqs.MCMixedState(
@@ -258,6 +260,13 @@ def test_serialization(vstate):
     assert vstate.n_discard_per_chain == vstate_new.n_discard_per_chain
     assert vstate.n_samples_diag == vstate_new.n_samples_diag
     assert vstate.n_discard_per_chain_diag == vstate_new.n_discard_per_chain_diag
+    assert vstate.chunk_size == vstate_new.chunk_size
+
+    old_samples = vstate.samples
+    bdata = serialization.to_bytes(vstate)
+    vstate_new = serialization.from_bytes(vstate_new, bdata)
+
+    np.testing.assert_allclose(old_samples, vstate_new.samples)
 
 
 @common.skipif_mpi


### PR DESCRIPTION
This PR addressees two issues in the serialization of variational states:
 - The `chunk_size` was not serialised 
 - When serialising a state that was sampled, the 'current' `sampler_state` was saved. This lead to a situation where it Wass impossible to regenerate the old samples, because the previous PRNGKey was lost. This PR now keeps around the old sampler state so that it can be serialised.

Both, but in particular the latter, are necessary to actually implement checkpointing.