### PR TITLE
Make ExactState.expect_and_grad return nk.stats.Stats (so we also have variance)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 ### New features
 
 ### Bug Fixes
-
+* {class}`nk.vqs.ExactState` `expect_and_grad` returned a scalar while `expect` returned a {class}`nk.stats.Stats` object with 0 error. The inconsistency has been addressed and now they both return a `Stats` object. This changes the format of the files logged when running `VMC`, which will now store the average under `Mean` instead of `value` [#1325](https://github.com/netket/netket/pull/1325).
 
 
 ## NetKet 3.5.1 (Bug Fixes)
@@ -19,6 +19,7 @@
 ### Bug Fixes
 * Continuous operatorors now work correctly when `chunk_size != None`. This was broken in v3.5 [#1316](https://github.com/netket/netket/pull/1316).
 * Fixed a bug ([#1101](https://github.com/netket/netket/pull/1101)) that crashed NetKet when trying to take the product of two different Hilber spaces. It happened because the logic to build a `TensorHilbert` was ending in an endless loop. [#1321](https://github.com/netket/netket/pull/1321).
+
 
 ## NetKet 3.5 (☀️ 18 August 2022)
 

--- a/test/variational/test_exact_state.py
+++ b/test/variational/test_exact_state.py
@@ -139,7 +139,17 @@ def test_derivatives_agree(machine):
     ha = nk.operator.Ising(hilbert=hi, graph=g, h=1)
     vs = nk.vqs.ExactState(hi, machine)
 
-    _, grads_exact = vs.expect_and_grad(ha)
+    e_expect = vs.expect(ha)
+    assert isinstance(e_expect, nk.stats.Stats)
+    np.testing.assert_almost_equal(e_expect.error_of_mean, 0)
+
+    e, grads_exact = vs.expect_and_grad(ha)
+    assert isinstance(e, nk.stats.Stats)
+    np.testing.assert_almost_equal(e.error_of_mean, 0)
+
+    # check that energies match
+    np.testing.assert_almost_equal(e_expect.mean, e.mean)
+    np.testing.assert_almost_equal(e_expect.variance, e.variance)
 
     # Prepare the exact estimations
     pars_0 = vs.parameters

--- a/test/variational/test_exact_state.py
+++ b/test/variational/test_exact_state.py
@@ -227,7 +227,7 @@ def test_TFIM_energy_strictly_decreases(
     log = nk.logging.RuntimeLog()
     gs.run(n_iter=n_iterations, out=log)
 
-    energies = log.data["Energy"]["value"]
+    energies = log.data["Energy"]["Mean"]
 
     for i in range(len(energies) - 1):
         assert energies[i + 1] < energies[i]


### PR DESCRIPTION
`ExactState.expect()` did return a `Stats` object, so this simply makes the two methods consistent.