### PR TITLE
Improve docstrings for `ARNN*.features`

### DIFF
--- a/netket/models/autoreg.py
+++ b/netket/models/autoreg.py
@@ -104,7 +104,7 @@ class ARNNDense(AbstractARNN):
     layers: int
     """number of layers."""
     features: Union[Iterable[int], int]
-    """number of features in each layer. If a single number is given,
+    """output feature density in each layer. If a single number is given,
     all layers except the last one will have the same number of features."""
     activation: Callable[[Array], Array] = jax.nn.selu
     """the nonlinear activation function between hidden layers (default: selu)."""
@@ -156,7 +156,7 @@ class ARNNConv1D(AbstractARNN):
     layers: int
     """number of layers."""
     features: Union[Iterable[int], int]
-    """number of features in each layer. If a single number is given,
+    """output feature density in each layer. If a single number is given,
     all layers except the last one will have the same number of features."""
     kernel_size: int
     """length of the convolutional kernel."""
@@ -213,7 +213,7 @@ class ARNNConv2D(AbstractARNN):
     layers: int
     """number of layers."""
     features: Union[Iterable[int], int]
-    """number of features in each layer. If a single number is given,
+    """output feature density in each layer. If a single number is given,
     all layers except the last one will have the same number of features."""
     kernel_size: Tuple[int, int]
     """shape of the convolutional kernel `(h, w)`. Typically, `h = w // 2 + 1`."""

--- a/netket/models/fast_autoreg.py
+++ b/netket/models/fast_autoreg.py
@@ -47,7 +47,7 @@ class FastARNNDense(AbstractARNN):
     layers: int
     """number of layers."""
     features: Union[Iterable[int], int]
-    """number of features in each layer. If a single number is given,
+    """output feature density in each layer. If a single number is given,
     all layers except the last one will have the same number of features."""
     activation: Callable[[Array], Array] = jax.nn.selu
     """the nonlinear activation function between hidden layers (default: selu)."""
@@ -107,7 +107,7 @@ class FastARNNConv1D(AbstractARNN):
     layers: int
     """number of layers."""
     features: Union[Iterable[int], int]
-    """number of features in each layer. If a single number is given,
+    """output feature density in each layer. If a single number is given,
     all layers except the last one will have the same number of features."""
     kernel_size: int
     """length of the convolutional kernel."""
@@ -171,7 +171,7 @@ class FastARNNConv2D(AbstractARNN):
     layers: int
     """number of layers."""
     features: Union[Iterable[int], int]
-    """number of features in each layer. If a single number is given,
+    """output feature density in each layer. If a single number is given,
     all layers except the last one will have the same number of features."""
     kernel_size: Tuple[int, int]
     """shape of the convolutional kernel `(h, w)`. Typically, `h = w // 2 + 1`."""

--- a/netket/nn/fast_masked_linear.py
+++ b/netket/nn/fast_masked_linear.py
@@ -47,7 +47,7 @@ class FastMaskedDense1D(nn.Module):
     size: int
     """number of sites."""
     features: int
-    """number of output features, should be the last dimension."""
+    """output feature density, should be the last dimension."""
     exclusive: bool
     """True if an output element does not depend on the input element at the same index."""
     use_bias: bool = True

--- a/netket/nn/masked_linear.py
+++ b/netket/nn/masked_linear.py
@@ -44,7 +44,7 @@ class MaskedDense1D(nn.Module):
     """1D linear transformation module with mask for autoregressive NN."""
 
     features: int
-    """number of output features, should be the last dimension."""
+    """output feature density, should be the last dimension."""
     exclusive: bool
     """True if an output element does not depend on the input element at the same index."""
     use_bias: bool = True


### PR DESCRIPTION
In autoregressively masked linear and conv layers, `features` is used as a dimension different from the input size, and it's also called 'channels'. However, in most models it's called 'feature density'.