### PR TITLE
fix mpi test

### DIFF
--- a/netket/operator/_sumoperators.py
+++ b/netket/operator/_sumoperators.py
@@ -88,8 +88,7 @@ class SumOperator(ContinuousOperator):
     ):
         term_coefficients, term_datas = data
         result = [
-            term_coefficients[i]
-            * op._expect_kernel(logpsi, params, x, term_datas[i])
+            term_coefficients[i] * op._expect_kernel(logpsi, params, x, term_datas[i])
             for i, op in enumerate(self._ops)
         ]
 

--- a/netket/vqs/mc/mc_state/expect.py
+++ b/netket/vqs/mc/mc_state/expect.py
@@ -136,7 +136,7 @@ def _expect(
     #    n_chains=σ_shape[0],
     # )
 
-    L_σ = local_value_kernel(logpsi, parameters, σ, *local_value_args)
+    L_σ = local_value_kernel(logpsi, parameters, σ, local_value_args)
     L_σ = L_σ.reshape((σ_shape[0], -1))
     Ō_stats = mpi_statistics(L_σ.T)
 

--- a/netket/vqs/mc/mc_state/expect.py
+++ b/netket/vqs/mc/mc_state/expect.py
@@ -18,8 +18,7 @@ from functools import partial
 import jax
 from jax import numpy as jnp
 
-from netket import jax as nkjax
-from netket.stats import Stats
+from netket.stats import Stats, statistics as mpi_statistics
 from netket.utils.types import PyTree
 from netket.utils.dispatch import dispatch
 
@@ -126,13 +125,19 @@ def _expect(
     def log_pdf(w, σ):
         return machine_pow * model_apply_fun({"params": w, **model_state}, σ).real
 
-    _, Ō_stats = nkjax.expect(
-        log_pdf,
-        partial(local_value_kernel, logpsi),
-        parameters,
-        σ,
-        local_value_args,
-        n_chains=σ_shape[0],
-    )
+    # TODO: Broken until google/jax#11916 is resolved.
+    # should uncomment and remove code below once this is fixed
+    # _, Ō_stats = nkjax.expect(
+    #    log_pdf,
+    #    partial(local_value_kernel, logpsi),
+    #    parameters,
+    #    σ,
+    #    local_value_args,
+    #    n_chains=σ_shape[0],
+    # )
+
+    L_σ = local_value_kernel(logpsi, parameters, σ, *local_value_args)
+    L_σ = L_σ.reshape((σ_shape[0], -1))
+    Ō_stats = mpi_statistics(L_σ.T)
 
     return Ō_stats

--- a/test/common.py
+++ b/test/common.py
@@ -62,6 +62,13 @@ Example:
 
 """
 
+xfailif_mpi = pytest.mark.xfail(
+    nk.utils.mpi.n_nodes > 1, reason="custom_vjp not supports effects."
+)
+"""Use as a decorator to mark a test to be expected to fail only when running with 
+at least 2 MPI processes.
+"""
+
 
 class netket_disable_mpi:
     """

--- a/test/mpi/test_mpi_utils.py
+++ b/test/mpi/test_mpi_utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
 import jax.numpy as jnp
 
 import netket as nk
@@ -20,7 +21,7 @@ from .. import common
 
 
 @common.onlyif_mpi
-def test_key_split(_mpi_size, _mpi_comm):
+def test_key_split(_mpi_size, _mpi_comm, _mpi_rank):
     from mpi4py import MPI
 
     size = _mpi_size
@@ -33,5 +34,14 @@ def test_key_split(_mpi_size, _mpi_comm):
 
     key, _ = nk.jax.mpi_split(key)
     keys = MPI.COMM_WORLD.allgather(key)
-    assert all([not jnp.all(k == keys) for k in keys])
+
+    # print(f"{comm.Get_rank()} : k{key}, {type(key)}")
+    # print(f"{comm.Get_rank()} : ks{keys}, {type(keys)}, {type(keys[0])}")
+
+    for r, ki in enumerate(keys):
+        if _mpi_rank == r:
+            assert np.array(key) == np.array(ki)
+        else:
+            assert not np.array(key) == np.array(ki)
+
     assert len(keys) == size

--- a/test/variational/test_variational.py
+++ b/test/variational/test_variational.py
@@ -477,6 +477,7 @@ def test_local_estimators(vstate, operator):
 
 # Have a different test because the above is marked as xfail.
 # This only checks that the code runs.
+@common.xfailif_mpi
 def test_expect_grad_nonhermitian_works(vstate):
     op = nk.operator.spin.sigmap(vstate.hilbert, 0)
     O_stat, O_grad = vstate.expect_and_grad(op)


### PR DESCRIPTION
This PR fixes two things: 
- an mpi test broken by recent jax changes (how they split rng keys) 
- The fact that until https://github.com/google/jax/issues/11916 is fixed, some tests will be failing on recent versions of jax. As the failing tests are quite exotic, this should not be a big problem