### PR TITLE
Add a deepset model

### DIFF
--- a/docs/api/models.md
+++ b/docs/api/models.md
@@ -30,6 +30,7 @@ neural quantum states.
    ARNNConv2D
    FastARNNConv1D
    FastARNNConv2D
+   DeepSet
    DeepSetRelDistance
    MLP
 

--- a/docs/api/models.md
+++ b/docs/api/models.md
@@ -30,7 +30,7 @@ neural quantum states.
    ARNNConv2D
    FastARNNConv1D
    FastARNNConv2D
-   DeepSet
+   DeepSetMLP
    DeepSetRelDistance
    MLP
 

--- a/docs/api/nn.md
+++ b/docs/api/nn.md
@@ -75,5 +75,6 @@ Read more about the design goal of this module in their [README](https://github.
    :nosignatures:
 
     blocks.MLP
+    blocks.DeepSetMLP
 
 ```

--- a/netket/models/__init__.py
+++ b/netket/models/__init__.py
@@ -18,7 +18,7 @@ from .full_space import LogStateVector
 from .jastrow import Jastrow
 from .mps import MPSPeriodic
 from .gaussian import Gaussian
-from .deepset import DeepSetRelDistance, DeepSet
+from .deepset import DeepSetRelDistance, DeepSetMLP
 from .ndm import NDM
 from .autoreg import AbstractARNN, ARNNDense, ARNNConv1D, ARNNConv2D as _ARNNConv2D
 from .fast_autoreg import (

--- a/netket/models/__init__.py
+++ b/netket/models/__init__.py
@@ -18,7 +18,7 @@ from .full_space import LogStateVector
 from .jastrow import Jastrow
 from .mps import MPSPeriodic
 from .gaussian import Gaussian
-from .deepset import DeepSetRelDistance
+from .deepset import DeepSetRelDistance, DeepSet
 from .ndm import NDM
 from .autoreg import AbstractARNN, ARNNDense, ARNNConv1D, ARNNConv2D as _ARNNConv2D
 from .fast_autoreg import (

--- a/netket/models/deepset.py
+++ b/netket/models/deepset.py
@@ -12,7 +12,7 @@ from jax.nn.initializers import (
 
 from netket.utils import deprecate_dtype
 from netket.hilbert import ContinuousHilbert
-import netket as nk
+from .mlp import MLP
 
 
 def check_features_length(features, n_layers, name):
@@ -91,7 +91,7 @@ class DeepSet(nn.Module):
             if out_dim is None:
                 return None
             else:
-                return nk.models.MLP(
+                return MLP(
                     output_dim=out_dim,
                     hidden_dims=hidden_dims,
                     param_dtype=self.param_dtype,

--- a/netket/models/deepset.py
+++ b/netket/models/deepset.py
@@ -98,7 +98,7 @@ class DeepSet(nn.Module):
 
     @nn.compact
     def __call__(self, x):
-        """The input shape must have an axis that is reshaped to(..., N, D), where we pool over N."""
+        """The input shape must have an axis that is reshaped to (..., N, D), where we pool over N."""
 
         """ The phi transformation """
         for layer in self.phi:

--- a/netket/models/deepset.py
+++ b/netket/models/deepset.py
@@ -136,8 +136,10 @@ class DeepSetRelDistance(nn.Module):
     param_dtype: DType = jnp.float64
     """The dtype of the weights."""
 
-    activation: Callable = jax.nn.gelu
+    activation: Optional[Callable] = jax.nn.gelu
     """The nonlinear activation function between hidden layers."""
+    output_activation: Optional[Callable] = None
+    """The nonlinear activation function at the output layer."""
 
     pooling: Callable = jnp.sum
     """The pooling operation to be used after the phi-transformation"""
@@ -181,7 +183,7 @@ class DeepSetRelDistance(nn.Module):
             features_rho,
             param_dtype=self.param_dtype,
             hidden_activation=self.activation,
-            output_activation=None,
+            output_activation=self.output_activation,
             pooling=self.pooling,
             use_bias=self.use_bias,
             kernel_init=self.kernel_init,

--- a/netket/models/mlp.py
+++ b/netket/models/mlp.py
@@ -12,14 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Tuple, Callable, Union
+from typing import Optional, Tuple, Callable, Union
 
-import numpy as np
+import jax
+import jax.numpy as jnp
 
 from flax import linen as nn
 from jax.nn.initializers import lecun_normal, zeros
 
-from netket.utils.types import NNInitFunc
+from netket.utils.types import NNInitFunc, DType
 from netket import nn as nknn
 
 default_kernel_init = lecun_normal()
@@ -42,25 +43,25 @@ class MLP(nn.Module):
     Forms a common building block for models such as
     `PauliNet (continuous) <https://www.nature.com/articles/s41557-020-0544-y>`_
     """
-    hidden_dims: Tuple[int] = None
+    hidden_dims: Optional[Union[int, Tuple[int, ...]]] = None
     """The size of the hidden layers, excluding the output layer."""
-    hidden_dims_alpha: Tuple[int] = None
+    hidden_dims_alpha: Optional[Union[int, Tuple[int, ...]]] = None
     """The size of the hidden layers provided as number of times the input size.
     One must choose to either specify this or the hidden_dims keyword argument"""
-    param_dtype: Any = np.float64
+    param_dtype: DType = jnp.float64
     """The dtype of the weights."""
-    hidden_activations: Union[Callable, Tuple[Callable]] = nknn.gelu
+    hidden_activations: Optional[Union[Callable, Tuple[Callable, ...]]] = nknn.gelu
     """The nonlinear activation function after each hidden layer.
     Can be provided as a single activation,
     where the same activation will be used for every layer."""
-    output_activation: Callable = None
+    output_activation: Optional[Callable] = None
     """The nonlinear activation at the output layer.
     If None is provided, the output layer will be essentially linear."""
     use_hidden_bias: bool = True
     """if True uses a bias in the hidden layer."""
     use_output_bias: bool = False
     """if True adds a bias to the output layer."""
-    precision: Any = None
+    precision: Optional[jax.lax.Precision] = None
     """Numerical precision of the computation see :class:`jax.lax.Precision` for details."""
     kernel_init: NNInitFunc = default_kernel_init
     """Initializer for the Dense layer matrix."""

--- a/netket/nn/blocks/__init__.py
+++ b/netket/nn/blocks/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from .mlp import MLP
+from .deepset import DeepSetMLP
 
 from netket.utils import _hide_submodules
 

--- a/netket/nn/blocks/deepset.py
+++ b/netket/nn/blocks/deepset.py
@@ -1,0 +1,119 @@
+from typing import Tuple, Any, Callable
+
+import jax
+from jax import numpy as jnp
+from flax import linen as nn
+from netket.utils.types import NNInitFunc
+from jax.nn.initializers import (
+    zeros,
+    lecun_normal,
+)
+
+from .mlp import MLP
+
+
+def check_features_length(features, n_layers, name):
+    if len(features) != n_layers:
+        raise ValueError(
+            f"The number of {name} layers ({n_layers}) does not match "
+            f"the length of the features list ({len(features)})."
+        )
+
+
+def _process_features(features):
+    """
+    Convert some inputs to a consistent format of features.
+    Returns output dimension and hidden features of the MLP
+    """
+    if features is None:
+        feat, out = None, None
+    elif isinstance(features, int):
+        feat, out = None, features
+    elif len(features) == 0:
+        feat, out = None, None
+    elif len(features) == 1:
+        feat, out = None, features[0]
+    else:
+        feat, out = features[:-1], features[-1]
+    return feat, out
+
+
+class DeepSetMLP(nn.Module):
+    r"""Implements the DeepSets architecture, which is permutation invariant.
+
+    .. math ::
+
+        f(x_1,...,x_N) = \rho\left(\sum_i \phi(x_i)\right)
+
+    that is suitable for the simulation of bosonic.
+
+    The input shape must have an axis that is reshaped to (..., N, D), where we pool over N.
+
+    """
+
+    features_phi: Tuple[int] = None
+    """Number of features in each layer for phi network."""
+    features_rho: Tuple[int] = None
+    """
+    Number of features in each layer for rho network.
+    Should include final dimension of size 1.
+    """
+
+    param_dtype: Any = jnp.float64
+    """The dtype of the weights."""
+
+    hidden_activation: Callable = jax.nn.gelu
+    """The nonlinear activation function between hidden layers."""
+    output_activation: Callable = None
+    """The nonlinear activation function at the output layer."""
+
+    pooling: Callable = jnp.sum
+    """The pooling operation to be used after the phi-transformation"""
+
+    use_bias: bool = True
+    """if True uses a bias in all layers."""
+
+    kernel_init: NNInitFunc = lecun_normal()
+    """Initializer for the Dense layer matrix"""
+    bias_init: NNInitFunc = zeros
+    """Initializer for the hidden bias"""
+    precision: Any = None
+    """numerical precision of the computation see `jax.lax.Precision`for details."""
+
+    def setup(self):
+        def _create_mlp(features, output_activation, name):
+            hidden_dims, out_dim = _process_features(features)
+            if out_dim is None:
+                return None
+            else:
+                return MLP(
+                    output_dim=out_dim,
+                    hidden_dims=hidden_dims,
+                    param_dtype=self.param_dtype,
+                    hidden_activations=self.hidden_activation,
+                    output_activation=output_activation,
+                    use_hidden_bias=self.use_bias,
+                    use_output_bias=self.use_bias,
+                    kernel_init=self.kernel_init,
+                    name=name,
+                )
+
+        self.phi = _create_mlp(self.features_phi, self.hidden_activation, "ds_phi")
+        self.rho = _create_mlp(self.features_rho, self.output_activation, "ds_rho")
+
+    @nn.compact
+    def __call__(self, x):
+        """The input shape must have an axis that is reshaped to (..., N, D), where we pool over N."""
+        if x.ndim < 2:
+            raise ValueError(
+                f"input of deepset should have shape (..., N, D), but got {x.shape}"
+            )
+
+        if self.phi:
+            x = self.phi(x)
+        if self.pooling:
+            x = self.pooling(x, axis=-2)
+        if self.rho:
+            x = self.rho(x)
+
+        return x

--- a/netket/nn/blocks/mlp.py
+++ b/netket/nn/blocks/mlp.py
@@ -12,14 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Tuple, Callable, Union
+from typing import Tuple, Callable, Union, Optional
 
-import numpy as np
+import jax
+import jax.numpy as jnp
 
 from flax import linen as nn
 from jax.nn.initializers import lecun_normal, zeros
 
-from netket.utils.types import NNInitFunc
+from netket.utils.types import NNInitFunc, DType
 from netket import nn as nknn
 
 default_kernel_init = lecun_normal()
@@ -42,25 +43,25 @@ class MLP(nn.Module):
     """
     output_dim: int = 1
     """The output dimension"""
-    hidden_dims: Tuple[int] = None
+    hidden_dims: Optional[Union[int, Tuple[int, ...]]] = None
     """The size of the hidden layers, excluding the output layer."""
-    hidden_dims_alpha: Tuple[int] = None
+    hidden_dims_alpha: Optional[Union[int, Tuple[int, ...]]] = None
     """The size of the hidden layers provided as number of times the input size.
     One must choose to either specify this or the hidden_dims keyword argument"""
-    param_dtype: Any = np.float64
+    param_dtype: DType = jnp.float64
     """The dtype of the weights."""
-    hidden_activations: Union[Callable, Tuple[Callable]] = nknn.gelu
+    hidden_activations: Optional[Union[Callable, Tuple[Callable, ...]]] = nknn.gelu
     """The nonlinear activation function after each hidden layer.
     Can be provided as a single activation,
     where the same activation will be used for every layer."""
-    output_activation: Callable = None
+    output_activation: Optional[Callable] = None
     """The nonlinear activation at the output layer.
     If None is provided, the output layer will be essentially linear."""
     use_hidden_bias: bool = True
     """If True uses a bias in the hidden layer."""
     use_output_bias: bool = True
     """If True adds a bias to the output layer."""
-    precision: Any = None
+    precision: Optional[jax.lax.Precision] = None
     """Numerical precision of the computation see :class:`jax.lax.Precision` for details."""
     kernel_init: NNInitFunc = default_kernel_init
     """Initializer for the Dense layer matrix."""

--- a/test/models/test_deepset.py
+++ b/test/models/test_deepset.py
@@ -20,16 +20,23 @@ import netket as nk
 
 def test_deepset_model_output():
     # make sure that the output of a model is flattened
-    ma = nk.models.DeepSetMLP(features_rho=(16, 1))
+    ma = nk.models.DeepSetMLP(features_phi=(16,), features_rho=(16,))
     x = np.zeros((2, 1024, 16, 3))
 
     pars = ma.init(nk.jax.PRNGKey(), x)
     out = ma.apply(pars, x)
     assert out.shape == (2, 1024)
 
-    with pytest.raises(ValueError):
-        ma = nk.models.DeepSetMLP(features_rho=(16, 4))  # cannot be squeezed
-        x = np.zeros((2, 1024, 16, 3))
+    ma = nk.models.DeepSetMLP(features_phi=16, features_rho=16)
+    x = np.zeros((2, 1024, 16, 3))
 
-        pars = ma.init(nk.jax.PRNGKey(), x)
-        out = ma.apply(pars, x)
+    pars = ma.init(nk.jax.PRNGKey(), x)
+    out = ma.apply(pars, x)
+    assert out.shape == (2, 1024)
+
+    ma = nk.models.DeepSetMLP(features_phi=None, features_rho=None)
+    x = np.zeros((2, 1024, 16, 3))
+
+    pars = ma.init(nk.jax.PRNGKey(), x)
+    out = ma.apply(pars, x)
+    assert out.shape == (2, 1024)

--- a/test/models/test_deepset.py
+++ b/test/models/test_deepset.py
@@ -49,8 +49,9 @@ def test_deepset():
     )
     params = ds.init(key, x)
     out = ds.apply(params, x)
