### PR TITLE
Remove extra computation of log Psi gradient in KineticEnergy

### DIFF
--- a/netket/operator/_kinetic.py
+++ b/netket/operator/_kinetic.py
@@ -64,6 +64,8 @@ class KineticEnergy(ContinuousOperator):
         dlogpsi_x = jax.grad(logpsi_x)
 
         dp_dx, f_jvp = jax.linearize(dlogpsi_x, x)
+        dp_dx = dp_dx**2
+
         basis = jnp.eye(x.shape[0], dtype=dp_dx.dtype)
 
         dp_dx2 = jnp.diag(jax.vmap(f_jvp)(basis))

--- a/netket/operator/_kinetic.py
+++ b/netket/operator/_kinetic.py
@@ -63,12 +63,10 @@ class KineticEnergy(ContinuousOperator):
 
         dlogpsi_x = jax.grad(logpsi_x)
 
-        y, f_jvp = jax.linearize(dlogpsi_x, x)
-        basis = jnp.eye(x.shape[0], dtype=y.dtype)
+        dp_dx, f_jvp = jax.linearize(dlogpsi_x, x)
+        basis = jnp.eye(x.shape[0], dtype=dp_dx.dtype)
 
         dp_dx2 = jnp.diag(jax.vmap(f_jvp)(basis))
-
-        dp_dx = dlogpsi_x(x) ** 2
 
         res = -0.5 * jnp.sum(mass * (dp_dx2 + dp_dx), axis=-1)
         return res


### PR DESCRIPTION
Even though we had dlogpsi(x)/dx already from linearize, we recomputed it once explicitly.