### PR TITLE
Fix #1347

### DIFF
--- a/netket/optimizer/qgt/qgt_jacobian_dense.py
+++ b/netket/optimizer/qgt/qgt_jacobian_dense.py
@@ -69,6 +69,7 @@ def QGTJacobianDense(
             mode=mode,
             holomorphic=holomorphic,
             rescale_shift=rescale_shift,
+            chunk_size=chunk_size,
             **kwargs,
         )
 

--- a/netket/optimizer/qgt/qgt_jacobian_pytree.py
+++ b/netket/optimizer/qgt/qgt_jacobian_pytree.py
@@ -70,6 +70,7 @@ def QGTJacobianPyTree(
             mode=mode,
             holomorphic=holomorphic,
             rescale_shift=rescale_shift,
+            chunk_size=chunk_size,
             **kwargs,
         )
 

--- a/netket/optimizer/qgt/qgt_onthefly.py
+++ b/netket/optimizer/qgt/qgt_onthefly.py
@@ -47,7 +47,7 @@ def QGTOnTheFly(vstate=None, *, chunk_size=None, **kwargs) -> "QGTOnTheFlyT":
                     memory than the forward pass).
     """
     if vstate is None:
-        return partial(QGTOnTheFly, **kwargs)
+        return partial(QGTOnTheFly, chunk_size=chunk_size, **kwargs)
 
     if "centered" in kwargs:
         warn_deprecation(

--- a/test/optimizer/test_sr_api.py
+++ b/test/optimizer/test_sr_api.py
@@ -14,6 +14,8 @@
 
 import pytest
 
+from typing import Callable
+
 import netket as nk
 
 from .. import common
@@ -37,3 +39,28 @@ def test_deprecated_sr():
 
     with pytest.warns(FutureWarning):
         nk.optimizer.sr.SRLazyGMRES()
+
+
+@pytest.mark.parametrize(
+    "qgt", [nk.optimizer.qgt.QGTJacobianDense, nk.optimizer.qgt.QGTJacobianPyTree]
+)
+def test_qgt_partial_jacobian(qgt):
+    # mode and holomorphic can't be both specified for an actual QGT
+    # but we'll never create one
+    args = {
+        "mode": "real",
+        "holomorphic": False,
+        "diag_shift": 0.03,
+        "rescale_shift": True,
+        "chunk_size": 16,
+    }
+    QGT = qgt(**args)
+    assert isinstance(QGT, Callable)
+    assert QGT.keywords == args
+
+
+def test_qgt_partial_onthefly():
+    args = {"diag_shift": 0.03, "chunk_size": 16}
+    QGT = nk.optimizer.qgt.QGTOnTheFly(**args)
+    assert isinstance(QGT, Callable)
+    assert QGT.keywords == args


### PR DESCRIPTION
I forgot to propagate `chunk_size` in the calling sequence of QGTs without variational states in #1347. This makes the parameter useless in workflows that use the `partial` construction of a QGT but not the SR object (which builds its own more robust `partial`s). This PR fixes that.

Any ideas for how we could test for this?