-    assert params["params"]["phi_0"]["kernel"].shape == (x.shape[-1], 16)
-    assert params["params"]["rho_0"]["kernel"].shape == (16, 32)
+    print(params)
+    assert params["params"]["ds_phi"]["Dense_0"]["kernel"].shape == (x.shape[-1], 16)
+    assert params["params"]["ds_rho"]["Dense_0"]["kernel"].shape == (16, 32)
 
     with pytest.raises(ValueError):
         # squeezing with dimension 3 should fail
@@ -67,7 +68,7 @@ def test_deepset():
         output_activation=None,
         hidden_activation=None,
         pooling=None,
-        dtype=complex,
+        param_dtype=complex,
     )
     params = ds.init(key, x)
     out = ds.apply(params, x)

--- a/test/models/test_deepset.py
+++ b/test/models/test_deepset.py
@@ -60,6 +60,18 @@ def test_deepset():
         params = ds.init(key, x)
         out = ds.apply(params, x)
 
+    # flexible, should still work
+    ds = nk.models.DeepSet(
+        features_phi=None,
+        features_rho=None,
+        output_activation=None,
+        hidden_activation=None,
+        pooling=None,
+        dtype=complex,
+    )
+    params = ds.init(key, x)
+    out = ds.apply(params, x)
+
 
 @pytest.mark.parametrize(
     "cusp_exponent", [pytest.param(None, id="cusp=None"), pytest.param(5, id="cusp=5")]

--- a/test/models/test_deepset.py
+++ b/test/models/test_deepset.py
@@ -14,8 +14,11 @@
 
 import pytest
 import numpy as np
+import jax.numpy as jnp
+import jax
 
 import netket as nk
+import netket.nn as nknn
 
 
 def test_deepset_model_output():
@@ -40,3 +43,71 @@ def test_deepset_model_output():
     pars = ma.init(nk.jax.PRNGKey(), x)
     out = ma.apply(pars, x)
     assert out.shape == (2, 1024)
+
+
+@pytest.mark.parametrize(
+    "cusp_exponent", [pytest.param(None, id="cusp=None"), pytest.param(5, id="cusp=5")]
+)
+@pytest.mark.parametrize(
+    "L",
+    [
+        pytest.param(1.0, id="1D"),
+        pytest.param((1.0, 1.0), id="2D-Square"),
+        pytest.param((1.0, 0.5), id="2D-Rectangle"),
+    ],
+)
+def test_rel_dist_deepsets(cusp_exponent, L):
+
+    hilb = nk.hilbert.Particle(N=2, L=L, pbc=True)
+    sdim = len(hilb.extent)
+    x = jnp.hstack([jnp.ones(4), -jnp.ones(4)]).reshape(1, -1)
+    xp = jnp.roll(x, sdim)
+    ds = nk.models.DeepSetRelDistance(
+        hilbert=hilb,
+        cusp_exponent=cusp_exponent,
+        layers_phi=2,
+        layers_rho=2,
+        features_phi=(10, 10),
+        features_rho=(10, 1),
+    )
+    p = ds.init(jax.random.PRNGKey(42), x)
+
+    assert jnp.allclose(ds.apply(p, x), ds.apply(p, xp))
+
+
+def test_rel_dist_deepsets_error():
+    hilb = nk.hilbert.Particle(N=2, L=1.0, pbc=True)
+    sdim = len(hilb.extent)
+
+    x = jnp.hstack([jnp.ones(4), -jnp.ones(4)]).reshape(1, -1)
+    xp = jnp.roll(x, sdim)
+    ds = nk.models.DeepSetRelDistance(
+        hilbert=hilb,
+        layers_phi=3,
+        layers_rho=3,
+        features_phi=(10, 10),
+        features_rho=(10, 1),
+        output_activation=nknn.gelu,
+    )
+    with pytest.raises(ValueError):
+        p = ds.init(jax.random.PRNGKey(42), x)
+
+    with pytest.raises(AssertionError):
+        ds = nk.models.DeepSetRelDistance(
+            hilbert=hilb,
+            layers_phi=2,
+            layers_rho=2,
+            features_phi=(10, 10),
+            features_rho=(10, 2),
+        )
+        p = ds.init(jax.random.PRNGKey(42), x)
+
+    with pytest.raises(ValueError):
+        ds = nk.models.DeepSetRelDistance(
+            hilbert=nk.hilbert.Particle(N=2, L=1.0, pbc=False),
+            layers_phi=2,
+            layers_rho=2,
+            features_phi=(10, 10),
+            features_rho=(10, 2),
+        )
+        p = ds.init(jax.random.PRNGKey(42), x)

--- a/test/models/test_deepset.py
+++ b/test/models/test_deepset.py
@@ -1,11 +1,11 @@
-# Copyright 2021 The NetKet Authors - All rights reserved.
-
+# Copyright 2022 The NetKet Authors - All rights reserved.
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -13,129 +13,23 @@
 # limitations under the License.
 
 import pytest
-
-import jax
-import jax.numpy as jnp
+import numpy as np
 
 import netket as nk
-import netket.nn as nknn
 
 
-def test_deepset():
-    """Test the permutation invariance"""
-    L = (1.0, 1.0)
-    n_particles = 6
-    hilb = nk.hilbert.Particle(N=n_particles, L=L, pbc=True)
-    sdim = len(hilb.extent)
-    key = jax.random.PRNGKey(42)
-    x = hilb.random_state(key, size=1024)
-    x = x.reshape(x.shape[0], n_particles, sdim)
+def test_deepset_model_output():
+    # make sure that the output of a model is flattened
+    ma = nk.models.DeepSetMLP(features_rho=(16, 1))
+    x = np.zeros((2, 1024, 16, 3))
 
-    xp = jnp.roll(x, 2, axis=-2)  # permute the particles
-
-    ds = nk.models.DeepSet(
-        features_phi=(16, 16), features_rho=(16, 1), squeeze_output=True
-    )
-    params = ds.init(key, x)
-    out = ds.apply(params, x)
-    outp = ds.apply(params, xp)
-    assert out.shape == outp.shape
-    assert out.shape == x.shape[:-2]
-
-    assert jnp.allclose(out, outp)
-
-    ds = nk.models.DeepSet(
-        features_phi=16, features_rho=32, output_activation=nknn.gelu
-    )
-    params = ds.init(key, x)
-    out = ds.apply(params, x)
-    print(params)
-    assert params["params"]["ds_phi"]["Dense_0"]["kernel"].shape == (x.shape[-1], 16)
-    assert params["params"]["ds_rho"]["Dense_0"]["kernel"].shape == (16, 32)
+    pars = ma.init(nk.jax.PRNGKey(), x)
+    out = ma.apply(pars, x)
+    assert out.shape == (2, 1024)
 
     with pytest.raises(ValueError):
-        # squeezing with dimension 3 should fail
-        ds = nk.models.DeepSet(
-            features_phi=(16,), features_rho=(16, 3), squeeze_output=True
-        )
-        params = ds.init(key, x)
-        out = ds.apply(params, x)
+        ma = nk.models.DeepSetMLP(features_rho=(16, 4))  # cannot be squeezed
+        x = np.zeros((2, 1024, 16, 3))
 
-    # flexible, should still work
-    ds = nk.models.DeepSet(
-        features_phi=None,
-        features_rho=None,
-        output_activation=None,
-        hidden_activation=None,
-        pooling=None,
-        param_dtype=complex,
-    )
-    params = ds.init(key, x)
-    out = ds.apply(params, x)
-
-
-@pytest.mark.parametrize(
-    "cusp_exponent", [pytest.param(None, id="cusp=None"), pytest.param(5, id="cusp=5")]
-)
-@pytest.mark.parametrize(
-    "L",
-    [
-        pytest.param(1.0, id="1D"),
-        pytest.param((1.0, 1.0), id="2D-Square"),
-        pytest.param((1.0, 0.5), id="2D-Rectangle"),
-    ],
-)
-def test_rel_dist_deepsets(cusp_exponent, L):
-
-    hilb = nk.hilbert.Particle(N=2, L=L, pbc=True)
-    sdim = len(hilb.extent)
-    x = jnp.hstack([jnp.ones(4), -jnp.ones(4)]).reshape(1, -1)
-    xp = jnp.roll(x, sdim)
-    ds = nk.models.DeepSetRelDistance(
-        hilbert=hilb,
-        cusp_exponent=cusp_exponent,
-        layers_phi=2,
-        layers_rho=2,
-        features_phi=(10, 10),
-        features_rho=(10, 1),
-    )
-    p = ds.init(jax.random.PRNGKey(42), x)
-
-    assert jnp.allclose(ds.apply(p, x), ds.apply(p, xp))
-
-
-def test_rel_dist_deepsets_error():
-    hilb = nk.hilbert.Particle(N=2, L=1.0, pbc=True)
-    sdim = len(hilb.extent)
-
-    x = jnp.hstack([jnp.ones(4), -jnp.ones(4)]).reshape(1, -1)
-    xp = jnp.roll(x, sdim)
-    ds = nk.models.DeepSetRelDistance(
-        hilbert=hilb,
-        layers_phi=3,
-        layers_rho=3,
-        features_phi=(10, 10),
-        features_rho=(10, 1),
-    )
-    with pytest.raises(ValueError):
-        p = ds.init(jax.random.PRNGKey(42), x)
-
-    with pytest.raises(AssertionError):
-        ds = nk.models.DeepSetRelDistance(
-            hilbert=hilb,
-            layers_phi=2,
-            layers_rho=2,
-            features_phi=(10, 10),
-            features_rho=(10, 2),
-        )
-        p = ds.init(jax.random.PRNGKey(42), x)
-
-    with pytest.raises(ValueError):
-        ds = nk.models.DeepSetRelDistance(
-            hilbert=nk.hilbert.Particle(N=2, L=1.0, pbc=False),
-            layers_phi=2,
-            layers_rho=2,
-            features_phi=(10, 10),
-            features_rho=(10, 2),
-        )
-        p = ds.init(jax.random.PRNGKey(42), x)
+        pars = ma.init(nk.jax.PRNGKey(), x)
+        out = ma.apply(pars, x)

--- a/test/models/test_mlp.py
+++ b/test/models/test_mlp.py
@@ -32,3 +32,16 @@ def test_mlp_model_output():
     pars = ma.init(nk.jax.PRNGKey(), x)
     out = ma.apply(pars, x)
     assert out.shape == (2, 1024)
+
+    ma = nk.models.MLP(
+        hidden_dims=None,
+        param_dtype=np.complex128,
+        hidden_activations=None,
+        output_activation=None,
+        use_output_bias=False,
+    )
+    x = np.zeros((2, 1024, 16))
+
+    pars = ma.init(nk.jax.PRNGKey(), x)
+    out = ma.apply(pars, x)
+    assert out.shape == (2, 1024)

--- a/test/nn/test_blocks.py
+++ b/test/nn/test_blocks.py
@@ -128,7 +128,6 @@ def test_deepset():
     )
     params = ds.init(key, x)
     out = ds.apply(params, x)
