### PR TITLE
Support logging flax.core.FrozenDict in History

### DIFF
--- a/netket/utils/history.py
+++ b/netket/utils/history.py
@@ -18,6 +18,8 @@ from numbers import Number
 
 import numpy as np
 
+from flax.core import FrozenDict
+
 from .dispatch import dispatch
 from .numbers import is_scalar
 from .types import Array, DType
@@ -366,7 +368,7 @@ def accum_in_tree(fun, tree_accum, tree, compound=True, **kwargs):
             accum_in_tree(fun, _accum, _tree, **kwargs)
             for _accum, _tree in zip(tree_accum, tree)
         )
-    elif isinstance(tree, dict):
+    elif isinstance(tree, (dict, FrozenDict)):
         if tree_accum is None:
             tree_accum = {}
 

--- a/test/utils/test_history.py
+++ b/test/utils/test_history.py
@@ -56,7 +56,7 @@ def create_mock_data_iter(iter):
         "npint": np.array(iter),
         "jaxcomplex": jnp.array(iter + 1j * iter),
         "dict": {"int": iter},
-        "frozendict": flax.core.freeze({"sub":{"int": iter}}),
+        "frozendict": flax.core.freeze({"sub": {"int": iter}}),
         "compound": MockCompoundType(iter, iter * 10),
         "mockdict": MockDictType(iter, iter * 10),
         "mock": MockClass(iter),
@@ -83,7 +83,9 @@ def test_accum_mvhistory():
     repr(tree)
 
     # check frozen
-    np.testing.assert_allclose(np.array(tree["frozendict"]["sub"]["int"]), np.arange(10))
+    np.testing.assert_allclose(
+        np.array(tree["frozendict"]["sub"]["int"]), np.arange(10)
+    )
 
 
 def test_append():

--- a/test/utils/test_history.py
+++ b/test/utils/test_history.py
@@ -19,6 +19,8 @@ import jax
 import jax.numpy as jnp
 from dataclasses import dataclass
 
+import flax
+
 from .. import common
 
 pytestmark = common.skipif_mpi
@@ -54,6 +56,7 @@ def create_mock_data_iter(iter):
         "npint": np.array(iter),
         "jaxcomplex": jnp.array(iter + 1j * iter),
         "dict": {"int": iter},
+        "frozendict": flax.core.freeze({"sub":{"int": iter}}),
         "compound": MockCompoundType(iter, iter * 10),
         "mockdict": MockDictType(iter, iter * 10),
         "mock": MockClass(iter),
@@ -78,6 +81,9 @@ def test_accum_mvhistory():
 
     # test that repr does not fail
     repr(tree)
+
+    # check frozen
+    np.testing.assert_allclose(np.array(tree["frozendict"]["sub"]["int"]), np.arange(10))
 
 
 def test_append():


### PR DESCRIPTION
This arises if you attempt to log the parameters without unfreezing them. It is because frozendict does not report to be a dictionary.