### PR TITLE
Annotate `mutable` to be `CollectionFilter` in vstates

### DIFF
--- a/netket/vqs/base.py
+++ b/netket/vqs/base.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import abc
-from typing import Any, Optional, Tuple
+from typing import Optional, Tuple
 
 import numpy as np
 
@@ -23,6 +23,7 @@ from jax.nn.initializers import normal
 
 import flax
 from flax.core.frozen_dict import FrozenDict
+from flax.core.scope import CollectionFilter
 
 import netket.jax as nkjax
 from netket.operator import AbstractOperator, Squared
@@ -168,7 +169,7 @@ class VariationalState(abc.ABC):
         Ô,
         *,
         use_covariance: Optional[bool] = None,
-        mutable: Optional[Any] = None,
+        mutable: Optional[CollectionFilter] = None,
     ) -> PyTree:
         r"""Estimates the gradient of the quantum expectation value of a given operator O.
 
@@ -187,7 +188,7 @@ class VariationalState(abc.ABC):
         self,
         Ô: AbstractOperator,
         *,
-        mutable: Optional[Any] = None,
+        mutable: Optional[CollectionFilter] = None,
         use_covariance: Optional[bool] = None,
     ) -> Tuple[Stats, PyTree]:
         r"""Estimates the quantum expectation value and its gradient for a given operator O.
@@ -217,7 +218,7 @@ class VariationalState(abc.ABC):
         self,
         Ô: AbstractOperator,
         *,
-        mutable: Optional[Any] = None,
+        mutable: Optional[CollectionFilter] = None,
     ) -> Tuple[Stats, PyTree]:
         r"""Estimates the quantum expectation value and corresponding force vector for a given operator O.
 
@@ -362,7 +363,7 @@ def expect_and_grad(
     operator: AbstractOperator,
     use_covariance: Optional[bool],
     *args,
-    mutable=None,
+    mutable: CollectionFilter,
     **kwargs,
 ):
     r"""Estimates the quantum expectation value and its gradient for a given operator O.