-    print(params)
     assert params["params"]["ds_phi"]["Dense_0"]["kernel"].shape == (x.shape[-1], 16)
     assert params["params"]["ds_rho"]["Dense_0"]["kernel"].shape == (16, 32)
 
@@ -148,70 +147,3 @@ def test_deepset():
     )
     params = ds.init(key, x)
     out = ds.apply(params, x)
-
-
-@pytest.mark.parametrize(
-    "cusp_exponent", [pytest.param(None, id="cusp=None"), pytest.param(5, id="cusp=5")]
-)
-@pytest.mark.parametrize(
-    "L",
-    [
-        pytest.param(1.0, id="1D"),
-        pytest.param((1.0, 1.0), id="2D-Square"),
-        pytest.param((1.0, 0.5), id="2D-Rectangle"),
-    ],
-)
-def test_rel_dist_deepsets(cusp_exponent, L):
-
-    hilb = nk.hilbert.Particle(N=2, L=L, pbc=True)
-    sdim = len(hilb.extent)
-    x = jnp.hstack([jnp.ones(4), -jnp.ones(4)]).reshape(1, -1)
-    xp = jnp.roll(x, sdim)
-    ds = nk.models.DeepSetRelDistance(
-        hilbert=hilb,
-        cusp_exponent=cusp_exponent,
-        layers_phi=2,
-        layers_rho=2,
-        features_phi=(10, 10),
-        features_rho=(10, 1),
-    )
-    p = ds.init(jax.random.PRNGKey(42), x)
-
-    assert jnp.allclose(ds.apply(p, x), ds.apply(p, xp))
-
-
-def test_rel_dist_deepsets_error():
-    hilb = nk.hilbert.Particle(N=2, L=1.0, pbc=True)
-    sdim = len(hilb.extent)
-
-    x = jnp.hstack([jnp.ones(4), -jnp.ones(4)]).reshape(1, -1)
-    xp = jnp.roll(x, sdim)
-    ds = nk.models.DeepSetRelDistance(
-        hilbert=hilb,
-        layers_phi=3,
-        layers_rho=3,
-        features_phi=(10, 10),
-        features_rho=(10, 1),
-    )
-    with pytest.raises(ValueError):
-        p = ds.init(jax.random.PRNGKey(42), x)
-
-    with pytest.raises(AssertionError):
-        ds = nk.models.DeepSetRelDistance(
-            hilbert=hilb,
-            layers_phi=2,
-            layers_rho=2,
-            features_phi=(10, 10),
-            features_rho=(10, 2),
-        )
-        p = ds.init(jax.random.PRNGKey(42), x)
-
-    with pytest.raises(ValueError):
-        ds = nk.models.DeepSetRelDistance(
-            hilbert=nk.hilbert.Particle(N=2, L=1.0, pbc=False),
-            layers_phi=2,
-            layers_rho=2,
-            features_phi=(10, 10),
-            features_rho=(10, 2),
-        )
-        p = ds.init(jax.random.PRNGKey(42), x)

