### PR TITLE
add `.serialize` method to runtimelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * The method `MCState.local_estimators` has been added, which returns the local estimators `O_loc(s) = 〈s|O|ψ〉 / 〈s|ψ〉` (which are known as local energies if `O` is the Hamiltonian). [#1179](https://github.com/netket/netket/pull/1179)
 * The permutation equivariant {class}`nk.models.DeepSetRelDistance` for use with particles in periodic potentials has been added together with an example. [#1199](https://github.com/netket/netket/pull/1199)
 * The class {class}`HDF5Log` has been added to the experimental submodule. This logger writes log data and variational state variables into a single HDF5 file. [#1200](https://github.com/netket/netket/issues/1200)
+* Added a new method {meth}`~nk.logging.RuntimeLog.serialize` to store the content of the logger to disk [#XXX](https://github.com/netket/netket/issues/XXX).
 
 ### Dependencies
 * NetKet now requires at least Flax v0.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 * The method `MCState.local_estimators` has been added, which returns the local estimators `O_loc(s) = 〈s|O|ψ〉 / 〈s|ψ〉` (which are known as local energies if `O` is the Hamiltonian). [#1179](https://github.com/netket/netket/pull/1179)
 * The permutation equivariant {class}`nk.models.DeepSetRelDistance` for use with particles in periodic potentials has been added together with an example. [#1199](https://github.com/netket/netket/pull/1199)
 * The class {class}`HDF5Log` has been added to the experimental submodule. This logger writes log data and variational state variables into a single HDF5 file. [#1200](https://github.com/netket/netket/issues/1200)
-* Added a new method {meth}`~nk.logging.RuntimeLog.serialize` to store the content of the logger to disk [#XXX](https://github.com/netket/netket/issues/XXX).
+* Added a new method {meth}`~nk.logging.RuntimeLog.serialize` to store the content of the logger to disk [#1255](https://github.com/netket/netket/issues/1255).
 
 ### Dependencies
 * NetKet now requires at least Flax v0.5

--- a/docs/api/logging.md
+++ b/docs/api/logging.md
@@ -6,7 +6,8 @@
 
 ```
 
-This module contains the loggers that can be used with the optimization drivers.
+This module contains the loggers that can be used with the optimization drivers by passing them to the `out=` keyword argument of 
+{meth}`~netket.driver.AbstractVariationalDriver.run`.
 
 
 ```{eval-rst}

--- a/netket/experimental/logging/hdf5_log.py
+++ b/netket/experimental/logging/hdf5_log.py
@@ -126,7 +126,7 @@ class HDF5Log:
             save_params_every: every how many iterations should machine parameters be
                 flushed to file
         """
-        import h5py
+        import h5py  # noqa: F401
 
         super().__init__()
 

--- a/netket/logging/json_log.py
+++ b/netket/logging/json_log.py
@@ -25,8 +25,7 @@ from .runtime_log import RuntimeLog
 
 class JsonLog(RuntimeLog):
     """
-    Logger for an optimisation Driver, serializing data and the model
-    parameters to a json file.
+      This logger serializes expectation values and other log data to a JSON file and can save the latest model parameters in MessagePack encoding to a separate file.
 
     It can be passed with keyword argument `out` to Monte Carlo drivers in order
     to serialize the output data of the simulation.

--- a/netket/logging/json_log.py
+++ b/netket/logging/json_log.py
@@ -16,7 +16,6 @@ import time
 
 import os
 from os import path as _path
-import numpy as np
 
 from flax import serialization
 

--- a/netket/logging/json_log.py
+++ b/netket/logging/json_log.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import orjson
 import time
 
 import os
@@ -24,46 +23,25 @@ from flax import serialization
 from .runtime_log import RuntimeLog
 
 
-def _exists_json(prefix):
-    return _path.exists(prefix + ".log") or _path.exists(prefix + ".mpack")
-
-
-def default(obj):
-    if hasattr(obj, "to_json"):
-        return obj.to_json()
-    elif hasattr(obj, "to_dict"):
-        return obj.to_dict()
-    elif isinstance(obj, np.ndarray):
-        if np.issubdtype(obj.dtype, np.complexfloating):
-            return {"real": obj.real, "imag": obj.imag}
-        else:
-            if obj.ndim == 0:
-                return obj.item()
-            elif obj.ndim == 1:
-                return obj.tolist()
-            else:
-                raise TypeError
-
-    elif hasattr(obj, "_device"):
-        return np.array(obj)
-    elif isinstance(obj, complex):
-        return {"real": obj.real, "imag": obj.imag}
-
-    raise TypeError
-
-
 class JsonLog(RuntimeLog):
     """
-    Json Logger, that can be passed with keyword argument `logger` to Monte
-    Carlo drivers in order to serialize the output data of the simulation.
+    Logger for an optimisation Driver, serializing data and the model
+    parameters to a json file.
 
-    If the model state is serialized, then it is serialized using the msgpack protocol
+    It can be passed with keyword argument `out` to Monte Carlo drivers in order
+    to serialize the output data of the simulation.
+
+    This logger inherits from :class:`netket.logging.RuntimeLog`, so it maintains the dictionary
+    of all logged quantities in memory, which can be accessed through the attribute
+    :attr:`~netket.logging.JsonLog.data`.
+
+    If the model state is serialized, then it can be de-serialized using the msgpack protocol
     of flax. For more information on how to de-serialize the output, see
     `here <https://flax.readthedocs.io/en/latest/flax.serialization.html>`_.
     The target of the serialization is the variational state itself.
 
     Data is serialized to json as several nested dictionaries. You can deserialize
-    by simply calling :code:`json.load(open(filename))`.
+    by simply calling :func:`json.load(open(filename)) <json.load>`.
     Logged expectation values will be captured inside histories objects, so they will
     have a subfield `iter` with the iterations at which that quantity has been computed,
     then `Mean` and others.
@@ -116,7 +94,9 @@ class JsonLog(RuntimeLog):
         if mode == "append":
             raise ValueError("Append mode is no longer supported.")
 
-        file_exists = _exists_json(output_prefix)
+        file_exists = _path.exists(output_prefix + ".log") or _path.exists(
+            output_prefix + ".mpack"
+        )
 
         if file_exists and mode == "fail":
             raise ValueError(
@@ -177,15 +157,13 @@ class JsonLog(RuntimeLog):
         self._steps_notflushed_pars += 1
 
     def _flush_log(self):
-        self._last_flush_time = time.time()
-        with open(self._prefix + ".log", "wb") as outfile:
-
-            outfile.write(orjson.dumps(self.data, default=default))
-            self._steps_notflushed_write = 0
-
         # Time how long flushing data takes.
+        self._last_flush_time = time.time()
+        self.serialize(self._prefix + ".log")
         self._last_flush_runtime = time.time() - self._last_flush_time
+
         self._flush_log_time += self._last_flush_runtime
+        self._steps_notflushed_write = 0
 
     def _flush_params(self, variational_state):
         if not self._save_params:

--- a/netket/logging/runtime_log.py
+++ b/netket/logging/runtime_log.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import orjson
+from pathlib import Path
 
 from netket.utils import accum_histories_in_tree
 
@@ -61,18 +62,29 @@ class RuntimeLog:
         Args:
             path: The path of the output file. It must be a valid path.
         """
-        if not path.endswith((".log", ".json")):
-            path = path + ".json"
+        if isinstance(path, str):
+            path = Path(path)
 
-        with open(path, "wb") as outfile:
-            outfile.write(
-                orjson.dumps(
-                    self.data,
-                    default=default,
-                    # TODO: Activate this option
-                    #option=orjson.OPT_SERIALIZE_NUMPY,
-                )
+        if isinstance(path, Path):
+            parent = path.parent
+            filename = path.name
+            if not filename.endswith((".log", ".json")):
+                filename = filename + ".json"
+            path = parent / filename
+
+            with open(path, "wb") as io:
+                self._serialize(io)
+        else:
+            self._serialize(io)
+
+    def _serialize(self, outfile):
+        outfile.write(
+            orjson.dumps(
+                self.data,
+                default=default,
+                option=orjson.OPT_SERIALIZE_NUMPY,
             )
+        )
 
 
 def default(obj):

--- a/netket/logging/runtime_log.py
+++ b/netket/logging/runtime_log.py
@@ -12,15 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import orjson
+
 from netket.utils import accum_histories_in_tree
 
 
 class RuntimeLog:
     """
-    Runtim Logger, that can be passed with keyword argument `logger` to Monte
-    Carlo drivers in order to serialize the output data of the simulation.
+    Logger for an optimisation Driver, accumulating data in a set of nested
+    dictionaries which is stored in memory. Does not serialise to disk.
 
-    This logger keeps the data in memory, and does not save it to disk.
+    It can be passed with keyword argument `out` to Monte Carlo drivers in order
+    to serialize the output data of the simulation.
+
+    This logger keeps the data in memory, and does not save it to disk. To serialize
+    the current content to a file, use the method :py:meth:`~netket.logging.RuntimeLog.serialize`.
     """
 
     def __init__(self):
@@ -46,3 +52,48 @@ class RuntimeLog:
 
     def flush(self, variational_state):
         pass
+
+    def serialize(self, path: str):
+        """
+        Serialize the content of :py:attr:`~netket.logging.RuntimeLog.data` to a file.
+
+        If the file already exists, it is overwritten.
+
+        Args:
+            path: The path of the output file. It must be a valid path.
+        """
+        if not file_name.endswith((".log", ".json")):
+            file_name = file_name + ".json"
+
+        with open(file_name, "wb") as outfile:
+            outfile.write(
+                orjson.dumps(
+                    self.data,
+                    default=default,
+                    option=orjson.OPT_SERIALIZE_NUMPY,
+                )
+            )
+
+
+def default(obj):
+    if hasattr(obj, "to_json"):
+        return obj.to_json()
+    elif hasattr(obj, "to_dict"):
+        return obj.to_dict()
+    elif isinstance(obj, np.ndarray):
+        if np.issubdtype(obj.dtype, np.complexfloating):
+            return {"real": obj.real, "imag": obj.imag}
+        else:
+            if obj.ndim == 0:
+                return obj.item()
+            elif obj.ndim == 1:
+                return obj.tolist()
+            else:
+                raise TypeError
+
+    elif hasattr(obj, "_device"):
+        return np.array(obj)
+    elif isinstance(obj, complex):
+        return {"real": obj.real, "imag": obj.imag}
+
+    raise TypeError

--- a/netket/logging/runtime_log.py
+++ b/netket/logging/runtime_log.py
@@ -12,8 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Union, IO
+
 import orjson
 from pathlib import Path
+
+import numpy as np
 
 from netket.utils import accum_histories_in_tree
 
@@ -53,8 +57,8 @@ class RuntimeLog:
     def flush(self, variational_state):
         pass
 
-    def serialize(self, path: str):
-        """
+    def serialize(self, path: Union[str, Path, IO]):
+        r"""
         Serialize the content of :py:attr:`~netket.logging.RuntimeLog.data` to a file.
 
         If the file already exists, it is overwritten.
@@ -75,10 +79,13 @@ class RuntimeLog:
             with open(path, "wb") as io:
                 self._serialize(io)
         else:
-            self._serialize(io)
+            self._serialize(path)
 
-    def _serialize(self, outfile):
-        outfile.write(
+    def _serialize(self, outstream: IO):
+        r"""
+        Inner method of `serialize`, working on an IO object. 
+        """
+        outstream.write(
             orjson.dumps(
                 self.data,
                 default=default,

--- a/netket/logging/runtime_log.py
+++ b/netket/logging/runtime_log.py
@@ -93,6 +93,10 @@ class RuntimeLog:
             )
         )
 
+    def __repr__(self):
+        _str = "RuntimeLog():\n"
+        _str += f" keys = {list(self.data.keys())}"
+        return _str
 
 def default(obj):
     if hasattr(obj, "to_json"):

--- a/netket/logging/runtime_log.py
+++ b/netket/logging/runtime_log.py
@@ -62,15 +62,16 @@ class RuntimeLog:
         Args:
             path: The path of the output file. It must be a valid path.
         """
-        if not file_name.endswith((".log", ".json")):
-            file_name = file_name + ".json"
+        if not path.endswith((".log", ".json")):
+            path = path + ".json"
 
-        with open(file_name, "wb") as outfile:
+        with open(path, "wb") as outfile:
             outfile.write(
                 orjson.dumps(
                     self.data,
                     default=default,
-                    option=orjson.OPT_SERIALIZE_NUMPY,
+                    # TODO: Activate this option
+                    #option=orjson.OPT_SERIALIZE_NUMPY,
                 )
             )
 

--- a/netket/logging/runtime_log.py
+++ b/netket/logging/runtime_log.py
@@ -19,8 +19,7 @@ from netket.utils import accum_histories_in_tree
 
 class RuntimeLog:
     """
-    Logger for an optimisation Driver, accumulating data in a set of nested
-    dictionaries which is stored in memory. Does not serialise to disk.
+    This logger accumulates log data in a set of nested dictionaries which are stored in memory. The log data is not automatically saved to the filesystem.
 
     It can be passed with keyword argument `out` to Monte Carlo drivers in order
     to serialize the output data of the simulation.

--- a/netket/logging/runtime_log.py
+++ b/netket/logging/runtime_log.py
@@ -83,7 +83,7 @@ class RuntimeLog:
 
     def _serialize(self, outstream: IO):
         r"""
-        Inner method of `serialize`, working on an IO object. 
+        Inner method of `serialize`, working on an IO object.
         """
         outstream.write(
             orjson.dumps(
@@ -97,6 +97,7 @@ class RuntimeLog:
         _str = "RuntimeLog():\n"
         _str += f" keys = {list(self.data.keys())}"
         return _str
+
 
 def default(obj):
     if hasattr(obj, "to_json"):

--- a/netket/models/autoreg.py
+++ b/netket/models/autoreg.py
@@ -22,7 +22,6 @@ from jax import numpy as jnp
 from jax.nn.initializers import zeros
 from plum import dispatch
 
-from netket.hilbert import Fock, Qubit, Spin
 from netket.hilbert.homogeneous import HomogeneousHilbert
 from netket.nn import MaskedConv1D, MaskedConv2D, MaskedDense1D
 from netket.nn.masked_linear import default_kernel_init

--- a/netket/sampler/base.py
+++ b/netket/sampler/base.py
@@ -134,7 +134,7 @@ class Sampler(abc.ABC):
         """
         The total number of independent chains across all MPI ranks.
 
-        If you are not using MPI, this is equal to `n_chains_per_rank`.
+        If you are not using MPI, this is equal to :attr:`~Sampler.n_chains_per_rank`.
         """
         return self.n_chains_per_rank * mpi.n_nodes
 

--- a/test/logging/test_runtime.py
+++ b/test/logging/test_runtime.py
@@ -37,24 +37,35 @@ def test_serialize(vstate, tmp_path):
     log = nk.logging.RuntimeLog()
     e = vstate.expect(nk.operator.spin.sigmax(vstate.hilbert, 0))
 
-    for i in np.arange(0,1,0.1):
-        log(i, {'energy': e, 'vals':{'energy':e, 'random':1.0, 'matrix': jnp.array(np.random.rand(3))}}, None)
+    for i in np.arange(0, 1, 0.1):
+        log(
+            i,
+            {
+                "energy": e,
+                "vals": {
+                    "energy": e,
+                    "random": 1.0,
+                    "matrix": jnp.array(np.random.rand(3)),
+                },
+            },
+            None,
+        )
 
     log.serialize(tmp_path / "file_1")
     filename = tmp_path / "file_1.json"
-    with open(filename, 'rb') as f:
+    with open(filename, "rb") as f:
         data1 = orjson.loads(f.read())
 
     log.serialize(str(tmp_path) + "/file_2.log")
     filename = tmp_path / "file_2.log"
-    with open(filename, 'rb') as f:
+    with open(filename, "rb") as f:
         data2 = orjson.loads(f.read())
 
     filename = tmp_path / "file_3"
-    with open(filename, 'wb') as f:
+    with open(filename, "wb") as f:
         log.serialize(f)
 
-    with open(filename, 'rb') as f:
+    with open(filename, "rb") as f:
         data3 = orjson.loads(f.read())
 
     assert data1 == data2
@@ -70,7 +81,6 @@ def test_serialize(vstate, tmp_path):
     assert len(data1["vals"]["random"]["value"]) == 10
     assert len(data1["vals"]["random"]["iters"]) == 10
 
-    assert np.array(data1["vals"]["matrix"]["value"]).shape == (10,3)
+    assert np.array(data1["vals"]["matrix"]["value"]).shape == (10, 3)
 
     assert repr(log).startswith("RuntimeLog")
-

--- a/test/logging/test_runtime.py
+++ b/test/logging/test_runtime.py
@@ -1,0 +1,76 @@
+import pytest
+
+import glob
+
+import numpy as np
+import netket as nk
+import netket.experimental as nkx
+from jax.nn.initializers import normal
+from jax import numpy as jnp
+
+import orjson
+
+from .. import common
+
+pytestmark = common.skipif_mpi
+
+
+@pytest.fixture()
+def vstate(request):
+    N = 8
+    hi = nk.hilbert.Spin(1 / 2, N)
+
+    ma = nk.models.RBM(
+        alpha=1,
+        dtype=float,
+        hidden_bias_init=normal(),
+        visible_bias_init=normal(),
+    )
+
+    return nk.vqs.MCState(
+        nk.sampler.MetropolisLocal(hi),
+        ma,
+    )
+
+
+def test_serialize(vstate, tmp_path):
+    log = nk.logging.RuntimeLog()
+    e = vstate.expect(nk.operator.spin.sigmax(vstate.hilbert, 0))
+
+    for i in np.arange(0,1,0.1):
+        log(i, {'energy': e, 'vals':{'energy':e, 'random':1.0, 'matrix': jnp.array(np.random.rand(3))}}, None)
+
+    log.serialize(tmp_path / "file_1")
+    filename = tmp_path / "file_1.json"
+    with open(filename, 'rb') as f:
+        data1 = orjson.loads(f.read())
+
+    log.serialize(str(tmp_path) + "/file_2.log")
+    filename = tmp_path / "file_2.log"
+    with open(filename, 'rb') as f:
+        data2 = orjson.loads(f.read())
+
+    filename = tmp_path / "file_3"
+    with open(filename, 'wb') as f:
+        log.serialize(f)
+
+    with open(filename, 'rb') as f:
+        data3 = orjson.loads(f.read())
+
+    assert data1 == data2
+    assert data2 == data3
+
+    assert "energy" in data1
+    assert "vals" in data1
+    assert "energy" in data1["vals"]
+    assert "random" in data1["vals"]
+    assert "value" in data1["vals"]["random"]
+    assert "iters" in data1["vals"]["random"]
+
+    assert len(data1["vals"]["random"]["value"]) == 10
+    assert len(data1["vals"]["random"]["iters"]) == 10
+
+    assert np.array(data1["vals"]["matrix"]["value"]).shape == (10,3)
+
+    assert repr(log).startswith("RuntimeLog")
+


### PR DESCRIPTION
This moves the json serialization stuff to `RuntimeLog` from `JsonLog`, so that it's possible to save to disk the data.

The idea is still that `JsonLog` saves to json while running and `RuntimeLog` does not, but now if you're playing with `RuntimeLog` and want to save its content to disk you can.

(This was triggered by a question in slack)