### PR TITLE
Document and simplify usage of configuration options

### DIFF
--- a/docs/docs/configurations.md
+++ b/docs/docs/configurations.md
@@ -1,45 +1,95 @@
 # Configuration Options
 
-NetKet exposes a few configuration options which can be set through environment variables or (in some cases) by accessing {func}`netket.config.update(option_name, value)`.
+NetKet exposes a few configuration options which can be set through environment variables by doing something like
+```bash
+# without exporting it
+NETKET_DEBUG=1 python
+
+# by exporting it
+export NETKET_DEBUG=1
+python ...
+
+# by setting it within python
+python
+>>> import os
+>>> os.environ["NETKET_DEBUG"] = "1"
+>>> import netket as nk
+```
+Some configuration options can also be changed at runtime by using the function {func}`netket.config.update(option_name, value)`, which can be used as:
+```python
+>>> import netket as nk
+>>> nk.config.update("NETKET_DEBUG", True)
+>>> ...
+```
+
+You can always query the value of an option by accessing the `nk.config` module:
+```python
+>>> import netket as nk
+>>> nk.config.netket_debug
+False
+>>> nk.config.update("NETKET_DEBUG", True)
+>>> nk.config.netket_debug
+True
+```
+
+Please note that not all configurations can be set at runtime, and some will raise an error.
 
 Options are used to activate experimental or debug functionalities or to disable some parts of netket. 
+Please keep in mind that all options related to experimental or internal functionalities might be removed in a future release.
 
-The supported options are the following:
+# List of configuration options
 
 `````{list-table}
 :header-rows: 1
-:widths: 10 5 10 20
+:widths: 5 2 10 20
 
 * - Name
-  - Values [default]
+  - Values **[default]**
   - Changeable
   - Description
+
 * - `NETKET_DEBUG`
-  - [False]/True
+  - True/**[False]**
   - yes
   - Enable debug logging in many netket functions.
+
 * - `NETKET_EXPERIMENTAL`
-  - **[False]**/True
+  - True/**[False]**
   - yes
   - Enable experimental features such as gradients of non-hermitian operators.
+
 * - `NETKET_MPI_WARNING`
   - **[True]**/False
   - no
   - Raise a warning when running python under MPI without mpi4py and other mpi dependencies installed.
+
 * - `NETKET_MPI`
   - **[True]**/False
   - no
   - When true, NetKet will always attempt to load (and initialize) MPI. If this flag is `0` `mpi4py` and `mpi4jax` will not be imported. This can be used to prevent crashes with some `MPI` variants such as Cray which cannot be initialised when not running under `mpirun`.
+
 * - `NETKET_USE_PLAIN_RHAT`
   - **[True]**/False
   - yes
   - By default, NetKet uses the split-R̂ Gelman-Rubin diagnostic in `netket.stats.statistics`,
-        which detects non-stationarity in the MCMC chains (in addition to the classes of
-        chain-mixing failures detected by plain R) since version 3.4.
-        Enabling this flag restores the previous behavior of using plain (non-split) Rhat..
+    which detects non-stationarity in the MCMC chains (in addition to the classes of
+    chain-mixing failures detected by plain R) since version 3.4.
+    Enabling this flag restores the previous behavior of using plain (non-split) Rhat.
+
+* - `NETKET_EXPERIMENTAL_FFT_AUTOCORRELATION`
+  - True/**[False]**
+  - yes
+  - The integrated autocorrelation time $\tau_c$ is computed separately for each chain $c$.
+    To summarize it for the user, `Stats.tau_corr` is changed to contain the average over all
+    chains and a new field `Stats.tau_corr_max` is added containing the maximum autocorrelation
+    among all chains (which helps to identify outliers). Using the average $\tau$ over all chains
+    seems like a good choice as it results in a low-variance estimate
+    (see [here](https://emcee.readthedocs.io/en/stable/tutorials/autocorr/#autocorr) for a good
+    discussion).
+
 * - `NETKET_SPHINX_BUILD`
-  - **[False]**/True
+  - True/**[False]**
   - no
-  - Set to True when building documentation with Sphinx. Disables some decorators.
+  - Set to True when building documentation with Sphinx. Disables some decorators. This is for internal use only.
   
 `````

