### PR TITLE
Improve API to define autoregressive networks, maybe make them public?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,14 @@
 
 ## NetKet 3.7 (⚙️ In development)
 
-### New features
+### Improvements
+* The underlying extension API for Autoregressive models that can be used with Ancestral/Autoregressive samplers has been simplified and stabilized and will be documented as part of the public API. For most models, you should now inherit from `AbstractARNN` and define `conditionals_log_psi`. For additional performance, implementers can also redefine `__call__` and `conditional` but this should not be needed in general. This will cause some breaking changes if you were relying on the old undocumented interface [#1361](https://github.com/netket/netket/pull/1361).
 
 ### Bug Fixes
 
 ### Deprecations
+* `AbstractARNN._conditional` has been removed from the API, and its use will throw a deprecation warning. Update your ARNN models accordingly! [#1361](https://github.com/netket/netket/pull/1361).
+* Several undocumented internal methods from `nk.models.ARNN` have been removed [#1361](https://github.com/netket/netket/pull/1361).
 
 
 ## NetKet 3.6 (🏔️ 6 November 2022)

--- a/netket/models/autoreg.py
+++ b/netket/models/autoreg.py
@@ -64,7 +64,7 @@ class AbstractARNN(nn.Module):
 
         Subtypes of `AbstractARNN` should implement at least this function and
         initialize eventual sublayers/parameters in `.setup()`. If desired, one
-        can also override the methods `.__call__` and `._conditionals`
+        can also override the methods `.__call__` and `.conditional`
 
         Args:
           inputs: configurations with dimensions (batch, Hilbert.size).
@@ -113,7 +113,7 @@ class AbstractARNN(nn.Module):
         p = jnp.exp(self.machine_pow * log_psi.real)
         return p
 
-    def _conditional(self, inputs: Array, index: int) -> Array:
+    def conditional(self, inputs: Array, index: int) -> Array:
         """
         Computes the conditional probabilities for a site to take a given value.
 

--- a/netket/models/autoreg.py
+++ b/netket/models/autoreg.py
@@ -155,6 +155,16 @@ class ARNNSequential(AbstractARNN):
 
     Subclasses must implement `activation` as a field or a method,
     and assign a list of ARNN layers to `self._layers` in `setup`.
+
+    Note:
+        If you want to use real parameters and output a complex wave function, such as in
+        `Hibat-Allah et. {\\it al} <https://arxiv.org/abs/2002.02973>`_,
+        you can implement `conditionals_log_psi` differently, compute the modulus and the phase
+        using the output of the last RNN layer, and combine them into the wave function.
+
+        During the sampling, `conditionals_log_psi` is called and only the modulus is
+        needed, so the computation of the phase becomes an overhead. To avoid this
+        overhead, you can override `conditional` and only compute the modulus there.
     """
 
     def conditionals_log_psi(self, inputs: Array) -> Array:

--- a/netket/models/autoreg.py
+++ b/netket/models/autoreg.py
@@ -148,8 +148,7 @@ class AbstractARNN(nn.Module):
 class AbstractRecursiveARNN(AbstractARNN):
     def conditionals_log_psi(self, inputs: Array) -> Array:
         """
-        Computes the log of the conditional wave-functions for each site if it takes each value.
-        See `AbstractARNN.conditionals`.
+        Implementation of a ARNN that repeatedly calls a set of layers.
         """
         inputs = self._reshape_inputs(inputs)
 

--- a/netket/models/autoreg.py
+++ b/netket/models/autoreg.py
@@ -113,6 +113,15 @@ class AbstractARNN(nn.Module):
         Returns:
           The probabilities with dimensions (batch, Hilbert.local_size).
         """
+        # TODO: remove this in future
+        if hasattr(self, "_conditional"):
+            from netket.utils import warn_deprecation
+
+            warn_deprecation(
+                "AbstractARNN._conditional has been renamed to AbstractARNN.conditional "
+                "as a public API. Please update you code to use fast AR sampling."
+            )
+
         return self.conditionals(inputs)[:, index, :]
 
     def __call__(self, inputs: Array) -> Array:

--- a/netket/models/autoreg.py
+++ b/netket/models/autoreg.py
@@ -119,8 +119,9 @@ class AbstractARNN(nn.Module):
 
             warn_deprecation(
                 "AbstractARNN._conditional has been renamed to AbstractARNN.conditional "
-                "as a public API. Please update you code to use fast AR sampling."
+                "as a public API. Please update your subclass to use fast AR sampling."
             )
+            return self._conditional(inputs, index)
 
         return self.conditionals(inputs)[:, index, :]
 

--- a/netket/models/autoreg.py
+++ b/netket/models/autoreg.py
@@ -33,8 +33,10 @@ class AbstractARNN(nn.Module):
     """
     Base class for autoregressive neural networks.
 
-    Subclasses must implement the methods `__call__` and `conditionals`.
-    They can also override `_conditional` to implement the caching for fast autoregressive sampling.
+    Subclasses must implement the method `conditionals_log_psi`, or override the methods
+    `__call__` and `conditional` if desired.
+
+    They can override `conditional` to implement the caching for fast autoregressive sampling.
     See :class:`netket.nn.FastARNNConv1D` for example.
 
     They must also implement the field `machine_pow`,
@@ -43,8 +45,6 @@ class AbstractARNN(nn.Module):
 
     hilbert: HomogeneousHilbert
     """the Hilbert space. Only homogeneous unconstrained Hilbert spaces are supported."""
-
-    # machine_pow: int = 2 Must be defined on subclasses
 
     def __post_init__(self):
         super().__post_init__()
@@ -60,28 +60,13 @@ class AbstractARNN(nn.Module):
     @abc.abstractmethod
     def conditionals_log_psi(self, inputs: Array) -> Array:
         """
-        Computes the conditional log-probabilities for each site to take each value.
-
-        Subtypes of `AbstractARNN` should implement at least this function and
-        initialize eventual sublayers/parameters in `.setup()`. If desired, one
-        can also override the methods `.__call__` and `.conditional`
+        Computes the log of the conditional wave-functions for each site to take each value.
 
         Args:
           inputs: configurations with dimensions (batch, Hilbert.size).
 
         Returns:
-          The probabilities with dimensions (batch, Hilbert.size, Hilbert.local_size).
-
-        Examples:
-
-          >>> import pytest; pytest.skip("skip automated test of this docstring")
-          >>>
-          >>> p = model.apply(variables, σ, method=model.conditionals_log_psi)
-          >>> print(p[2, 3, :])
-          [0.3 0.7]
-          # For the 3rd spin of the 2nd sample in the batch,
-          # it takes probability 0.3 to be spin down (local state index 0),
-          # and probability 0.7 to be spin up (local state index 1).
+          The log psi with dimensions (batch, Hilbert.size, Hilbert.local_size).
         """
 
     def conditionals(self, inputs: Array) -> Array:
@@ -115,14 +100,15 @@ class AbstractARNN(nn.Module):
 
     def conditional(self, inputs: Array, index: int) -> Array:
         """
-        Computes the conditional probabilities for a site to take a given value.
+        Computes the conditional probabilities for one site to take each value.
 
         It should only be called successively with indices 0, 1, 2, ...,
         as in the autoregressive sampling procedure.
 
         Args:
-          inputs: configurations with dimensions (batch, Hilbert.size).
-          index: index of the site.
+          inputs: configurations of partially sampled sites with dimensions (batch, Hilbert.size),
+            where the sites that `index` depends on must be already sampled.
+          index: index of the site being queried.
 
         Returns:
           The probabilities with dimensions (batch, Hilbert.local_size).
@@ -130,7 +116,15 @@ class AbstractARNN(nn.Module):
         return self.conditionals(inputs)[:, index, :]
 
     def __call__(self, inputs: Array) -> Array:
-        """Returns log_psi."""
+        """
+        Computes the log wave-functions for input configurations.
+
+        Args:
+          inputs: configurations with dimensions (batch, Hilbert.size).
+
+        Returns:
+          The log psi with dimension (batch,).
+        """
 
         if inputs.ndim == 1:
             inputs = jnp.expand_dims(inputs, axis=0)
@@ -145,16 +139,20 @@ class AbstractARNN(nn.Module):
         return log_psi
 
 
-class AbstractRecursiveARNN(AbstractARNN):
+class ARNNSequential(AbstractARNN):
+    """
+    Implementation of an ARNN that sequentially calls its layers and activation function.
+
+    Subclasses must implement `activation` as a field or a method,
+    and assign a list of ARNN layers to `self._layers` in `setup`.
+    """
+
     def conditionals_log_psi(self, inputs: Array) -> Array:
-        """
-        Implementation of a ARNN that repeatedly calls a set of layers.
-        """
-        inputs = self._reshape_inputs(inputs)
+        inputs = self.reshape_inputs(inputs)
 
         x = jnp.expand_dims(inputs, axis=-1)
 
-        for i in range(self.layers):
+        for i in range(len(self._layers)):
             if i > 0:
                 x = self.activation(x)
             x = self._layers[i](x)
@@ -163,15 +161,16 @@ class AbstractRecursiveARNN(AbstractARNN):
         log_psi = _normalize(x, self.machine_pow)
         return log_psi
 
-    def _reshape_inputs(model: Any, inputs: Array) -> Array:  # noqa: F811
+    def reshape_inputs(model: Any, inputs: Array) -> Array:
         """
-        ???
+        Reshapes the inputs from (batch_size, hilbert_size) to (batch_size, spatial_dims...)
+        before sending them to the ARNN layers.
         """
         return inputs
 
 
 @deprecate_dtype
-class ARNNDense(AbstractRecursiveARNN):
+class ARNNDense(ARNNSequential):
     """Autoregressive neural network with dense layers."""
 
     layers: int
@@ -217,7 +216,7 @@ class ARNNDense(AbstractRecursiveARNN):
 
 
 @deprecate_dtype
-class ARNNConv1D(AbstractRecursiveARNN):
+class ARNNConv1D(ARNNSequential):
     """Autoregressive neural network with 1D convolution layers."""
 
     layers: int
@@ -268,7 +267,7 @@ class ARNNConv1D(AbstractRecursiveARNN):
         ]
 
 
-class ARNNConv2D(AbstractRecursiveARNN):
+class ARNNConv2D(ARNNSequential):
     """Autoregressive neural network with 2D convolution layers."""
 
     layers: int
@@ -322,7 +321,7 @@ class ARNNConv2D(AbstractRecursiveARNN):
             for i in range(self.layers)
         ]
 
-    def _reshape_inputs(self, inputs: Array) -> Array:
+    def reshape_inputs(self, inputs: Array) -> Array:
         return inputs.reshape((inputs.shape[0], self.L, self.L))
 
 

--- a/netket/models/fast_autoreg.py
+++ b/netket/models/fast_autoreg.py
@@ -17,14 +17,10 @@ from typing import Any, Callable, Iterable, Tuple, Union
 
 from jax import numpy as jnp
 from jax.nn.initializers import zeros
-from plum import dispatch
 
 from netket.models.autoreg import (
-    AbstractARNN,
-    _call,
-    _conditionals,
+    AbstractRecursiveARNN,
     _normalize,
-    _reshape_inputs,
 )
 from netket.nn import FastMaskedConv1D, FastMaskedConv2D, FastMaskedDense1D
 from netket.nn import activation as nkactivation
@@ -33,8 +29,30 @@ from netket.utils.types import Array, DType, NNInitFunc
 from netket.utils import deprecate_dtype
 
 
+class FastRecursiveARNN(AbstractRecursiveARNN):
+    def _conditional(self, inputs: Array, index: int) -> Array:
+        """
+        Computes the conditional probabilities for a site to take a given value.
+        See `AbstractARNN._conditional`.
+        """
+        if inputs.ndim == 1:
+            inputs = jnp.expand_dims(inputs, axis=0)
+
+        # When `index = 0`, it doesn't matter which site we take
+        x = inputs[:, index - 1, None]
+
+        for i in range(self.layers):
+            if i > 0:
+                x = self.activation(x)
+            x = self._layers[i].update_site(x, index)
+
+        log_psi = _normalize(x, self.machine_pow)
+        p = jnp.exp(self.machine_pow * log_psi.real)
+        return p
+
+
 @deprecate_dtype
-class FastARNNDense(AbstractARNN):
+class FastARNNDense(FastRecursiveARNN):
     """
     Fast autoregressive neural network with dense layers.
 
@@ -86,18 +104,9 @@ class FastARNNDense(AbstractARNN):
             for i in range(self.layers)
         ]
 
-    def _conditional(self, inputs: Array, index: int) -> Array:
-        return _conditional(self, inputs, index)
-
-    def conditionals(self, inputs: Array) -> Array:
-        return _conditionals(self, inputs)
-
-    def __call__(self, inputs: Array) -> Array:
-        return _call(self, inputs)
-
 
 @deprecate_dtype
-class FastARNNConv1D(AbstractARNN):
+class FastARNNConv1D(FastRecursiveARNN):
     """
     Fast autoregressive neural network with 1D convolution layers.
 
@@ -151,17 +160,8 @@ class FastARNNConv1D(AbstractARNN):
             for i in range(self.layers)
         ]
 
-    def _conditional(self, inputs: Array, index: int) -> Array:
-        return _conditional(self, inputs, index)
 
-    def conditionals(self, inputs: Array) -> Array:
-        return _conditionals(self, inputs)
-
-    def __call__(self, inputs: Array) -> Array:
-        return _call(self, inputs)
-
-
-class FastARNNConv2D(AbstractARNN):
+class FastARNNConv2D(FastRecursiveARNN):
     """
     Fast autoregressive neural network with 2D convolution layers.
 
@@ -220,37 +220,5 @@ class FastARNNConv2D(AbstractARNN):
             for i in range(self.layers)
         ]
 
-    def _conditional(self, inputs: Array, index: int) -> Array:
-        return _conditional(self, inputs, index)
-
-    def conditionals(self, inputs: Array) -> Array:
-        return _conditionals(self, inputs)
-
-    def __call__(self, inputs: Array) -> Array:
-        return _call(self, inputs)
-
-
-def _conditional(model: AbstractARNN, inputs: Array, index: int) -> Array:
-    """
-    Computes the conditional probabilities for a site to take a given value.
-    See `AbstractARNN._conditional`.
-    """
-    if inputs.ndim == 1:
-        inputs = jnp.expand_dims(inputs, axis=0)
-
-    # When `index = 0`, it doesn't matter which site we take
-    x = inputs[:, index - 1, None]
-
-    for i in range(model.layers):
-        if i > 0:
-            x = model.activation(x)
-        x = model._layers[i].update_site(x, index)
-
-    log_psi = _normalize(x, model.machine_pow)
-    p = jnp.exp(model.machine_pow * log_psi.real)
-    return p
-
-
-@dispatch
-def _reshape_inputs(model: FastARNNConv2D, inputs: Array) -> Array:  # noqa: F811
-    return inputs.reshape((inputs.shape[0], model.L, model.L))
+    def _reshape_inputs(self, inputs: Array) -> Array:  # noqa: F811
+        return inputs.reshape((inputs.shape[0], self.L, self.L))

--- a/netket/models/fast_autoreg.py
+++ b/netket/models/fast_autoreg.py
@@ -30,10 +30,10 @@ from netket.utils import deprecate_dtype
 
 
 class FastRecursiveARNN(AbstractRecursiveARNN):
-    def _conditional(self, inputs: Array, index: int) -> Array:
+    def conditional(self, inputs: Array, index: int) -> Array:
         """
         Computes the conditional probabilities for a site to take a given value.
-        See `AbstractARNN._conditional`.
+        See `AbstractARNN.conditional`.
         """
         if inputs.ndim == 1:
             inputs = jnp.expand_dims(inputs, axis=0)

--- a/netket/sampler/autoreg.py
+++ b/netket/sampler/autoreg.py
@@ -56,13 +56,13 @@ class ARDirectSampler(Sampler):
     Direct sampler for autoregressive neural networks.
 
     This sampler only works with Flax models.
-    This flax model must expose a specific method, `model._conditional`, which given
+    This flax model must expose a specific method, `model.conditional`, which given
     a batch of samples and an index `i∈[0,self.hilbert.size]` must return the vector
     of partial probabilities at index `i` for the various (partial) samples provided.
 
     In short, if your model can be sampled according to a probability
     $ p(x) = p_1(x_1)p_2(x_2|x_1)\dots p_N(x_N|x_{N-1}\dots x_1) $ then
-    `model._conditional(x, i)` should return $p_i(x)$.
+    `model.conditional(x, i)` should return $p_i(x)$.
 
     NetKet implements some autoregressive networks that can be used together with this
     sampler.
@@ -106,7 +106,7 @@ class ARDirectSampler(Sampler):
         return True
 
     def _init_cache(sampler, model, σ, key):
-        variables = model.init(key, σ, 0, method=model._conditional)
+        variables = model.init(key, σ, 0, method=model.conditional)
         if "cache" in variables:
             cache = variables["cache"]
         else:
@@ -136,7 +136,7 @@ class ARDirectSampler(Sampler):
                 _variables,
                 σ,
                 index,
-                method=model._conditional,
+                method=model.conditional,
                 mutable=["cache"],
             )
             if "cache" in mutables:

