### PR TITLE
One arm irreps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * The permutation equivariant {class}`nk.models.DeepSetRelDistance` for use with particles in periodic potentials has been added together with an example. [#1199](https://github.com/netket/netket/pull/1199)
 * The class {class}`HDF5Log` has been added to the experimental submodule. This logger writes log data and variational state variables into a single HDF5 file. [#1200](https://github.com/netket/netket/issues/1200)
 * Added a new method {meth}`~nk.logging.RuntimeLog.serialize` to store the content of the logger to disk [#1255](https://github.com/netket/netket/issues/1255).
+* Added a new method {meth}`nk.graph.SpaceGroupBuilder.one_arm_irreps` to construct GCNN projection coefficients to project on single-wave-vector components of irreducible representations. [#1260](https://github.com/netket/netket/issues/1260).
 
 ### Dependencies
 * NetKet now requires at least Flax v0.5

--- a/test/graph/test_graph.py
+++ b/test/graph/test_graph.py
@@ -819,3 +819,20 @@ def test_lattice_k_neighbors():
     g = nk.graph.Square(10, pbc=True, max_neighbor_order=2)
     assert len(g.edges(filter_color=0)) == 200
     assert len(g.edges(filter_color=1)) == 200
+
+
+def test_one_arm_irrep():
+    g = nk.graph.Square(6)
+    sgb = g.space_group_builder()
+    # Stars consist of one arm
+    np.testing.assert_almost_equal(
+        sgb.space_group_irreps(0, 0), sgb.one_arm_irreps(0, 0)
+    )
+    np.testing.assert_almost_equal(
+        sgb.space_group_irreps(pi, pi), sgb.one_arm_irreps(pi, pi)
+    )
+    # Star consists of two arms, with irreps listed in different order
+    np.testing.assert_almost_equal(
+        sgb.space_group_irreps(pi, 0),
+        sgb.one_arm_irreps(pi, 0) + sgb.one_arm_irreps(0, pi)[[0, 2, 1, 3]],
+    )


### PR DESCRIPTION
One of the observations I had with GCNNs was that multidimensional irreps are usually more stable when you project on a specific subspace rather than allowing the full irrep space. A common scenario is when two different wave vectors are forced to be degenerate by a point group symmetry that maps them on one another. This PR introduces `one_arm_irreps` as an alternative to `space_group_irreps` which only returns the component of the irrep with the given wave vector, not all the others in its star. Strictly speaking these are not irrep characters, but can be used in GCNN projections equally well (you just project on a narrower subspace). 

(Footnote: "arms" of "stars" are standard crystallographic terminology for wave vectors related by point group symmetries.)