### PR TITLE
Improve messages of QGTJacobian user-errors 

### DIFF
--- a/netket/optimizer/qgt/common.py
+++ b/netket/optimizer/qgt/common.py
@@ -47,25 +47,23 @@ def check_valid_vector_type(x: PyTree, target: PyTree):
                     vector separately and then recomposing the two.
 
                     This is happening because you have real parameters or a non-holomorphic
-                    complex wavefunction. In this case, the Quantum Geometric Tensor is
-                    actually only the real part of it.
+                    complex wave function. In this case, the Quantum Geometric Tensor object
+                    only stores the real part of the QGT.
 
                     If you were executing a matmul `G@vec`, try using:
 
                        >>> vec_real = jax.tree_map(lambda x: x.real, vec)
                        >>> G@vec_real
 
-                    or
+                    If you used the QGT in a linear solver, try using:
 
                        >>> vec_real = jax.tree_map(lambda x: x.real, vec)
                        >>> G.solve(linear_solver, vec_real)
 
                     to fix this error.
 
-                    NOTE!!!
-                    You probably should pay attention whever you need the real or imaginary part
+                    Be careful whether you need the real or imaginary part
                     of the vector in your equations!
-
                     """
                 )
             )

--- a/netket/optimizer/qgt/common.py
+++ b/netket/optimizer/qgt/common.py
@@ -18,6 +18,7 @@ import jax
 from jax import numpy as jnp
 
 from netket.utils.types import PyTree
+from netket.utils.errors import ComplexDomainError
 
 
 def check_valid_vector_type(x: PyTree, target: PyTree):
@@ -37,15 +38,50 @@ def check_valid_vector_type(x: PyTree, target: PyTree):
             vec_iscomplex = jnp.iscomplexobj(target)
 
         if not par_iscomplex and vec_iscomplex:
-            raise TypeError(
+            raise ComplexDomainError(
                 dedent(
                     """
                     Cannot multiply the (real part of the) QGT by a complex vector.
                     You should either take the real part of the vector, or perform
                     the multiplication against the real and imaginary part of the
                     vector separately and then recomposing the two.
+
+                    This is happening because you have real parameters or a non-holomorphic
+                    complex wavefunction. In this case, the Quantum Geometric Tensor is
+                    actually only the real part of it.
+
+                    If you were executing a matmul `G@vec`, try using:
+
+                       >>> vec_real = jax.tree_map(lambda x: x.real, vec)
+                       >>> G@vec_real
+
+                    or
+
+                       >>> vec_real = jax.tree_map(lambda x: x.real, vec)
+                       >>> G.solve(linear_solver, vec_real)
+
+                    to fix this error.
+
+                    NOTE!!!
+                    You probably should pay attention whever you need the real or imaginary part
+                    of the vector in your equations!
+
                     """
                 )
             )
 
-    jax.tree_map(check, x, target)
+    try:
+        jax.tree_map(check, x, target)
+    except ValueError:
+        # catches jax tree map errors
+        pars_struct = jax.tree_map(lambda x: jax.ShapeDtypeStruct(x.shape, x.dtype), x)
+        vec_struct = jax.tree_map(
+            lambda x: jax.ShapeDtypeStruct(x.shape, x.dtype), target
+        )
+
+        raise ValueError(
+            "PyTree mismatch: Parameters have shape \n\n"
+            f"{pars_struct}\n\n"
+            "but the vector has shape \n\n"
+            f"{vec_struct}\n\n"
+        )

--- a/netket/utils/__init__.py
+++ b/netket/utils/__init__.py
@@ -19,6 +19,7 @@ from . import struct
 from . import numbers
 from . import types
 from . import float
+from . import errors
 
 from .array import HashableArray
 from .partial import HashablePartial
@@ -46,5 +47,7 @@ from . import mpi
 from . import _dependencies_check
 
 _hide_submodules(
-    __name__, remove_self=False, ignore=["numbers", "types", "float", "dispatch"]
+    __name__,
+    remove_self=False,
+    ignore=["numbers", "types", "float", "dispatch", "errors"],
 )

--- a/netket/utils/errors.py
+++ b/netket/utils/errors.py
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .qgt_jacobian_dense import QGTJacobianDense
-from .qgt_jacobian_pytree import QGTJacobianPyTree
-from .qgt_onthefly import QGTOnTheFly
 
-from .default import QGTAuto
+class ComplexDomainError(Exception):
+    """
+    Error to be used when a complex value is used where a real value
+    was expected.
+    """
 
-from netket.utils import _hide_submodules
-
-_hide_submodules(__name__)
+    pass

--- a/test/optimizer/test_qgt_solvers.py
+++ b/test/optimizer/test_qgt_solvers.py
@@ -27,7 +27,7 @@ from .. import common  # noqa: F401
 
 QGT_types = {}
 QGT_types["QGTOnTheFly"] = nk.optimizer.qgt.QGTOnTheFly
-# QGT_types["QGTJacobianDense"] = nk.optimizer.qgt.QGTJacobianDense
+QGT_types["QGTJacobianDense"] = nk.optimizer.qgt.QGTJacobianDense
 QGT_types["QGTJacobianPyTree"] = nk.optimizer.qgt.QGTJacobianPyTree
 
 QGT_objects = {}

--- a/test/optimizer/test_qgt_solvers.py
+++ b/test/optimizer/test_qgt_solvers.py
@@ -97,5 +97,5 @@ def test_qgt_throws(SType):
     S = vs.quantum_geometric_tensor(SType)
     g_cmplx = jax.tree_map(lambda x: x + x * 0.1j, vs.parameters)
 
-    with pytest.raises(TypeError, match="Cannot multiply the"):
+    with pytest.raises(nk.utils.errors.ComplexDomainError, match="Cannot multiply the"):
         S @ g_cmplx


### PR DESCRIPTION
This PR does:
 - Improve the readability of the message introduced a while back explaining that you can't multiply the real part of a QGT with a complex vector
 - Improves the readability of the message thrown by `QGT` when you multiply the qgt by a pytree with the wrong shape
 - Adds this input validation logic to `QGTJacobianDense` as well