--- a/docs/docs/configurations.md
+++ b/docs/docs/configurations.md
@@ -3,7 +3,7 @@
 NetKet exposes a few configuration options which can be set through environment variables by doing something like
 ```bash
 # without exporting it
-NETKET_DEBUG=1 python
+NETKET_DEBUG=1 python ...
 
 # by exporting it
 export NETKET_DEBUG=1

--- a/docs/docs/configurations.md
+++ b/docs/docs/configurations.md
@@ -1,0 +1,45 @@
+# Configuration Options
+
+NetKet exposes a few configuration options which can be set through environment variables or (in some cases) by accessing {func}`netket.config.update(option_name, value)`.
+
+Options are used to activate experimental or debug functionalities or to disable some parts of netket. 
+
+The supported options are the following:
+
+`````{list-table}
+:header-rows: 1
+:widths: 10 5 10 20
+
+* - Name
+  - Values [default]
+  - Changeable
+  - Description
+* - `NETKET_DEBUG`
+  - [False]/True
+  - yes
+  - Enable debug logging in many netket functions.
+* - `NETKET_EXPERIMENTAL`
+  - **[False]**/True
+  - yes
+  - Enable experimental features such as gradients of non-hermitian operators.
+* - `NETKET_MPI_WARNING`
+  - **[True]**/False
+  - no
+  - Raise a warning when running python under MPI without mpi4py and other mpi dependencies installed.
+* - `NETKET_MPI`
+  - **[True]**/False
+  - no
+  - When true, NetKet will always attempt to load (and initialize) MPI. If this flag is `0` `mpi4py` and `mpi4jax` will not be imported. This can be used to prevent crashes with some `MPI` variants such as Cray which cannot be initialised when not running under `mpirun`.
+* - `NETKET_USE_PLAIN_RHAT`
+  - **[True]**/False
+  - yes
+  - By default, NetKet uses the split-R̂ Gelman-Rubin diagnostic in `netket.stats.statistics`,
+        which detects non-stationarity in the MCMC chains (in addition to the classes of
+        chain-mixing failures detected by plain R) since version 3.4.
+        Enabling this flag restores the previous behavior of using plain (non-split) Rhat..
+* - `NETKET_SPHINX_BUILD`
+  - **[False]**/True
+  - no
+  - Set to True when building documentation with Sphinx. Disables some decorators.
+  
+`````

--- a/docs/docs/configurations.md
+++ b/docs/docs/configurations.md
@@ -14,21 +14,23 @@ python
 >>> import os
 >>> os.environ["NETKET_DEBUG"] = "1"
 >>> import netket as nk
+>>> print(netket.config.netket_debug)
+True
 ```
-Some configuration options can also be changed at runtime by using the function {func}`netket.config.update(option_name, value)`, which can be used as:
+Some configuration options can also be changed at runtime by setting it as:
 ```python
 >>> import netket as nk
->>> nk.config.update("NETKET_DEBUG", True)
+>>> nk.config.netket_debug = True
 >>> ...
 ```
 
 You can always query the value of an option by accessing the `nk.config` module:
 ```python
 >>> import netket as nk
->>> nk.config.netket_debug
+>>> print(nk.config.netket_debug)
 False
->>> nk.config.update("NETKET_DEBUG", True)
->>> nk.config.netket_debug
+>>> nk.config.netket_debug = True
+>>> print(nk.config.netket_debug)
 True
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -91,6 +91,7 @@ advanced/custom_operators
 
 api/api-stability
 docs/changelog
+docs/configurations
 api/api
 api/api-experimental
 ```

--- a/netket/stats/mc_stats.py
+++ b/netket/stats/mc_stats.py
@@ -100,7 +100,7 @@ class Stats:
         jsd["Sigma"] = _maybe_item(self.error_of_mean)
         jsd["R_hat"] = _maybe_item(self.R_hat)
         jsd["TauCorr"] = _maybe_item(self.tau_corr)
-        if config.FLAGS["NETKET_EXPERIMENTAL_FFT_AUTOCORRELATION"]:
+        if config.netket_experimental_fft_autocorrelation:
             jsd["TauCorrMax"] = _maybe_item(self.tau_corr_max)
         return jsd
 
