### PR TITLE
Icosahedral point groups

### DIFF
--- a/netket/utils/group/__init__.py
+++ b/netket/utils/group/__init__.py
@@ -17,4 +17,4 @@ from ._group import FiniteGroup
 from ._permutation_group import Permutation, PermutationGroup
 from ._point_group import PGSymmetry, PointGroup, trivial_point_group
 
-from . import axial, cubic, planar
+from . import axial, cubic, planar, icosa

--- a/netket/utils/group/icosa.py
+++ b/netket/utils/group/icosa.py
@@ -1,0 +1,54 @@
+# Copyright 2021 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+from netket.utils.moduletools import export, hide_unexported
+
+from .axial import inversion_group as _inv_group
+from .axial import C as _C
+from ._point_group import PointGroup
+
+
+hide_unexported(__name__)
+
+__all__ = [
+    "icosahedral_rotations",
+    "icosahedral",
+]
+
+@export
+def I() -> PointGroup:
+    """
+    Rotational symmetries of an icosahedron with two vertices on z axis
+    and two others in the xz plane.
+    """
+    g1 = group.axial.C(5, axis = (0,0,1))
+    g2 = group.axial.C(5, axis = (2/5**0.5, 0, 1/5**0.5))
+    g = (g2 @ g1).remove_duplicates()
+    g = (g @ g2).remove_duplicates()
+    g = (g @ g1).remove_duplicates()
+    return g
+
+icosahedral_rotations = I
+
+@export
+def Ih() -> PointGroup:
+    """
+    Symmetry group of an icosahedron with two vertices on z axis
+    and two others in the xz plane.
+    """
+    return _inv_group() @ I()
+
+icosahedral = Ih

--- a/test/utils/test_group.py
+++ b/test/utils/test_group.py
@@ -71,7 +71,12 @@ cubics = [
     group.cubic.Fd3m(),
 ]
 cubics_proper = [True, False, False, True, False, False]
-point_groups = planars + uniaxials + screws + biaxials + impropers + cubics
+icosas = [
+    group.icosa.I(),
+    group.icosa.Ih(),
+]
+icosas_proper = [True, False]
+point_groups = planars + uniaxials + screws + biaxials + impropers + cubics + icosas
 proper = (
     planars_proper
     + uniaxials_proper
@@ -79,6 +84,7 @@ proper = (
     + biaxials_proper
     + impropers_proper
     + cubics_proper
+    + icosas_proper
 )
 perms = [
     nk.graph.Hypercube(2, n_dim=3).point_group(),
@@ -140,6 +146,8 @@ details = [
     (group.cubic.O(), [1, 6, 3, 8, 6], [1, 1, 2, 3, 3]),
     (group.cubic.Oh(), [1, 6, 3, 8, 6] * 2, [1, 1, 2, 3, 3] * 2),
     (group.cubic.Fd3m(), [1, 6, 3, 8, 6] * 2, [1, 1, 2, 3, 3] * 2),
+    (group.icosa.I(), [1,12,12,20,15], [1,3,3,4,5]),
+    (group.icosa.I(), [1,12,12,20,15]*2, [1,3,3,4,5]*2),
 ]
 
 


### PR DESCRIPTION
Implements the two icosahedral point groups I and Ih. These are not crystallographical, but come up in quantum chemistry and molecular magnets.