### PR TITLE
allow option to disable jitting of ode solvers in TDVP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ## NetKet 3.6 (In development)
 
 ### New features
+* Added a new configuration option `nk.config.netket_experimental_disable_ode_jit` to disable jitting of the ODE solvers. This can be useful to avoid hangs that might happen when working on GPUs with some particular systems [#13XX](https://github.com/netket/netket/pull/13XX).
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 ## NetKet 3.6 (In development)
 
 ### New features
-* Added a new configuration option `nk.config.netket_experimental_disable_ode_jit` to disable jitting of the ODE solvers. This can be useful to avoid hangs that might happen when working on GPUs with some particular systems [#13XX](https://github.com/netket/netket/pull/13XX).
+* Added a new configuration option `nk.config.netket_experimental_disable_ode_jit` to disable jitting of the ODE solvers. This can be useful to avoid hangs that might happen when working on GPUs with some particular systems [#1304](https://github.com/netket/netket/pull/1304).
 
 ### Bug Fixes
 

--- a/Examples/Dynamics/ising1d.py
+++ b/Examples/Dynamics/ising1d.py
@@ -14,6 +14,7 @@
 
 import netket as nk
 import numpy as np
+from functools import partial
 
 import netket.experimental as nkx
 
@@ -30,16 +31,20 @@ ha = nk.operator.Ising(hilbert=hi, graph=g, h=1.0)
 
 # RBM Spin Machine
 ma = nk.models.RBM(alpha=1, use_visible_bias=True, param_dtype=complex)
+ma = nk.models.RBMModPhase(alpha=2)
+
+# ma = nk.models.ARNNDense(hilbert=hi, layers=3, features=2, param_dtype=complex, activation=nk.nn.activation.reim_selu)
 
 # Metropolis Local Sampling
 sa = nk.sampler.MetropolisHamiltonian(hi, ha, n_chains=16)
+# sa = nk.sampler.ARDirectSampler(hi)
 
 # Variational state
 vs = nk.vqs.MCState(sa, ma, n_samples=1024, n_discard_per_chain=16)
 
 # Optimizer
 op = nk.optimizer.Sgd(0.01)
-sr = nk.optimizer.SR(diag_shift=1e-4)
+sr = nk.optimizer.SR(diag_shift=1e-4, holomorphic=False)
 
 # Variational monte carlo driver
 gs = nk.VMC(ha, op, variational_state=vs, n_samples=1000, n_discard_per_chain=50)
@@ -49,10 +54,14 @@ Sx = sum([nk.operator.spin.sigmax(hi, i) for i in range(L)])
 
 # Run the optimization for 300 iterations to determine the ground state, used as
 # initial state of the time-evolution
-gs.run(n_iter=300, out="example_ising1d_GS", obs={"Sx": Sx})
+gs.run(n_iter=100, out="example_ising1d_GS", obs={"Sx": Sx})
+
+del gs
+p0 = vs.parameters
 
 # Create integrator for time propagation
 integrator = nkx.dynamics.RK23(dt=0.01, adaptive=True, rtol=1e-3, atol=1e-3)
+integrator = nkx.dynamics.Midpoint(dt=0.001)
 print(integrator)
 
 # Quenched hamiltonian: this has a different transverse field than `ha`
@@ -62,8 +71,9 @@ te = nkx.TDVP(
     variational_state=vs,
     integrator=integrator,
     t0=0.0,
-    qgt=nk.optimizer.qgt.QGTJacobianDense(holomorphic=True, diag_shift=1e-4),
+    qgt=nk.optimizer.qgt.QGTJacobianDense(holomorphic=False, diag_shift=0.0),
     error_norm="qgt",
+    linear_solver=partial(nk.optimizer.solver.svd, rcond=1e-7),
 )
 
 log = nk.logging.JsonLog("example_ising1d_TE")
@@ -74,5 +84,5 @@ te.run(
     out=log,
     show_progress=True,
     obs={"Sx": Sx},
-    tstops=np.linspace(0.0, 1.0, 101, endpoint=True),
+    tstops=np.linspace(0.0, 1.0, 1001, endpoint=True),
 )

--- a/docs/api/api-experimental.md
+++ b/docs/api/api-experimental.md
@@ -82,6 +82,18 @@ This module contains experimental loggers that can be used with the optimization
 
 ## Time Evolution Driver
 
+````{admonition} Apple ARM (M1) processors 
+:class: warning
+
+Those drivers are automatically jitted with `jax.jit`. To disable jitting set 
+```python
+netket.config.netket_disable_ode_jit = True
+```
+or set the equivalent environment variable.
+
+````
+
+
 ```{eval-rst}
 .. currentmodule:: netket.experimental
 ```
@@ -97,8 +109,18 @@ This module contains experimental loggers that can be used with the optimization
 
 ## ODE Integrators
 
-This is a collection of ODE integrators that can be used with the TDVP
-driver above.
+This is a collection of ODE integrators that can be used with the TDVP driver above.
+
+````{admonition} Apple ARM (M1) processors 
+:class: warning
+
+Those drivers are automatically jitted with `jax.jit`. To disable jitting set 
+```python
+netket.config.netket_disable_ode_jit = True
+```
+or set the equivalent environment variable.
+
+````
 
 ```{eval-rst}
 .. currentmodule:: netket.experimental

--- a/docs/docs/configurations.md
+++ b/docs/docs/configurations.md
@@ -89,6 +89,12 @@ Please keep in mind that all options related to experimental or internal functio
     (see [here](https://emcee.readthedocs.io/en/stable/tutorials/autocorr/#autocorr) for a good
     discussion).
 
+* - `NETKET_EXPERIMENTAL_DISABLE_ODE_JIT`
+  - True/**[False]**
+  - yes
+  - Disables the jitting of the whole ode solver, mainly used within TDVP solvers.
+    The jitting is sometimes incompatible with GPU-based calculations, and on large calculations it gives negligible speedups so it might be beneficial to disable it.
+
 * - `NETKET_SPHINX_BUILD`
   - True/**[False]**
   - no

--- a/netket/experimental/driver/tdvp.py
+++ b/netket/experimental/driver/tdvp.py
@@ -596,4 +596,3 @@ def odefun_host_callback(state, driver, *args, **kwargs):
         (args, kwargs),
         result_shape=result_shape,
     )
-    return odefun(state, driver, *args, **kwargs)

--- a/netket/experimental/driver/tdvp.py
+++ b/netket/experimental/driver/tdvp.py
@@ -208,18 +208,18 @@ class TDVP(AbstractVariationalDriver):
         elif error_norm == "maximum":
             self._error_norm = maximum_norm
         elif error_norm == "qgt":
-            error_norm = (HashablePartial(qgt_norm, self),)
-            if not config.netket_experimental_disable_ode_jit:
-                # QGT norm is called via host callback since it accesses the driver
-                # TODO: make this also an hashablepartial on self to reduce recompilation
+            if config.netket_experimental_disable_ode_jit:
+                self._error_norm = HashablePartial(qgt_norm, self)
+            else:
                 w = self.state.parameters
                 norm_dtype = nk.jax.dtype_real(nk.jax.tree_dot(w, w))
-                error_norm = lambda x: hcb.call(
-                    error_norm,
+                # QGT norm is called via host callback since it accesses the driver
+                # TODO: make this also an hashablepartial on self to reduce recompilation
+                self._error_norm = lambda x: hcb.call(
+                    HashablePartial(qgt_norm, self),
                     x,
                     result_shape=jax.ShapeDtypeStruct((), norm_dtype),
                 )
-            self._error_norm = error_norm
         else:
             raise ValueError(
                 "error_norm must be a callable or one of 'euclidean', 'qgt', 'maximum',"

--- a/netket/experimental/dynamics/_rk_solver_structures.py
+++ b/netket/experimental/dynamics/_rk_solver_structures.py
@@ -20,11 +20,24 @@ import jax
 import jax.numpy as jnp
 
 import netket as nk
+from netket import config
 from netket.utils.mpi.primitives import mpi_all_jax
 from netket.utils.struct import dataclass, field
 from netket.utils.types import Array, PyTree
 
 from . import _rk_tableau as rkt
+
+
+def maybe_jax_jit(fun, *args, **kwargs):
+    """
+    Only jit if `config.netket_experimental_disable_ode_jit` is False.
+
+    This is used to disable jitting when this config is set.
+    """
+    if config.netket_experimental_disable_ode_jit:
+        return fun
+    else:
+        return jax.jit(*args, **kwargs)
 
 
 class SolverFlags(IntFlag):
@@ -156,7 +169,7 @@ def propose_time_step(
     )
 
 
-@partial(jax.jit, static_argnames=["f", "norm_fn", "dt_limits"])
+@partial(maybe_jax_jit, static_argnames=["f", "norm_fn", "dt_limits"])
 def general_time_step_adaptive(
     tableau: rkt.TableauRKExplicit,
     f: Callable,
@@ -247,7 +260,7 @@ def general_time_step_adaptive(
     )
 
 
-@partial(jax.jit, static_argnames=["f"])
+@partial(maybe_jax_jit, static_argnames=["f"])
 def general_time_step_fixed(
     tableau: rkt.TableauRKExplicit,
     f: Callable,

--- a/netket/experimental/dynamics/_rk_solver_structures.py
+++ b/netket/experimental/dynamics/_rk_solver_structures.py
@@ -37,7 +37,7 @@ def maybe_jax_jit(fun, *args, **kwargs):
     if config.netket_experimental_disable_ode_jit:
         return fun
     else:
-        return jax.jit(*args, **kwargs)
+        return jax.jit(fun, *args, **kwargs)
 
 
 class SolverFlags(IntFlag):

--- a/netket/utils/config_flags.py
+++ b/netket/utils/config_flags.py
@@ -203,6 +203,20 @@ config.define(
 )
 
 config.define(
+    "NETKET_EXPERIMENTAL_DISABLE_ODE_JIT",
+    bool,
+    default=False,
+    help=dedent(
+        """
+        Disables the jitting of the whole ode solver, mainly used within TDVP solvers.
+        The jitting is sometimes incompatible with GPU-based calculations, and on large
+        calculations it gives negligible speedups so it might be beneficial to disable it.
+        """
+    ),
+    runtime=True,
+)
+
+config.define(
     "NETKET_SPHINX_BUILD",
     bool,
     default=False,

--- a/test/common.py
+++ b/test/common.py
@@ -1,9 +1,13 @@
 # File containing common commands for NetKet Test infrastructure
 
-import pytest
-import netket as nk
+from typing import Any
 
+from functools import partial
 import os
+
+import pytest
+
+import netket as nk
 
 
 def _is_true(x):
@@ -94,26 +98,32 @@ class netket_disable_mpi:
         nk.utils.mpi.primitives.n_nodes = self._orig_nodes
 
 
-class netket_experimental_fft_autocorrelation:
+class set_config:
     """
-    Temporarily enables the experimental fft autocorrelation logic
+    Temporarily changes the value of the configuration `name`.
 
     Example:
 
-    >>> with netket_experimental_fft_autocorrelation(True):
+    >>> with set_config("netket_experimental_disable_ode_jit", True):
     >>>     run_code
 
     """
 
-    def __init__(self, val):
-        self._value = val
+    def __init__(self, name: str, value: Any):
+        self._name = name.upper()
+        self._value = value
 
     def __enter__(self):
-        self._orig_value = nk.config.netket_experimental_fft_autocorrelation
-        nk.config.update("NETKET_EXPERIMENTAL_FFT_AUTOCORRELATION", self._value)
+        self._orig_value = nk.config.FLAGS[self._name]
+        nk.config.update(self._name, self._value)
 
     def __exit__(self, exc_type, exc_value, traceback):
-        nk.config.update("NETKET_EXPERIMENTAL_FFT_AUTOCORRELATION", self._orig_value)
+        nk.config.update(self._name, self._orig_value)
+
+
+netket_experimental_fft_autocorrelation = partial(
+    set_config, "NETKET_EXPERIMENTAL_FFT_AUTOCORRELATION"
+)
 
 
 def hash_for_seed(obj):

--- a/test/dynamics/test_driver.py
+++ b/test/dynamics/test_driver.py
@@ -107,10 +107,10 @@ def l4_norm(x):
     ) ** (1.0 / 4.0)
 
 
-@pytest.mark.parametrize("disable_jit", [False, True])
 @pytest.mark.parametrize("error_norm", ["euclidean", "qgt", "maximum", l4_norm])
 @pytest.mark.parametrize("integrator", adaptive_step_integrators)
 @pytest.mark.parametrize("propagation_type", ["real", "imag"])
+@pytest.mark.parametrize("disable_jit", [False, True])
 def test_one_adaptive_step(integrator, error_norm, propagation_type, disable_jit):
     with common.set_config("NETKET_EXPERIMENTAL_DISABLE_ODE_JIT", disable_jit):
         ha, vstate, _ = _setup_system(L=2)

--- a/test/dynamics/test_driver.py
+++ b/test/dynamics/test_driver.py
@@ -22,6 +22,8 @@ import numpy as np
 import netket as nk
 import netket.experimental as nkx
 
+from .. import common
+
 
 SEED = 214748364
 
@@ -105,21 +107,23 @@ def l4_norm(x):
     ) ** (1.0 / 4.0)
 
 
+@pytest.mark.parametrize("disable_jit", [False, True])
 @pytest.mark.parametrize("error_norm", ["euclidean", "qgt", "maximum", l4_norm])
 @pytest.mark.parametrize("integrator", adaptive_step_integrators)
 @pytest.mark.parametrize("propagation_type", ["real", "imag"])
-def test_one_adaptive_step(integrator, error_norm, propagation_type):
-    ha, vstate, _ = _setup_system(L=2)
-    te = nkx.TDVP(
-        ha,
-        vstate,
-        integrator,
-        qgt=nk.optimizer.qgt.QGTJacobianDense(holomorphic=True),
-        propagation_type=propagation_type,
-        error_norm=error_norm,
-    )
-    te.run(T=0.01, callback=_stop_after_one_step)
-    assert te.t > 0.0
+def test_one_adaptive_step(integrator, error_norm, propagation_type, disable_jit):
+    with common.set_config("NETKET_EXPERIMENTAL_DISABLE_ODE_JIT", disable_jit):
+        ha, vstate, _ = _setup_system(L=2)
+        te = nkx.TDVP(
+            ha,
+            vstate,
+            integrator,
+            qgt=nk.optimizer.qgt.QGTJacobianDense(holomorphic=True),
+            propagation_type=propagation_type,
+            error_norm=error_norm,
+        )
+        te.run(T=0.01, callback=_stop_after_one_step)
+        assert te.t > 0.0
 
 
 @pytest.mark.parametrize("integrator", all_integrators)


### PR DESCRIPTION
In most things I'm doing nowadays, I cannot jit the TDVP solvers.
Moreover, not sitting them leads to huge speedups in compile time.

This PR introduces a new configuration flag that allows us to turn it off.  My plan would be to disable the hitting by default in the next release if this works well.