@@ -113,7 +113,7 @@ class Stats:
             ext = ", R̂={:.4f}".format(self.R_hat)
         else:
             ext = ""
-        if config.FLAGS["NETKET_EXPERIMENTAL_FFT_AUTOCORRELATION"]:
+        if config.netket_experimental_fft_autocorrelation:
             if not (math.isnan(self.tau_corr) and math.isnan(self.tau_corr_max)):
                 ext += ", τ={:.1f}<{:.1f}".format(self.tau_corr, self.tau_corr_max)
         return "{} ± {} [σ²={}{}]".format(mean, err, var, ext)
@@ -169,7 +169,7 @@ def _batch_variance(data):
 
 def _split_R_hat(data, W):
     N = data.shape[-1]
-    if not config.FLAGS["NETKET_USE_PLAIN_RHAT"]:
+    if not config.netket_use_plain_rhat:
         # compute split-chain batch variance
         local_batch_size = data.shape[0]
         if N % 2 == 0:
@@ -230,7 +230,7 @@ def statistics(data):
         Gelman et al., `Bayesian Data Analysis <http://www.stat.columbia.edu/~gelman/book/>`_,
         or Vehtari et al., `arXiv:1903.08008 <https://arxiv.org/abs/1903.08008>`_.)
     """
-    if config.FLAGS["NETKET_EXPERIMENTAL_FFT_AUTOCORRELATION"]:
+    if config.netket_experimental_fft_autocorrelation:
         return _statistics(data)
     else:
         from .mc_stats_old import statistics as statistics_blocks

--- a/netket/stats/mc_stats_old.py
+++ b/netket/stats/mc_stats_old.py
@@ -168,7 +168,7 @@ def _statistics(data, batch_size):
     if n_batches > 1:
         N = data.shape[-1]
 
-        if not config.FLAGS["NETKET_USE_PLAIN_RHAT"]:
+        if not config.netket_use_plain_rhat:
             # compute split-chain batch variance
             local_batch_size = data.shape[0]
             if N % 2 == 0:

--- a/netket/utils/config_flags.py
+++ b/netket/utils/config_flags.py
@@ -140,7 +140,7 @@ config.define(
     bool,
     default=False,
     help="Enable experimental features.",
-    runtime=False,
+    runtime=True,
 )
 
 config.define(

--- a/netket/utils/config_flags.py
+++ b/netket/utils/config_flags.py
@@ -76,6 +76,12 @@ class Config:
         self._editable_at_runtime[name] = runtime
         self._values[name] = get_env(name, type, default)
 
+        @property
+        def _read_config(self):
+            return self.FLAGS[name]
+
+        setattr(Config, name.lower(), _read_config)
+
     @property
     def FLAGS(self):
         """
@@ -85,12 +91,20 @@ class Config:
 
     def update(self, name, value):
         """
-        Updates a variable in netket
+        Updates a configuration variable in netket.
 
         Args:
             name: the name of the variable
             value: the new value
         """
+        name = name.upper()
+
+        if not self._editable_at_runtime[name]:
+            raise RuntimeError(
+                f"Flag `{name}` can only be set through an environment"
+                "variable before importing netket."
+            )
+
         self._values[name] = self._types[name](value)
 
 

--- a/netket/utils/config_flags.py
+++ b/netket/utils/config_flags.py
@@ -80,6 +80,10 @@ class Config:
         def _read_config(self):
             return self.FLAGS[name]
 
+        @_read_config.setter
+        def _read_config(self, value):
+            self.update(name, value)
+
         setattr(Config, name.lower(), _read_config)
 
     @property
