### PR TITLE
Better docs

### DIFF
--- a/docs/api/api-experimental.md
+++ b/docs/api/api-experimental.md
@@ -39,11 +39,11 @@ several CPUs, but you have to start jax with a specific environment variable.
    :template: class
    :nosignatures:
 
-   netket.experimental.sampler.MetropolisPtSampler
-   netket.experimental.sampler.MetropolisLocalPt
-   netket.experimental.sampler.MetropolisExchangePt
+   sampler.MetropolisPtSampler
+   sampler.MetropolisLocalPt
+   sampler.MetropolisExchangePt
 
-   netket.experimental.sampler.MetropolisSamplerPmap
+   sampler.MetropolisSamplerPmap
 ```
 
 (experimental-variational-api)=
@@ -51,7 +51,7 @@ several CPUs, but you have to start jax with a specific environment variable.
 ## Logging
 
 ```{eval-rst}
-.. currentmodule:: netket.experimental.logging
+.. currentmodule:: netket.experimental
 
 ```
 
@@ -63,7 +63,7 @@ This module contains experimental loggers that can be used with the optimization
    :toctree: _generated/experimental/logging
    :nosignatures:
 
-   HDF5Log
+   logging.HDF5Log
 
 ```
 
@@ -72,7 +72,7 @@ This module contains experimental loggers that can be used with the optimization
 ## Variational State Interface
 
 ```{eval-rst}
-.. currentmodule:: netket
+.. currentmodule:: netket.experimental
 ```
 
 ```{eval-rst}
@@ -80,15 +80,15 @@ This module contains experimental loggers that can be used with the optimization
   :toctree: _generated/experimental/variational
   :nosignatures:
 
-  netket.experimental.vqs.variables_from_file
-  netket.experimental.vqs.variables_from_tar
+  vqs.variables_from_file
+  vqs.variables_from_tar
 
 ```
 
 ## Time Evolution Driver
 
 ```{eval-rst}
-.. currentmodule:: netket
+.. currentmodule:: netket.experimental
 ```
 
 ```{eval-rst}
@@ -96,7 +96,7 @@ This module contains experimental loggers that can be used with the optimization
   :toctree: _generated/experimental/dynamics
   :nosignatures:
 
-  netket.experimental.driver.TDVP
+  TDVP
 
 ```
 
@@ -106,7 +106,7 @@ This is a collection of ODE integrators that can be used with the TDVP
 driver above.
 
 ```{eval-rst}
-.. currentmodule:: netket
+.. currentmodule:: netket.experimental
 ```
 
 ```{eval-rst}
@@ -114,13 +114,13 @@ driver above.
    :toctree: _generated/experimental/dynamics
    :nosignatures:
 
-   netket.experimental.dynamics.Euler
-   netket.experimental.dynamics.Heun
-   netket.experimental.dynamics.Midpoint
-   netket.experimental.dynamics.RK12
-   netket.experimental.dynamics.RK23
-   netket.experimental.dynamics.RK4
-   netket.experimental.dynamics.RK45
+   dynamics.Euler
+   dynamics.Heun
+   dynamics.Midpoint
+   dynamics.RK12
+   dynamics.RK23
+   dynamics.RK4
+   dynamics.RK45
 ```
 
 ## Fermions
@@ -129,7 +129,7 @@ This modules contains hilbert space and operator implementations of fermions in 
 It is experimental until it has been thoroughly tested by the community, meaning feedback is welcome.
 
 ```{eval-rst}
-.. currentmodule:: netket
+.. currentmodule:: netket.experimental
 ```
 
 ```{eval-rst}
@@ -138,7 +138,7 @@ It is experimental until it has been thoroughly tested by the community, meaning
    :template: class
    :nosignatures:
 
-   netket.experimental.hilbert.SpinOrbitalFermions
+   hilbert.SpinOrbitalFermions
 ```
 
 ```{eval-rst}
@@ -147,8 +147,8 @@ It is experimental until it has been thoroughly tested by the community, meaning
    :template: class
    :nosignatures:
 
-   netket.experimental.operator.FermionOperator2nd
-   netket.experimental.operator.fermion.create
-   netket.experimental.operator.fermion.destroy
-   netket.experimental.operator.fermion.number
+   operator.FermionOperator2nd
+   operator.fermion.create
+   operator.fermion.destroy
+   operator.fermion.number
 ```

