### PR TITLE
move away from experimental host callback and use pure_callback on new versions of jax

### DIFF
--- a/netket/experimental/driver/tdvp.py
+++ b/netket/experimental/driver/tdvp.py
@@ -19,7 +19,6 @@ from functools import partial
 
 import jax
 import jax.numpy as jnp
-import jax.experimental.host_callback as hcb
 import numpy as np
 from tqdm import tqdm
 
@@ -33,7 +32,7 @@ from netket.logging.json_log import JsonLog
 from netket.operator import AbstractOperator
 from netket.optimizer import LinearOperator
 from netket.optimizer.qgt import QGTAuto
-from netket.utils import mpi
+from netket.utils import mpi, module_version
 from netket.utils.dispatch import dispatch
 from netket.utils.types import PyTree
 from netket.vqs import VariationalState, VariationalMixedState, MCState, ExactState
@@ -43,6 +42,12 @@ from netket.experimental.dynamics._rk_solver_structures import (
     euclidean_norm,
     maximum_norm,
 )
+
+# TODO: remove the switch when we support only jax >= 0.3.17
+if module_version("jax") >= (0, 3, 17):
+    from jax import pure_callback
+else:
+    from jax.experimental.host_callback import call as pure_callback
 
 
 class TDVP(AbstractVariationalDriver):
@@ -215,7 +220,7 @@ class TDVP(AbstractVariationalDriver):
                 norm_dtype = nk.jax.dtype_real(nk.jax.tree_dot(w, w))
                 # QGT norm is called via host callback since it accesses the driver
                 # TODO: make this also an hashablepartial on self to reduce recompilation
