### PR TITLE
QGT: don't differentiate through samples

### DIFF
--- a/netket/optimizer/qgt/qgt_jacobian_dense_logic.py
+++ b/netket/optimizer/qgt/qgt_jacobian_dense_logic.py
@@ -76,13 +76,13 @@ def jacobian_real_holo(forward_fn: Callable, params: PyTree, σ: Array) -> PyTre
     Returns:
         The Jacobian matrix ∂/∂pₖ ln Ψ(σⱼ) as a PyTree
     """
-    y, vjp_fun = jax.vjp(single_sample(forward_fn), params, σ)
-    res, _ = vjp_fun(np.array(1.0, dtype=jnp.result_type(y)))
+    y, vjp_fun = jax.vjp(lambda pars: single_sample(forward_fn)(pars, σ), params)
+    (res,) = vjp_fun(np.array(1.0, dtype=jnp.result_type(y)))
     return res
 
 
 def _jacobian_cplx(
-    forward_fn: Callable, params: PyTree, samples: Array, _build_fn: Callable
+    forward_fn: Callable, params: PyTree, σ: Array, _build_fn: Callable
 ) -> PyTree:
     """Calculates one Jacobian entry.
     Assumes the function is R→C, backpropagates 1 and -1j
@@ -95,9 +95,9 @@ def _jacobian_cplx(
     Returns:
         The Jacobian matrix ∂/∂pₖ ln Ψ(σⱼ) as a PyTree
     """
-    y, vjp_fun = jax.vjp(single_sample(forward_fn), params, samples)
-    gr, _ = vjp_fun(np.array(1.0, dtype=jnp.result_type(y)))
-    gi, _ = vjp_fun(np.array(-1.0j, dtype=jnp.result_type(y)))
+    y, vjp_fun = jax.vjp(lambda pars: single_sample(forward_fn)(pars, σ), params)
+    (gr,) = vjp_fun(np.array(1.0, dtype=jnp.result_type(y)))
+    (gi,) = vjp_fun(np.array(-1.0j, dtype=jnp.result_type(y)))
     return _build_fn(gr, gi)
 
 

--- a/test/optimizer/test_qgt_solvers.py
+++ b/test/optimizer/test_qgt_solvers.py
@@ -99,3 +99,21 @@ def test_qgt_throws(SType):
 
     with pytest.raises(nk.utils.errors.ComplexDomainError, match="Cannot multiply the"):
         S @ g_cmplx
+
+
+@common.skipif_mpi
+@pytest.mark.parametrize(
+    "SType", [pytest.param(T, id=name) for name, T in QGT_types.items()]
+)
+def test_qgt_nondiff_sigma(SType):
+    # Test that we dont attempt to differentiate through the samples
+    # by testing a model that would fail in that case because its
+    # nondifferentiable.
+
+    hi = nk.hilbert.Spin(s=1 / 2, N=5)
+    ma = nk.models.LogStateVector(hi)
+    sa = nk.sampler.MetropolisLocal(hi, n_chains=2, reset_chains=False)
+    vs = nk.vqs.MCState(sa, ma, n_samples=2, n_discard_per_chain=0)
+
+    S = vs.quantum_geometric_tensor(SType)
+    S @ vs.parameters

--- a/test/optimizer/test_qgt_solvers.py
+++ b/test/optimizer/test_qgt_solvers.py
@@ -102,6 +102,9 @@ def test_qgt_throws(SType):
 
 
 @common.skipif_mpi
+@pytest.mark.skipif(
+    module_version("jax") < (0, 3, 17), reason="Needs jax.pure_callback"
+)
 @pytest.mark.parametrize(
     "SType", [pytest.param(T, id=name) for name, T in QGT_types.items()]
 )

--- a/test/optimizer/test_qgt_solvers.py
+++ b/test/optimizer/test_qgt_solvers.py
@@ -21,6 +21,7 @@ import jax.flatten_util
 from jax.nn.initializers import normal
 
 import netket as nk
+from netket.utils import module_version
 from netket.optimizer import qgt
 
 from .. import common  # noqa: F401


### PR DESCRIPTION
Some models (LogStateVec) are non-differentiable in their samples. QGT does not need to differentiate through them, but the code was differentiating through the samples and then discarding the derivative. This PR avoids computing it in the first place.