### PR TITLE
Add `chunk_size` parameter to QGT constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### New features
 * Added a new 'Full statevector' model {class}`nk.models.LogStateVector` that stores the exponentially large state and can be used as an exact ansatz [#1324](https://github.com/netket/netket/pull/1324).
 * Added a new `nkx.driver.TDVPSchmitt` driver, implementing the signal-to-noise ratio TDVP regularisation by Schmitt and Heyl [#1306](https://github.com/netket/netket/pull/1306).
+* QGT classes accept a `chunk_size` parameter that overrides the `chunk_size` set by the variational state object [#1347](https://github.com/netket/netket/pull/1347).
 
 ### Bug Fixes
 * {class}`nk.vqs.ExactState` `expect_and_grad` returned a scalar while `expect` returned a {class}`nk.stats.Stats` object with 0 error. The inconsistency has been addressed and now they both return a `Stats` object. This changes the format of the files logged when running `VMC`, which will now store the average under `Mean` instead of `value` [#1325](https://github.com/netket/netket/pull/1325).

--- a/netket/optimizer/qgt/qgt_jacobian_dense.py
+++ b/netket/optimizer/qgt/qgt_jacobian_dense.py
@@ -36,6 +36,7 @@ def QGTJacobianDense(
     mode: str = None,
     holomorphic: bool = None,
     rescale_shift=False,
+    chunk_size=None,
     **kwargs,
 ) -> "QGTJacobianDenseT":
     """
@@ -86,10 +87,8 @@ def QGTJacobianDense(
     elif holomorphic is not None:
         raise ValueError("Cannot specify both `mode` and `holomorphic`.")
 
-    if hasattr(vstate, "chunk_size"):
+    if chunk_size is None and hasattr(vstate, "chunk_size"):
         chunk_size = vstate.chunk_size
-    else:
-        chunk_size = None
 
     O, scale = prepare_centered_oks(
         vstate._apply_fun,

--- a/netket/optimizer/qgt/qgt_jacobian_dense.py
+++ b/netket/optimizer/qgt/qgt_jacobian_dense.py
@@ -57,7 +57,10 @@ def QGTJacobianDense(
               models. holomorphic works for any function assuming it's holomorphic
               or real valued.
         holomorphic: a flag to indicate that the function is holomorphic.
-        rescale_shift: If True rescales the diagonal shift
+        rescale_shift: If True rescales the diagonal shift.
+        chunk_size: If supplied, overrides the chunk size of the variational state
+                    (useful for models where the backward pass requires more
+                    memory than the forward pass).
     """
 
     if vstate is None:

--- a/netket/optimizer/qgt/qgt_jacobian_pytree.py
+++ b/netket/optimizer/qgt/qgt_jacobian_pytree.py
@@ -38,6 +38,7 @@ def QGTJacobianPyTree(
     mode: str = None,
     holomorphic: bool = None,
     rescale_shift=False,
+    chunk_size=None,
     **kwargs,
 ) -> "QGTJacobianPyTreeT":
     """
@@ -92,10 +93,8 @@ def QGTJacobianPyTree(
     elif holomorphic is not None:
         raise ValueError("Cannot specify both `mode` and `holomorphic`.")
 
-    if hasattr(vstate, "chunk_size"):
+    if chunk_size is None and hasattr(vstate, "chunk_size"):
         chunk_size = vstate.chunk_size
-    else:
-        chunk_size = None
 
     O, scale = prepare_centered_oks(
         vstate._apply_fun,

--- a/netket/optimizer/qgt/qgt_jacobian_pytree.py
+++ b/netket/optimizer/qgt/qgt_jacobian_pytree.py
@@ -60,6 +60,9 @@ def QGTJacobianPyTree(
               or real valued.
         holomorphic: a flag to indicate that the function is holomorphic.
         rescale_shift: If True rescales the diagonal shift.
+        chunk_size: If supplied, overrides the chunk size of the variational state
+                    (useful for models where the backward pass requires more
+                    memory than the forward pass).
     """
     if vstate is None:
         return partial(

--- a/netket/optimizer/qgt/qgt_onthefly.py
+++ b/netket/optimizer/qgt/qgt_onthefly.py
@@ -42,6 +42,9 @@ def QGTOnTheFly(vstate=None, *, chunk_size=None, **kwargs) -> "QGTOnTheFlyT":
 
     Args:
         vstate: The variational State.
+        chunk_size: If supplied, overrides the chunk size of the variational state
+                    (useful for models where the backward pass requires more
+                    memory than the forward pass).
     """
     if vstate is None:
         return partial(QGTOnTheFly, **kwargs)

--- a/netket/optimizer/qgt/qgt_onthefly.py
+++ b/netket/optimizer/qgt/qgt_onthefly.py
@@ -29,7 +29,7 @@ from .qgt_onthefly_logic import mat_vec_factory, mat_vec_chunked_factory
 from ..linear_operator import LinearOperator, Uninitialized
 
 
-def QGTOnTheFly(vstate=None, **kwargs) -> "QGTOnTheFlyT":
+def QGTOnTheFly(vstate=None, *, chunk_size=None, **kwargs) -> "QGTOnTheFlyT":
     """
     Lazy representation of an S Matrix computed by performing 2 jvp
     and 1 vjp products, using the variational state's model, the
@@ -63,7 +63,8 @@ def QGTOnTheFly(vstate=None, **kwargs) -> "QGTOnTheFlyT":
     else:
         samples = vstate.samples.reshape((-1, vstate.samples.shape[-1]))
 
-    chunk_size = vstate.chunk_size
+    if chunk_size is None and hasattr(vstate, "chunk_size"):
+        chunk_size = vstate.chunk_size
     n_samples = samples.shape[0]
 
     if chunk_size is None or chunk_size >= n_samples:


### PR DESCRIPTION
This PR adds a `chunk_size` parameter to all three QGT constructors. These allow the QGTs to use a different chunk size than the underlying vstate, which is useful for some architectures, where backpropagation costs more memory than the forward pass. No existing behaviour changes, if `chunk_size` is not supplied, the default is still `vstate.chunk_size`