### PR TITLE
Fix serialization of complex 2D arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 ### Bug Fixes
 * Fixed bug where a `nk.operator.LocalOperator` representing the identity would lead to a crash. [#1197](https://github.com/netket/netket/pull/1197)
 * Use np.isclose to allow for some tolerance in checking the hermicity of a `nkx.operator.FermionOperator2nd` [#1233](https://github.com/netket/netket/pull/1233)
+* Fix serialization of some arrays with complex dtype in `RuntimeLog` and `JsonLog` [#...](https://github.com/netket/netket/pull/...)
 
 ## NetKet 3.4.2 (BugFixes & DepWarns again)
 

--- a/netket/logging/runtime_log.py
+++ b/netket/logging/runtime_log.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 from typing import Union, IO
-
-import orjson
 from pathlib import Path
 
+import jax
 import numpy as np
+import orjson
 
 from netket.utils import accum_histories_in_tree
 
@@ -106,17 +106,12 @@ def default(obj):
         return obj.to_dict()
     elif isinstance(obj, np.ndarray):
         if np.issubdtype(obj.dtype, np.complexfloating):
-            return {"real": obj.real, "imag": obj.imag}
-        else:
-            if obj.ndim == 0:
-                return obj.item()
-            elif obj.ndim == 1:
-                return obj.tolist()
-            else:
-                raise TypeError
-
+            return jax.tree_map(
+                np.ascontiguousarray, {"real": obj.real, "imag": obj.imag}
+            )
+    # TODO: replace with isinstance(obj, jnp.ndarray) once all support JAX versions have it
     elif hasattr(obj, "_device"):
-        return np.array(obj)
+        return np.ascontiguousarray(obj)
     elif isinstance(obj, complex):
         return {"real": obj.real, "imag": obj.imag}
 

--- a/test/logging/test_runtime.py
+++ b/test/logging/test_runtime.py
@@ -37,15 +37,20 @@ def test_serialize(vstate, tmp_path):
     log = nk.logging.RuntimeLog()
     e = vstate.expect(nk.operator.spin.sigmax(vstate.hilbert, 0))
 
-    for i in np.arange(0, 1, 0.1):
+    steps = np.arange(0, 1, 0.1)
+    for i in steps:
         log(
             i,
             {
                 "energy": e,
                 "vals": {
                     "energy": e,
-                    "random": 1.0,
-                    "matrix": jnp.array(np.random.rand(3)),
+                    "scalar": 1.0,
+                    "scalar_ndarray": jnp.array(1.0),
+                    "vector": jnp.array([1.0, 1.0]),
+                    "matrix": jnp.array([[1.0, 2.0], [2.0, 1.0]]),
+                    "complex_scalar": 1.0j,
+                    "complex_matrix": jnp.array([[1.0j], [1.0j]]),
                 },
             },
             None,
@@ -74,13 +79,34 @@ def test_serialize(vstate, tmp_path):
     assert "energy" in data1
     assert "vals" in data1
     assert "energy" in data1["vals"]
-    assert "random" in data1["vals"]
-    assert "value" in data1["vals"]["random"]
-    assert "iters" in data1["vals"]["random"]
 
-    assert len(data1["vals"]["random"]["value"]) == 10
-    assert len(data1["vals"]["random"]["iters"]) == 10
+    assert "scalar" in data1["vals"]
+    assert "value" in data1["vals"]["scalar"]
+    assert "iters" in data1["vals"]["scalar"]
+    assert len(data1["vals"]["scalar"]["value"]) == 10
+    assert len(data1["vals"]["scalar"]["iters"]) == 10
 
-    assert np.array(data1["vals"]["matrix"]["value"]).shape == (10, 3)
+    assert "scalar_ndarray" in data1["vals"]
+    assert "value" in data1["vals"]["scalar_ndarray"]
+    assert "iters" in data1["vals"]["scalar_ndarray"]
+    assert len(data1["vals"]["scalar_ndarray"]["value"]) == 10
+    assert len(data1["vals"]["scalar_ndarray"]["iters"]) == 10
+
+    assert "vector" in data1["vals"]
+    assert np.array(data1["vals"]["vector"]["value"]).shape == (10, 2)
+
+    assert "matrix" in data1["vals"]
+    assert np.array(data1["vals"]["matrix"]["value"]).shape == (10, 2, 2)
+
+    assert "complex_scalar" in data1["vals"]
+    assert "real" in data1["vals"]["complex_scalar"]["value"]
+    assert "imag" in data1["vals"]["complex_scalar"]["value"]
+
+    assert "complex_matrix" in data1["vals"]
+    assert "real" in data1["vals"]["complex_matrix"]["value"]
+    assert "imag" in data1["vals"]["complex_matrix"]["value"]
+    shape = (10, 2, 1)
+    assert np.array(data1["vals"]["complex_matrix"]["value"]["real"]).shape == shape
+    assert np.array(data1["vals"]["complex_matrix"]["value"]["imag"]).shape == shape
 
     assert repr(log).startswith("RuntimeLog")


### PR DESCRIPTION
This PR fixes a bug encountered when serializing certain 2D arrays of complex dtypes to JSON using `orjson`, such as
```python3
a = np.array([[1.0j], [1.0j]])
```
This happened because we use a custom `default` function to encode complex dtype arrays to JSON as
```python3
{"real": obj.real, "imag": obj.imag}
```
While this looks like it should work together with `orjson`s built-in numpy support (which can handle real dtype arrays), it can fail in some cases. This is because `obj.real` can be a non-contiguous array and those are unsupported by `orjson`. This is fixed here by calling `np.ascontiguousarray` on the returned arrays.