### PR TITLE
Improve PauliOperator constructor

### DIFF
--- a/test/operator/test_operator.py
+++ b/test/operator/test_operator.py
@@ -365,6 +365,26 @@ def test_pauli(hilbert):
     assert op.to_sparse().shape == op_l.to_sparse().shape
 
 
+def test_pauli_simple_constructor():
+    operator = "XX"
+    weight = 0.3
+
+    op1 = nk.operator.PauliStrings(operator, weight)
+    op2 = nk.operator.PauliStrings([operator], [weight])
+
+    assert np.allclose(op1.to_dense(), op2.to_dense())
+
+
+def test_pauli_simple_constructor_2():
+    operators = ["XX", "YZ", "IZ"]
+    weight = 0.3
+
+    op1 = nk.operator.PauliStrings(operators, weight)
+    op2 = nk.operator.PauliStrings(operators, [weight for _ in operators])
+
+    assert np.allclose(op1.to_dense(), op2.to_dense())
+
+
 def test_pauli_trivials():
     operators = ["XX", "YZ", "IZ"]
     weights = [0.1, 0.2, -1.4]


### PR DESCRIPTION
Allows to construct a PauliOperator by passing a string alone like

```python
PauliOperator("XXYZ")
```

instead of requiring users to wrap it in a list `PauliOperator(["XXYZ"])`

Also, now supports passing a single coefficient that is applied to all strings identically

```python
PauliOperator(["XXYZ", "XYZX", "YYYZ"], 0.3) == PauliOperator(["XXYZ", "XYZX", "YYYZ"], [0.3, 0.3, 0.3])
```
-- 

By the way, I think we should have simple constructors for Pualistrings like `spin.sigmax/y/z` but explicitly for Paulis, with the same syntax. But I don't know where to keep them and how to call them.