--- a/test/models/test_autoreg.py
+++ b/test/models/test_autoreg.py
@@ -209,7 +209,7 @@ class TestARNN:
 
         key_spins, key_model = jax.random.split(jax.random.PRNGKey(0))
         spins = hilbert.random_state(key_spins, size=batch_size)
-        variables = model2.init(key_model, spins, 0, method=model2._conditional)
+        variables = model2.init(key_model, spins, 0, method=model2.conditional)
 
         p1 = model1.apply(variables, spins, method=model1.conditionals)
         p2 = model2.apply(variables, spins, method=model2.conditionals)
@@ -226,7 +226,7 @@ class TestARNN:
                 variables,
                 spins,
                 i,
-                method=model2._conditional,
+                method=model2.conditional,
                 mutable=["cache"],
             )
             cache = mutables["cache"]


### PR DESCRIPTION
One year ago @wdphy16 had to work around some bugs in Flax inheritance and put several functions (`__call__` and `__conditional_log_psi__`) of the models as standalone functions and all the interface was pretty messy.

Those bugs have long been fixed in Flax, so I would like to clean up our Autoregressive method inheritance so that the interface is cleaner and implementing a custom Neural Network becomes simpler.

Compared to the previous interface, this one essentially asks users to inherit either from `AbstractRecursiveARNN` and only define a set of layers in the `setup()` method, or to inherit from `AbstractARNN` and declare a `conditionals_log_psi` function that returns the set of conditional log wavefucntions.

The resulting interface is quite clean, in my opinion. I would like the opinion of @wdphy16 and Zakari. In particular, I would like to understand if this can play well with the RNN Pr of @wdphy16  