@@ -391,9 +392,6 @@ def expect_and_grad(
         else:
             use_covariance = TrueT() if operator.is_hermitian else FalseT()
 
-    if mutable is None:
-        mutable = vstate.mutable
-
     return expect_and_grad(
         vstate, operator, use_covariance, *args, mutable=mutable, **kwargs
     )
@@ -404,7 +402,7 @@ def expect_and_forces(
     vstate: VariationalState,
     operator: AbstractOperator,
     *args,
-    mutable=None,
+    mutable: CollectionFilter,
     **kwargs,
 ):
     r"""Estimates the quantum expectation value and corresponding force vector for a given operator O.

--- a/netket/vqs/exact/expect.py
+++ b/netket/vqs/exact/expect.py
@@ -13,10 +13,12 @@
 # limitations under the License.
 
 from functools import partial, lru_cache
-from typing import Callable, Any, Tuple
+from typing import Callable, Tuple
 
 import jax
 from jax import numpy as jnp
+from flax.core.scope import CollectionFilter
+
 from netket import jax as nkjax
 from netket.operator import Squared
 from netket.stats import Stats
@@ -68,7 +70,7 @@ def expect_and_forces(
     vstate: ExactState,
     Ô: DiscreteOperator,
     *,
-    mutable: Any,
+    mutable: CollectionFilter,
 ) -> Tuple[Stats, PyTree]:
     if isinstance(Ô, Squared):
         raise NotImplementedError("expect_and_forces not yet implemented for `Squared`")
@@ -98,7 +100,7 @@ def expect_and_forces(
 @partial(jax.jit, static_argnums=(0, 1))
 def _exp_forces(
     model_apply_fun: Callable,
-    mutable: bool,
+    mutable: CollectionFilter,
     parameters: PyTree,
     model_state: PyTree,
     σ: jnp.ndarray,
@@ -136,7 +138,7 @@ def expect_and_grad(
     Ô: DiscreteOperator,
     use_covariance: TrueT,
     *,
-    mutable: Any,
+    mutable: CollectionFilter,
 ) -> Tuple[Stats, PyTree]:
     Ō, Ō_grad = expect_and_forces(vstate, Ô, mutable=mutable)
     Ō_grad = _force_to_grad(Ō_grad, vstate.parameters)

--- a/netket/vqs/exact/state.py
+++ b/netket/vqs/exact/state.py
@@ -20,6 +20,7 @@ from jax import numpy as jnp
 
 import flax
 from flax import serialization
+from flax.core.scope import CollectionFilter
 
 from netket import jax as nkjax
 from netket import nn
@@ -70,7 +71,7 @@ class ExactState(VariationalState):
         init_fun: NNInitFunc = None,
         apply_fun: Callable = None,
         seed: Optional[SeedT] = None,
-        mutable: bool = False,
+        mutable: CollectionFilter = False,
         training_kwargs: Dict = {},
         dtype=float,
     ):
@@ -82,7 +83,7 @@ class ExactState(VariationalState):
             model: (Optional) The model. If not provided, you must provide init_fun and apply_fun.
             parameters: Optional PyTree of weights from which to start.
             seed: rng seed used to generate a set of parameters (only if parameters is not passed). Defaults to a random one.
-            mutable: Dict specifying mutable arguments. Use it to specify if the model has a state that can change
+            mutable: Name or list of names of mutable arguments. Use it to specify if the model has a state that can change
                 during evaluation, but that should not be optimised. See also flax.linen.module.apply documentation
                 (default=False)
             init_fun: Function of the signature f(model, shape, rng_key, dtype) -> Optional_state, parameters used to

--- a/netket/vqs/mc/mc_mixed_state/state.py
+++ b/netket/vqs/mc/mc_mixed_state/state.py
@@ -79,7 +79,7 @@ class MCMixedState(VariationalMixedState, MCState):
             parameters: Optional PyTree of weights from which to start.
             seed: rng seed used to generate a set of parameters (only if parameters is not passed). Defaults to a random one.
             sampler_seed: rng seed used to initialise the sampler. Defaults to a random one.
-            mutable: Dict specifying mutable arguments. Use it to specify if the model has a state that can change
+            mutable: Name or list of names of mutable arguments. Use it to specify if the model has a state that can change
                 during evaluation, but that should not be optimised. See also flax.linen.module.apply documentation
                 (default=False)
             init_fun: Function of the signature f(model, shape, rng_key, dtype) -> Optional_state, parameters used to

--- a/netket/vqs/mc/mc_state/expect_forces.py
+++ b/netket/vqs/mc/mc_state/expect_forces.py
@@ -13,10 +13,11 @@
 # limitations under the License.
 
 from functools import partial
-from typing import Any, Callable, Tuple
+from typing import Callable, Tuple
 
 import jax
 from jax import numpy as jnp
+from flax.core.scope import CollectionFilter
 
 from netket import jax as nkjax
 from netket.stats import Stats, statistics
@@ -41,7 +42,7 @@ def expect_and_forces(  # noqa: F811
     vstate: MCState,
     Ô: AbstractOperator,
     *,
-    mutable: Any,
+    mutable: CollectionFilter,
 ) -> Tuple[Stats, PyTree]:
     σ, args = get_local_kernel_arguments(vstate, Ô)
 
@@ -67,7 +68,7 @@ def expect_and_forces(  # noqa: F811
 def forces_expect_hermitian(
     local_value_kernel: Callable,
     model_apply_fun: Callable,
-    mutable: bool,
+    mutable: CollectionFilter,
     parameters: PyTree,
     model_state: PyTree,
     σ: jnp.ndarray,

--- a/netket/vqs/mc/mc_state/expect_forces_chunked.py
+++ b/netket/vqs/mc/mc_state/expect_forces_chunked.py
@@ -19,6 +19,7 @@ import warnings
 import jax
 from jax import numpy as jnp
 from jax import tree_map
+from flax.core.scope import CollectionFilter
 
 from netket import jax as nkjax
 from netket.operator import AbstractOperator
@@ -71,7 +72,7 @@ def expect_and_forces_impl(  # noqa: F811
     Ô: AbstractOperator,
     chunk_size: int,
     *,
-    mutable: Any,
+    mutable: CollectionFilter,
 ) -> Tuple[Stats, PyTree]:
     σ, args = get_local_kernel_arguments(vstate, Ô)
 
@@ -99,7 +100,7 @@ def forces_expect_hermitian_chunked(
     chunk_size: int,
     local_value_kernel_chunked: Callable,
     model_apply_fun: Callable,
-    mutable: bool,
+    mutable: CollectionFilter,
     parameters: PyTree,
     model_state: PyTree,
     σ: jnp.ndarray,

--- a/netket/vqs/mc/mc_state/expect_grad.py
+++ b/netket/vqs/mc/mc_state/expect_grad.py
@@ -13,10 +13,11 @@
 # limitations under the License.
 
 from functools import partial
-from typing import Any, Callable, Tuple
+from typing import Callable, Tuple
 
 import jax
 from jax import numpy as jnp
+from flax.core.scope import CollectionFilter
 
 from netket import jax as nkjax
 from netket import config
@@ -50,7 +51,7 @@ def expect_and_grad_covariance(
     Ô: AbstractOperator,
     use_covariance: TrueT,
     *,
-    mutable: Any,
+    mutable: CollectionFilter,
 ) -> Tuple[Stats, PyTree]:
     Ō, Ō_grad = expect_and_forces(vstate, Ô, mutable=mutable)
     Ō_grad = _force_to_grad(Ō_grad, vstate.parameters)
@@ -87,7 +88,7 @@ def expect_and_grad_nonherm(
     Ô,
     use_covariance,
     *,
-    mutable: Any,
+    mutable: CollectionFilter,
 ) -> Tuple[Stats, PyTree]:
 
     if not isinstance(Ô, Squared) and not config.netket_experimental:
@@ -128,7 +129,7 @@ def grad_expect_operator_kernel(
     local_value_kernel: Callable,
     model_apply_fun: Callable,
     machine_pow: int,
-    mutable: bool,
+    mutable: CollectionFilter,
     parameters: PyTree,
     model_state: PyTree,
     σ: jnp.ndarray,

--- a/netket/vqs/mc/mc_state/expect_grad_chunked.py
+++ b/netket/vqs/mc/mc_state/expect_grad_chunked.py
@@ -17,6 +17,7 @@ import warnings
 
 import jax
 from jax import numpy as jnp
+from flax.core.scope import CollectionFilter
 
 from netket.operator import AbstractOperator
 from netket.stats import Stats
@@ -68,7 +69,7 @@ def expect_and_grad_covariance_chunked(  # noqa: F811
     use_covariance: TrueT,
     chunk_size: int,
     *,
-    mutable: Any,
+    mutable: CollectionFilter,
 ) -> Tuple[Stats, PyTree]:
 
     Ō, Ō_grad = expect_and_forces(vstate, Ô, chunk_size, mutable=mutable)

--- a/netket/vqs/mc/mc_state/state.py
+++ b/netket/vqs/mc/mc_state/state.py
@@ -23,6 +23,7 @@ from jax import numpy as jnp
 
 import flax
 from flax import serialization
+from flax.core.scope import CollectionFilter
 
 from netket import jax as nkjax
 from netket import nn
@@ -147,7 +148,7 @@ class MCState(VariationalState):
         sample_fun: Callable = None,
         seed: Optional[SeedT] = None,
         sampler_seed: Optional[SeedT] = None,
-        mutable: bool = False,
+        mutable: CollectionFilter = False,
         training_kwargs: Dict = {},
     ):
         """
@@ -164,7 +165,7 @@ class MCState(VariationalState):
             parameters: Optional PyTree of weights from which to start.
             seed: rng seed used to generate a set of parameters (only if parameters is not passed). Defaults to a random one.
             sampler_seed: rng seed used to initialise the sampler. Defaults to a random one.
-            mutable: Dict specifying mutable arguments. Use it to specify if the model has a state that can change
+            mutable: Name or list of names of mutable arguments. Use it to specify if the model has a state that can change
                 during evaluation, but that should not be optimised. See also flax.linen.module.apply documentation
                 (default=False)
             init_fun: Function of the signature f(model, shape, rng_key, dtype) -> Optional_state, parameters used to
@@ -606,7 +607,7 @@ class MCState(VariationalState):
         self,
         Ô: AbstractOperator,
         *,
-        mutable: Optional[Any] = None,
+        mutable: Optional[CollectionFilter] = None,
         use_covariance: Optional[bool] = None,
     ) -> Tuple[Stats, PyTree]:
         r"""Estimates the quantum expectation value and its gradient for a given operator O.
@@ -639,7 +640,7 @@ class MCState(VariationalState):
         self,
         Ô: AbstractOperator,
         *,
-        mutable: Optional[Any] = None,
+        mutable: Optional[CollectionFilter] = None,
     ) -> Tuple[Stats, PyTree]:
         r"""Estimates the quantum expectation value and the corresponding force vector for a given operator O.
 


### PR DESCRIPTION
The previous annotations always made me puzzled when reading the source code for vstates. Actually its type should be `CollectionFilter = Union[bool, str, Collection[str]]`, as defined in [`flax.core.scope`](https://github.com/google/flax/blob/45c29559f9c105a6d7e97d218d8557f8c1600716/flax/core/scope.py#L72) and used in [`flax.linen.Module.apply`](https://github.com/google/flax/blob/45c29559f9c105a6d7e97d218d8557f8c1600716/flax/linen/module.py#L1182). Its default value should be `False` when initializing the vstate.

Methods like `vstate.expect_and_grad` can have a parameter `mutable: Optional[CollectionFilter] = None` to override the initial `vstate.mutable`, just like how `chain_length` in `vstate.sample` overrides the initial `vstate.chain_length`. Here `None` means not to override, and `False` means to disable mutation even if the vstate is mutable initially. Outside those methods, `mutable` should never be `None`.