--- a/test/nn/test_blocks.py
+++ b/test/nn/test_blocks.py
@@ -14,8 +14,11 @@
 
 import pytest
 import numpy as np
+import jax
+import jax.numpy as jnp
 
 import netket as nk
+import netket.nn as nknn
 
 
 def test_mlp_alpha():
@@ -97,3 +100,118 @@ def test_mlp_input():
             output_dim=1, hidden_dims=(16, 32), hidden_dims_alpha=(1, 1)
         )
         _eval_model(ma)
+
+
+def test_deepset():
+    """Test the permutation invariance"""
+    L = (1.0, 1.0)
+    n_particles = 6
+    hilb = nk.hilbert.Particle(N=n_particles, L=L, pbc=True)
+    sdim = len(hilb.extent)
+    key = jax.random.PRNGKey(42)
+    x = hilb.random_state(key, size=1024)
+    x = x.reshape(x.shape[0], n_particles, sdim)
+
+    xp = jnp.roll(x, 2, axis=-2)  # permute the particles
+
+    ds = nk.nn.blocks.DeepSetMLP(features_phi=(16, 16), features_rho=(16, 1))
+    params = ds.init(key, x)
+    out = ds.apply(params, x)
+    outp = ds.apply(params, xp)
+    assert out.shape == outp.shape
+    assert out.shape[-1] == 1
+
+    assert jnp.allclose(out, outp)
+
+    ds = nk.nn.blocks.DeepSetMLP(
+        features_phi=16, features_rho=32, output_activation=nknn.gelu
+    )
+    params = ds.init(key, x)
+    out = ds.apply(params, x)
+    print(params)
+    assert params["params"]["ds_phi"]["Dense_0"]["kernel"].shape == (x.shape[-1], 16)
+    assert params["params"]["ds_rho"]["Dense_0"]["kernel"].shape == (16, 32)
+
+    ds = nk.nn.blocks.DeepSetMLP(features_phi=(16,), features_rho=(16, 3))
+    params = ds.init(key, x)
+    out = ds.apply(params, x)
+    assert out.shape[-1] == 3
+
+    # flexible, should still work
+    ds = nk.nn.blocks.DeepSetMLP(
+        features_phi=None,
+        features_rho=None,
+        output_activation=None,
+        hidden_activation=None,
+        pooling=None,
+        param_dtype=complex,
+    )
+    params = ds.init(key, x)
+    out = ds.apply(params, x)
+
+
+@pytest.mark.parametrize(
+    "cusp_exponent", [pytest.param(None, id="cusp=None"), pytest.param(5, id="cusp=5")]
+)
+@pytest.mark.parametrize(
+    "L",
+    [
+        pytest.param(1.0, id="1D"),
+        pytest.param((1.0, 1.0), id="2D-Square"),
+        pytest.param((1.0, 0.5), id="2D-Rectangle"),
+    ],
+)
+def test_rel_dist_deepsets(cusp_exponent, L):
+
+    hilb = nk.hilbert.Particle(N=2, L=L, pbc=True)
+    sdim = len(hilb.extent)
+    x = jnp.hstack([jnp.ones(4), -jnp.ones(4)]).reshape(1, -1)
+    xp = jnp.roll(x, sdim)
+    ds = nk.models.DeepSetRelDistance(
+        hilbert=hilb,
+        cusp_exponent=cusp_exponent,
+        layers_phi=2,
+        layers_rho=2,
+        features_phi=(10, 10),
+        features_rho=(10, 1),
+    )
+    p = ds.init(jax.random.PRNGKey(42), x)
+
+    assert jnp.allclose(ds.apply(p, x), ds.apply(p, xp))
+
+
+def test_rel_dist_deepsets_error():
+    hilb = nk.hilbert.Particle(N=2, L=1.0, pbc=True)
+    sdim = len(hilb.extent)
+
+    x = jnp.hstack([jnp.ones(4), -jnp.ones(4)]).reshape(1, -1)
+    xp = jnp.roll(x, sdim)
+    ds = nk.models.DeepSetRelDistance(
+        hilbert=hilb,
+        layers_phi=3,
+        layers_rho=3,
+        features_phi=(10, 10),
+        features_rho=(10, 1),
+    )
+    with pytest.raises(ValueError):
+        p = ds.init(jax.random.PRNGKey(42), x)
+
+    with pytest.raises(AssertionError):
+        ds = nk.models.DeepSetRelDistance(
+            hilbert=hilb,
+            layers_phi=2,
+            layers_rho=2,
+            features_phi=(10, 10),
+            features_rho=(10, 2),
+        )
+        p = ds.init(jax.random.PRNGKey(42), x)
+
+    with pytest.raises(ValueError):
+        ds = nk.models.DeepSetRelDistance(
+            hilbert=nk.hilbert.Particle(N=2, L=1.0, pbc=False),
+            layers_phi=2,
+            layers_rho=2,
+            features_phi=(10, 10),
+            features_rho=(10, 2),
+        )
+        p = ds.init(jax.random.PRNGKey(42), x)

