### PR TITLE
[NFC] Unify QGTJacoboian implementations

### DIFF
--- a/netket/optimizer/qgt/qgt_jacobian_dense_logic.py
+++ b/netket/optimizer/qgt/qgt_jacobian_dense_logic.py
@@ -85,6 +85,9 @@ dense_jacobian_real_holo = nkjax.compose(ravel, jacobian_real_holo)
 dense_jacobian_cplx = nkjax.compose(stack_jacobian_tuple, jacobian_cplx)
 
 
+# TODO: This function is identical to the one in JacobianPyTree, with
+# the only difference in the `jacobian_fun` that can be selected.
+# The two should be unified.
 @partial(jax.jit, static_argnames=("apply_fun", "mode", "rescale_shift", "chunk_size"))
 def prepare_centered_oks(
     apply_fun: Callable,

--- a/netket/optimizer/qgt/qgt_jacobian_dense_logic.py
+++ b/netket/optimizer/qgt/qgt_jacobian_dense_logic.py
@@ -13,13 +13,11 @@
 # limitations under the License.
 
 from typing import Callable, Optional, Tuple
-from functools import partial, wraps
+from functools import partial
 import math
 
 import jax
 from jax import numpy as jnp
-
-import numpy as np
 
 from netket.stats import subtract_mean
 from netket.utils.types import PyTree, Array
@@ -27,7 +25,9 @@ from netket.utils import mpi
 import netket.jax as nkjax
 
 from .qgt_jacobian_pytree_logic import (
-    single_sample,
+    jacobian_real_holo,
+    jacobian_cplx,
+    _rescale_leaf as _rescale,
 )
 
 from netket.jax.utils import RealImagTuple
@@ -59,53 +59,12 @@ def vec_to_real(vec: Array) -> Tuple[Array, Callable]:
         return vec, lambda x: x
 
 
-# TODO those 3 functions are the same as those in qgt_jac_pytree_logic.py
-# but without the vmap.
-# we should cleanup and de-duplicate the code.
-
-
-def jacobian_real_holo(forward_fn: Callable, params: PyTree, σ: Array) -> PyTree:
-    """Calculates one Jacobian entry.
-    Assumes the function is R→R or holomorphic C→C, so single vjp is enough.
-
-    Args:
-        forward_fn: the log wavefunction ln Ψ
-        params : a pytree of parameters p
-        σ : a single sample (vector)
-
-    Returns:
-        The Jacobian matrix ∂/∂pₖ ln Ψ(σⱼ) as a PyTree
+def ravel(x: PyTree) -> Array:
     """
-    y, vjp_fun = jax.vjp(lambda pars: single_sample(forward_fn)(pars, σ), params)
-    (res,) = vjp_fun(np.array(1.0, dtype=jnp.result_type(y)))
-    return res
-
-
-def _jacobian_cplx(
-    forward_fn: Callable, params: PyTree, σ: Array, _build_fn: Callable
-) -> PyTree:
-    """Calculates one Jacobian entry.
-    Assumes the function is R→C, backpropagates 1 and -1j
-
-    Args:
-        forward_fn: the log wavefunction ln Ψ
-        params : a pytree of parameters p
-        σ : a single sample (vector)
-
-    Returns:
-        The Jacobian matrix ∂/∂pₖ ln Ψ(σⱼ) as a PyTree
+    shorthand for tree_ravel
     """
-    y, vjp_fun = jax.vjp(lambda pars: single_sample(forward_fn)(pars, σ), params)
-    (gr,) = vjp_fun(np.array(1.0, dtype=jnp.result_type(y)))
-    (gi,) = vjp_fun(np.array(-1.0j, dtype=jnp.result_type(y)))
-    return _build_fn(gr, gi)
-
-
-@partial(wraps(_jacobian_cplx))
-def jacobian_cplx(
-    forward_fn, params, samples, _build_fn=partial(jax.tree_map, jax.lax.complex)
-):
-    return _jacobian_cplx(forward_fn, params, samples, _build_fn)
+    dense, _ = nkjax.tree_ravel(x)
+    return dense
 
 
 def stack_jacobian_tuple(ok_re_im):
@@ -119,43 +78,11 @@ def stack_jacobian_tuple(ok_re_im):
         ok_re_im : a tuple (ΔOᵣ, ΔOᵢ) of two PyTrees representing the real and imag part of ΔOⱼₖ
     """
     re, im = ok_re_im
-
-    re_dense = ravel(re)
-    im_dense = ravel(im)
-    res = jnp.stack([re_dense, im_dense], axis=0)
-
-    return res
-
-
-def ravel(x: PyTree) -> Array:
-    """
-    shorthand for tree_ravel
-    """
-    dense, _ = nkjax.tree_ravel(x)
-    return dense
+    return jnp.stack([ravel(re), ravel(im)], axis=0)
 
 
 dense_jacobian_real_holo = nkjax.compose(ravel, jacobian_real_holo)
-dense_jacobian_cplx = nkjax.compose(
-    stack_jacobian_tuple, partial(jacobian_cplx, _build_fn=lambda *x: x)
-)
-
-
-def _rescale(centered_oks):
-    """
-    compute ΔOₖ/√Sₖₖ and √Sₖₖ
-    to do scale-invariant regularization (Becca & Sorella 2017, pp. 143)
-    Sₖₗ/(√Sₖₖ√Sₗₗ) = ΔOₖᴴΔOₗ/(√Sₖₖ√Sₗₗ) = (ΔOₖ/√Sₖₖ)ᴴ(ΔOₗ/√Sₗₗ)
-    """
-    scale = (
-        mpi.mpi_sum_jax(
-            jnp.sum((centered_oks * centered_oks.conj()).real, axis=0, keepdims=True)
-        )[0]
-        ** 0.5
-    )
-    centered_oks = jnp.divide(centered_oks, scale)
-    scale = jnp.squeeze(scale, axis=0)
-    return centered_oks, scale
+dense_jacobian_cplx = nkjax.compose(stack_jacobian_tuple, jacobian_cplx)
 
 
 @partial(jax.jit, static_argnames=("apply_fun", "mode", "rescale_shift", "chunk_size"))
@@ -232,26 +159,22 @@ def prepare_centered_oks(
     else:
         f = forward_fn
 
-    def gradf_fun(params, σ):
-        gradf_dense = jacobian_fun(f, params, σ)
-        return gradf_dense
-
     # jacobians has shape:
     # - (n_samples, 2, n_pars) if mode complex, holding the real and imaginary jacobian
     # - (n_samples, n_pars) if mode real/holomorphic
-    jacobians = nkjax.vmap_chunked(gradf_fun, in_axes=(None, 0), chunk_size=chunk_size)(
-        params, samples
+    jacobians = nkjax.vmap_chunked(jacobian_fun, in_axes=(None, None, 0), chunk_size=chunk_size)(
+        f, params, samples
     )
 
     n_samp = samples.shape[0] * mpi.n_nodes
-    centered_oks = subtract_mean(jacobians, axis=0) / math.sqrt(
+    centered_jacs = subtract_mean(jacobians, axis=0) / math.sqrt(
         n_samp
     )  # maintain weak type!
 
     # here the jacobian is reshaped and the real/complex part are concatenated.
-    centered_oks = centered_oks.reshape(-1, centered_oks.shape[-1])
+    centered_jacs = centered_jacs.reshape(-1, centered_jacs.shape[-1])
 
     if rescale_shift:
-        return _rescale(centered_oks)
+        return _rescale(centered_jacs)
     else:
-        return centered_oks, None
+        return centered_jacs, None

--- a/netket/optimizer/qgt/qgt_jacobian_dense_logic.py
+++ b/netket/optimizer/qgt/qgt_jacobian_dense_logic.py
@@ -24,10 +24,10 @@ from netket.utils.types import Array, PyTree, Scalar
 from netket.utils import mpi
 import netket.jax as nkjax
 
+from .qgt_jacobian_common import rescale
 from .qgt_jacobian_pytree_logic import (
     jacobian_real_holo,
     jacobian_cplx,
-    _rescale,
 )
 
 from netket.jax.utils import RealImagTuple
@@ -175,7 +175,7 @@ def prepare_centered_oks(
 
     if rescale_shift:
         ndims = 1 if mode != "complex" else 2
-        return _rescale(centered_jacs, ndims=ndims)
+        return rescale(centered_jacs, ndims=ndims)
     else:
         return centered_jacs, None
 

--- a/netket/optimizer/qgt/qgt_jacobian_pytree_logic.py
+++ b/netket/optimizer/qgt/qgt_jacobian_pytree_logic.py
@@ -101,16 +101,6 @@ def _multiply_by_pdf(oks, pdf):
     )
 
 
-def stack_jacobian(centered_oks: PyTree) -> PyTree:
-    """
-    Return the real and imaginary parts of ΔOⱼₖ stacked along the sample axis
-    Re[S] = Re[(ΔOᵣ + i ΔOᵢ)ᴴ(ΔOᵣ + i ΔOᵢ)] = ΔOᵣᵀ ΔOᵣ + ΔOᵢᵀ ΔOᵢ = [ΔOᵣ ΔOᵢ]ᵀ [ΔOᵣ ΔOᵢ]
-    """
-    return jax.tree_map(
-        lambda x: jnp.concatenate([x.real, x.imag], axis=0), centered_oks
-    )
-
-
 def stack_jacobian_tuple(centered_oks_re_im):
     """
     stack the real and imaginary parts of ΔOⱼₖ along the sample axis

--- a/netket/optimizer/qgt/qgt_jacobian_pytree_logic.py
+++ b/netket/optimizer/qgt/qgt_jacobian_pytree_logic.py
@@ -226,11 +226,7 @@ def prepare_centered_oks(
 
         # avoid converting to complex and then back
         # by passing around the oks as a tuple of two pytrees representing the real and imag parts
-        jacobian_fun = compose(
-            stack_jacobian_tuple,
-            jacobian_cplx,
-        )
-
+        jacobian_fun = compose(stack_jacobian_tuple, jacobian_cplx)
     elif mode == "holomorphic":
         split_complex_params = False
         jacobian_fun = jacobian_real_holo
@@ -244,10 +240,7 @@ def prepare_centered_oks(
     if split_complex_params:
         # doesn't do anything if the params are already real
         params, reassemble = tree_to_real(params)
-
-        def f(W, σ):
-            return forward_fn(reassemble(W), σ)
-
+        f = lambda W, σ: forward_fn(reassemble(W), σ)
     else:
         f = forward_fn
 

--- a/test/optimizer/test_qgt_itersolve.py
+++ b/test/optimizer/test_qgt_itersolve.py
@@ -322,7 +322,10 @@ def test_qgt_pytree_diag_shift(qgt, vstate):
     diag_shift = S.diag_shift
     if isinstance(S, (QGTJacobianPyTreeT, QGTJacobianDenseT)):
         # extract the necessary shape for the diag_shift
-        t = jax.eval_shape(partial(jax.tree_map, lambda x: x[0], S.O))
+        if S.mode == "complex":
+            t = jax.eval_shape(partial(jax.tree_map, lambda x: x[0, 0], S.O))
+        else:
+            t = jax.eval_shape(partial(jax.tree_map, lambda x: x[0], S.O))
     else:
         t = v
     diag_shift_tree = jax.tree_map(


### PR DESCRIPTION
This changes nothing for the user.

Internally, it changes the way we store the jacobian of non holomorphic wavefuntions in QGTJacobianPyTree to store it as a `(N_samples, 2, ...)` instead of `(2*Nsamples, ...)`. Performance wise this changes nothing, but it makes the implementation cleaner and allows to finally unify those two implementations


This also fixes a bug where `holomorphic=False` for `ExactState` returned the imaginary part of the QGT...