### PR TITLE
Add `LogStateVector` model that stores the log- of the wavefunction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ## NetKet 3.6 (In development)
 
 ### New features
+* Added a new 'Full statevector' model {class}`nk.models.LogStateVector` that stores the exponentially large state and can be used as an exact ansatz [#1324](https://github.com/netket/netket/pull/1324).
 
 ### Bug Fixes
 

--- a/docs/api/models.md
+++ b/docs/api/models.md
@@ -15,6 +15,7 @@ neural quantum states.
    :template: flax_model
    :nosignatures:
 
+   LogStateVector
    RBM
    RBMModPhase
    RBMMultiVal

--- a/docs/api/nn.md
+++ b/docs/api/nn.md
@@ -52,6 +52,7 @@ Read more about the design goal of this module in their [README](https://github.
     :toctree: _generated/nn
 
     binary_encoding
+    states_to_numbers
 ```
 
 ## Utility functions

--- a/netket/models/__init__.py
+++ b/netket/models/__init__.py
@@ -14,6 +14,7 @@
 
 from .rbm import RBM, RBMModPhase, RBMMultiVal, RBMSymm
 from .equivariant import GCNN
+from .full_space import LogStateVector
 from .jastrow import Jastrow
 from .mps import MPSPeriodic
 from .gaussian import Gaussian

--- a/netket/models/full_space.py
+++ b/netket/models/full_space.py
@@ -15,8 +15,6 @@
 import flax.linen as nn
 import jax.numpy as jnp
 
-from jax.nn.initializers import normal
-
 from netket.hilbert import DiscreteHilbert
 from netket.nn import states_to_numbers
 from netket.utils.types import DType, Array, NNInitFunc
@@ -24,18 +22,22 @@ from netket.utils.types import DType, Array, NNInitFunc
 
 class LogStateVector(nn.Module):
     r"""
-    Jastrow wave function :math:`\Psi(s) = \exp(\sum_{ij} s_i W_{ij} s_j)`.
+    _Exact_ ansatz storing the logarithm of the full, exponentially-large
+    wavefunction coefficients.
 
-    The W matrix is stored as a non-symmetric matrix, and symmetrized
-    during computation by doing :code:`W = W + W.T` in the computation.
+    This Ansatz can only be used with hilbert spaces which are small enough to
+    be indexable.
+
+    By default it initialises as a uniform state.
     """
 
     hilbert: DiscreteHilbert
+    """The Hilbert space."""
 
     dtype: DType = jnp.complex128
     """The dtype of the weights."""
 
-    logstate_init: NNInitFunc = normal()
+    logstate_init: NNInitFunc = nn.initializers.uniform()
     """Initializer for the weights."""
 
     def setup(self):

--- a/netket/models/full_space.py
+++ b/netket/models/full_space.py
@@ -22,10 +22,11 @@ from netket.utils.types import DType, Array, NNInitFunc
 
 class LogStateVector(nn.Module):
     r"""
-    _Exact_ ansatz storing the logarithm of the full, exponentially-large
-    wavefunction coefficients.
+    _Exact_ ansatz storing the logarithm of the full, exponentially large
+    wavefunction coefficients. As with other models, coefficients do not need
+    to be normalised.
 
-    This Ansatz can only be used with hilbert spaces which are small enough to
+    This ansatz can only be used with Hilbert spaces which are small enough to
     be indexable.
 
     By default it initialises as a uniform state.

--- a/netket/models/full_space.py
+++ b/netket/models/full_space.py
@@ -1,0 +1,63 @@
+# Copyright 2021 The NetKet Authors - All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#    http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import flax.linen as nn
+import jax.numpy as jnp
+
+import jax
+from jax.nn.initializers import normal
+
+import jax.experimental.host_callback as hcb
+
+from netket.hilbert import DiscreteHilbert
+from netket.utils.types import DType, Array, NNInitFunc
+
+
+def states_to_numbers(hilbert, σ):
+    # calls back into python
+    return hcb.call(
+        hilbert.states_to_numbers,
+        σ,
+        result_shape=jax.ShapeDtypeStruct(σ.shape[:-1], jnp.int64),
+    )
+
+
+class LogStateVector(nn.Module):
+    r"""
+    Jastrow wave function :math:`\Psi(s) = \exp(\sum_{ij} s_i W_{ij} s_j)`.
+
+    The W matrix is stored as a non-symmetric matrix, and symmetrized
+    during computation by doing :code:`W = W + W.T` in the computation.
+    """
+
+    hilbert: DiscreteHilbert
+
+    dtype: DType = jnp.complex128
+    """The dtype of the weights."""
+
+    logstate_init: NNInitFunc = normal()
+    """Initializer for the weights."""
+
+    def setup(self):
+        if not self.hilbert.is_indexable:
+            raise ValueError(
+                "StateVector can only be used with indexable hilbert spaces."
+            )
+
+        self.logstate = self.param(
+            "logstate", self.logstate_init, (self.hilbert.n_states, ), self.dtype
+        )
+
+    def __call__(self, x_in: Array):
+        return self.logstate[states_to_numbers(self.hilbert, x_in)]

--- a/netket/models/full_space.py
+++ b/netket/models/full_space.py
@@ -15,22 +15,11 @@
 import flax.linen as nn
 import jax.numpy as jnp
 
-import jax
 from jax.nn.initializers import normal
 
-import jax.experimental.host_callback as hcb
-
 from netket.hilbert import DiscreteHilbert
+from netket.nn import states_to_numbers
 from netket.utils.types import DType, Array, NNInitFunc
-
-
-def states_to_numbers(hilbert, σ):
-    # calls back into python
-    return hcb.call(
-        hilbert.states_to_numbers,
-        σ,
-        result_shape=jax.ShapeDtypeStruct(σ.shape[:-1], jnp.int64),
-    )
 
 
 class LogStateVector(nn.Module):
@@ -56,7 +45,7 @@ class LogStateVector(nn.Module):
             )
 
         self.logstate = self.param(
-            "logstate", self.logstate_init, (self.hilbert.n_states, ), self.dtype
+            "logstate", self.logstate_init, (self.hilbert.n_states,), self.dtype
         )
 
     def __call__(self, x_in: Array):

--- a/netket/models/full_space.py
+++ b/netket/models/full_space.py
@@ -34,10 +34,10 @@ class LogStateVector(nn.Module):
     hilbert: DiscreteHilbert
     """The Hilbert space."""
 
-    dtype: DType = jnp.complex128
+    param_dtype: DType = jnp.complex128
     """The dtype of the weights."""
 
-    logstate_init: NNInitFunc = nn.initializers.uniform()
+    logstate_init: NNInitFunc = nn.initializers.ones
     """Initializer for the weights."""
 
     def setup(self):
@@ -47,7 +47,7 @@ class LogStateVector(nn.Module):
             )
 
         self.logstate = self.param(
-            "logstate", self.logstate_init, (self.hilbert.n_states,), self.dtype
+            "logstate", self.logstate_init, (self.hilbert.n_states,), self.param_dtype
         )
 
     def __call__(self, x_in: Array):

--- a/netket/nn/__init__.py
+++ b/netket/nn/__init__.py
@@ -57,6 +57,7 @@ from .utils import (
     split_array_mpi,
     update_dense_symm,
     binary_encoding,
+    states_to_numbers,
 )
 
 from .deprecation import (

--- a/netket/nn/utils.py
+++ b/netket/nn/utils.py
@@ -234,11 +234,14 @@ def binary_encoding(
 
 def states_to_numbers(hilbert: DiscreteHilbert, σ: Array) -> Array:
     """
-    Converts the configuration σ to a 64-bit integer labelling the Hilbert Space.
+    Converts the configuration σ to a 64-bit integer denoting its index in the full Hilbert space.
+    
+    This function calls `hilbert.states_to_numbers` as a JAX pure callback and can thus be used within
+    `jax.jit`.
 
     .. Note::
 
-        Requires jax >= 0.3.17 and will crash on older versions.
+        Requires jax >= 0.3.17 and will raise an exception on older versions.
 
 
     Args:

--- a/netket/nn/utils.py
+++ b/netket/nn/utils.py
@@ -255,11 +255,11 @@ def states_to_numbers(hilbert: DiscreteHilbert, σ: Array) -> Array:
             f"have {module_version('jax')}"
         )
 
-    if not hasattr(hilbert, "is_indexable"):
-        raise TypeError(f"Hilbert space {hilbert} cannot be indexed.")
-
     if not hilbert.is_indexable:
-        raise ValueError(f"Hilbert space {hilbert} is too large to be indexed.")
+        raise ValueError(
+            f"Hilbert space {hilbert} is too large to be indexed or "
+            f"cannot be indexed at all."
+        )
 
     # calls back into python
     return jax.pure_callback(

--- a/netket/nn/utils.py
+++ b/netket/nn/utils.py
@@ -235,7 +235,7 @@ def binary_encoding(
 def states_to_numbers(hilbert: DiscreteHilbert, σ: Array) -> Array:
     """
     Converts the configuration σ to a 64-bit integer denoting its index in the full Hilbert space.
-    
+
     This function calls `hilbert.states_to_numbers` as a JAX pure callback and can thus be used within
     `jax.jit`.
 

--- a/test/models/test_fullspace.py
+++ b/test/models/test_fullspace.py
@@ -39,13 +39,14 @@ def test_logstatevec():
 
     np.testing.assert_allclose(s1, s2)
     np.testing.assert_allclose(pars["params"]["logstate"][hi.states_to_numbers(x)], s1)
-    
+
+
 @pytest.mark.skipif(
     module_version("jax") < (0, 3, 17), reason="Needs jax.pure_callback"
 )
 def test_groundstate():
     g = nk.graph.Chain(8)
-    hi = nk.hilbert.Spin(1/2, g.n_nodes)
+    hi = nk.hilbert.Spin(1 / 2, g.n_nodes)
     ham = nk.operator.Ising(hi, g, h=0.5)
 
     w, v = nk.exact.lanczos_ed(ham, compute_eigenvectors=True)

--- a/test/models/test_fullspace.py
+++ b/test/models/test_fullspace.py
@@ -17,12 +17,16 @@ import numpy as np
 import jax
 import jax.numpy as jnp
 from jax.nn.initializers import uniform
+from netket.utils import module_version
 
 from .test_nn import _setup_symm
 
 import pytest
 
 
+@pytest.mark.skipif(
+    module_version("jax") < (0, 3, 17), reason="Needs jax.pure_callback"
+)
 def test_logstatevec():
     hi = nk.hilbert.Fock(3, 4)
     x = hi.random_state(nk.jax.PRNGKey(3), (3, 4))

--- a/test/models/test_fullspace.py
+++ b/test/models/test_fullspace.py
@@ -1,0 +1,37 @@
+# Copyright 2021 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import netket as nk
+import numpy as np
+import jax
+import jax.numpy as jnp
+from jax.nn.initializers import uniform
+
+from .test_nn import _setup_symm
+
+import pytest
+
+
+def test_logstatevec():
+    hi = nk.hilbert.Fock(3, 4)
+    x = hi.random_state(nk.jax.PRNGKey(3), (3, 4))
+
+    ma = nk.models.LogStateVector(hi, param_dtype=complex)
+    pars = ma.init(nk.jax.PRNGKey(), hi.random_state(nk.jax.PRNGKey(), 1))
+
+    s1 = jax.jit(ma.apply)(pars, x)
+    s2 = jax.jit(jax.vmap(ma.apply, in_axes=(None, 0)))(pars, x)
+
+    np.testing.assert_allclose(s1, s2)
+    np.testing.assert_allclose(pars["params"]["logstate"][hi.states_to_numbers(x)], s1)

--- a/test/nn/test_utils.py
+++ b/test/nn/test_utils.py
@@ -24,6 +24,7 @@ from jax.nn.initializers import normal
 
 import netket as nk
 from netket.nn import binary_encoding
+from netket.utils import module_version
 
 from .. import common  # noqa: F401
 
@@ -156,6 +157,9 @@ def test_binary_encoding(hilbert_shape):
         np.testing.assert_allclose(encoded_with_hilbert, desired_state)
 
 
+@pytest.mark.skipif(
+    module_version("jax") < (0, 3, 17), reason="Needs jax.pure_callback"
+)
 @pytest.mark.parametrize(
     "hilbert",
     [
@@ -178,3 +182,14 @@ def test_states_to_numbers(hilbert):
 
     i = jax.jit(jax.vmap(lambda x: nk.nn.states_to_numbers(hilbert, x)))(s)
     np.testing.assert_allclose(i, np.arange(hilbert.n_states))
+
+
+def test_states_to_numbers_fails():
+    with pytest.raises(ValueError):
+        nk.nn.states_to_numbers(nk.hilbert.Particle(3, 2, True), 1.0)
+
+
+@pytest.mark.skipif(module_version("jax") >= (0, 3, 17), reason="Testing older jax")
+def test_states_error_on_old_jax():
+    with pytest.raises(RuntimeError):
+        nk.nn.states_to_numbers(nk.hilbert.Spin(0.5, 3), 1.0)

--- a/test/nn/test_utils.py
+++ b/test/nn/test_utils.py
@@ -154,3 +154,27 @@ def test_binary_encoding(hilbert_shape):
         assert total_bits == encoded_with_hilbert.size
         desired_state = sum(_state_to_binary_list(random_state, bits_per_site), [])
         np.testing.assert_allclose(encoded_with_hilbert, desired_state)
+
+
+@pytest.mark.parametrize(
+    "hilbert",
+    [
+        pytest.param(h, id=f"{h}")
+        for h in [
+            nk.hilbert.Spin(0.5, 3),
+            nk.hilbert.Spin(0.5, 4, total_sz=0.0),
+            nk.hilbert.Spin(0.5, 3) * nk.hilbert.Fock(3),
+        ]
+    ],
+)
+def test_states_to_numbers(hilbert):
+    s = hilbert.numbers_to_states(np.arange(hilbert.n_states))
+
+    i = nk.nn.states_to_numbers(hilbert, s)
+    np.testing.assert_allclose(i, np.arange(hilbert.n_states))
+
+    i = jax.jit(lambda x: nk.nn.states_to_numbers(hilbert, x))(s)
+    np.testing.assert_allclose(i, np.arange(hilbert.n_states))
+
+    i = jax.jit(jax.vmap(lambda x: nk.nn.states_to_numbers(hilbert, x)))(s)
+    np.testing.assert_allclose(i, np.arange(hilbert.n_states))

--- a/test/nn/test_utils.py
+++ b/test/nn/test_utils.py
@@ -184,6 +184,9 @@ def test_states_to_numbers(hilbert):
     np.testing.assert_allclose(i, np.arange(hilbert.n_states))
 
 
+@pytest.mark.skipif(
+    module_version("jax") < (0, 3, 17), reason="Needs jax.pure_callback"
+)
 def test_states_to_numbers_fails():
     with pytest.raises(ValueError):
         nk.nn.states_to_numbers(nk.hilbert.Particle(3, 2, True), 1.0)


### PR DESCRIPTION
With the recent release of jax 0.3.17 we can now officially use callbacks inside of our models. 

So I can finally contribute this.

It's exponentially costly, but it is handy sometimes to check if the problem is the sampling or something else. Also, in combination with `ExactState` (which in hindsight should have been called `FullSummationState`), it allows to have a 100% exact state in our calculations.