@@ -101,8 +105,20 @@ class Config:
 
         if not self._editable_at_runtime[name]:
             raise RuntimeError(
-                f"Flag `{name}` can only be set through an environment"
-                "variable before importing netket."
+                f"\n\nFlag `{name}` can only be set through an environment "
+                "variable before importing netket.\n"
+                "Try launching python with:\n\n"
+                f"\t{name}={self.FLAGS[name]} python\n\n"
+                "or execute the following snippet BEFORE importing netket:\n\n"
+                "\t>>>import os\n"
+                f'\t>>>os.environ["{name}"]="{self.FLAGS[name]}"\n'
+                "\t>>>import netket as nk\n\n"
+            )
+
+        if not isinstance(value, self._types[name]):
+            raise TypeError(
+                f"Configuration {name} must be a {self._types[name]}, but the "
+                f"value {value} is a {type(value)}."
             )
 
         self._values[name] = self._types[name](value)

--- a/netket/utils/deprecation.py
+++ b/netket/utils/deprecation.py
@@ -104,7 +104,7 @@ def deprecate_dtype(clz):
     # Sphinx is terrible at understanding wrappers of classses, so we detect
     # this env variable set by us sphinx's conf.py, and we do not apply the
     # deecorator if that's the case.
-    if config.FLAGS["NETKET_SPHINX_BUILD"]:
+    if config.netket_sphinx_build:
         return clz
 
     # If it is a class, then add the deprecated dtype attribute returning

--- a/netket/utils/mpi/mpi.py
+++ b/netket/utils/mpi/mpi.py
@@ -24,7 +24,7 @@ _mpi4jax_loaded = False
 mpi4jax_available = False
 
 try:
-    if not config.FLAGS["NETKET_MPI"]:  # pragma: no cover
+    if not config.netket_mpi:  # pragma: no cover
         # if mpi is disabled, import a package that does not exist
         # to trigger import error and follow the no-mpi code path
         import this_package_does_not_exist_zuzzurellone  # noqa: F401
@@ -64,7 +64,7 @@ except ImportError:
     MPI = FakeMPI()
 
     # Try to detect if we are running under MPI and warn that mpi4py is not installed
-    if config.FLAGS["NETKET_MPI_WARNING"]:
+    if config.netket_mpi_warning:
         _MPI_ENV_VARIABLES = [
             "OMPI_COMM_WORLD_SIZE",
             "I_MPI_HYDRA_HOST_FILE",

--- a/netket/vqs/mc/mc_state/expect_grad.py
+++ b/netket/vqs/mc/mc_state/expect_grad.py
@@ -90,7 +90,7 @@ def expect_and_grad_nonherm(
     mutable: Any,
 ) -> Tuple[Stats, PyTree]:
 
-    if not isinstance(Ô, Squared) and not config.FLAGS["NETKET_EXPERIMENTAL"]:
+    if not isinstance(Ô, Squared) and not config.netket_experimental:
         raise RuntimeError(
             """
             Computing the gradient of non hermitian operator is an

--- a/test/common.py
+++ b/test/common.py
@@ -109,7 +109,7 @@ class netket_experimental_fft_autocorrelation:
         self._value = val
 
     def __enter__(self):
-        self._orig_value = nk.config.FLAGS["NETKET_EXPERIMENTAL_FFT_AUTOCORRELATION"]
+        self._orig_value = nk.config.netket_experimental_fft_autocorrelation
         nk.config.update("NETKET_EXPERIMENTAL_FFT_AUTOCORRELATION", self._value)
 
     def __exit__(self, exc_type, exc_value, traceback):

--- a/test/utils/test_config.py
+++ b/test/utils/test_config.py
@@ -2,7 +2,7 @@ import netket as nk
 import pytest
 
 with pytest.raises(RuntimeError):
-    nk.config.netket_experimental = True
+    nk.config.netket_mpi = True
 
 assert isinstance(nk.config.netket_debug, bool)
 

--- a/test/utils/test_config.py
+++ b/test/utils/test_config.py
@@ -1,0 +1,10 @@
+import netket as nk
+import pytest
+
+with pytest.raises(RuntimeError):
+    nk.config.netket_experimental = True
+
+assert isinstance(nk.config.netket_debug, bool)
+
+with pytest.raises(TypeError):
+    nk.config.netket_debug = 1


### PR DESCRIPTION
This PR adds documentation for the usage of configuration options available in netket as environment/config variables, and simplifies the interface to access them, mimicking jax.

Now config options can be queried by doing `netket.config.netket_debug` instead of `netket.config.FLAGS["NETKET_DEBUG"]` 