### PR TITLE
Remove n_particles>0 requirement in Fock

### DIFF
--- a/netket/hilbert/fock.py
+++ b/netket/hilbert/fock.py
@@ -74,8 +74,11 @@ class Fock(HomogeneousHilbert):
 
         if n_particles is not None:
             n_particles = int(n_particles)
+            if n_particles < 0:
+                raise ValueError(
+                    f"Number of particles must be larger than 0, but received {n_particles}."
+                )
             self._n_particles = n_particles
-            assert n_particles > 0
 
             if self._n_max is None:
                 self._n_max = n_particles

--- a/netket/hilbert/fock.py
+++ b/netket/hilbert/fock.py
@@ -76,7 +76,7 @@ class Fock(HomogeneousHilbert):
             n_particles = int(n_particles)
             if n_particles < 0:
                 raise ValueError(
-                    f"Number of particles must be larger than 0, but received {n_particles}."
+                    f"Number of particles must be >= 0, but received {n_particles}."
                 )
             self._n_particles = n_particles
 

--- a/test/hilbert/test_hilbert.py
+++ b/test/hilbert/test_hilbert.py
@@ -118,6 +118,9 @@ hilberts["SpinOrbitalFermions (n_fermions)"] = nkx.hilbert.SpinOrbitalFermions(
 hilberts["SpinOrbitalFermions (n_fermions=list)"] = nkx.hilbert.SpinOrbitalFermions(
     5, s=1 / 2, n_fermions=(2, 3)
 )
+hilberts["SpinOrbitalFermions (polarized)"] = nkx.hilbert.SpinOrbitalFermions(
+    5, s=1 / 2, n_fermions=(2, 0)
+)
 
 # Continuous space
 # no pbc
@@ -481,3 +484,16 @@ def test_fermions_get_index():
     assert hi._get_index(0, +0.5) == 3
     # first block (-0.5) and second site (1) --> idx = 1 + n_orbital
     assert hi._get_index(1, +0.5) == 4
+
+
+def test_no_particles():
+    hi = Fock(n_max=3, n_particles=0, N=4)
+    states = hi.all_states()
+    assert states.shape[0] == 1
+    assert np.allclose(states, 0.0)
+
+    # same for fermions
+    hi = nkx.hilbert.SpinOrbitalFermions(2, s=1 / 2, n_fermions=(0, 0))
+    states = hi.all_states()
+    assert states.shape[0] == 1
+    assert np.allclose(states, 0.0)

--- a/test/hilbert/test_hilbert.py
+++ b/test/hilbert/test_hilbert.py
@@ -497,3 +497,7 @@ def test_no_particles():
     states = hi.all_states()
     assert states.shape[0] == 1
     assert np.allclose(states, 0.0)
+
+    with pytest.raises(ValueError):
+        # also test negative particles
+        _ = Fock(n_max=3, n_particles=-1, N=4)


### PR DESCRIPTION
To generate fully polarized fermions, we need to relax the (unnecessary) condition in Fock that n_particles > 0.