### PR TITLE
Add invariant and constant diagonal shift at the same time in `QGTJacobian*`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,13 @@
 * Added a new 'Full statevector' model {class}`nk.models.LogStateVector` that stores the exponentially large state and can be used as an exact ansatz [#1324](https://github.com/netket/netket/pull/1324).
 * Added a new `nkx.driver.TDVPSchmitt` driver, implementing the signal-to-noise ratio TDVP regularisation by Schmitt and Heyl [#1306](https://github.com/netket/netket/pull/1306).
 * QGT classes accept a `chunk_size` parameter that overrides the `chunk_size` set by the variational state object [#1347](https://github.com/netket/netket/pull/1347).
+* `nk.optimizer.qgt.QGTJacobianPyTree` and `QGTJacobianDense` support diagonal entry regularisation with constant and scale-invariant contributions. They accept a new `diag_scale` argument to pass the scale-invariant component [#1352](https://github.com/netket/netket/pull/1352).
 
 ### Bug Fixes
 * {class}`nk.vqs.ExactState` `expect_and_grad` returned a scalar while `expect` returned a {class}`nk.stats.Stats` object with 0 error. The inconsistency has been addressed and now they both return a `Stats` object. This changes the format of the files logged when running `VMC`, which will now store the average under `Mean` instead of `value` [#1325](https://github.com/netket/netket/pull/1325).
+
+### Deprecations
+* The `rescale_shift` argument of `nk.optimizer.qgt.QGTJacobianPyTree` and `QGTJacobianDense` is deprecated inf avour the more flexible syntax with `diag_scale`. `rescale_shift=False` should be removed. `rescale_shift=True` should be replaced with `diag_scale=old_diag_shift`. [#1352](https://github.com/netket/netket/pull/1352).
 
 
 ## NetKet 3.5.1 (Bug Fixes)

--- a/netket/optimizer/qgt/qgt_jacobian_common.py
+++ b/netket/optimizer/qgt/qgt_jacobian_common.py
@@ -115,8 +115,13 @@ def choose_jacobian_mode(afun, pars, state, samples, *, mode, holomorphic):
 def sanitize_diag_shift(diag_shift, diag_scale, rescale_shift):
     """Sanitises different inputs for diag_shift etc.
 
-    Output: diag_shift, diag_scale.
-    Raises deprecation warnings for `rescale_shift`."""
+
+    Also raises a deprecation warnings for `rescale_shift`.
+
+    Returns:
+        the tuple `(diag_shift, diag_scale)`.
+    """
+
     if diag_shift is None:
         diag_shift = 0.01 if diag_scale is None else 0.0
 

--- a/netket/optimizer/qgt/qgt_jacobian_common.py
+++ b/netket/optimizer/qgt/qgt_jacobian_common.py
@@ -173,7 +173,7 @@ def rescale(centered_oks, offset, *, ndims: int = 1):
 
     scale = jax.tree_map(
         lambda x: (
-            mpi.mpi_sum_jax(jnp.sum((x * x.conj()).real, axis=0, keepdims=True))[0]
+            mpi.mpi_sum_jax(jnp.sum((x * x.conj()).real, axis=axis, keepdims=True))[0]
             + offset
         )
         ** 0.5,

--- a/netket/optimizer/qgt/qgt_jacobian_common.py
+++ b/netket/optimizer/qgt/qgt_jacobian_common.py
@@ -120,7 +120,7 @@ def sanitize_diag_shift(diag_shift, diag_scale, rescale_shift):
     if diag_shift is None:
         diag_shift = 0.01 if diag_scale is None else 0.0
 
-    if rescale_shift == False:
+    if rescale_shift is False:
         warn_deprecation(
             "`rescale_shift` is deprecated, please do not specify `rescale_shift=False`."
         )
@@ -130,7 +130,7 @@ def sanitize_diag_shift(diag_shift, diag_scale, rescale_shift):
             )
 
         return diag_shift, 0.0
-    elif rescale_shift == True:
+    elif rescale_shift is True:
         warn_deprecation(
             f"`rescale_shift` is deprecated, use `diag_scale={diag_shift}, diag_shift=0` instead."
         )

--- a/netket/optimizer/qgt/qgt_jacobian_common.py
+++ b/netket/optimizer/qgt/qgt_jacobian_common.py
@@ -21,6 +21,7 @@ import jax.numpy as jnp
 
 import netket.jax as nkjax
 from netket.utils import mpi
+from netket.utils import warn_deprecation
 
 
 @partial(jax.jit, static_argnums=(0, 4, 5))
@@ -111,7 +112,50 @@ def choose_jacobian_mode(afun, pars, state, samples, *, mode, holomorphic):
         raise ValueError(f"unknown mode {i}")
 
 
-def rescale(centered_oks, *, ndims: int = 1):
+def sanitize_diag_shift(diag_shift, diag_scale, rescale_shift):
+    """Sanitises different inputs for diag_shift etc.
+
+    Output: diag_shift, diag_scale.
+    Raises deprecation warnings for `rescale_shift`."""
+    if diag_shift is None:
+        diag_shift = 0.01 if diag_scale is None else 0.0
+
+    if rescale_shift == False:
+        warn_deprecation(
+            "`rescale_shift` is deprecated, please do not specify `rescale_shift=False`."
+        )
+        if diag_scale is not None:
+            raise ValueError(
+                "`rescale_shift` and `diag_scale` must not be specified together."
+            )
+
+        return diag_shift, 0.0
+    elif rescale_shift == True:
+        warn_deprecation(
+            f"`rescale_shift` is deprecated, use `diag_scale={diag_shift}, diag_shift=0` instead."
+        )
+        if diag_scale is not None:
+            raise ValueError(
+                "`rescale_shift` and `diag_scale` must not be specified together."
+            )
+
+        return 0.0, diag_shift
+    elif rescale_shift is None:
+        if diag_scale is None:
+            diag_scale = 0.0
+        return diag_shift, diag_scale
+    else:
+        raise ValueError("`rescale_shift` must be boolean or None.")
+
+
+def to_shift_offset(diag_shift, diag_scale):
+    if diag_scale == 0.0:
+        return diag_shift, None
+    else:
+        return diag_scale, diag_shift / diag_scale
+
+
+def rescale(centered_oks, offset, *, ndims: int = 1):
     """
     compute ΔOₖ/√Sₖₖ and √Sₖₖ
     to do scale-invariant regularization (Becca & Sorella 2017, pp. 143)
@@ -128,9 +172,10 @@ def rescale(centered_oks, *, ndims: int = 1):
     axis = tuple(range(ndims))
 
     scale = jax.tree_map(
-        lambda x: mpi.mpi_sum_jax(
-            jnp.sum((x * x.conj()).real, axis=axis, keepdims=True)
-        )[0]
+        lambda x: (
+            mpi.mpi_sum_jax(jnp.sum((x * x.conj()).real, axis=0, keepdims=True))[0]
+            + offset
+        )
         ** 0.5,
         centered_oks,
     )

--- a/netket/optimizer/qgt/qgt_jacobian_dense.py
+++ b/netket/optimizer/qgt/qgt_jacobian_dense.py
@@ -81,11 +81,12 @@ def QGTJacobianDense(
     :math:`\\epsilon_{1,2}` are specified using `diag_scale` and `diag_shift`,
     respectively. By default, `diag_scale=0.0`, `diag_shift=0.01`.
     """
+    if mode is not None and holomorphic is not None:
+        raise ValueError("Cannot specify both `mode` and `holomorphic`.")
+    if rescale_shift is not None and diag_scale is not None:
+        raise ValueError("Cannot specify both `rescale_shift` and `diag_scale`.")
+
     if vstate is None:
-        if mode is not None and holomorphic is not None:
-            raise ValueError("Cannot specify both `mode` and `holomorphic`.")
-        if rescale_shift is not None and diag_scale is not None:
-            raise ValueError("Cannot specify both `rescale_shift` and `diag_scale`.")
         if diag_shift is not None:
             kwargs["diag_shift"] = diag_shift
         if diag_scale is not None:

--- a/netket/optimizer/qgt/qgt_jacobian_dense.py
+++ b/netket/optimizer/qgt/qgt_jacobian_dense.py
@@ -87,17 +87,14 @@ def QGTJacobianDense(
         raise ValueError("Cannot specify both `rescale_shift` and `diag_scale`.")
 
     if vstate is None:
-        if diag_shift is not None:
-            kwargs["diag_shift"] = diag_shift
-        if diag_scale is not None:
-            kwargs["diag_scale"] = diag_scale
-        if rescale_shift is not None:
-            kwargs["rescale_shift"] = rescale_shift
         return partial(
             QGTJacobianDense,
             mode=mode,
             holomorphic=holomorphic,
             chunk_size=chunk_size,
+            diag_shift=diag_shift,
+            diag_scale=diag_scale,
+            rescale_shift=rescale_shift,
             **kwargs,
         )
 

--- a/netket/optimizer/qgt/qgt_jacobian_dense.py
+++ b/netket/optimizer/qgt/qgt_jacobian_dense.py
@@ -69,6 +69,9 @@ def QGTJacobianDense(
                     (useful for models where the backward pass requires more
                     memory than the forward pass).
     """
+    if mode is not None and holomorphic is not None:
+        raise ValueError("Cannot specify both `mode` and `holomorphic`.")
+
     diag_shift, diag_scale = sanitize_diag_shift(diag_shift, diag_scale, rescale_shift)
 
     if vstate is None:
@@ -76,8 +79,9 @@ def QGTJacobianDense(
             QGTJacobianDense,
             mode=mode,
             holomorphic=holomorphic,
-            rescale_shift=rescale_shift,
             chunk_size=chunk_size,
+            diag_shift=diag_shift,
+            diag_scale=diag_scale,
             **kwargs,
         )
 
@@ -96,13 +100,11 @@ def QGTJacobianDense(
             mode=mode,
             holomorphic=holomorphic,
         )
-    elif holomorphic is not None:
-        raise ValueError("Cannot specify both `mode` and `holomorphic`.")
-
-    shift, offset = to_shift_offset(diag_shift, diag_scale)
 
     if chunk_size is None and hasattr(vstate, "chunk_size"):
         chunk_size = vstate.chunk_size
+
+    shift, offset = to_shift_offset(diag_shift, diag_scale)
 
     O, scale = prepare_centered_oks(
         vstate._apply_fun,

--- a/netket/optimizer/qgt/qgt_jacobian_dense.py
+++ b/netket/optimizer/qgt/qgt_jacobian_dense.py
@@ -55,21 +55,6 @@ def QGTJacobianDense(
     The details on how the ⟨S⟩⁻¹⟨F⟩ system is solved are contained in
     the field `sr`.
 
-    Args:
-        vstate: The variational state
-        mode: "real", "complex" or "holomorphic": specifies the implementation
-              used to compute the jacobian. "real" discards the imaginary part
-              of the output of the model. "complex" splits the real and imaginary
-              part of the parameters and output. It works also for non holomorphic
-              models. holomorphic works for any function assuming it's holomorphic
-              or real valued.
-        holomorphic: a flag to indicate that the function is holomorphic.
-        diag_scale: Fractional shift :math:`\\epsilon_1` added to diagonal entries (see below)
-        diag_shift: Constant shift :math:`\\epsilon_2` added to diagonal entries (see below)
-        chunk_size: If supplied, overrides the chunk size of the variational state
-                    (useful for models where the backward pass requires more
-                    memory than the forward pass).
-
     Numerical estimates of the QGT are usually ill-conditioned and require
     regularisation. The standard approach is to add a positive constant to the diagonal;
     alternatively, Becca and Sorella (2017) propose scaling this offset with the
@@ -81,6 +66,21 @@ def QGTJacobianDense(
 
     :math:`\\epsilon_{1,2}` are specified using `diag_scale` and `diag_shift`,
     respectively. By default, `diag_scale=0.0`, `diag_shift=0.01`.
+
+    Args:
+        vstate: The variational state
+        mode: "real", "complex" or "holomorphic": specifies the implementation
+              used to compute the jacobian. "real" discards the imaginary part
+              of the output of the model. "complex" splits the real and imaginary
+              part of the parameters and output. It works also for non holomorphic
+              models. holomorphic works for any function assuming it's holomorphic
+              or real valued.
+        holomorphic: a flag to indicate that the function is holomorphic.
+        diag_scale: Fractional shift :math:`\\epsilon_1` added to diagonal entries (see above)
+        diag_shift: Constant shift :math:`\\epsilon_2` added to diagonal entries (see above)
+        chunk_size: If supplied, overrides the chunk size of the variational state
+                    (useful for models where the backward pass requires more
+                    memory than the forward pass).
     """
     if mode is not None and holomorphic is not None:
         raise ValueError("Cannot specify both `mode` and `holomorphic`.")

--- a/netket/optimizer/qgt/qgt_jacobian_dense.py
+++ b/netket/optimizer/qgt/qgt_jacobian_dense.py
@@ -63,8 +63,8 @@ def QGTJacobianDense(
               models. holomorphic works for any function assuming it's holomorphic
               or real valued.
         holomorphic: a flag to indicate that the function is holomorphic.
-        diag_scale: Fractional shift :math:`\epsilon_1` added to diagonal entries (see below)
-        diag_shift: Constant shift :math:`\epsilon_2` added to diagonal entries (see below)
+        diag_scale: Fractional shift :math:`\\epsilon_1` added to diagonal entries (see below)
+        diag_shift: Constant shift :math:`\\epsilon_2` added to diagonal entries (see below)
         chunk_size: If supplied, overrides the chunk size of the variational state
                     (useful for models where the backward pass requires more
                     memory than the forward pass).
@@ -76,9 +76,9 @@ def QGTJacobianDense(
 
     .. math::
 
-        S_{ii} \mapsto S_{ii} + \epsilon_1 S_{ii} + \epsilon_2;
+        S_{ii} \\mapsto S_{ii} + \\epsilon_1 S_{ii} + \\epsilon_2;
 
-    :math:`\epsilon_{1,2}` are specified using `diag_scale` and `diag_shift`,
+    :math:`\\epsilon_{1,2}` are specified using `diag_scale` and `diag_shift`,
     respectively. By default, `diag_scale=0.0`, `diag_shift=0.01`.
     """
     if vstate is None:

--- a/netket/optimizer/qgt/qgt_jacobian_dense.py
+++ b/netket/optimizer/qgt/qgt_jacobian_dense.py
@@ -65,7 +65,7 @@ def QGTJacobianDense(
         S_{ii} \\mapsto S_{ii} + \\epsilon_1 S_{ii} + \\epsilon_2;
 
     :math:`\\epsilon_{1,2}` are specified using `diag_scale` and `diag_shift`,
-    respectively. By default, `diag_scale=0.0`, `diag_shift=0.01`.
+    respectively.
 
     Args:
         vstate: The variational state
@@ -76,8 +76,8 @@ def QGTJacobianDense(
               models. holomorphic works for any function assuming it's holomorphic
               or real valued.
         holomorphic: a flag to indicate that the function is holomorphic.
-        diag_scale: Fractional shift :math:`\\epsilon_1` added to diagonal entries (see above)
-        diag_shift: Constant shift :math:`\\epsilon_2` added to diagonal entries (see above)
+        diag_scale: Fractional shift :math:`\\epsilon_1` added to diagonal entries (see above).
+        diag_shift: Constant shift :math:`\\epsilon_2` added to diagonal entries (see above).
         chunk_size: If supplied, overrides the chunk size of the variational state
                     (useful for models where the backward pass requires more
                     memory than the forward pass).

--- a/netket/optimizer/qgt/qgt_jacobian_dense_logic.py
+++ b/netket/optimizer/qgt/qgt_jacobian_dense_logic.py
@@ -173,7 +173,7 @@ def prepare_centered_oks(
     # here the jacobian is reshaped and the real/complex part are concatenated.
     # centered_jacs = centered_jacs.reshape(-1, centered_jacs.shape[-1])
 
-    if rescale_shift:
+    if offset is not None:
         ndims = 1 if mode != "complex" else 2
         return rescale(centered_jacs, offset, ndims=ndims)
     else:

--- a/netket/optimizer/qgt/qgt_jacobian_dense_logic.py
+++ b/netket/optimizer/qgt/qgt_jacobian_dense_logic.py
@@ -88,14 +88,14 @@ dense_jacobian_cplx = nkjax.compose(stack_jacobian_tuple, jacobian_cplx)
 # TODO: This function is identical to the one in JacobianPyTree, with
 # the only difference in the `jacobian_fun` that can be selected.
 # The two should be unified.
-@partial(jax.jit, static_argnames=("apply_fun", "mode", "rescale_shift", "chunk_size"))
+@partial(jax.jit, static_argnames=("apply_fun", "mode", "chunk_size"))
 def prepare_centered_oks(
     apply_fun: Callable,
     params: PyTree,
     samples: Array,
     model_state: Optional[PyTree],
     mode: str,
-    rescale_shift: bool,
+    offset: Optional[float],
     chunk_size: int = None,
 ) -> PyTree:
     """
@@ -175,7 +175,7 @@ def prepare_centered_oks(
 
     if rescale_shift:
         ndims = 1 if mode != "complex" else 2
-        return rescale(centered_jacs, ndims=ndims)
+        return rescale(centered_jacs, offset, ndims=ndims)
     else:
         return centered_jacs, None
 

--- a/netket/optimizer/qgt/qgt_jacobian_pytree.py
+++ b/netket/optimizer/qgt/qgt_jacobian_pytree.py
@@ -88,17 +88,14 @@ def QGTJacobianPyTree(
         raise ValueError("Cannot specify both `rescale_shift` and `diag_scale`.")
 
     if vstate is None:
-        if diag_shift is not None:
-            kwargs["diag_shift"] = diag_shift
-        if diag_scale is not None:
-            kwargs["diag_scale"] = diag_scale
-        if rescale_shift is not None:
-            kwargs["rescale_shift"] = rescale_shift
         return partial(
             QGTJacobianPyTree,
             mode=mode,
             holomorphic=holomorphic,
             chunk_size=chunk_size,
+            diag_shift=diag_shift,
+            diag_scale=diag_scale,
+            rescale_shift=rescale_shift,
             **kwargs,
         )
 

--- a/netket/optimizer/qgt/qgt_jacobian_pytree.py
+++ b/netket/optimizer/qgt/qgt_jacobian_pytree.py
@@ -64,8 +64,8 @@ def QGTJacobianPyTree(
               models. holomorphic works for any function assuming it's holomorphic
               or real valued.
         holomorphic: a flag to indicate that the function is holomorphic.
-        diag_scale: Fractional shift :math:`\epsilon_1` added to diagonal entries (see below)
-        diag_shift: Constant shift :math:`\epsilon_2` added to diagonal entries (see below)
+        diag_scale: Fractional shift :math:`\\epsilon_1` added to diagonal entries (see below)
+        diag_shift: Constant shift :math:`\\epsilon_2` added to diagonal entries (see below)
         chunk_size: If supplied, overrides the chunk size of the variational state
                     (useful for models where the backward pass requires more
                     memory than the forward pass).
@@ -77,9 +77,9 @@ def QGTJacobianPyTree(
 
     .. math::
 
-        S_{ii} \mapsto S_{ii} + \epsilon_1 S_{ii} + \epsilon_2;
+        S_{ii} \\mapsto S_{ii} + \\epsilon_1 S_{ii} + \\epsilon_2;
 
-    :math:`\epsilon_{1,2}` are specified using `diag_scale` and `diag_shift`,
+    :math:`\\epsilon_{1,2}` are specified using `diag_scale` and `diag_shift`,
     respectively. By default, `diag_scale=0.0`, `diag_shift=0.01`.
     """
     if vstate is None:

--- a/netket/optimizer/qgt/qgt_jacobian_pytree.py
+++ b/netket/optimizer/qgt/qgt_jacobian_pytree.py
@@ -55,21 +55,6 @@ def QGTJacobianPyTree(
     The details on how the ⟨S⟩⁻¹⟨F⟩ system is solved are contained in
     the field `sr`.
 
-    Args:
-        vstate: The variational state
-        mode: "real", "complex" or "holomorphic": specifies the implementation
-              used to compute the jacobian. "real" discards the imaginary part
-              of the output of the model. "complex" splits the real and imaginary
-              part of the parameters and output. It works also for non holomorphic
-              models. holomorphic works for any function assuming it's holomorphic
-              or real valued.
-        holomorphic: a flag to indicate that the function is holomorphic.
-        diag_scale: Fractional shift :math:`\\epsilon_1` added to diagonal entries (see below)
-        diag_shift: Constant shift :math:`\\epsilon_2` added to diagonal entries (see below)
-        chunk_size: If supplied, overrides the chunk size of the variational state
-                    (useful for models where the backward pass requires more
-                    memory than the forward pass).
-
     Numerical estimates of the QGT are usually ill-conditioned and require
     regularisation. The standard approach is to add a positive constant to the diagonal;
     alternatively, Becca and Sorella (2017) propose scaling this offset with the
@@ -81,6 +66,21 @@ def QGTJacobianPyTree(
 
     :math:`\\epsilon_{1,2}` are specified using `diag_scale` and `diag_shift`,
     respectively. By default, `diag_scale=0.0`, `diag_shift=0.01`.
+
+    Args:
+        vstate: The variational state
+        mode: "real", "complex" or "holomorphic": specifies the implementation
+              used to compute the jacobian. "real" discards the imaginary part
+              of the output of the model. "complex" splits the real and imaginary
+              part of the parameters and output. It works also for non holomorphic
+              models. holomorphic works for any function assuming it's holomorphic
+              or real valued.
+        holomorphic: a flag to indicate that the function is holomorphic.
+        diag_scale: Fractional shift :math:`\\epsilon_1` added to diagonal entries (see above)
+        diag_shift: Constant shift :math:`\\epsilon_2` added to diagonal entries (see above)
+        chunk_size: If supplied, overrides the chunk size of the variational state
+                    (useful for models where the backward pass requires more
+                    memory than the forward pass).
     """
     if mode is not None and holomorphic is not None:
         raise ValueError("Cannot specify both `mode` and `holomorphic`.")

--- a/netket/optimizer/qgt/qgt_jacobian_pytree.py
+++ b/netket/optimizer/qgt/qgt_jacobian_pytree.py
@@ -65,7 +65,7 @@ def QGTJacobianPyTree(
         S_{ii} \\mapsto S_{ii} + \\epsilon_1 S_{ii} + \\epsilon_2;
 
     :math:`\\epsilon_{1,2}` are specified using `diag_scale` and `diag_shift`,
-    respectively. By default, `diag_scale=0.0`, `diag_shift=0.01`.
+    respectively.
 
     Args:
         vstate: The variational state
@@ -76,8 +76,8 @@ def QGTJacobianPyTree(
               models. holomorphic works for any function assuming it's holomorphic
               or real valued.
         holomorphic: a flag to indicate that the function is holomorphic.
-        diag_scale: Fractional shift :math:`\\epsilon_1` added to diagonal entries (see above)
-        diag_shift: Constant shift :math:`\\epsilon_2` added to diagonal entries (see above)
+        diag_scale: Fractional shift :math:`\\epsilon_1` added to diagonal entries (see above).
+        diag_shift: Constant shift :math:`\\epsilon_2` added to diagonal entries (see above).
         chunk_size: If supplied, overrides the chunk size of the variational state
                     (useful for models where the backward pass requires more
                     memory than the forward pass).

--- a/netket/optimizer/qgt/qgt_jacobian_pytree.py
+++ b/netket/optimizer/qgt/qgt_jacobian_pytree.py
@@ -82,11 +82,12 @@ def QGTJacobianPyTree(
     :math:`\\epsilon_{1,2}` are specified using `diag_scale` and `diag_shift`,
     respectively. By default, `diag_scale=0.0`, `diag_shift=0.01`.
     """
+    if mode is not None and holomorphic is not None:
+        raise ValueError("Cannot specify both `mode` and `holomorphic`.")
+    if rescale_shift is not None and diag_scale is not None:
+        raise ValueError("Cannot specify both `rescale_shift` and `diag_scale`.")
+
     if vstate is None:
-        if mode is not None and holomorphic is not None:
-            raise ValueError("Cannot specify both `mode` and `holomorphic`.")
-        if rescale_shift is not None and diag_scale is not None:
-            raise ValueError("Cannot specify both `rescale_shift` and `diag_scale`.")
         if diag_shift is not None:
             kwargs["diag_shift"] = diag_shift
         if diag_scale is not None:

--- a/netket/optimizer/qgt/qgt_jacobian_pytree.py
+++ b/netket/optimizer/qgt/qgt_jacobian_pytree.py
@@ -70,6 +70,9 @@ def QGTJacobianPyTree(
                     (useful for models where the backward pass requires more
                     memory than the forward pass).
     """
+    if mode is not None and holomorphic is not None:
+        raise ValueError("Cannot specify both `mode` and `holomorphic`.")
+
     diag_shift, diag_scale = sanitize_diag_shift(diag_shift, diag_scale, rescale_shift)
 
     if vstate is None:
@@ -77,6 +80,7 @@ def QGTJacobianPyTree(
             QGTJacobianPyTree,
             mode=mode,
             holomorphic=holomorphic,
+            chunk_size=chunk_size,
             diag_shift=diag_shift,
             diag_scale=diag_scale,
             **kwargs,
@@ -102,13 +106,11 @@ def QGTJacobianPyTree(
             mode=mode,
             holomorphic=holomorphic,
         )
-    elif holomorphic is not None:
-        raise ValueError("Cannot specify both `mode` and `holomorphic`.")
-
-    shift, offset = to_shift_offset(diag_shift, diag_scale)
 
     if chunk_size is None and hasattr(vstate, "chunk_size"):
         chunk_size = vstate.chunk_size
+
+    shift, offset = to_shift_offset(diag_shift, diag_scale)
 
     O, scale = prepare_centered_oks(
         vstate._apply_fun,

--- a/netket/optimizer/qgt/qgt_jacobian_pytree.py
+++ b/netket/optimizer/qgt/qgt_jacobian_pytree.py
@@ -64,27 +64,44 @@ def QGTJacobianPyTree(
               models. holomorphic works for any function assuming it's holomorphic
               or real valued.
         holomorphic: a flag to indicate that the function is holomorphic.
-        diag_shift: Constant shift added to diagonal entries.
-        diag_scale: Fractional shift added to diagonal entries.
+        diag_scale: Fractional shift :math:`\epsilon_1` added to diagonal entries (see below)
+        diag_shift: Constant shift :math:`\epsilon_2` added to diagonal entries (see below)
         chunk_size: If supplied, overrides the chunk size of the variational state
                     (useful for models where the backward pass requires more
                     memory than the forward pass).
+
+    Numerical estimates of the QGT are usually ill-conditioned and require
+    regularisation. The standard approach is to add a positive constant to the diagonal;
+    alternatively, Becca and Sorella (2017) propose scaling this offset with the
+    diagonal entry itself. NetKet allows using both in tandem:
+
+    .. math::
+
+        S_{ii} \mapsto S_{ii} + \epsilon_1 S_{ii} + \epsilon_2;
+
+    :math:`\epsilon_{1,2}` are specified using `diag_scale` and `diag_shift`,
+    respectively. By default, `diag_scale=0.0`, `diag_shift=0.01`.
     """
-    if mode is not None and holomorphic is not None:
-        raise ValueError("Cannot specify both `mode` and `holomorphic`.")
-
-    diag_shift, diag_scale = sanitize_diag_shift(diag_shift, diag_scale, rescale_shift)
-
     if vstate is None:
+        if mode is not None and holomorphic is not None:
+            raise ValueError("Cannot specify both `mode` and `holomorphic`.")
+        if rescale_shift is not None and diag_scale is not None:
+            raise ValueError("Cannot specify both `rescale_shift` and `diag_scale`.")
+        if diag_shift is not None:
+            kwargs["diag_shift"] = diag_shift
+        if diag_scale is not None:
+            kwargs["diag_scale"] = diag_scale
+        if rescale_shift is not None:
+            kwargs["rescale_shift"] = rescale_shift
         return partial(
             QGTJacobianPyTree,
             mode=mode,
             holomorphic=holomorphic,
             chunk_size=chunk_size,
-            diag_shift=diag_shift,
-            diag_scale=diag_scale,
             **kwargs,
         )
+
+    diag_shift, diag_scale = sanitize_diag_shift(diag_shift, diag_scale, rescale_shift)
 
     # TODO: Find a better way to handle this case
     from netket.vqs import ExactState

--- a/netket/optimizer/qgt/qgt_jacobian_pytree_logic.py
+++ b/netket/optimizer/qgt/qgt_jacobian_pytree_logic.py
@@ -145,14 +145,14 @@ def _mat_vec(v: PyTree, oks: PyTree) -> PyTree:
 # here the other modes are converted
 
 
-@partial(jax.jit, static_argnames=("apply_fun", "mode", "rescale_shift", "chunk_size"))
+@partial(jax.jit, static_argnames=("apply_fun", "mode", "chunk_size"))
 def prepare_centered_oks(
     apply_fun: Callable,
     params: PyTree,
     samples: Array,
     model_state: Optional[PyTree],
     mode: str,
-    rescale_shift: bool,
+    offset: Optional[float],
     pdf=None,
     chunk_size: int = None,
 ) -> PyTree:
@@ -237,9 +237,9 @@ def prepare_centered_oks(
 
         centered_jacs = _multiply_by_pdf(centered_jacs, jnp.sqrt(pdf))
 
-    if rescale_shift:
+    if offset:
         ndims = 1 if mode != "complex" else 2
-        return rescale(centered_jacs, ndims=ndims)
+        return rescale(centered_jacs, offset, ndims=ndims)
     else:
         return centered_jacs, None
 

--- a/netket/optimizer/qgt/qgt_jacobian_pytree_logic.py
+++ b/netket/optimizer/qgt/qgt_jacobian_pytree_logic.py
@@ -22,7 +22,7 @@ import jax.numpy as jnp
 
 import numpy as np
 
-from netket.stats import subtract_mean, sum
+from netket.stats import subtract_mean, sum as sum_mpi
 from netket.utils import mpi
 from netket.utils.types import Array, Callable, PyTree, Scalar
 from netket.jax import (
@@ -34,30 +34,18 @@ from netket.jax import (
     vmap_chunked,
 )
 
+from .qgt_jacobian_common import rescale
+
 
 # TODO better name and move it somewhere sensible
 def single_sample(forward_fn):
     """
     A decorator to make the forward_fn accept a single sample
     """
-
-    def f(W, σ):
-        return forward_fn(W, σ[jnp.newaxis, :])[0]
-
-    return f
+    return lambda W, σ: forward_fn(W, σ[jnp.newaxis, :])[0]
 
 
-# TODO move it somewhere reasonable
-def tree_subtract_mean(oks: PyTree) -> PyTree:
-    """
-    subtract the mean with MPI along axis 0 of every leaf
-    """
-    return jax.tree_map(partial(subtract_mean, axis=0), oks)  # MPI
-
-
-def jacobian_real_holo(
-    forward_fn: Callable, params: PyTree, samples: Array, chunk_size: int = None
-) -> PyTree:
+def jacobian_real_holo(forward_fn: Callable, params: PyTree, samples: Array) -> PyTree:
     """Calculates Jacobian entries by vmapping grad.
     Assumes the function is R→R or holomorphic C→C, so single grad is enough
 
@@ -70,23 +58,16 @@ def jacobian_real_holo(
         The Jacobian matrix ∂/∂pₖ ln Ψ(σⱼ) as a PyTree
     """
 
-    def _jacobian_real_holo(forward_fn, params, samples):
-        y, vjp_fun = jax.vjp(
-            lambda pars: single_sample(forward_fn)(pars, samples), params
-        )
-        (res,) = vjp_fun(np.array(1.0, dtype=jnp.result_type(y)))
-        return res
-
-    return vmap_chunked(
-        _jacobian_real_holo, in_axes=(None, None, 0), chunk_size=chunk_size
-    )(forward_fn, params, samples)
+    y, vjp_fun = jax.vjp(lambda pars: single_sample(forward_fn)(pars, samples), params)
+    (res,) = vjp_fun(np.array(1.0, dtype=jnp.result_type(y)))
+    return res
 
 
-def jacobian_cplx(
+def _jacobian_cplx(
     forward_fn: Callable,
     params: PyTree,
     samples: Array,
-    chunk_size: int = None,
+    *,
     _build_fn: Callable = partial(jax.tree_map, jax.lax.complex),
 ) -> PyTree:
     """Calculates Jacobian entries by vmapping grad.
@@ -101,30 +82,13 @@ def jacobian_cplx(
         The Jacobian matrix ∂/∂pₖ ln Ψ(σⱼ) as a PyTree
     """
 
-    def _jacobian_cplx(forward_fn, params, samples, _build_fn):
-        y, vjp_fun = jax.vjp(
-            lambda pars: single_sample(forward_fn)(pars, samples), params
-        )
-        (gr,) = vjp_fun(np.array(1.0, dtype=jnp.result_type(y)))
-        (gi,) = vjp_fun(np.array(-1.0j, dtype=jnp.result_type(y)))
-        return _build_fn(gr, gi)
-
-    return vmap_chunked(
-        _jacobian_cplx, in_axes=(None, None, 0, None), chunk_size=chunk_size
-    )(forward_fn, params, samples, _build_fn)
+    y, vjp_fun = jax.vjp(lambda pars: single_sample(forward_fn)(pars, samples), params)
+    (gr,) = vjp_fun(np.array(1.0, dtype=jnp.result_type(y)))
+    (gi,) = vjp_fun(np.array(-1.0j, dtype=jnp.result_type(y)))
+    return _build_fn(gr, gi)
 
 
-centered_jacobian_real_holo = compose(tree_subtract_mean, jacobian_real_holo)
-centered_jacobian_cplx = compose(tree_subtract_mean, jacobian_cplx)
-
-
-def _divide_by_sqrt_n_samp(oks, samples):
-    """
-    divide Oⱼₖ by √n
-    """
-    n_samp = samples.shape[0] * mpi.n_nodes  # MPI
-    sqrt_n = math.sqrt(n_samp)  # enforce weak type
-    return jax.tree_map(lambda x: x / sqrt_n, oks)
+jacobian_cplx = partial(_jacobian_cplx, _build_fn=lambda *x: x)
 
 
 def _multiply_by_pdf(oks, pdf):
@@ -139,16 +103,6 @@ def _multiply_by_pdf(oks, pdf):
     )
 
 
-def stack_jacobian(centered_oks: PyTree) -> PyTree:
-    """
-    Return the real and imaginary parts of ΔOⱼₖ stacked along the sample axis
-    Re[S] = Re[(ΔOᵣ + i ΔOᵢ)ᴴ(ΔOᵣ + i ΔOᵢ)] = ΔOᵣᵀ ΔOᵣ + ΔOᵢᵀ ΔOᵢ = [ΔOᵣ ΔOᵢ]ᵀ [ΔOᵣ ΔOᵢ]
-    """
-    return jax.tree_map(
-        lambda x: jnp.concatenate([x.real, x.imag], axis=0), centered_oks
-    )
-
-
 def stack_jacobian_tuple(centered_oks_re_im):
     """
     stack the real and imaginary parts of ΔOⱼₖ along the sample axis
@@ -158,27 +112,7 @@ def stack_jacobian_tuple(centered_oks_re_im):
     Args:
         centered_oks_re_im : a tuple (ΔOᵣ, ΔOᵢ) of two PyTrees representing the real and imag part of ΔOⱼₖ
     """
-    return jax.tree_map(
-        lambda re, im: jnp.concatenate([re, im], axis=0), *centered_oks_re_im
-    )
-
-
-def _rescale(centered_oks):
-    """
-    compute ΔOₖ/√Sₖₖ and √Sₖₖ
-    to do scale-invariant regularization (Becca & Sorella 2017, pp. 143)
-    Sₖₗ/(√Sₖₖ√Sₗₗ) = ΔOₖᴴΔOₗ/(√Sₖₖ√Sₗₗ) = (ΔOₖ/√Sₖₖ)ᴴ(ΔOₗ/√Sₗₗ)
-    """
-    scale = jax.tree_map(
-        lambda x: mpi.mpi_sum_jax(jnp.sum((x * x.conj()).real, axis=0, keepdims=True))[
-            0
-        ]
-        ** 0.5,
-        centered_oks,
-    )
-    centered_oks = jax.tree_map(jnp.divide, centered_oks, scale)
-    scale = jax.tree_map(partial(jnp.squeeze, axis=0), scale)
-    return centered_oks, scale
+    return jax.tree_map(lambda re, im: jnp.stack([re, im], axis=0), *centered_oks_re_im)
 
 
 def _jvp(oks: PyTree, v: PyTree) -> Array:
@@ -194,7 +128,7 @@ def _vjp(oks: PyTree, w: Array) -> PyTree:
     """
     Compute the vector-matrix product between the vector w and the pytree jacobian oks
     """
-    res = jax.tree_map(partial(jnp.tensordot, w, axes=1), oks)
+    res = jax.tree_map(partial(jnp.tensordot, w, axes=w.ndim), oks)
     return jax.tree_map(lambda x: mpi.mpi_sum_jax(x)[0], res)  # MPI
 
 
@@ -258,22 +192,15 @@ def prepare_centered_oks(
 
     if mode == "real":
         split_complex_params = True  # convert C→R and R&C→R to R→R
-        centered_jacobian_fun = centered_jacobian_real_holo
         jacobian_fun = jacobian_real_holo
     elif mode == "complex":
         split_complex_params = True  # convert C→C and R&C→C to R→C
-        # centered_jacobian_fun = compose(stack_jacobian, centered_jacobian_cplx)
 
         # avoid converting to complex and then back
         # by passing around the oks as a tuple of two pytrees representing the real and imag parts
-        centered_jacobian_fun = compose(
-            stack_jacobian_tuple,
-            partial(centered_jacobian_cplx, _build_fn=lambda *x: x),
-        )
-        jacobian_fun = jacobian_cplx
+        jacobian_fun = compose(stack_jacobian_tuple, jacobian_cplx)
     elif mode == "holomorphic":
         split_complex_params = False
-        centered_jacobian_fun = centered_jacobian_real_holo
         jacobian_fun = jacobian_real_holo
     else:
         raise NotImplementedError(
@@ -285,33 +212,36 @@ def prepare_centered_oks(
     if split_complex_params:
         # doesn't do anything if the params are already real
         params, reassemble = tree_to_real(params)
-
-        def f(W, σ):
-            return forward_fn(reassemble(W), σ)
-
+        f = lambda W, σ: forward_fn(reassemble(W), σ)
     else:
         f = forward_fn
 
-    if pdf is None:
-        centered_oks = _divide_by_sqrt_n_samp(
-            centered_jacobian_fun(
-                f,
-                params,
-                samples,
-                chunk_size=chunk_size,
-            ),
-            samples,
-        )
-    else:
-        oks = jacobian_fun(f, params, samples)
-        oks_mean = jax.tree_map(partial(sum, axis=0), _multiply_by_pdf(oks, pdf))
-        centered_oks = jax.tree_map(lambda x, y: x - y, oks, oks_mean)
+    # jacobians is a tree with leaf shapes:
+    # - (n_samples, 2, ...) if mode complex, holding the real and imaginary jacobian
+    # - (n_samples, ...) if mode real/holomorphic
+    jacobians = vmap_chunked(
+        jacobian_fun, in_axes=(None, None, 0), chunk_size=chunk_size
+    )(f, params, samples)
 
-        centered_oks = _multiply_by_pdf(centered_oks, jnp.sqrt(pdf))
-    if rescale_shift:
-        return _rescale(centered_oks)
+    if pdf is None:
+        sqrt_n_samp = math.sqrt(samples.shape[0] * mpi.n_nodes)  # maintain weak type
+        centered_jacs = jax.tree_map(
+            lambda x: subtract_mean(x, axis=0) / sqrt_n_samp, jacobians
+        )
+
     else:
-        return centered_oks, None
+        jacobians_avg = jax.tree_map(
+            partial(sum_mpi, axis=0), _multiply_by_pdf(jacobians, pdf)
+        )
+        centered_jacs = jax.tree_map(lambda x, y: x - y, jacobians, jacobians_avg)
+
+        centered_jacs = _multiply_by_pdf(centered_jacs, jnp.sqrt(pdf))
+
+    if rescale_shift:
+        ndims = 1 if mode != "complex" else 2
+        return rescale(centered_jacs, ndims=ndims)
+    else:
+        return centered_jacs, None
 
 
 def mat_vec(v: PyTree, centered_oks: PyTree, diag_shift: Scalar) -> PyTree:

--- a/netket/optimizer/qgt/qgt_jacobian_pytree_logic.py
+++ b/netket/optimizer/qgt/qgt_jacobian_pytree_logic.py
@@ -237,7 +237,7 @@ def prepare_centered_oks(
 
         centered_jacs = _multiply_by_pdf(centered_jacs, jnp.sqrt(pdf))
 
-    if offset:
+    if offset is not None:
         ndims = 1 if mode != "complex" else 2
         return rescale(centered_jacs, offset, ndims=ndims)
     else:

--- a/test/optimizer/test_qgt_itersolve.py
+++ b/test/optimizer/test_qgt_itersolve.py
@@ -40,16 +40,22 @@ QGT_objects["JacobianPyTree"] = partial(qgt.QGTJacobianPyTree, diag_shift=0.01)
 QGT_objects["JacobianPyTree(mode=holomorphic)"] = partial(
     qgt.QGTJacobianPyTree, holomorphic=True, diag_shift=0.01
 )
-QGT_objects["JacobianPyTree(rescale_shift=True)"] = partial(
-    qgt.QGTJacobianPyTree, rescale_shift=True, diag_shift=0.01
+QGT_objects["JacobianPyTree(diag_scale=0.01)"] = partial(
+    qgt.QGTJacobianPyTree, diag_scale=0.01, diag_shift=0.0
+)
+QGT_objects["JacobianPyTree(diag_scale=0.01, diag_shift=0.01)"] = partial(
+    qgt.QGTJacobianPyTree, diag_scale=0.01, diag_shift=0.01
 )
 
 QGT_objects["JacobianDense"] = partial(qgt.QGTJacobianDense, diag_shift=0.01)
 QGT_objects["JacobianDense(mode=holomorphic)"] = partial(
     qgt.QGTJacobianDense, holomorphic=True, diag_shift=0.01
 )
-QGT_objects["JacobianDense(rescale_shift=True)"] = partial(
-    qgt.QGTJacobianDense, rescale_shift=True, diag_shift=0.01
+QGT_objects["JacobianDense(diag_scale=0.01)"] = partial(
+    qgt.QGTJacobianDense, diag_scale=0.01, diag_shift=0.0
+)
+QGT_objects["JacobianDense(diag_scale=0.01, diag_shift=0.01)"] = partial(
+    qgt.QGTJacobianDense, diag_scale=0.01, diag_shift=0.01
 )
 
 solvers = {}

--- a/test/optimizer/test_qgt_itersolve.py
+++ b/test/optimizer/test_qgt_itersolve.py
@@ -322,7 +322,10 @@ def test_qgt_pytree_diag_shift(qgt, vstate):
     diag_shift = S.diag_shift
     if isinstance(S, (QGTJacobianPyTreeT, QGTJacobianDenseT)):
         # extract the necessary shape for the diag_shift
-        t = jax.eval_shape(partial(jax.tree_map, lambda x: x[0], S.O))
+        if S.mode == "complex":
+            t = jax.eval_shape(partial(jax.tree_map, lambda x: x[0, 0], S.O))
+        else:
+            t = jax.eval_shape(partial(jax.tree_map, lambda x: x[0], S.O))
     else:
         t = v
     diag_shift_tree = jax.tree_map(

--- a/test/optimizer/test_qgt_logic.py
+++ b/test/optimizer/test_qgt_logic.py
@@ -484,6 +484,7 @@ def test_scale_invariant_regularization(e_offset, outdtype, pardtype, offset):
         ((0.02, None, True), (0.0, 0.02)),
         ((None, 0.02, True), "error"),
         ((0.01, 0.02, True), "error"),
+        ((None, None, 0.0), "error"),
     ],
 )
 def test_sanitize_diag_shift(inputs, expected):

--- a/test/optimizer/test_qgt_logic.py
+++ b/test/optimizer/test_qgt_logic.py
@@ -158,7 +158,7 @@ class Example:
     def n_samp(self):
         return len(self.samples)
 
-    def __init__(self, n_samp, seed, outdtype, pardtype, holomorphic):
+    def __init__(self, n_samp, seed, outdtype, pardtype, holomorphic, offset=0.0):
 
         self.dtype = outdtype
 
@@ -226,7 +226,7 @@ class Example:
         self.S_real = (
             self.dok_real.conjugate().transpose() @ self.dok_real / n_samp
         ).real
-        self.scale = jnp.sqrt(self.S_real.diagonal())
+        self.scale = jnp.sqrt(self.S_real.diagonal() + offset)
         self.S_real_scaled = self.S_real / (jnp.outer(self.scale, self.scale))
 
 
@@ -390,7 +390,8 @@ def test_matvec_treemv(e, jit, holomorphic, pardtype, outdtype, chunk_size):
 def test_matvec_treemv_modes(e, jit, holomorphic, pardtype, outdtype):
     diag_shift = 0.01
     model_state = {}
-    rescale_shift = False
+    # rescale_shift = False
+    offset = None
 
     def apply_fun(params, samples):
         return e.f(params["params"], samples)
@@ -416,7 +417,7 @@ def test_matvec_treemv_modes(e, jit, holomorphic, pardtype, outdtype):
         mv = jax.jit(mv)
 
     centered_oks, _ = qgt_jacobian_pytree_logic.prepare_centered_oks(
-        apply_fun, e.params, e.samples, model_state, mode, rescale_shift
+        apply_fun, e.params, e.samples, model_state, mode, offset
     )
     actual = reassemble(mv(v, centered_oks, diag_shift))
     expected = reassemble_complex(
@@ -426,13 +427,20 @@ def test_matvec_treemv_modes(e, jit, holomorphic, pardtype, outdtype):
     tree_samedtypes(actual, expected)
 
 
+@pytest.fixture
+def e_offset(n_samp, outdtype, pardtype, holomorphic, offset, seed=123):
+    return Example(n_samp, seed, outdtype, pardtype, holomorphic, offset)
+
+
 @pytest.mark.parametrize("holomorphic", [True])
 @pytest.mark.parametrize("n_samp", [25, 1024])
 @pytest.mark.parametrize(
     "outdtype, pardtype",
     r_c_test_types,  # r_r_test_types + c_c_test_types + r_c_test_types
 )
-def test_scale_invariant_regularization(e, outdtype, pardtype):
+@pytest.mark.parametrize("offset", [0.0, 0.1])
+def test_scale_invariant_regularization(e_offset, outdtype, pardtype, offset):
+    e = e_offset
     mv = qgt_jacobian_pytree_logic._mat_vec
 
     if not nkjax.is_complex_dtype(pardtype) and nkjax.is_complex_dtype(outdtype):
@@ -450,13 +458,41 @@ def test_scale_invariant_regularization(e, outdtype, pardtype):
     centered_oks = centered_jacobian_fun(e.f, e.params, e.samples)
     centered_oks = divide_by_sqrt_n_samp(centered_oks, e.samples)
 
-    centered_oks_scaled, scale = qgt_jacobian_common.rescale(centered_oks, ndims=ndims)
+    centered_oks_scaled, scale = qgt_jacobian_common.rescale(
+        centered_oks, offset, ndims=ndims
+    )
     actual = mv(e.v, centered_oks_scaled)
     expected = reassemble_complex(e.S_real_scaled @ e.v_real_flat, target=e.target)
 
     rtol = 1e-5 if pardtype is jnp.float32 else 1e-8
     assert_tree_allclose(actual, expected, rtol=rtol)
     tree_samedtypes(actual, expected)
+
+
+@pytest.mark.parametrize(
+    "inputs, expected",
+    [
+        ((None, None, None), (0.01, 0.0)),
+        ((0.02, None, None), (0.02, 0.0)),
+        ((None, 0.02, None), (0.0, 0.02)),
+        ((0.01, 0.02, None), (0.01, 0.02)),
+        ((None, None, False), (0.01, 0.0)),
+        ((0.02, None, False), (0.02, 0.0)),
+        ((None, 0.02, False), "error"),
+        ((0.01, 0.02, False), "error"),
+        ((None, None, True), (0.0, 0.01)),
+        ((0.02, None, True), (0.0, 0.02)),
+        ((None, 0.02, True), "error"),
+        ((0.01, 0.02, True), "error"),
+    ],
+)
+def test_sanitize_diag_shift(inputs, expected):
+    if expected == "error":
+        with pytest.raises(ValueError):
+            qgt_jacobian_common.sanitize_diag_shift(*inputs)
+    else:
+        output = qgt_jacobian_common.sanitize_diag_shift(*inputs)
+        assert output == expected
 
 
 # TODO test with MPI

--- a/test/optimizer/test_sr_api.py
+++ b/test/optimizer/test_sr_api.py
@@ -45,22 +45,33 @@ def test_deprecated_sr():
     "qgt", [nk.optimizer.qgt.QGTJacobianDense, nk.optimizer.qgt.QGTJacobianPyTree]
 )
 def test_qgt_partial_jacobian(qgt):
+    with pytest.raises(ValueError):
+        qgt(mode="real", holomorphic=True)
+
     # mode and holomorphic can't be both specified for an actual QGT
     # but we'll never create one
     args = {
         "mode": "real",
-        "holomorphic": False,
         "diag_shift": 0.03,
-        "rescale_shift": True,
+        "diag_scale": 0.02,
         "chunk_size": 16,
     }
     QGT = qgt(**args)
     assert isinstance(QGT, Callable)
-    assert QGT.keywords == args
+    for k, v in args.items():
+        assert k in QGT.keywords
+        assert QGT.keywords[k] == v
+
+    QGT = qgt(diag_shift=0.03, rescale_shift=True)
+    for k, v in {"diag_shift": 0.0, "diag_scale": 0.03}.items():
+        assert k in QGT.keywords
+        assert QGT.keywords[k] == v
 
 
 def test_qgt_partial_onthefly():
     args = {"diag_shift": 0.03, "chunk_size": 16}
     QGT = nk.optimizer.qgt.QGTOnTheFly(**args)
     assert isinstance(QGT, Callable)
-    assert QGT.keywords == args
+    for k, v in args.items():
+        assert k in QGT.keywords
+        assert QGT.keywords[k] == v


### PR DESCRIPTION
This PR allows specifying both a scale-invariant and a constant diagonal offset in `QGTJacobian*` at the same time.

@chrisrothUT and I discovered that adding a diagonal shift of the form `diag_shift + diag_scale * S_ii` is much more stable than pure scale-invariant shifting but remains faster and better converging than simply using `diag_shift`. To accommodate both, this PR deprecates `rescale_shift` and introduces `diag_scale`, the coefficient of S_ii in the shift.

Defaults:
* If nothing is specified, `diag_shift=0.01, diag_scale=0.0` to recover the original behaviour
* If only `diag_scale` is specified, `diag_shift=0.0`
* If `rescale_shift` is specified, it behaves as it used to, but there is a deprecation warning
* Specifying `rescale_shift` and `diag_scale` together leads to an error

Internally, `diag_scale` is implemented the same way `rescale_shift` once was; `diag_shift` is added to it by adding `offset=diag_shift/diag_scale` to the scale factors used to rescale rows/columns of the S matrix. 

There are some bits to iron out, most importantly whether the defaults above are good and `diag_scale` is a good name for the new parameter.