--- a/test/nn/test_blocks.py
+++ b/test/nn/test_blocks.py
@@ -143,7 +143,7 @@ def test_deepset():
         features_rho=None,
         output_activation=None,
         hidden_activation=None,
-        pooling=None,
+        pooling=jnp.prod,
         param_dtype=complex,
     )
     params = ds.init(key, x)

--- a/test/variational/test_variational.py
+++ b/test/variational/test_variational.py
@@ -43,27 +43,32 @@ RBMModPhase = partial(nk.models.RBMModPhase, hidden_bias_init=standard_init)
 
 nk.models.RBM(
     alpha=1,
-    dtype=complex,
+    param_dtype=complex,
     kernel_init=normal(stddev=0.1),
     hidden_bias_init=normal(stddev=0.1),
 )
 machines["model:(R->R)"] = RBM(
     alpha=1,
-    dtype=float,
+    param_dtype=float,
     kernel_init=normal(stddev=0.1),
     hidden_bias_init=normal(stddev=0.1),
 )
 machines["model:(R->C)"] = RBMModPhase(
     alpha=1,
-    dtype=float,
+    param_dtype=float,
     kernel_init=normal(stddev=0.1),
     hidden_bias_init=normal(stddev=0.1),
 )
 machines["model:(C->C)"] = RBM(
     alpha=1,
-    dtype=complex,
+    param_dtype=complex,
     kernel_init=normal(stddev=0.1),
     hidden_bias_init=normal(stddev=0.1),
+)
+machines["model:(C->C,nonholo)"] = nk.models.RBM(
+    alpha=1,
+    param_dtype=complex,
+    activation=lambda x: nk.nn.log_cosh(0.3 * x * x + 0.6 * x.conj()),
 )
 
 operators = {}
@@ -90,13 +95,6 @@ for i in range(H.hilbert.size):
     H += nk.operator.spin.sigmap(H.hilbert, i)
 
 operators["operator:(Non Hermitian)"] = H
-
-machines["model:(C->C)-nonholo"] = nk.models.ARNNDense(
-    layers=1,
-    features=2,
-    hilbert=hi,
-    dtype=complex,
-)
 
 
 @pytest.fixture(params=[pytest.param(ma, id=name) for name, ma in machines.items()])
@@ -547,9 +545,7 @@ def test_local_estimators(vstate, operator):
         assert st1.error_of_mean == pytest.approx(st2.error_of_mean)
 
     def inner_test():
-        print(vstate.samples.shape)
         oloc = vstate.local_estimators(operator)
-        print(oloc.shape)
         assert oloc.shape == (vstate.sampler.n_chains, vstate.n_samples)
 
         stats1 = nk.stats.statistics(oloc)


### PR DESCRIPTION
NetKet has a very specific DeepSetRelDists model, but does not yet contain a simple DeepSet architecture. I've added a relatively flexible one. I tried to keep DeepSetRelDists untouched.