### PR TITLE
allow disabling of MPI

### DIFF
--- a/netket/utils/config_flags.py
+++ b/netket/utils/config_flags.py
@@ -127,6 +127,19 @@ config.define(
 )
 
 config.define(
+    "NETKET_MPI",
+    bool,
+    default=True,
+    help=dedent(
+        """
+        Used to forcibly shut-down MPI in NetKet. If this flag is
+        `0` `mpi4py` and `mpi4jax` will not be imported.
+        """
+    ),
+    runtime=False,
+)
+
+config.define(
     "NETKET_USE_PLAIN_RHAT",
     bool,
     default=False,

--- a/netket/utils/mpi/mpi.py
+++ b/netket/utils/mpi/mpi.py
@@ -24,6 +24,11 @@ _mpi4jax_loaded = False
 mpi4jax_available = False
 
 try:
+    if not config.FLAGS["NETKET_MPI"]:
+        # if mpi is disabled, import a package that does not exist
+        # to trigger import error and follow the no-mpi code path
+        import this_package_does_not_exist_zuzzurellone
+
     from mpi4py import MPI
 
     _mpi4py_loaded = True


### PR DESCRIPTION
In some clusters/mpi (eg, Epfl scats) implementation calling MPI.Init() twice or when not running under MPI will lead to a crash making it Impossible to import netket unless `mpi4py/jax` are uninstalled, which is not nice.

This PR adds the env variable `NETKET_MPI` (defaults to 1/true) which if set to `=0` will disable MPI within netket.