-                self._error_norm = lambda x: hcb.call(
+                self._error_norm = lambda x: pure_callback(
                     HashablePartial(qgt_norm, self),
                     x,
                     result_shape=jax.ShapeDtypeStruct((), norm_dtype),
@@ -592,9 +597,9 @@ def odefun_host_callback(state, driver, *args, **kwargs):
         state.parameters,
     )
 
-    return hcb.call(
+    return pure_callback(
         lambda args_and_kw: odefun(state, driver, *args_and_kw[0], **args_and_kw[1]),
-        # pack args and kwargs together, since host_callback passes a single argument:
+        # TODO: once we support only jax>0.3.17 pass directly args and kwargs
         (args, kwargs),
         result_shape=result_shape,
     )

--- a/netket/hilbert/random/fock.py
+++ b/netket/hilbert/random/fock.py
@@ -18,13 +18,7 @@ from jax import numpy as jnp
 
 from netket.hilbert import Fock
 from netket.utils.dispatch import dispatch
-from netket.utils import module_version
-
-# TODO: remove the switch when we support only jax >= 0.3.17
-if module_version("jax") >= (0, 3, 17):
-    from jax import pure_callback
-else:
-    from jax.experimental.host_callback import call as pure_callback
+from netket.utils import pure_callback
 
 
 @dispatch
@@ -39,8 +33,8 @@ def random_state(hilb: Fock, key, batches: int, *, dtype=np.float32):
     else:
         state = pure_callback(
             lambda rng: _random_states_with_constraint(hilb, rng, batches, dtype),
+            jax.ShapeDtypeStruct(shape, dtype),
             key,
-            result_shape=jax.ShapeDtypeStruct(shape, dtype),
         )
 
         return state

--- a/netket/hilbert/random/fock.py
+++ b/netket/hilbert/random/fock.py
@@ -42,7 +42,7 @@ def random_state(hilb: Fock, key, batches: int, *, dtype=np.float32):
 
 def _random_states_with_constraint(hilb, rngkey, n_batches, dtype):
     out = np.zeros((n_batches, hilb.size), dtype=dtype)
-    rgen = np.random.default_rng(rngkey)
+    rgen = np.random.default_rng(np.asarray(rngkey))
 
     for b in range(n_batches):
         sites = list(range(hilb.size))

--- a/netket/hilbert/random/fock.py
+++ b/netket/hilbert/random/fock.py
@@ -18,6 +18,13 @@ from jax import numpy as jnp
 
 from netket.hilbert import Fock
 from netket.utils.dispatch import dispatch
+from netket.utils import module_version
+
+# TODO: remove the switch when we support only jax >= 0.3.17
+if module_version("jax") >= (0, 3, 17):
+    from jax import pure_callback
+else:
+    from jax.experimental.host_callback import call as pure_callback
 
 
 @dispatch
@@ -30,9 +37,7 @@ def random_state(hilb: Fock, key, batches: int, *, dtype=np.float32):
         return jnp.asarray(rs, dtype=dtype)
 
     else:
-        from jax.experimental import host_callback as hcb
-
-        state = hcb.call(
+        state = pure_callback(
             lambda rng: _random_states_with_constraint(hilb, rng, batches, dtype),
             key,
             result_shape=jax.ShapeDtypeStruct(shape, dtype),

--- a/netket/hilbert/random/spin.py
+++ b/netket/hilbert/random/spin.py
@@ -18,6 +18,13 @@ from jax import numpy as jnp
 
 from netket.hilbert import Spin
 from netket.utils.dispatch import dispatch
+from netket.utils import module_version
+
+# TODO: remove the switch when we support only jax >= 0.3.17
+if module_version("jax") >= (0, 3, 17):
+    from jax import pure_callback
+else:
+    from jax.experimental.host_callback import call as pure_callback
 
 
 @dispatch
@@ -63,9 +70,7 @@ def random_state(hilb: Spin, key, batches: int, *, dtype=np.float32):
         # if constrained and S != 1/2, then use a slow fallback algorithm
         # TODO: find better, faster way to smaple constrained arbitrary spaces.
         else:
-            from jax.experimental import host_callback as hcb
-
-            state = hcb.call(
+            state = pure_callback(
                 lambda rng: _random_states_with_constraint(hilb, rng, batches, dtype),
                 key,
                 result_shape=jax.ShapeDtypeStruct(shape, dtype),

--- a/netket/hilbert/random/spin.py
+++ b/netket/hilbert/random/spin.py
@@ -76,7 +76,7 @@ def random_state(hilb: Spin, key, batches: int, *, dtype=np.float32):
 # TODO: could numba-jit this
 def _random_states_with_constraint(hilb, rngkey, n_batches, dtype):
     out = np.full((n_batches, hilb.size), -round(2 * hilb._s), dtype=dtype)
-    rgen = np.random.default_rng(rngkey)
+    rgen = np.random.default_rng(np.asarray(rngkey))
 
     for b in range(n_batches):
         sites = list(range(hilb.size))

--- a/netket/hilbert/random/spin.py
+++ b/netket/hilbert/random/spin.py
@@ -18,13 +18,7 @@ from jax import numpy as jnp
 
 from netket.hilbert import Spin
 from netket.utils.dispatch import dispatch
-from netket.utils import module_version
-
-# TODO: remove the switch when we support only jax >= 0.3.17
-if module_version("jax") >= (0, 3, 17):
-    from jax import pure_callback
-else:
-    from jax.experimental.host_callback import call as pure_callback
+from netket.utils import pure_callback
 
 
 @dispatch
@@ -72,8 +66,8 @@ def random_state(hilb: Spin, key, batches: int, *, dtype=np.float32):
         else:
             state = pure_callback(
                 lambda rng: _random_states_with_constraint(hilb, rng, batches, dtype),
+                jax.ShapeDtypeStruct(shape, dtype),
                 key,
-                result_shape=jax.ShapeDtypeStruct(shape, dtype),
             )
 
             return state

--- a/netket/jax/_scanmap.py
+++ b/netket/jax/_scanmap.py
@@ -2,11 +2,9 @@ import jax
 import jax.numpy as jnp
 
 from jax import linear_util as lu
-from jax.api_util import argnums_partial as _argnums_partial
+from jax.api_util import argnums_partial
 
-from functools import partial, wraps
-
-from netket.utils import module_version
+from functools import partial
 
 _tree_add = partial(jax.tree_map, jax.lax.add)
 _tree_zeros_like = partial(jax.tree_map, lambda x: jnp.zeros(x.shape, dtype=x.dtype))
@@ -18,19 +16,6 @@ def _multimap(f, *args):
         return tuple(map(lambda a: f(*a), zip(*args)))
     except TypeError:
         return f(*args)
-
-
-# TODO: When minimum jax is v0.2.22, remove this function and import directly
-# argnums_partial.
-# This works around onled argnums_partial implementations that did not have
-# require_static_args_hashable kwarg (which was implicitly False).
-if module_version(jax) >= (0, 2, 22):
-    argnums_partial = _argnums_partial
-else:
-
-    @wraps(_argnums_partial)
-    def argnums_partial(*args, require_static_args_hashable=True, **kwargs):
-        return _argnums_partial(*args, **kwargs)
 
 
 def scan_append_reduce(f, x, append_cond, op=_tree_add):

--- a/netket/sampler/exact.py
+++ b/netket/sampler/exact.py
@@ -18,12 +18,18 @@ from functools import partial
 import jax
 from flax import linen as nn
 from jax import numpy as jnp
-from jax.experimental import host_callback as hcb
 
 from netket.nn import to_array
 from netket.utils import struct
 from netket.utils.deprecation import warn_deprecation
 from netket.utils.types import PyTree, SeedT
+from netket.utils import module_version
+
+# TODO: remove the switch when we support only jax >= 0.3.17
+if module_version("jax") >= (0, 3, 17):
+    from jax import pure_callback
+else:
+    from jax.experimental.host_callback import call as pure_callback
 
 from .base import Sampler, SamplerState
 
@@ -113,7 +119,7 @@ class ExactSampler(Sampler):
         # For future investigators:
         # this will lead to a crash if numbers_to_state throws.
         # it throws if we feed it nans!
-        samples = hcb.call(
+        samples = pure_callback(
             lambda numbers: sampler.hilbert.numbers_to_states(numbers),
             numbers,
             result_shape=jax.ShapeDtypeStruct(

--- a/netket/sampler/exact.py
+++ b/netket/sampler/exact.py
@@ -23,13 +23,7 @@ from netket.nn import to_array
 from netket.utils import struct
 from netket.utils.deprecation import warn_deprecation
 from netket.utils.types import PyTree, SeedT
-from netket.utils import module_version
-
-# TODO: remove the switch when we support only jax >= 0.3.17
-if module_version("jax") >= (0, 3, 17):
-    from jax import pure_callback
-else:
-    from jax.experimental.host_callback import call as pure_callback
+from netket.utils import pure_callback
 
 from .base import Sampler, SamplerState
 
@@ -121,11 +115,11 @@ class ExactSampler(Sampler):
         # it throws if we feed it nans!
         samples = pure_callback(
             lambda numbers: sampler.hilbert.numbers_to_states(numbers),
-            numbers,
-            result_shape=jax.ShapeDtypeStruct(
+            jax.ShapeDtypeStruct(
                 (chain_length * sampler.n_chains_per_rank, sampler.hilbert.size),
                 jnp.float64,
             ),
+            numbers,
         )
         samples = jnp.asarray(samples, dtype=sampler.dtype).reshape(
             chain_length, sampler.n_chains_per_rank, sampler.hilbert.size

--- a/netket/utils/__init__.py
+++ b/netket/utils/__init__.py
@@ -32,6 +32,7 @@ from .deprecation import (
     deprecated,
     deprecated_new_name,
     deprecate_dtype,
+    pure_callback,
 )
 from .moduletools import _hide_submodules, rename_class, auto_export as _auto_export
 from .version_check import module_version

--- a/netket/utils/deprecation.py
+++ b/netket/utils/deprecation.py
@@ -19,6 +19,7 @@ import inspect
 from textwrap import dedent
 
 from .config_flags import config
+from .version_check import module_version
 
 
 def deprecated(reason=None, func_name=None):
@@ -133,3 +134,17 @@ def deprecate_dtype(clz):
         return res
 
     return helper
+
+
+# TODO: remove the switch when we support only jax >= 0.3.17
+
+
+def pure_callback(callback, result_shape_dtypes, *args):
+    if module_version("jax") >= (0, 3, 17):
+        from jax import pure_callback
+
+        return pure_callback(callback, result_shape_dtypes, *args)
+    else:
+        from jax.experimental.host_callback import call
+
+        return call(callback, *args, result_shape=result_shape_dtypes)


### PR DESCRIPTION
`jax.experimental.host_callback` has a few issues that have been solved in `jax.pure_callback`.
This should work better inside of TDVP when we jit the solvers.

Also, the experimental function will eventually be deprecated.

For now we just add a version switch everywhere. We can remove it if we ever increase the minimum jax version that we require