### PR TITLE
Make QGTJacobian*** work when `Jax_disable_jit=1`

### DIFF
--- a/netket/optimizer/qgt/qgt_jacobian_common.py
+++ b/netket/optimizer/qgt/qgt_jacobian_common.py
@@ -98,7 +98,7 @@ def choose_jacobian_mode(afun, pars, state, samples, *, mode, holomorphic):
     """
     Select an implementation of Jacobian
     """
-    i = _choose_jacobian_mode(afun, pars, state, samples, mode, holomorphic).item()
+    i = int(_choose_jacobian_mode(afun, pars, state, samples, mode, holomorphic))
     if i == 0:
         return "real"
     elif i == 1:


### PR DESCRIPTION
We don't officially support running netket with jax-jit disabled, but @alelovato recently tried doing it and It seems we just need this simple fix to make it work, so might as well add it.

Happens because without jit `_choose_jacobian_mode` returns a standard python int which does not have .item() 