### PR TITLE
maintenance: fix cpuinfo on M1 and fix docstring

### DIFF
--- a/netket/operator/_hamiltonian.py
+++ b/netket/operator/_hamiltonian.py
@@ -227,12 +227,13 @@ class Ising(SpecialHamiltonian):
 
         if self.h != 0:
             for i in range(self.hilbert.size):
-                ha -= self.h * spin.sigmax(self.hilbert, i)
+                ha -= self.h * spin.sigmax(self.hilbert, i, dtype=self.dtype)
 
         if self.J != 0:
             for (i, j) in self.edges:
                 ha += self.J * (
-                    spin.sigmaz(self.hilbert, i) * spin.sigmaz(self.hilbert, j)
+                    spin.sigmaz(self.hilbert, i, dtype=self.dtype)
+                    * spin.sigmaz(self.hilbert, j, dtype=self.dtype)
                 )
 
         return ha

--- a/netket/operator/_potential.py
+++ b/netket/operator/_potential.py
@@ -66,4 +66,4 @@ class PotentialEnergy(ContinuousOperator):
         return self.coefficient
 
     def __repr__(self):
-        return f"Potential(coefficient={self.coefficient}, function+{self._afun})"
+        return f"Potential(coefficient={self.coefficient}, function={self._afun})"

--- a/netket/tools/_cpu_info.py
+++ b/netket/tools/_cpu_info.py
@@ -75,7 +75,9 @@ def get_sysctl_cpu():
         except ValueError:
             pass
         info[key] = value
-    flags = [flag.lower() for flag in info["features"].split()]
+    # features is absent in M1 macs
+    info_features = info.get("features", "")
+    flags = [flag.lower() for flag in info_features.split()]
     info["flags"] = [SYSCTL_FLAG_TRANSLATIONS.get(flag, flag) for flag in flags]
     info["unknown_flags"] = ["3dnow"]
     info["supports_avx"] = "hw.optional.avx1_0: 1\n" in sysctl_text

--- a/test/operator/test_operator.py
+++ b/test/operator/test_operator.py
@@ -514,6 +514,12 @@ def test_pauli_zero():
     assert np.allclose(mels, 0)
 
 
+def test_ising_int_dtype():
+    H = nk.operator.Ising(nk.hilbert.Spin(0.5, 4), nk.graph.Chain(4), h=1, J=-1)
+    H.to_local_operator()
+    (H @ H).collect()
+
+
 def test_operator_on_subspace():
     hi = nk.hilbert.Spin(1 / 2, N=3) * nk.hilbert.Qubit(N=3)
     g = nk.graph.Chain(3, pbc=False)


### PR DESCRIPTION
Fixes 3 bugs:
 - cpuinfo callide by `netket.tools.info` crashed on M1 Macs because `sysctl -a` changed output format
 - operator.Ising() with integer dtypes could not be converted to local operators
 - fix docstring