--- a/docs/api/nn.md
+++ b/docs/api/nn.md
@@ -73,6 +73,6 @@ Read more about the design goal of this module in their [README](https://github.
    :toctree: _generated/nn
    :nosignatures:
 
-    MLP
+    blocks.MLP
 
 ```

--- a/netket/experimental/dynamics/__init__.py
+++ b/netket/experimental/dynamics/__init__.py
@@ -25,7 +25,7 @@ __all__ = [
     "RK45",
 ]
 
-from ._rk_solver import RungeKuttaIntegrator, RKIntegratorConfig
+from ._rk_solver_structures import RungeKuttaIntegrator, RKIntegratorConfig
 from ._rk_solver import Euler, Heun, Midpoint, RK4, RK12, RK23, RK45
 
 from netket.utils import _hide_submodules

--- a/netket/experimental/dynamics/_rk_solver.py
+++ b/netket/experimental/dynamics/_rk_solver.py
@@ -1,0 +1,120 @@
+# Copyright 2021 The NetKet Authors - All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from . import _rk_tableau as rkt
+from ._rk_solver_structures import RKIntegratorConfig
+
+args_fixed_dt_docstring = """
+    Args:
+        dt: Timestep (floating-point number).
+"""
+
+args_adaptive_docstring = """
+    Args:
+        dt: Timestep (floating-point number). When :code:`adaptive==False` this value
+            is never changed, when :code:`adaptive == True` this is the initial timestep.
+        adaptive: Whether to use adaptive timestepping (Defaults to False).
+            Not all integrators support adaptive timestepping.
+        atol: Maximum absolute error at every time-step during adaptive timestepping.
+            A larger value will lead to larger timestep. This option is ignored if
+            `adaptive=False`. A value of 0 means it is ignored. Note that the `norm` used
+            to compute the error can be  changed in the :ref:`netket.experimental.TDVP`
+            driver. (Defaults to 0).
+        rtol: Maximum relative error at every time-step during adaptive timestepping.
+            A larger value will lead to larger timestep. This option is ignored if
+            `adaptive=False`. Note that the `norm` used to compute the error can be
+            changed in the :ref:`netket.experimental.TDVP` driver. (Defaults to 1e-7)
+        dt_limits: A length-2 tuple of minimum and maximum timesteps considered by
+            adaptive time-stepping. A value of None signals that there is no bound.
+            Defaults to :code:`(None, 10*dt)`.
+"""
+
+
+def append_docstring(doc):
+    """
+    Decorator that appends the string `doc` to the decorated function.
+
+    This is needed here because docstrings cannot be f-strings or manipulated strings.
+    """
+
+    def _append_docstring(fun):
+        fun.__doc__ = fun.__doc__ + doc
+        return fun
+
+    return _append_docstring
+
+
+@append_docstring(args_fixed_dt_docstring)
+def Euler(dt):
+    r"""
+    The canonical first-order forward Euler method. Fixed timestep only.
+
+    """
+    return RKIntegratorConfig(dt, tableau=rkt.bt_feuler)
+
+
+@append_docstring(args_fixed_dt_docstring)
+def Midpoint(dt):
+    r"""
+    The second order midpoint method. Fixed timestep only.
+
+    """
+    return RKIntegratorConfig(dt, tableau=rkt.bt_midpoint)
+
+
+@append_docstring(args_fixed_dt_docstring)
+def Heun(dt):
+    r"""
+    The second order Heun's method. Fixed timestep only.
+
+    """
+    return RKIntegratorConfig(dt, tableau=rkt.bt_heun)
+
+
+@append_docstring(args_fixed_dt_docstring)
+def RK4(dt):
+    r"""
+    The canonical Runge-Kutta Order 4 method. Fixed timestep only.
+
+    """
+    return RKIntegratorConfig(dt, tableau=rkt.bt_rk4)
+
+
+@append_docstring(args_adaptive_docstring)
+def RK12(dt, **kwargs):
+    r"""
+    The second order Heun's method. Uses embedded Euler method for adaptivity.
+    Also known as Heun-Euler method.
+
+    """
+    return RKIntegratorConfig(dt, tableau=rkt.bt_rk12, **kwargs)
+
+
+@append_docstring(args_adaptive_docstring)
+def RK23(dt, **kwargs):
+    r"""
+    2nd order adaptive solver with 3rd order error control,
+    using the Bogacki–Shampine coefficients
+
+    """
+    return RKIntegratorConfig(dt, tableau=rkt.bt_rk23, **kwargs)
+
+
+@append_docstring(args_adaptive_docstring)
+def RK45(dt, **kwargs):
+    r"""
+    Dormand-Prince's 5/4 Runge-Kutta method. (free 4th order interpolant).
+
+    """
+    return RKIntegratorConfig(dt, tableau=rkt.bt_rk4_dopri, **kwargs)

--- a/netket/experimental/dynamics/_rk_solver_structures.py
+++ b/netket/experimental/dynamics/_rk_solver_structures.py
@@ -380,6 +380,11 @@ class RungeKuttaIntegrator:
 
 class RKIntegratorConfig:
     def __init__(self, dt, tableau, *, adaptive=False, **kwargs):
+        if not tableau.data.is_adaptive and adaptive:
+            raise ValueError(
+                "Cannot set `adaptive=True` for a non-adaptive integrator."
+            )
+
         self.dt = dt
         self.tableau = tableau
         self.adaptive = adaptive
@@ -405,21 +410,3 @@ class RKIntegratorConfig:
             self.adaptive,
             f", **kwargs={self.kwargs}" if self.kwargs else "",
         )
-
-
-# Solvers with preset tableaus
-
-Euler = partial(RKIntegratorConfig, tableau=rkt.bt_feuler)
-"""First-order Euler solver"""
-Midpoint = partial(RKIntegratorConfig, tableau=rkt.bt_midpoint)
-"""Second-order midpoint method solver"""
-Heun = partial(RKIntegratorConfig, tableau=rkt.bt_heun)
-"""Second-order Heun solver"""
-RK4 = partial(RKIntegratorConfig, tableau=rkt.bt_rk4)
-"""Fourth-order Runge-Kutta solver"""
-RK12 = partial(RKIntegratorConfig, tableau=rkt.bt_rk12)
-"""Heun-Euler solver (adaptive)"""
-RK23 = partial(RKIntegratorConfig, tableau=rkt.bt_rk23)
-"""Bogacki–Shampine method solver (adaptive)"""
-RK45 = partial(RKIntegratorConfig, tableau=rkt.bt_rk4_dopri)
-"""Dormand-Prince (dopri) method solver (adaptive)"""

--- a/netket/experimental/logging/hdf5_log.py
+++ b/netket/experimental/logging/hdf5_log.py
@@ -83,11 +83,12 @@ class HDF5Log:
     The logger has support for scalar numbers, NumPy/JAX arrays, and netket.stats.Stats objects.
     These are stored as individual groups within a HDF5 file, under the main group `data/`:
 
-    - scalars are stored as a group with one dataset values of shape (n_steps,) containing the logged values,
-    - arrays are stored in the same way, but with values having shape (n_steps, *array_shape),
-    - netket.stats.Stats are stored as a group containing each field (Mean, Variance, etc...) as a separate dataset.
+    - scalars are stored as a group with one dataset values of shape :code:`(n_steps,)` containing the logged values,
+    - arrays are stored in the same way, but with values having shape :code:`(n_steps, *array_shape)`,
+    - netket.stats.Stats are stored as a group containing each field :code:`(Mean, Variance, etc...)` as a separate dataset.
 
-    Importantly, each group has a dataset `iters`, which tracks the iteration number of the logged quantity.
+    Importantly, each group has a dataset :code:`iters`, which tracks the
+    iteration number of the logged quantity.
 
     If the model state is serialized, then it is serialized as a dataset in the group `variational_state/`.
     The target of the serialization is the parameters PyTree of the variational state (stored in the group

--- a/test/dynamics/test_solvers.py
+++ b/test/dynamics/test_solvers.py
@@ -57,10 +57,17 @@ explicit_adaptive_solvers = {
     "RK45": RK45,
 }
 
+tableaus_params = [pytest.param(obj, id=name) for name, obj in tableaus.items()]
+explicit_fixed_step_solvers_params = [
+    pytest.param(obj, id=name) for name, obj in explicit_fixed_step_solvers.items()
+]
+explicit_adaptive_solvers_params = [
+    pytest.param(obj, id=name) for name, obj in explicit_adaptive_solvers.items()
+]
 
-@pytest.mark.parametrize("tableau", tableaus)
+
+@pytest.mark.parametrize("tableau", tableaus_params)
 def test_tableau(tableau: str):
-    tableau = tableaus[tableau]  # type: NamedTableau
     assert tableau.name != ""
     td = tableau.data
 
@@ -84,14 +91,20 @@ def test_tableau(tableau: str):
         assert td.b.shape[0] == 2
 
 
-@pytest.mark.parametrize("method", explicit_fixed_step_solvers)
+@pytest.mark.parametrize("method", explicit_fixed_step_solvers_params)
+def test_fixed_adaptive_error(method):
+    with pytest.raises(TypeError):
+        method(dt=0.01, adaptive=True)
+
+
+@pytest.mark.parametrize("method", explicit_fixed_step_solvers_params)
 def test_ode_solver(method):
     def ode(t, x, **_):
         return -t * x
 
     dt = 0.01
     n_steps = 100
-    solver = explicit_fixed_step_solvers[method](dt=dt)
+    solver = method(dt=dt)
 
     y0 = np.array([1.0])
     times = np.linspace(0, n_steps * dt, n_steps, endpoint=False)
@@ -120,14 +133,12 @@ def test_ode_solver(method):
     rtol = {
         "Euler": 1e-2,
         "RK4": 5e-4,
-    }.get(method, 1e-3)
+    }.get(solver.tableau.name, 1e-3)
     np.testing.assert_allclose(y_t[:, 0], y_ref, rtol=rtol)
 
 
-@pytest.mark.parametrize("solver", explicit_adaptive_solvers)
+@pytest.mark.parametrize("solver", explicit_adaptive_solvers_params)
 def test_adaptive_solver(solver):
-    solver = explicit_adaptive_solvers[solver]
-
     tol = 1e-7
 
     def ode(t, x, **_):


### PR DESCRIPTION
All experimental section of the docs was with broken links. This fixes it.

@femtobit this creates actual docstrings for our integrators which otherwise where.. undocumented. Can you give a look? 
[old docs](https://netket.readthedocs.io/en/latest/api/api-experimental.html)
[new docs](https://netket--1299.org.readthedocs.build/en/1299/api/api-experimental.html)
