### PR TITLE
Add `expect_and_forces` method to variational states

### DIFF
--- a/netket/experimental/driver/tdvp.py
+++ b/netket/experimental/driver/tdvp.py
@@ -541,30 +541,6 @@ def odefun(state: MCState, driver: TDVP, t, w, *, stage=0):  # noqa: F811
 
 @partial(jax.jit, static_argnums=(3, 4))
 def _map_parameters(forces, parameters, loss_grad_factor, propagation_type, state_T):
-    # pars_f, _ = jax.tree_flatten(jax.tree_map(jnp.iscomplexobj, parameters))
-    # if all(pars_f):
-    #    all_complex = True
-    # else:
-    #    all_complex = False
-    #
-    # take_real = False
-    #
-    # if issubclass(state_T, VariationalMixedState):
-    #    # assuming Lindblad Dynamics
-    #    # TODO: support density-matrix imaginary time evolution
-    #    if propagation_type == "real":
-    #        loss_grad_factor = 1.0
-    #    else:
-    #        raise ValueError(
-    #            "only real-time Lindblad evolution is supported for " "mixed states"
-    #        )
-    # else:
-    #    if propagation_type == "real":
-    #        loss_grad_factor = -1.0j
-    #    elif propagation_type == "imag":
-    #        loss_grad_factor = -1.0
-    #    else:
-    #        raise ValueError("propagation_type must be one of 'real', 'imag'")
 
     forces = jax.tree_map(
         lambda x, target: loss_grad_factor * x,

--- a/netket/vqs/__init__.py
+++ b/netket/vqs/__init__.py
@@ -12,7 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .base import VariationalState, VariationalMixedState, expect, expect_and_grad
+from .base import (
+    VariationalState,
+    VariationalMixedState,
+    expect,
+    expect_and_grad,
+    expect_and_forces,
+)
 
 from .mc import MCState, MCMixedState, get_local_kernel_arguments, get_local_kernel
 from .exact import ExactState

--- a/netket/vqs/exact/expect.py
+++ b/netket/vqs/exact/expect.py
@@ -119,14 +119,6 @@ def _exp_forces(
 
     Ō_grad = vjp_fun(ΔOΨ)[0]
 
-    Ō_grad = jax.tree_map(
-        lambda x, target: (x if jnp.iscomplexobj(target) else 2 * x.real).astype(
-            target.dtype
-        ),
-        Ō_grad,
-        parameters,
-    )
-
     new_model_state = new_model_state[0] if is_mutable else None
 
     return (

--- a/netket/vqs/exact/expect.py
+++ b/netket/vqs/exact/expect.py
@@ -18,6 +18,7 @@ from typing import Callable, Any, Tuple
 import jax
 from jax import numpy as jnp
 from netket import jax as nkjax
+from netket.operator import Squared
 from netket.stats import Stats
 from netket.utils.types import PyTree
 from netket.utils.dispatch import dispatch, TrueT
@@ -69,6 +70,9 @@ def expect_and_forces(
     *,
     mutable: Any,
 ) -> Tuple[Stats, PyTree]:
+    if isinstance(Ô, Squared):
+        raise NotImplementedError("expect_and_forces not yet implemented for `Squared`")
+
     _check_hilbert(vstate, Ô)
 
     O = sparsify(Ô)

--- a/netket/vqs/mc/mc_mixed_state/expect_grad_chunked.py
+++ b/netket/vqs/mc/mc_mixed_state/expect_grad_chunked.py
@@ -15,7 +15,7 @@
 from netket.operator import AbstractOperator
 from netket.utils.dispatch import Bool
 
-from netket.vqs import expect_and_grad
+from netket.vqs import expect_and_grad, expect_and_forces
 
 from .state import MCMixedState
 
@@ -31,3 +31,15 @@ def expect_and_grad_nochunking(
     **kwargs,
 ):
     return expect_and_grad(vstate, operator, use_covariance, *args, **kwargs)
+
+
+# If batch_size is None, ignore it and remove it from signature
+@expect_and_forces.dispatch
+def expect_and_forces_nochunking(
+    vstate: MCMixedState,
+    operator: AbstractOperator,
+    chunk_size: None,
+    *args,
+    **kwargs,
+):
+    return expect_and_forces(vstate, operator, *args, **kwargs)

--- a/netket/vqs/mc/mc_state/__init__.py
+++ b/netket/vqs/mc/mc_state/__init__.py
@@ -16,6 +16,8 @@ from .state import MCState
 
 from . import expect
 from . import expect_grad
+from . import expect_forces
 
 from . import expect_chunked
 from . import expect_grad_chunked
+from . import expect_forces_chunked

--- a/netket/vqs/mc/mc_state/expect_forces.py
+++ b/netket/vqs/mc/mc_state/expect_forces.py
@@ -1,0 +1,116 @@
+# Copyright 2021 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import partial
+from typing import Any, Callable, Tuple
+
+import jax
+from jax import numpy as jnp
+
+from netket import jax as nkjax
+from netket.stats import Stats, statistics
+from netket.utils import mpi
+from netket.utils.types import PyTree
+from netket.utils.dispatch import dispatch
+
+from netket.operator import (
+    AbstractOperator,
+)
+
+from netket.vqs.mc import (
+    get_local_kernel_arguments,
+    get_local_kernel,
+)
+
+from .state import MCState
+
+
+@dispatch
+def expect_and_forces(  # noqa: F811
+    vstate: MCState,
+    Ô: AbstractOperator,
+    *,
+    mutable: Any,
+) -> Tuple[Stats, PyTree]:
+    σ, args = get_local_kernel_arguments(vstate, Ô)
+
+    local_estimator_fun = get_local_kernel(vstate, Ô)
+
+    Ō, Ō_grad, new_model_state = forces_expect_hermitian(
+        local_estimator_fun,
+        vstate._apply_fun,
+        mutable,
+        vstate.parameters,
+        vstate.model_state,
+        σ,
+        args,
+    )
+
+    if mutable is not False:
+        vstate.model_state = new_model_state
+
+    return Ō, Ō_grad
+
+
+@partial(jax.jit, static_argnums=(0, 1, 2))
+def forces_expect_hermitian(
+    local_value_kernel: Callable,
+    model_apply_fun: Callable,
+    mutable: bool,
+    parameters: PyTree,
+    model_state: PyTree,
+    σ: jnp.ndarray,
+    local_value_args: PyTree,
+) -> Tuple[PyTree, PyTree]:
+
+    σ_shape = σ.shape
+    if jnp.ndim(σ) != 2:
+        σ = σ.reshape((-1, σ_shape[-1]))
+
+    n_samples = σ.shape[0] * mpi.n_nodes
+
+    O_loc = local_value_kernel(
+        model_apply_fun,
+        {"params": parameters, **model_state},
+        σ,
+        local_value_args,
+    )
+
+    Ō = statistics(O_loc.reshape(σ_shape[:-1]).T)
+
+    O_loc -= Ō.mean
+
+    # Then compute the vjp.
+    # Code is a bit more complex than a standard one because we support
+    # mutable state (if it's there)
+    is_mutable = mutable is not False
+    _, vjp_fun, *new_model_state = nkjax.vjp(
+        lambda w: model_apply_fun({"params": w, **model_state}, σ, mutable=mutable),
+        parameters,
+        conjugate=True,
+        has_aux=is_mutable,
+    )
+    Ō_grad = vjp_fun(jnp.conjugate(O_loc) / n_samples)[0]
+
+    # Ō_grad = jax.tree_map(
+    #    lambda x, target: (x if jnp.iscomplexobj(target) else 2 * x.real).astype(
+    #        target.dtype
+    #    ),
+    #    Ō_grad,
+    #    parameters,
+    # )
+
+    new_model_state = new_model_state[0] if is_mutable else None
+
+    return Ō, jax.tree_map(lambda x: mpi.mpi_sum_jax(x)[0], Ō_grad), new_model_state

--- a/netket/vqs/mc/mc_state/expect_forces.py
+++ b/netket/vqs/mc/mc_state/expect_forces.py
@@ -103,14 +103,6 @@ def forces_expect_hermitian(
     )
     Ō_grad = vjp_fun(jnp.conjugate(O_loc) / n_samples)[0]
 
-    # Ō_grad = jax.tree_map(
-    #    lambda x, target: (x if jnp.iscomplexobj(target) else 2 * x.real).astype(
-    #        target.dtype
-    #    ),
-    #    Ō_grad,
-    #    parameters,
-    # )
-
     new_model_state = new_model_state[0] if is_mutable else None
 
     return Ō, jax.tree_map(lambda x: mpi.mpi_sum_jax(x)[0], Ō_grad), new_model_state

--- a/netket/vqs/mc/mc_state/expect_forces_chunked.py
+++ b/netket/vqs/mc/mc_state/expect_forces_chunked.py
@@ -145,12 +145,4 @@ def forces_expect_hermitian_chunked(
         (jnp.conjugate(O_loc) / n_samples),
     )[0]
 
-    # Ō_grad = jax.tree_map(
-    #    lambda x, target: (x if jnp.iscomplexobj(target) else 2 * x.real).astype(
-    #        target.dtype
-    #    ),
-    #    Ō_grad,
-    #    parameters,
-    # )
-
     return Ō, tree_map(lambda x: mpi.mpi_sum_jax(x)[0], Ō_grad), new_model_state

--- a/netket/vqs/mc/mc_state/expect_forces_chunked.py
+++ b/netket/vqs/mc/mc_state/expect_forces_chunked.py
@@ -1,0 +1,156 @@
+# Copyright 2021 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import partial
+from typing import Any, Callable, Tuple
+import warnings
+
+import jax
+from jax import numpy as jnp
+from jax import tree_map
+
+from netket import jax as nkjax
+from netket.operator import AbstractOperator
+from netket.stats import Stats, statistics
+from netket.utils import mpi
+from netket.utils.types import PyTree
+
+from netket.vqs import expect_and_forces
+from netket.vqs.mc import (
+    get_local_kernel,
+    get_local_kernel_arguments,
+)
+
+from .state import MCState
+
+
+# If batch_size is None, ignore it and remove it from signature
+@expect_and_forces.dispatch
+def expect_and_forces_nochunking(  # noqa: F811
+    vstate: MCState,
+    operator: AbstractOperator,
+    chunk_size: None,
+    *args,
+    **kwargs,
+):
+    return expect_and_forces(vstate, operator, *args, **kwargs)
+
+
+# if no implementation exists for batched, run the code unbatched
+@expect_and_forces.dispatch
+def expect_and_forces_fallback(  # noqa: F811
+    vstate: MCState,
+    operator: AbstractOperator,
+    chunk_size: Any,
+    *args,
+    **kwargs,
+):
+    warnings.warn(
+        f"Ignoring chunk_size={chunk_size} for expect_and_forces method with signature "
+        f"({type(vstate)}, {type(operator)}) because no implementation supporting "
+        f"chunking for this signature exists."
+    )
+
+    return expect_and_forces(vstate, operator, *args, **kwargs)
+
+
+@expect_and_forces.dispatch
+def expect_and_forces_impl(  # noqa: F811
+    vstate: MCState,
+    Ô: AbstractOperator,
+    chunk_size: int,
+    *,
+    mutable: Any,
+) -> Tuple[Stats, PyTree]:
+    σ, args = get_local_kernel_arguments(vstate, Ô)
+
+    local_estimator_fun = get_local_kernel(vstate, Ô, chunk_size)
+
+    Ō, Ō_grad, new_model_state = forces_expect_hermitian_chunked(
+        chunk_size,
+        local_estimator_fun,
+        vstate._apply_fun,
+        mutable,
+        vstate.parameters,
+        vstate.model_state,
+        σ,
+        args,
+    )
+
+    if mutable is not False:
+        vstate.model_state = new_model_state
+
+    return Ō, Ō_grad
+
+
+@partial(jax.jit, static_argnums=(0, 1, 2, 3))
+def forces_expect_hermitian_chunked(
+    chunk_size: int,
+    local_value_kernel_chunked: Callable,
+    model_apply_fun: Callable,
+    mutable: bool,
+    parameters: PyTree,
+    model_state: PyTree,
+    σ: jnp.ndarray,
+    local_value_args: PyTree,
+) -> Tuple[PyTree, PyTree]:
+
+    σ_shape = σ.shape
+    if jnp.ndim(σ) != 2:
+        σ = σ.reshape((-1, σ_shape[-1]))
+
+    n_samples = σ.shape[0] * mpi.n_nodes
+
+    O_loc = local_value_kernel_chunked(
+        model_apply_fun,
+        {"params": parameters, **model_state},
+        σ,
+        local_value_args,
+        chunk_size=chunk_size,
+    )
+
+    Ō = statistics(O_loc.reshape(σ_shape[:-1]).T)
+
+    O_loc -= Ō.mean
+
+    # Then compute the vjp.
+    # Code is a bit more complex than a standard one because we support
+    # mutable state (if it's there)
+    if mutable is False:
+        vjp_fun_chunked = nkjax.vjp_chunked(
+            lambda w, σ: model_apply_fun({"params": w, **model_state}, σ),
+            parameters,
+            σ,
+            conjugate=True,
+            chunk_size=chunk_size,
+            chunk_argnums=1,
+            nondiff_argnums=1,
+        )
+        new_model_state = None
+    else:
+        raise NotImplementedError
+
+    Ō_grad = vjp_fun_chunked(
+        (jnp.conjugate(O_loc) / n_samples),
+    )[0]
+
+    # Ō_grad = jax.tree_map(
+    #    lambda x, target: (x if jnp.iscomplexobj(target) else 2 * x.real).astype(
+    #        target.dtype
+    #    ),
+    #    Ō_grad,
+    #    parameters,
+    # )
+
+    return Ō, tree_map(lambda x: mpi.mpi_sum_jax(x)[0], Ō_grad), new_model_state

--- a/netket/vqs/mc/mc_state/expect_grad.py
+++ b/netket/vqs/mc/mc_state/expect_grad.py
@@ -20,16 +20,18 @@ from jax import numpy as jnp
 
 from netket import jax as nkjax
 from netket import config
-from netket.stats import Stats, statistics
+from netket.stats import Stats
 from netket.utils import mpi
 from netket.utils.types import PyTree
-from netket.utils.dispatch import dispatch, TrueT, FalseT
+from netket.utils.dispatch import TrueT, FalseT
 
 from netket.operator import (
     AbstractOperator,
     DiscreteOperator,
     Squared,
 )
+
+from netket.vqs import expect_and_grad, expect_and_forces
 
 from netket.vqs.mc import (
     get_local_kernel_arguments,
@@ -39,41 +41,38 @@ from netket.vqs.mc import (
 from .state import MCState
 
 
-@dispatch
-def expect_and_grad(  # noqa: F811
+@expect_and_grad.dispatch
+def expect_and_grad_covariance(
     vstate: MCState,
     Ô: AbstractOperator,
     use_covariance: TrueT,
     *,
     mutable: Any,
 ) -> Tuple[Stats, PyTree]:
-    σ, args = get_local_kernel_arguments(vstate, Ô)
-
-    local_estimator_fun = get_local_kernel(vstate, Ô)
-
-    Ō, Ō_grad, new_model_state = grad_expect_hermitian(
-        local_estimator_fun,
-        vstate._apply_fun,
-        mutable,
-        vstate.parameters,
-        vstate.model_state,
-        σ,
-        args,
-    )
-
-    if mutable is not False:
-        vstate.model_state = new_model_state
-
+    Ō, Ō_grad = expect_and_forces(vstate, Ô, mutable=mutable)
+    Ō_grad = _force_to_grad(Ō_grad, vstate.parameters)
     return Ō, Ō_grad
 
 
+@jax.jit
+def _force_to_grad(Ō_grad, parameters):
+    Ō_grad = jax.tree_map(
+        lambda x, target: (x if jnp.iscomplexobj(target) else 2 * x.real).astype(
+            target.dtype
+        ),
+        Ō_grad,
+        parameters,
+    )
+    return Ō_grad
+
+
 # pure state, squared operator
-@dispatch.multi(
+@expect_and_grad.dispatch_multi(
     (MCState, Squared[DiscreteOperator], FalseT),
     (MCState, Squared[AbstractOperator], FalseT),
     (MCState, AbstractOperator, FalseT),
 )
-def expect_and_grad(  # noqa: F811
+def expect_and_grad_nonherm(
     vstate,
     Ô,
     use_covariance,
@@ -112,59 +111,6 @@ def expect_and_grad(  # noqa: F811
         vstate.model_state = new_model_state
 
     return Ō, Ō_grad
-
-
-@partial(jax.jit, static_argnums=(0, 1, 2))
-def grad_expect_hermitian(
-    local_value_kernel: Callable,
-    model_apply_fun: Callable,
-    mutable: bool,
-    parameters: PyTree,
-    model_state: PyTree,
-    σ: jnp.ndarray,
-    local_value_args: PyTree,
-) -> Tuple[PyTree, PyTree]:
-
-    σ_shape = σ.shape
-    if jnp.ndim(σ) != 2:
-        σ = σ.reshape((-1, σ_shape[-1]))
-
-    n_samples = σ.shape[0] * mpi.n_nodes
-
-    O_loc = local_value_kernel(
-        model_apply_fun,
-        {"params": parameters, **model_state},
-        σ,
-        local_value_args,
-    )
-
-    Ō = statistics(O_loc.reshape(σ_shape[:-1]).T)
-
-    O_loc -= Ō.mean
-
-    # Then compute the vjp.
-    # Code is a bit more complex than a standard one because we support
-    # mutable state (if it's there)
-    is_mutable = mutable is not False
-    _, vjp_fun, *new_model_state = nkjax.vjp(
-        lambda w: model_apply_fun({"params": w, **model_state}, σ, mutable=mutable),
-        parameters,
-        conjugate=True,
-        has_aux=is_mutable,
-    )
-    Ō_grad = vjp_fun(jnp.conjugate(O_loc) / n_samples)[0]
-
-    Ō_grad = jax.tree_map(
-        lambda x, target: (x if jnp.iscomplexobj(target) else 2 * x.real).astype(
-            target.dtype
-        ),
-        Ō_grad,
-        parameters,
-    )
-
-    new_model_state = new_model_state[0] if is_mutable else None
-
-    return Ō, jax.tree_map(lambda x: mpi.mpi_sum_jax(x)[0], Ō_grad), new_model_state
 
 
 @partial(jax.jit, static_argnums=(0, 1, 2, 3))

--- a/netket/vqs/mc/mc_state/expect_grad_chunked.py
+++ b/netket/vqs/mc/mc_state/expect_grad_chunked.py
@@ -12,26 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from functools import partial
-from typing import Any, Callable, Tuple
+from typing import Any, Tuple
 import warnings
 
 import jax
 from jax import numpy as jnp
-from jax import tree_map
 
-from netket import jax as nkjax
 from netket.operator import AbstractOperator
-from netket.stats import Stats, statistics
-from netket.utils import mpi
+from netket.stats import Stats
 from netket.utils.types import PyTree
-from netket.utils.dispatch import dispatch, TrueT, Bool
+from netket.utils.dispatch import TrueT, Bool
 
-from netket.vqs import expect_and_grad
-from netket.vqs.mc import (
-    get_local_kernel,
-    get_local_kernel_arguments,
-)
+from netket.vqs import expect_and_grad, expect_and_forces
 
 from .state import MCState
 
@@ -68,8 +60,8 @@ def expect_and_grad_fallback(  # noqa: F811
     return expect_and_grad(vstate, operator, use_covariance, *args, **kwargs)
 
 
-@dispatch
-def expect_and_grad(  # noqa: F811
+@expect_and_grad.dispatch
+def expect_and_grad_covariance_chunked(  # noqa: F811
     vstate: MCState,
     Ô: AbstractOperator,
     use_covariance: TrueT,
@@ -77,78 +69,14 @@ def expect_and_grad(  # noqa: F811
     *,
     mutable: Any,
 ) -> Tuple[Stats, PyTree]:
-    σ, args = get_local_kernel_arguments(vstate, Ô)
 
-    local_estimator_fun = get_local_kernel(vstate, Ô, chunk_size)
-
-    Ō, Ō_grad, new_model_state = grad_expect_hermitian_chunked(
-        chunk_size,
-        local_estimator_fun,
-        vstate._apply_fun,
-        mutable,
-        vstate.parameters,
-        vstate.model_state,
-        σ,
-        args,
-    )
-
-    if mutable is not False:
-        vstate.model_state = new_model_state
-
+    Ō, Ō_grad = expect_and_forces(vstate, Ô, chunk_size, mutable=mutable)
+    Ō_grad = _force_to_grad(Ō_grad, vstate.parameters)
     return Ō, Ō_grad
 
 
-@partial(jax.jit, static_argnums=(0, 1, 2, 3))
-def grad_expect_hermitian_chunked(
-    chunk_size: int,
-    local_value_kernel_chunked: Callable,
-    model_apply_fun: Callable,
-    mutable: bool,
-    parameters: PyTree,
-    model_state: PyTree,
-    σ: jnp.ndarray,
-    local_value_args: PyTree,
-) -> Tuple[PyTree, PyTree]:
-
-    σ_shape = σ.shape
-    if jnp.ndim(σ) != 2:
-        σ = σ.reshape((-1, σ_shape[-1]))
-
-    n_samples = σ.shape[0] * mpi.n_nodes
-
-    O_loc = local_value_kernel_chunked(
-        model_apply_fun,
-        {"params": parameters, **model_state},
-        σ,
-        local_value_args,
-        chunk_size=chunk_size,
-    )
-
-    Ō = statistics(O_loc.reshape(σ_shape[:-1]).T)
-
-    O_loc -= Ō.mean
-
-    # Then compute the vjp.
-    # Code is a bit more complex than a standard one because we support
-    # mutable state (if it's there)
-    if mutable is False:
-        vjp_fun_chunked = nkjax.vjp_chunked(
-            lambda w, σ: model_apply_fun({"params": w, **model_state}, σ),
-            parameters,
-            σ,
-            conjugate=True,
-            chunk_size=chunk_size,
-            chunk_argnums=1,
-            nondiff_argnums=1,
-        )
-        new_model_state = None
-    else:
-        raise NotImplementedError
-
-    Ō_grad = vjp_fun_chunked(
-        (jnp.conjugate(O_loc) / n_samples),
-    )[0]
-
+@jax.jit
+def _force_to_grad(Ō_grad, parameters):
     Ō_grad = jax.tree_map(
         lambda x, target: (x if jnp.iscomplexobj(target) else 2 * x.real).astype(
             target.dtype
@@ -156,5 +84,4 @@ def grad_expect_hermitian_chunked(
         Ō_grad,
         parameters,
     )
-
-    return Ō, tree_map(lambda x: mpi.mpi_sum_jax(x)[0], Ō_grad), new_model_state
+    return Ō_grad

--- a/netket/vqs/mc/mc_state/expect_grad_chunked.py
+++ b/netket/vqs/mc/mc_state/expect_grad_chunked.py
@@ -60,6 +60,7 @@ def expect_and_grad_fallback(  # noqa: F811
     return expect_and_grad(vstate, operator, use_covariance, *args, **kwargs)
 
 
+# dispatch for given chunk_size and use_covariance == True
 @expect_and_grad.dispatch
 def expect_and_grad_covariance_chunked(  # noqa: F811
     vstate: MCState,

--- a/netket/vqs/mc/mc_state/state.py
+++ b/netket/vqs/mc/mc_state/state.py
@@ -41,7 +41,7 @@ from netket.utils.types import PyTree, SeedT, NNInitFunc
 from netket.optimizer import LinearOperator
 from netket.optimizer.qgt import QGTAuto
 
-from netket.vqs.base import VariationalState, expect, expect_and_grad
+from netket.vqs.base import VariationalState, expect, expect_and_grad, expect_and_forces
 from netket.vqs.mc import get_local_kernel, get_local_kernel_arguments
 
 
@@ -633,6 +633,36 @@ class MCState(VariationalState):
         return expect_and_grad(
             self, Ô, use_covariance, self.chunk_size, mutable=mutable
         )
+
+    # override to use chunks
+    def expect_and_forces(
+        self,
+        Ô: AbstractOperator,
+        *,
+        mutable: Optional[Any] = None,
+    ) -> Tuple[Stats, PyTree]:
+        r"""Estimates both the gradient of the quantum expectation value of a given operator O.
+
+        Args:
+            Ô: the operator Ô for which we compute the expectation value and it's gradient
+            mutable: Can be bool, str, or list. Specifies which collections in the model_state should
+                     be treated as  mutable: bool: all/no collections are mutable. str: The name of a
+                     single mutable  collection. list: A list of names of mutable collections.
+                     This is used to mutate the state of the model while you train it (for example
+                     to implement BatchNorm. Consult
+                     `Flax's Module.apply documentation <https://flax.readthedocs.io/en/latest/_modules/flax/linen/module.html#Module.apply>`_
+                     for a more in-depth explanation).
+            use_covariance: whether to use the covariance formula, usually reserved for
+                hermitian operators, ⟨∂logψ Oˡᵒᶜ⟩ - ⟨∂logψ⟩⟨Oˡᵒᶜ⟩
+
+        Returns:
+            An estimation of the quantum expectation value <O>.
+            An estimation of the average gradient of the quantum expectation value <O>.
+        """
+        if mutable is None:
+            mutable = self.mutable
+
+        return expect_and_forces(self, Ô, self.chunk_size, mutable=mutable)
 
     @deprecated("Use MCState.log_value(σ) instead.")
     def evaluate(self, σ: jnp.ndarray) -> jnp.ndarray:

--- a/test/variational/test_variational.py
+++ b/test/variational/test_variational.py
@@ -485,7 +485,7 @@ def test_forces_gradient_rule():
             )
 
             y = jnp.einsum("ij,...j", W, x)
-            return jnp.sum(jnp.tanh(y), axis=-1)
+            return jnp.sum(nk.nn.activation.reim_selu(y), axis=-1)
 
     class M2(nn.Module):
         n_h: int
@@ -503,7 +503,7 @@ def test_forces_gradient_rule():
             W = Wr + 1j * Wi
 
             y = jnp.einsum("ij,...j", W, x)
-            return jnp.sum(jnp.tanh(y), axis=-1)
+            return jnp.sum(nk.nn.activation.reim_selu(y), axis=-1)
 
     ma1 = M1(8)
     ma2 = M2(8)

--- a/test/variational/test_variational.py
+++ b/test/variational/test_variational.py
@@ -17,8 +17,11 @@ from functools import partial
 import pytest
 from pytest import approx, raises, warns
 
-import numpy as np
+import flax
+import flax.linen as nn
 import jax
+import jax.numpy as jnp
+import numpy as np
 
 import netket as nk
 from jax.nn.initializers import normal
@@ -439,6 +442,91 @@ def test_expect(vstate, operator):
 
     O_grad, _ = nk.jax.tree_ravel(O_grad)
     same_derivatives(O_grad, grad_exact, abs_eps=err, rel_eps=err)
+
+
+@common.skipif_mpi
+@pytest.mark.parametrize(
+    "operator",
+    [
+        pytest.param(
+            op,
+            id=name,
+            marks=pytest.mark.xfail(
+                reason="MUSTFIX: Non-hermitian and Squared forces known to be wrong"
+            )
+            if isinstance(op, nk.operator.Squared) or (not op.is_hermitian)
+            else [],
+        )
+        for name, op in operators.items()
+    ],
+)
+def test_forces(vstate, operator):
+    _, O_grad1 = vstate.expect_and_grad(operator)
+    O_grad2 = vstate.grad(operator)
+    jax.tree_map(np.testing.assert_array_equal, O_grad1, O_grad2)
+
+    _, f1 = vstate.expect_and_forces(operator)
+    if nk.jax.tree_leaf_iscomplex(vstate.parameters):
+        g1 = f1
+    else:
+        g1 = jax.tree_map(lambda x: 2.0 * np.real(x), f1)
+    jax.tree_map(np.testing.assert_array_equal, g1, O_grad1)
+
+
+def test_forces_gradient_rule():
+    class M1(nn.Module):
+        n_h: int
+
+        @nn.compact
+        def __call__(self, x):
+            n_v = x.shape[-1]
+            W = self.param(
+                "weights", nn.initializers.normal(), (self.n_h, n_v), jnp.complex128
+            )
+
+            y = jnp.einsum("ij,...j", W, x)
+            return jnp.sum(jnp.tanh(y), axis=-1)
+
+    class M2(nn.Module):
+        n_h: int
+
+        @nn.compact
+        def __call__(self, x):
+            n_v = x.shape[-1]
+            Wr = self.param(
+                "weights_re", nn.initializers.normal(), (self.n_h, n_v), jnp.float64
+            )
+            Wi = self.param(
+                "weights_im", nn.initializers.normal(), (self.n_h, n_v), jnp.float64
+            )
+
+            W = Wr + 1j * Wi
+
+            y = jnp.einsum("ij,...j", W, x)
+            return jnp.sum(jnp.tanh(y), axis=-1)
+
+    ma1 = M1(8)
+    ma2 = M2(8)
+    hi = nk.hilbert.Spin(1 / 2, N=4)
+    ha = nk.operator.Ising(hi, nk.graph.Chain(4), h=0.5)
+    samp = nk.sampler.ExactSampler(hi)
+    vs1 = nk.vqs.MCState(samp, model=ma1, n_samples=1024, sampler_seed=1234, seed=1234)
+    vs2 = nk.vqs.MCState(samp, model=ma2, n_samples=1024, sampler_seed=1234, seed=1234)
+    vs1.parameters = flax.core.freeze(
+        {"weights": vs2.parameters["weights_re"] + 1j * vs2.parameters["weights_im"]}
+    )
+
+    assert np.allclose(vs1.to_array(), vs2.to_array())
+
+    _, f1 = vs1.expect_and_forces(ha)
+    _, f2 = vs2.expect_and_forces(ha)
+    _, g1 = vs1.expect_and_grad(ha)
+    _, g2 = vs2.expect_and_grad(ha)
+
+    assert np.allclose(g1["weights"], f1["weights"])
+    assert np.allclose(g2["weights_re"], 2 * np.real(f2["weights_re"]))
+    assert np.allclose(g2["weights_im"], 2 * np.real(f2["weights_im"]))
+    assert np.allclose(g1["weights"], 0.5 * (g2["weights_re"] + 1j * g2["weights_im"]))
 
 
 @common.skipif_mpi


### PR DESCRIPTION
Gradients of observables are estimated in VMC via the covariance $F_j = \mathrm{cov}(O_j, E_\mathrm{loc})$ where $O_j = \partial\ln\psi(s)/\partial\theta_j$ is the derivative of the log-probability. This is called the _force vector_ here.

For real parameters, the observable gradient is then $\partial\langle \hat O\rangle / \partial\theta_j = 2\mathrm{Re}[F_j]$. For a complex holomorphic parametrization $\partial\langle \hat O\rangle / \partial\theta_j^* = F_j.$

Note that $F$ is generally complex even for real-parameter models. Since `expect_and_grad` returns the gradient and thus only the real part of $F$, information is lost in this step, which is needed in particular in time evolution (where the RHS of the equation of motion given by McLachlan's variational principle involves $\mathrm{Im}[F_j]$).

`expect_and_forces` adds a way to get the original forces for use in `TDVP`. I've added some tests and docs, the specific implementation in this PR has been written by @PhilipVinc.