### PR TITLE
Support schedules for preconditioners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ### New features
 * Added a new 'Full statevector' model {class}`netket.models.LogStateVector` that stores the exponentially large state and can be used as an exact ansatz [#1324](https://github.com/netket/netket/pull/1324).
-* Added a new {class}`netket.experimental.driver.TDVPSchmitt` driver, implementing the signal-to-noise ratio TDVP regularisation by Schmitt and Heyl [#1306](https://github.com/netket/netket/pull/1306).
+* Added a new experimental {class}`~netket.experimental.driver.TDVPSchmitt` driver, implementing the signal-to-noise ratio TDVP regularisation by Schmitt and Heyl [#1306](https://github.com/netket/netket/pull/1306).
 * QGT classes accept a `chunk_size` parameter that overrides the `chunk_size` set by the variational state object [#1347](https://github.com/netket/netket/pull/1347).
 * {func}`~netket.optimizer.qgt.QGTJacobianPyTree` and `QGTJacobianDense` support diagonal entry regularisation with constant and scale-invariant contributions. They accept a new `diag_scale` argument to pass the scale-invariant component [#1352](https://github.com/netket/netket/pull/1352).
 * {func}`~netket.optimizer.SR` preconditioner now supports scheduling of the diagonal shift and scale regularisations [#1364](https://github.com/netket/netket/pull/1364). 
@@ -17,7 +17,7 @@
 * Experimental RK solvers now store the error of the last timestep in the integrator state [#1328](https://github.com/netket/netket/pull/1328).
 * {class}`~netket.operator.PauliStrings` can now be constructed by passing a single string, instead of the previous requirement of a list of strings [#1331](https://github.com/netket/netket/pull/1331).
 * {class}`~netket.operator.PauliStrings` now support the subtraction operator [#1336](https://github.com/netket/netket/pull/1336).
-* {class}`flax.core.FrozenDict` can now be logged to netket's loggers, meaning that one does no longer need to unfreeze the parameters before logging them [#1338](https://github.com/netket/netket/pull/1338).
+* {class}`~flax.core.frozen_dict.FrozenDict` can now be logged to netket's loggers, meaning that one does no longer need to unfreeze the parameters before logging them [#1338](https://github.com/netket/netket/pull/1338).
 * Fermion operators are much more efficient and generate fewer connected elements [#1279](https://github.com/netket/netket/pull/1279).
 * NetKet now is completely PEP 621 compliant and does not have anymore a `setup.py` in favour of a `pyproject.toml` based on [hatchling](https://hatch.pypa.io/latest/). To install NetKet you should use a recent version of `pip` or a compatible tool such as poetry/hatch/flint [#1365](https://github.com/netket/netket/pull/1365).
 * {func}`~netket.optimizer.qgt.QGTJacobianDense` can now be used with {class}`~netket.vqs.ExactState` [#1358](https://github.com/netket/netket/pull/1358).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,26 @@
 * Added a new {class}`netket.experimental.driver.TDVPSchmitt` driver, implementing the signal-to-noise ratio TDVP regularisation by Schmitt and Heyl [#1306](https://github.com/netket/netket/pull/1306).
 * QGT classes accept a `chunk_size` parameter that overrides the `chunk_size` set by the variational state object [#1347](https://github.com/netket/netket/pull/1347).
 * {func}`~netket.optimizer.qgt.QGTJacobianPyTree` and {func}`~netket.optimizer.qgt.QGTJacobianDense` support diagonal entry regularisation with constant and scale-invariant contributions. They accept a new `diag_scale` argument to pass the scale-invariant component [#1352](https://github.com/netket/netket/pull/1352).
+* {meth}`~nk.optimizer.SR` preconditioner now supports scheduling of the diagonal shift and scale regularisations [#1364](https://github.com/netket/netket/pull/1364). 
+
+### Improvements
+* {meth}`~nk.vqs.ExactState.expect_and_grad` now returns a `nk.stats.Stats` object that also contains the variance, as `MCState` does [#1325](https://github.com/netket/netket/pull/1325).
+* Experimental RK solvers now store the error of the last timestep in the integrator state [#1328](https://github.com/netket/netket/pull/1328).
+* {class}`~nk.operator.PauliStrings` can now be constructed by passing a single string, instead of the previous requirement of a list of strings [#1331](https://github.com/netket/netket/pull/1331).
+* {class}`~nk.operator.PauliStrings` now support the subtraction operator [#1336](https://github.com/netket/netket/pull/1336).
+* `flax.core.FrozenDict` can now be logged to netket's loggers, meaning that one does no longer need to unfreeze the parameters before logging them [#1338](https://github.com/netket/netket/pull/1338).
+* Fermion operators are much more efficient and generate fewer connected elements [#1279](https://github.com/netket/netket/pull/1279).
+* NetKet now is completely PEP 621 compliant and does not have anymore a `setup.py` in favour of a `pyproject.toml` based on [hatchling](https://hatch.pypa.io/latest/). To install NetKet you should use a recent version of `pip` or a compatible tool such as poetry/hatch/flint [#1365](https://github.com/netket/netket/pull/1365).
+* {meth}`~nk.optimizer.qgt.QGTJacobianDense` can now be used with {class}`~nk.vqs.ExactState` [#1358](https://github.com/netket/netket/pull/1358).
+
 
 ### Bug Fixes
 * {meth}`netket.vqs.ExactState.expect_and_grad` returned a scalar while `expect` returned a {class}`nk.stats.Stats` object with 0 error. The inconsistency has been addressed and now they both return a `Stats` object. This changes the format of the files logged when running `VMC`, which will now store the average under `Mean` instead of `value` [#1325](https://github.com/netket/netket/pull/1325).
 * Autoregressive networks had a default activation function (`selu`) that did not act on the imaginary part of the inputs. We now changed that, and the activation function is `reim_selu`, which acts independently on the real and imaginary part. This changes nothing for real parameters, but improves the defaults for complex ones [#1371](https://github.com/netket/netket/pull/1371).
 
 ### Deprecations
-* The `rescale_shift` argument of {class}`~netket.optimizer.qgt.QGTJacobianPyTree` and `QGTJacobianDense` is deprecated inf avour the more flexible syntax with `diag_scale`. `rescale_shift=False` should be removed. `rescale_shift=True` should be replaced with `diag_scale=old_diag_shift`. [#1352](https://github.com/netket/netket/pull/1352).
+* The `rescale_shift` argument of `nk.optimizer.qgt.QGTJacobianPyTree` and `QGTJacobianDense` is deprecated inf avour the more flexible syntax with `diag_scale`. `rescale_shift=False` should be removed. `rescale_shift=True` should be replaced with `diag_scale=old_diag_shift`. [#1352](https://github.com/netket/netket/pull/1352).
+* The call signature of preconditioners passed to {class}`nk.VMC` and other drivers has changed as a consequence of scheduling, and preconditioners should now accept an extra optional argument `step`. The old signature is still supported but is deprecated and will eventually be removed [#1364](https://github.com/netket/netket/pull/1364).
 
 
 ## NetKet 3.5.1 (Bug Fixes)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,18 +9,18 @@
 * Added a new 'Full statevector' model {class}`netket.models.LogStateVector` that stores the exponentially large state and can be used as an exact ansatz [#1324](https://github.com/netket/netket/pull/1324).
 * Added a new {class}`netket.experimental.driver.TDVPSchmitt` driver, implementing the signal-to-noise ratio TDVP regularisation by Schmitt and Heyl [#1306](https://github.com/netket/netket/pull/1306).
 * QGT classes accept a `chunk_size` parameter that overrides the `chunk_size` set by the variational state object [#1347](https://github.com/netket/netket/pull/1347).
-* {func}`~netket.optimizer.qgt.QGTJacobianPyTree` and {func}`~netket.optimizer.qgt.QGTJacobianDense` support diagonal entry regularisation with constant and scale-invariant contributions. They accept a new `diag_scale` argument to pass the scale-invariant component [#1352](https://github.com/netket/netket/pull/1352).
-* {meth}`~nk.optimizer.SR` preconditioner now supports scheduling of the diagonal shift and scale regularisations [#1364](https://github.com/netket/netket/pull/1364). 
+* {func}`~netket.optimizer.qgt.QGTJacobianPyTree` and `QGTJacobianDense` support diagonal entry regularisation with constant and scale-invariant contributions. They accept a new `diag_scale` argument to pass the scale-invariant component [#1352](https://github.com/netket/netket/pull/1352).
+* {func}`~netket.optimizer.SR` preconditioner now supports scheduling of the diagonal shift and scale regularisations [#1364](https://github.com/netket/netket/pull/1364). 
 
 ### Improvements
-* {meth}`~nk.vqs.ExactState.expect_and_grad` now returns a `nk.stats.Stats` object that also contains the variance, as `MCState` does [#1325](https://github.com/netket/netket/pull/1325).
+* {meth}`~netket.vqs.ExactState.expect_and_grad` now returns a `nk.stats.Stats` object that also contains the variance, as `MCState` does [#1325](https://github.com/netket/netket/pull/1325).
 * Experimental RK solvers now store the error of the last timestep in the integrator state [#1328](https://github.com/netket/netket/pull/1328).
-* {class}`~nk.operator.PauliStrings` can now be constructed by passing a single string, instead of the previous requirement of a list of strings [#1331](https://github.com/netket/netket/pull/1331).
-* {class}`~nk.operator.PauliStrings` now support the subtraction operator [#1336](https://github.com/netket/netket/pull/1336).
-* `flax.core.FrozenDict` can now be logged to netket's loggers, meaning that one does no longer need to unfreeze the parameters before logging them [#1338](https://github.com/netket/netket/pull/1338).
+* {class}`~netket.operator.PauliStrings` can now be constructed by passing a single string, instead of the previous requirement of a list of strings [#1331](https://github.com/netket/netket/pull/1331).
+* {class}`~netket.operator.PauliStrings` now support the subtraction operator [#1336](https://github.com/netket/netket/pull/1336).
+* {class}`flax.core.FrozenDict` can now be logged to netket's loggers, meaning that one does no longer need to unfreeze the parameters before logging them [#1338](https://github.com/netket/netket/pull/1338).
 * Fermion operators are much more efficient and generate fewer connected elements [#1279](https://github.com/netket/netket/pull/1279).
 * NetKet now is completely PEP 621 compliant and does not have anymore a `setup.py` in favour of a `pyproject.toml` based on [hatchling](https://hatch.pypa.io/latest/). To install NetKet you should use a recent version of `pip` or a compatible tool such as poetry/hatch/flint [#1365](https://github.com/netket/netket/pull/1365).
-* {meth}`~nk.optimizer.qgt.QGTJacobianDense` can now be used with {class}`~nk.vqs.ExactState` [#1358](https://github.com/netket/netket/pull/1358).
+* {func}`~netket.optimizer.qgt.QGTJacobianDense` can now be used with {class}`~netket.vqs.ExactState` [#1358](https://github.com/netket/netket/pull/1358).
 
 
 ### Bug Fixes
@@ -28,8 +28,8 @@
 * Autoregressive networks had a default activation function (`selu`) that did not act on the imaginary part of the inputs. We now changed that, and the activation function is `reim_selu`, which acts independently on the real and imaginary part. This changes nothing for real parameters, but improves the defaults for complex ones [#1371](https://github.com/netket/netket/pull/1371).
 
 ### Deprecations
-* The `rescale_shift` argument of `nk.optimizer.qgt.QGTJacobianPyTree` and `QGTJacobianDense` is deprecated inf avour the more flexible syntax with `diag_scale`. `rescale_shift=False` should be removed. `rescale_shift=True` should be replaced with `diag_scale=old_diag_shift`. [#1352](https://github.com/netket/netket/pull/1352).
-* The call signature of preconditioners passed to {class}`nk.VMC` and other drivers has changed as a consequence of scheduling, and preconditioners should now accept an extra optional argument `step`. The old signature is still supported but is deprecated and will eventually be removed [#1364](https://github.com/netket/netket/pull/1364).
+* The `rescale_shift` argument of {class}`netket.optimizer.qgt.QGTJacobianPyTree` and `QGTJacobianDense` is deprecated inf avour the more flexible syntax with `diag_scale`. `rescale_shift=False` should be removed. `rescale_shift=True` should be replaced with `diag_scale=old_diag_shift`. [#1352](https://github.com/netket/netket/pull/1352).
+* The call signature of preconditioners passed to {class}`netket.VMC` and other drivers has changed as a consequence of scheduling, and preconditioners should now accept an extra optional argument `step`. The old signature is still supported but is deprecated and will eventually be removed [#1364](https://github.com/netket/netket/pull/1364).
 
 
 ## NetKet 3.5.1 (Bug Fixes)

--- a/Examples/Ising1d/ising1d_sr.py
+++ b/Examples/Ising1d/ising1d_sr.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import netket as nk
+import optax
 
 # 1D Lattice
 L = 20
@@ -34,7 +35,7 @@ sa = nk.sampler.MetropolisLocal(hi, n_chains=16)
 op = nk.optimizer.Sgd(learning_rate=0.1)
 
 # SR
-sr = nk.optimizer.SR(diag_shift=0.01)
+sr = nk.optimizer.SR(diag_shift=optax.linear_schedule(0.1, 0.01, 200))
 
 # Variational state
 vs = nk.vqs.MCState(sa, ma, n_samples=1000, n_discard_per_chain=100)

--- a/docs/docs/sr.md
+++ b/docs/docs/sr.md
@@ -2,6 +2,9 @@
 
 # Quantum Geometric Tensor and Stochastic Reconfiguration
 
+
+## Mathematical Background
+
 The Quantum Geometric Tensor (QGT) is the Fubini-Study metric tensor of the manifold on which a variational state is defined.
 In the general case (and in practise for any NQS ansatz), the QGT varies depending on the current quantum state and thus needs to be computed when the variational parameters $W$ change.
 To give an example, we consider a variational ansatz $ \psi\colon \mathbb{R} \rightarrow \mathscr{H} $ which maps elements $W$ of the parameter space to vectors in Hilbert space (quantum states) $\psi_W$.
@@ -10,6 +13,9 @@ The parameter space has a simple Euclidean metric, therefore the distance betwee
 However, what we really are interested in when optimizing variational ansätze is not the (Euclidean) distance between those two points in parameter space, but rather the distance in the Hilbert space between the corresponding quantum states (which also properly takes into account gauge degrees of freedom).
 The quantum mechanical distance function for quantum states is the Fubini-Study distance $ d(\psi, \phi) = \cos^{-1} \sqrt{\frac{\langle\psi|\phi\rangle \langle\phi|\psi\rangle}{\langle\psi|\psi\rangle \langle\phi|\phi\rangle}} $.
 This can be expanded to second order in an infinitesimal parameter change $\delta W$ as $ d(\psi_W, \psi_{W + \delta W}) = (\delta W)^\dagger S \delta W $ where $ S $ is the QGT.
+
+## Using the QGT in NetKet
+
 In NetKet you can obtain (an approximation of) the quantum geometric tensor of a variational state by calling {attr}`~netket.vqs.VariationalState.quantum_geometric_tensor`.
 
 ```python
@@ -46,6 +52,8 @@ Lastly, you can solve the linear system $ Q_{i,j} x_j = F_i $ by calling the sol
 x, info = qgt.solve(jax.scipy.sparse.linalg.gmres, grad)
 x, info = qgt.solve(nk.optimizer.solver.cholesky, grad)
 ```
+
+## The different QGT implementations
 
 While mathematically those operations are all well defined, there are several ways to implement them in code, all with different performance characteristics. For that reason, we have several (3) different implementations of the same Quantum Geometric Tensor object.
 The 3 implementations are:
@@ -133,13 +141,13 @@ gs = nk.VMC(hamiltonian, optimizer, variational_state=vstate, preconditioner=sr)
 
 Since SR leads to an optimisation that approximates an imaginary time evolution, we find that in general it is not a good idea to couple SR with advanced optimisers like ADAM, which modify the gradient remarkably. Stochastic Gradient Descent is the best choice in general.
 
-#### SR regularisation schedules
+### SR regularisation schedules
 
 Stochastic Reconfiguration supports scheduling the `diagonal_shift` and the `diagonal_scale` variables along the optimisation. To use this feature, simply pass a function accepting as input the iteration number and returning the diagonal shift for that iteration.
 
 Moreover, [optax](https://optax.readthedocs.io) provides [several pre-built schedules](https://optax.readthedocs.io/en/latest/api.html#optimizer-schedules) such as [linear scheduling](https://optax.readthedocs.io/en/latest/api.html#optax.linear_schedule) interpolating from an initial shift to a final one, [exponential scheduling](https://optax.readthedocs.io/en/latest/api.html#optax.exponential_decay), [oscillating schedules](https://optax.readthedocs.io/en/latest/api.html#optax.cosine_decay_schedule) and many more. 
 
-To use them in practice, you can do something like the following. Check the documentation page of SR for more extensive discussion on what options can be scheduled.
+To use them in practice, you can do something like the following. Check the documentation page of {func}`~netket.optimizer.SR` for more extensive discussion on what options can be scheduled.
 
 ```python
 sr = nk.optimizer.SR(diag_shift=optax.linear_schedule(0.01, 0.0001, 100))

--- a/netket/driver/steady_state.py
+++ b/netket/driver/steady_state.py
@@ -121,7 +121,7 @@ class SteadyState(AbstractVariationalDriver):
 
         # if it's the identity it does
         # self._dp = self._loss_grad
-        self._dp = self.preconditioner(self.state, self._loss_grad)
+        self._dp = self.preconditioner(self.state, self._loss_grad, self.step_count)
 
         # If parameters are real, then take only real part of the gradient (if it's complex)
         self._dp = jax.tree_map(

--- a/netket/driver/steady_state.py
+++ b/netket/driver/steady_state.py
@@ -155,7 +155,7 @@ class SteadyState(AbstractVariationalDriver):
         argument is the step, used to change some parameters along the
         optimisation.
 
-        Often, this is taken to be :ref:`nk.optimizer.SR`. If it is set to
+        Often, this is taken to be :func:`nk.optimizer.SR`. If it is set to
         `None`, then the identity is used.
         """
         return self._preconditioner

--- a/netket/driver/vmc.py
+++ b/netket/driver/vmc.py
@@ -140,7 +140,7 @@ class VMC(AbstractVariationalDriver):
         argument is the step, used to change some parameters along the
         optimisation.
 
-        Often, this is taken to be :ref:`nk.optimizer.SR`. If it is set to
+        Often, this is taken to be :func:`nk.optimizer.SR`. If it is set to
         `None`, then the identity is used.
         """
         return self._preconditioner

--- a/netket/driver/vmc.py
+++ b/netket/driver/vmc.py
@@ -133,7 +133,7 @@ class VMC(AbstractVariationalDriver):
 
         # if it's the identity it does
         # self._dp = self._loss_grad
-        self._dp = self.preconditioner(self.state, self._loss_grad)
+        self._dp = self.preconditioner(self.state, self._loss_grad, self.step_count)
 
         # If parameters are real, then take only real part of the gradient (if it's complex)
         self._dp = jax.tree_map(

--- a/netket/driver/vmc.py
+++ b/netket/driver/vmc.py
@@ -12,10 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Optional
+
 import jax
 import jax.numpy as jnp
 
 from textwrap import dedent
+from inspect import signature
 
 from netket.utils.types import PyTree
 from netket.operator import AbstractOperator
@@ -24,6 +27,7 @@ from netket.vqs import MCState
 from netket.optimizer import (
     identity_preconditioner,
     PreconditionerT,
+    _DeprecatedPreconditionerSignature,
 )
 from netket.utils import warn_deprecation
 
@@ -117,6 +121,39 @@ class VMC(AbstractVariationalDriver):
         self._dp = None  # type: PyTree
         self._S = None
         self._sr_info = None
+
+    @property
+    def preconditioner(self):
+        """
+        The preconditioner used to modify the gradient.
+
+        This is a function with the following signature
+
+        .. code-block:: python
+
+            precondtioner(vstate: VariationalState,
+                          grad: PyTree,
+                          step: Optional[Scalar] = None)
+
+        Where the first argument is a variational state, the second argument
+        is the PyTree of the gradient to precondition and the last optional
+        argument is the step, used to change some parameters along the
+        optimisation.
+
+        Often, this is taken to be :ref:`nk.optimizer.SR`. If it is set to
+        `None`, then the identity is used.
+        """
+        return self._preconditioner
+
+    @preconditioner.setter
+    def preconditioner(self, val: Optional[PreconditionerT]):
+        if val is None:
+            val = identity_preconditioner
+
+        if len(signature(val).parameters) == 2:
+            val = _DeprecatedPreconditionerSignature(val)
+
+        self._preconditioner = val
 
     def _forward_and_backward(self):
         """

--- a/netket/experimental/driver/tdvp.py
+++ b/netket/experimental/driver/tdvp.py
@@ -42,7 +42,7 @@ class TDVP(TDVPBaseDriver):
 
         When running computations on GPU, this can lead to infinite hangs or extremely long
         compilation times. In those cases, you might try setting the configuration variable
-        :py:`nk.config.netket_experimental_disable_ode_jit = True` to mitigate those issues.
+        `nk.config.netket_experimental_disable_ode_jit = True` to mitigate those issues.
 
     """
 
@@ -75,8 +75,8 @@ class TDVP(TDVPBaseDriver):
                 This must be a jax-jittable function :code:`f(A,b) -> x` that accepts a Matrix-like, Linear Operator
                 PyTree object :math:`A` and a vector-like PyTree :math:`b` and returns the PyTree :math:`x` solving
                 the system :math:`Ax=b`.
-                Defaults to :ref:`nk.optimizer.solver.svd` with the default svd threshold of 1e-10.
-                To change the svd threshold you can use :ref:`functools.partial` as follows:
+                Defaults to :func:`nk.optimizer.solver.svd` with the default svd threshold of 1e-10.
+                To change the svd threshold you can use :func:`functools.partial` as follows:
                 :code:`functools.partial(nk.optimizer.solver.svd, rcond=1e-4)`.
             linear_solver_restart: If False (default), the last solution of the linear system
                 is used as initial value in subsequent steps.

--- a/netket/experimental/driver/tdvp_schmitt.py
+++ b/netket/experimental/driver/tdvp_schmitt.py
@@ -82,7 +82,7 @@ class TDVPSchmitt(TDVPBaseDriver):
 
         When running computations on GPU, this can lead to infinite hangs or extremely long
         compilation times. In those cases, you might try setting the configuration variable
-        :py:`nk.config.netket_experimental_disable_ode_jit = True` to mitigate those issues.
+        `nk.config.netket_experimental_disable_ode_jit = True` to mitigate those issues.
 
     """
 

--- a/netket/jax/_vmap_chunked.py
+++ b/netket/jax/_vmap_chunked.py
@@ -84,7 +84,7 @@ def apply_chunked(f: Callable, in_axes=0, *, chunk_size: Optional[int]) -> Calla
 
     .. code-block:: python
 
-        assert f(x) == jnp.concatenate([f(x_i) for x_i in x], axis=0)`
+        assert f(x) == jnp.concatenate([f(x_i) for x_i in x], axis=0)
 
     which is automatically satisfied if `f` is obtained by vmapping a function,
     such as:

--- a/netket/optimizer/__init__.py
+++ b/netket/optimizer/__init__.py
@@ -21,6 +21,7 @@ from .preconditioner import (
     LinearPreconditioner,
     PreconditionerT,
     identity_preconditioner,
+    DeprecatedPreconditionerSignature as _DeprecatedPreconditionerSignature,
 )
 
 ## Optimisers

--- a/netket/optimizer/preconditioner.py
+++ b/netket/optimizer/preconditioner.py
@@ -44,14 +44,14 @@ class AbstractLinearPreconditioner:
     """Base class for a Linear Preconditioner solving a system :math:`Sx = F`.
 
     A LinearPreconditioner modifies the gradient :math:`F` in such a way that the new
-    gradient :math:`x` solves the linear system `:math:`Sx=F`. The linear operator 
+    gradient :math:`x` solves the linear system `:math:`Sx=F`. The linear operator
     :math:`S` is constructed from the variational state.
 
     To subtype this class and provide a concrete implementation, one needs to define
-    at least the function 
+    at least the function
 
     .. code::
-    
+
         @dataclass
         class MyLinearPreconditioner(AbstractLinearPreconditioner):
 
@@ -59,7 +59,7 @@ class AbstractLinearPreconditioner:
                 # here the lhs of the system should be constructed, for example by
                 # returning the geometric tensor or any other object
                 # return vstate.quantum_geometric_tensor()
-    
+
     """
 
     solver: SolverT

--- a/netket/optimizer/preconditioner.py
+++ b/netket/optimizer/preconditioner.py
@@ -14,34 +14,34 @@
 
 from typing import Callable, Optional, Any
 
+import abc
 from dataclasses import dataclass
 
-from netket.utils.types import PyTree
+from netket.utils.types import PyTree, Scalar
 from netket.vqs import VariationalState
 
 from .linear_operator import LinearOperator, SolverT
 
 # Generic signature of a preconditioner function/object
 
-PreconditionerT = Callable[[VariationalState, PyTree], PyTree]
+PreconditionerT = Callable[[VariationalState, PyTree, Optional[Scalar]], PyTree]
 """Signature for Gradient preconditioners supported by NetKet drivers."""
 
-LHSConstructorT = Callable[[VariationalState], LinearOperator]
+LHSConstructorT = Callable[[VariationalState, Optional[Scalar]], LinearOperator]
 """Signature for the constructor of a LinerOperator"""
 
 
-def identity_preconditioner(vstate: VariationalState, gradient: PyTree):
+def identity_preconditioner(
+    vstate: VariationalState, gradient: PyTree, step: Scalar = 0
+):
     return gradient
 
 
 @dataclass
-class LinearPreconditioner:
+class AbstractLinearPreconditioner:
     """Linear Preconditioner for the gradient. Needs a function to construct the LHS of
     the Linear System and a solver to solve the linear system.
     """
-
-    lhs_constructor: LHSConstructorT
-    """Constructor of the LHS of the linear system starting from the variational state."""
 
     solver: SolverT
     """Function used to solve the linear system."""
@@ -59,24 +59,57 @@ class LinearPreconditioner:
     _lhs: LinearOperator = None
     """LHS of the last linear system solved."""
 
-    def __init__(self, lhs_constructor, solver, *, solver_restart=False):
-        self.lhs_constructor = lhs_constructor
+    def __init__(self, solver, *, solver_restart=False):
         self.solver = solver
         self.solver_restart = solver_restart
 
-    def __call__(self, vstate: VariationalState, gradient: PyTree) -> PyTree:
+    def __call__(
+        self, vstate: VariationalState, gradient: PyTree, step: Optional[Scalar] = None
+    ) -> PyTree:
 
-        self._lhs = self.lhs_constructor(vstate)
+        self._lhs = self.lhs_constructor(vstate, step)
 
         x0 = self.x0 if self.solver_restart else None
         self.x0, self.info = self._lhs.solve(self.solver, gradient, x0=x0)
 
         return self.x0
 
+    @abc.abstractmethod
+    def lhs_constructor(self, vstate: VariationalState, step: Optional[Scalar] = None):
+        """
+        This method does things
+        """
+
     def __repr__(self):
         return (
             f"{type(self).__name__}("
-            + f"\n\tlhs_constructor = {self.lhs_constructor}, "
+            + f"\n\tsolver          = {self.solver}, "
+            + f"\n\tsolver_restart  = {self.solver_restart},"
+            + ")"
+        )
+
+
+# This exists for backward compatibility
+@dataclass
+class LinearPreconditioner(AbstractLinearPreconditioner):
+    lhs_constructor: LHSConstructorT
+    """Constructor of the LHS of the linear system starting from the variational state."""
+
+    def __init__(self, lhs_constructor, solver, *, solver_restart=False):
+        self._lhs_constructor = lhs_constructor
+        self.solver = solver
+        self.solver_restart = solver_restart
+
+    def lhs_constructor(self, vstate: VariationalState, step: Optional[Scalar] = None):
+        """
+        This method does things
+        """
+        return self._lhs_constructor(vstate, step)
+
+    def __repr__(self):
+        return (
+            f"{type(self).__name__}("
+            + f"\n\tlhs_constructor = {self._lhs_constructor}, "
             + f"\n\tsolver          = {self.solver}, "
             + f"\n\tsolver_restart  = {self.solver_restart},"
             + ")"

--- a/netket/optimizer/qgt/default.py
+++ b/netket/optimizer/qgt/default.py
@@ -57,10 +57,13 @@ def default_qgt_matrix(variational_state, solver=False, **kwargs):
     if _is_dense_solver(solver):
         return partial(QGTJacobianDense, **kwargs)
 
+    # TODO: Remove this once all QGT support diag_scale.
+    has_diag_rescale = kwargs.pop("diag_scale", None) is not None
+
     # arbitrary heuristic: if the network's parameters has many leaves
     # (an rbm has 3) then JacobianDense might be faster
     # the numbers chosen below are rather arbitrary and should be tuned.
-    if n_param_leaves > 6 and n_params > 800:
+    if (n_param_leaves > 6 and n_params > 800) or has_diag_rescale:
         if nkjax.tree_ishomogeneous(variational_state.variables):
             return partial(QGTJacobianDense, **kwargs)
         else:

--- a/netket/optimizer/qgt/qgt_onthefly.py
+++ b/netket/optimizer/qgt/qgt_onthefly.py
@@ -55,6 +55,12 @@ def QGTOnTheFly(vstate=None, *, chunk_size=None, **kwargs) -> "QGTOnTheFlyT":
         )
         kwargs.pop("centered")
 
+    if kwargs.pop("diag_scale", None) is not None:
+        raise ValueError("`diag_scale` argument is not yet supported by QGTOnTheFly."
+                         "Please use `QGTJacobianPyTree` or `QGTJacobianDense`.\n\n"
+                         "You are also encouraged to nag the developers to support "
+                         "this feature.\n\n")
+
     # TODO: Find a better way to handle this case
     from netket.vqs import ExactState
 

--- a/netket/optimizer/qgt/qgt_onthefly.py
+++ b/netket/optimizer/qgt/qgt_onthefly.py
@@ -56,10 +56,12 @@ def QGTOnTheFly(vstate=None, *, chunk_size=None, **kwargs) -> "QGTOnTheFlyT":
         kwargs.pop("centered")
 
     if kwargs.pop("diag_scale", None) is not None:
-        raise ValueError("`diag_scale` argument is not yet supported by QGTOnTheFly."
-                         "Please use `QGTJacobianPyTree` or `QGTJacobianDense`.\n\n"
-                         "You are also encouraged to nag the developers to support "
-                         "this feature.\n\n")
+        raise ValueError(
+            "\n`diag_scale` argument is not yet supported by QGTOnTheFly."
+            "Please use `QGTJacobianPyTree` or `QGTJacobianDense`.\n\n"
+            "You are also encouraged to nag the developers to support "
+            "this feature.\n\n"
+        )
 
     # TODO: Find a better way to handle this case
     from netket.vqs import ExactState

--- a/netket/optimizer/qgt/qgt_onthefly.py
+++ b/netket/optimizer/qgt/qgt_onthefly.py
@@ -56,7 +56,7 @@ def QGTOnTheFly(vstate=None, *, chunk_size=None, **kwargs) -> "QGTOnTheFlyT":
         kwargs.pop("centered")
 
     if kwargs.pop("diag_scale", None) is not None:
-        raise ValueError(
+        raise NotImplementedError(
             "\n`diag_scale` argument is not yet supported by QGTOnTheFly."
             "Please use `QGTJacobianPyTree` or `QGTJacobianDense`.\n\n"
             "You are also encouraged to nag the developers to support "

--- a/netket/optimizer/sr/api.py
+++ b/netket/optimizer/sr/api.py
@@ -236,11 +236,12 @@ class SR(AbstractLinearPreconditioner):
                 )
             diag_scale = diag_scale(step)
 
-        return self.qgt_constructor(vstate, 
-                                    diag_shift=diag_shift,
-                                    diag_scale=diag_scale,
-                                    **self.qgt_kwargs,
-                                    )
+        return self.qgt_constructor(
+            vstate,
+            diag_shift=diag_shift,
+            diag_scale=diag_scale,
+            **self.qgt_kwargs,
+        )
 
     def __repr__(self):
         return (

--- a/netket/optimizer/sr/api.py
+++ b/netket/optimizer/sr/api.py
@@ -34,9 +34,18 @@ default_iterative = "cg"
 
 
 def build_SR(*args, solver_restart: bool = False, **kwargs):
-    """
-    Construct the structure holding the parameters for using the
+    r"""
+    Constructs the structure holding the parameters for using the
     Stochastic Reconfiguration/Natural gradient method.
+
+    This preconditioner changes the gradient :math:`\nabla_i E` such that the
+    preconditioned gradient :math:`\delta_j` solves the system of equations
+
+    .. math::
+
+        S_{i,j}\delta_{j} = \nabla_i E
+
+    Where :math:`S` is the Quantum Geometric Tensor (or Fisher Information Matrix).
 
     Depending on the arguments, an implementation is chosen. For
     details on all possible kwargs check the specific SR implementations
@@ -50,12 +59,15 @@ def build_SR(*args, solver_restart: bool = False, **kwargs):
             jittable function taking as input a pytree and outputting
             a tuple of the solution and extra data.
         diag_shift: Diagonal shift added to the S matrix. Can be a Scalar
-            value, an `optax <https://optax.readthedocs.io>_` schedule
+            value, an `optax <https://optax.readthedocs.io>`_ schedule
             or a Callable function.
-        rescale_shift: Whether to rescale the diagonal offsets in SR according
-                       to diagonal entries (only with precomputed gradients)
-
-    Additional args:
+        diag_scale: Scale of the shift proportional to the diagonal of the
+            S matrix added added to it. Can be a Scalar value, an
+            `optax <https://optax.readthedocs.io>`_ schedule or a
+            Callable function.
+        solver_restart: If False uses the last solution of the linear
+            system as a starting point for the solution of the next
+            (default=False).
         holomorphic: boolean indicating if the ansatz is boolean or not. May
             speed up computations for models with complex-valued parameters.
     """
@@ -154,11 +166,11 @@ class SR(AbstractLinearPreconditioner):
 
     diag_shift: ScalarOrSchedule = 0.01
     """Diagonal shift added to the S matrix. Can be a Scalar value, an
-       `optax <https://optax.readthedocs.io>_` schedule or a Callable function."""
+       `optax <https://optax.readthedocs.io>`_ schedule or a Callable function."""
 
     diag_scale: Optional[ScalarOrSchedule] = None
     """Diagonal shift added to the S matrix. Can be a Scalar value, an
-       `optax <https://optax.readthedocs.io>_` schedule or a Callable function."""
+       `optax <https://optax.readthedocs.io>`_ schedule or a Callable function."""
 
     qgt_constructor: Callable = None
     """The Quantum Geometric Tensor type or a constructor."""
@@ -192,16 +204,15 @@ class SR(AbstractLinearPreconditioner):
                 jittable function taking as input a pytree and outputting
                 a tuple of the solution and extra data.
             diag_shift: Diagonal shift added to the S matrix. Can be a Scalar
-                value, an `optax <https://optax.readthedocs.io>_` schedule
+                value, an `optax <https://optax.readthedocs.io>`_ schedule
                 or a Callable function.
-            diag_shift: Scale of the shift proportional to the diagonal of the
+            diag_scale: Scale of the shift proportional to the diagonal of the
                 S matrix added added to it. Can be a Scalar value, an
-                `optax <https://optax.readthedocs.io>_` schedule or a
+                `optax <https://optax.readthedocs.io>`_ schedule or a
                 Callable function.
-            rescale_shift: Whether to rescale the diagonal offsets in SR according
-                           to diagonal entries (only with precomputed gradients)
-
-        Additional args:
+            solver_restart: If False uses the last solution of the linear
+                system as a starting point for the solution of the next
+                (default=False).
             holomorphic: boolean indicating if the ansatz is boolean or not. May
                 speed up computations for models with complex-valued parameters.
         """

--- a/netket/optimizer/sr/api.py
+++ b/netket/optimizer/sr/api.py
@@ -233,7 +233,7 @@ class SR(AbstractLinearPreconditioner):
         if callable(self.diag_shift):
             if step is None:
                 raise TypeError(
-                    "If you use a scheduled `diag_shift`, you must call"
+                    "If you use a scheduled `diag_shift`, you must call "
                     "the precoditioner with an extra argument `step`."
                 )
             diag_shift = diag_shift(step)
@@ -242,7 +242,7 @@ class SR(AbstractLinearPreconditioner):
         if callable(self.diag_scale):
             if step is None:
                 raise TypeError(
-                    "If you use a scheduled `diag_scale`, you must call"
+                    "If you use a scheduled `diag_scale`, you must call "
                     "the precoditioner with an extra argument `step`."
                 )
             diag_scale = diag_scale(step)

--- a/netket/optimizer/sr/api.py
+++ b/netket/optimizer/sr/api.py
@@ -177,7 +177,7 @@ class SR(AbstractLinearPreconditioner):
         **kwargs,
     ):
         """
-        Construct the structure holding the parameters for using the
+        Constructs the structure holding the parameters for using the
         Stochastic Reconfiguration/Natural gradient method.
 
         Depending on the arguments, an implementation is chosen. For

--- a/netket/optimizer/sr/api.py
+++ b/netket/optimizer/sr/api.py
@@ -12,15 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Callable, Optional
+
 from functools import partial
 from collections import namedtuple
+from dataclasses import dataclass
 
+from netket.vqs import VariationalState
 from netket.utils.numbers import is_scalar
+from netket.utils.types import Scalar, ScalarOrSchedule
 
 import jax
 
 from ..qgt import QGTAuto
-from ..preconditioner import LinearPreconditioner
+from ..preconditioner import AbstractLinearPreconditioner
 
 Preconditioner = namedtuple("Preconditioner", ["object", "solver"])
 
@@ -40,20 +45,22 @@ def build_SR(*args, solver_restart: bool = False, **kwargs):
     You can also construct one of those structures directly.
 
     Args:
-        diag_shift: Diagonal shift added to the S matrix
-        method: (cg, gmres) The specific method.
-        iterative: Whether to use an iterative method or not.
-        jacobian: Differentiation mode to precompute gradients
-                  can be "holomorphic", "R2R", "R2C",
-                  None (if they shouldn't be precomputed)
+        qgt: The Quantum Geometric Tensor type to use.
+        solver: The method used to solve the linear system. Must be a jax-
+            jittable function taking as input a pytree and outputting
+            a tuple of the solution and extra data.
+        diag_shift: Diagonal shift added to the S matrix. Can be a Scalar
+            value, an `optax <https://optax.readthedocs.io>_` schedule
+            or a Callable function.
         rescale_shift: Whether to rescale the diagonal offsets in SR according
                        to diagonal entries (only with precomputed gradients)
 
-    Returns:
-        The SR parameter structure.
+    Additional args:
+        holomorphic: boolean indicating if the ansatz is boolean or not. May
+            speed up computations for models with complex-valued parameters.
     """
 
-    #  try to understand if this is the old API or new
+    # try to understand if this is the old API or new
     # API
 
     old_api = False
@@ -61,7 +68,7 @@ def build_SR(*args, solver_restart: bool = False, **kwargs):
 
     if "matrix" in kwargs:
         # new syntax
-        return _SR(*args, **kwargs)
+        return SR(*args, **kwargs)
 
     legacy_kwargs = ["iterative", "method"]
     legacy_solver_kwargs = ["tol", "atol", "maxiter", "M", "restart", "solve_method"]
@@ -127,56 +134,98 @@ def build_SR(*args, solver_restart: bool = False, **kwargs):
 
         kwargs["solver"] = solver
 
-    return _SR(*args, solver_restart=solver_restart, **kwargs)
+    return SR(*args, solver_restart=solver_restart, **kwargs)
 
 
-class SR(LinearPreconditioner):
-    pass
+@dataclass
+class SR(AbstractLinearPreconditioner):
+    r"""
+    Stochastic Reconfiguration or Natural Gradient preconditioner for the gradient.
 
+    This preconditioner changes the gradient :math:`\nabla_i E` such that the
+    preconditioned gradient :math:`\delta_j` solves the system of equations
 
-# This will become the future implementation once legacy and semi-legacy
-# behaviour is removed
-def _SR(
-    qgt=None,
-    solver=None,
-    *,
-    diag_shift: float = 0.01,
-    solver_restart: bool = False,
-    **kwargs,
-):
-    """
-    Construct the structure holding the parameters for using the
-    Stochastic Reconfiguration/Natural gradient method.
+        :math:`S_{i,j}\delta_{j} = \nabla_i E`
 
-    Depending on the arguments, an implementation is chosen. For
-    details on all possible kwargs check the specific SR implementations
-    in the documentation.
+    Where :math:`S` is the Quantum Geometric Tensor (or Fisher Information Matrix).
 
-    You can also construct one of those structures directly.
-
-    Args:
-        qgt: The Quantum Geometric Tensor type to use.
-        diag_shift: Diagonal shift added to the S matrix
-        method: (cg, gmres) The specific method.
-        iterative: Whether to use an iterative method or not.
-        jacobian: Differentiation mode to precompute gradients
-                  can be "holomorphic", "R2R", "R2C",
-                         None (if they shouldn't be precomputed)
-        rescale_shift: Whether to rescale the diagonal offsets in SR according
-                       to diagonal entries (only with precomputed gradients)
-
-    Returns:
-        The SR parameter structure.
+    The algorithm used to solve the linear system must be a Jax-jittable function.
     """
 
-    if solver is None:
-        solver = jax.scipy.sparse.linalg.cg
+    diag_shift: ScalarOrSchedule = 0.01
+    """Diagonal shift added to the S matrix. Can be a Scalar value, an
+       `optax <https://optax.readthedocs.io>_` schedule or a Callable function."""
 
-    if qgt is None:
-        qgt = QGTAuto(solver)
+    qgt_constructor: Callable = None
+    """The Quantum Geometric Tensor type or a constructor."""
 
-    return SR(
-        partial(qgt, diag_shift=diag_shift, **kwargs),
-        solver=solver,
-        solver_restart=solver_restart,
-    )
+    qgt_kwargs: dict = None
+    """The keyword arguments to be passed to the Geometric Tensor constructor."""
+
+    def __init__(
+        self,
+        qgt: Optional[Callable] = None,
+        solver: Callable = jax.scipy.sparse.linalg.cg,
+        *,
+        diag_shift: ScalarOrSchedule = 0.01,
+        solver_restart: bool = False,
+        **kwargs,
+    ):
+        """
+        Construct the structure holding the parameters for using the
+        Stochastic Reconfiguration/Natural gradient method.
+
+        Depending on the arguments, an implementation is chosen. For
+        details on all possible kwargs check the specific SR implementations
+        in the documentation.
+
+        You can also construct one of those structures directly.
+
+        Args:
+            qgt: The Quantum Geometric Tensor type to use.
+            solver: The method used to solve the linear system. Must be a jax-
+                jittable function taking as input a pytree and outputting
+                a tuple of the solution and extra data.
+            diag_shift: Diagonal shift added to the S matrix. Can be a Scalar
+                value, an `optax <https://optax.readthedocs.io>_` schedule
+                or a Callable function.
+            rescale_shift: Whether to rescale the diagonal offsets in SR according
+                           to diagonal entries (only with precomputed gradients)
+
+        Additional args:
+            holomorphic: boolean indicating if the ansatz is boolean or not. May
+                speed up computations for models with complex-valued parameters.
+        """
+        if qgt is None:
+            qgt = QGTAuto(solver)
+
+        self.qgt_constructor = qgt
+        self.qgt_kwargs = kwargs
+        self.diag_shift = diag_shift
+        super().__init__(solver, solver_restart=solver_restart)
+
+    def lhs_constructor(self, vstate: VariationalState, step: Optional[Scalar] = None):
+        """
+        This method does things
+        """
+        diag_shift = self.diag_shift
+        if callable(self.diag_shift):
+            if step is None:
+                raise TypeError(
+                    "If you use a scheduled `diag_shift`, you must call"
+                    "the precoditioner with an extra argument `step`."
+                )
+            diag_shift = diag_shift(step)
+
+        return self.qgt_constructor(vstate, diag_shift=diag_shift, **self.qgt_kwargs)
+
+    def __repr__(self):
+        return (
+            f"{type(self).__name__}("
+            + f"\n  qgt_constructor = {self.qgt_constructor}, "
+            + f"\n  diag_shift      = {self.diag_shift}, "
+            + f"\n  qgt_kwargs      = {self.qgt_kwargs}, "
+            + f"\n  solver          = {self.solver}, "
+            + f"\n  solver_restart  = {self.solver_restart}"
+            + ")"
+        )

--- a/netket/utils/types.py
+++ b/netket/utils/types.py
@@ -14,6 +14,7 @@
 
 from typing import Any, Sequence, Callable, Union
 
+import optax as _optax
 import jax as _jax
 import jaxlib as _jaxlib
 import numpy as _np
@@ -32,3 +33,5 @@ NNInitFunc = Callable[[PRNGKeyT, Shape, DType], Array]
 PyTree = Any
 
 Scalar = Any
+
+ScalarOrSchedule = Union[Scalar, _optax.Schedule]

--- a/test/driver/test_steadystate.py
+++ b/test/driver/test_steadystate.py
@@ -117,3 +117,23 @@ def test_steadystate_steadystate_legacy_api():
             lind, op, variational_state=vs, sr=sr_config, sr_restart=True
         )
         assert driver.preconditioner == sr_config
+
+
+def test_no_preconditioner_api():
+    lind, vs, driver = _setup_ss()
+
+    driver.preconditioner = None
+    assert driver.preconditioner(None, 1) == 1
+    assert driver.preconditioner(None, 1, 2) == 1
+
+
+def test_preconditioner_deprecated_signature():
+    lind, vs, driver = _setup_ss()
+
+    sr = driver.preconditioner
+    _sr = lambda vstate, grad: sr(vstate, grad)
+
+    with pytest.warns(FutureWarning):
+        driver.preconditioner = _sr
+
+    driver.run(1)

--- a/test/optimizer/test_qgt_solvers.py
+++ b/test/optimizer/test_qgt_solvers.py
@@ -121,3 +121,16 @@ def test_qgt_nondiff_sigma(SType):
 
     S = vs.quantum_geometric_tensor(SType)
     S @ vs.parameters
+
+
+@common.skipif_mpi
+def test_qgt_otf_scale_err():
+    N = 5
+    hi = nk.hilbert.Spin(1 / 2, N)
+    ma = nk.models.RBM()
+    vstate = nk.vqs.MCState(
+        nk.sampler.MetropolisLocal(hi),
+        ma,
+    )
+    with pytest.raises(NotImplementedError):
+        nk.optimizer.qgt.QGTOnTheFly(vstate, diag_scale=0.01)

--- a/test/optimizer/test_sr_api.py
+++ b/test/optimizer/test_sr_api.py
@@ -119,3 +119,20 @@ def test_diag_shift_schedule(diag_shift):
         # check that the diag_shift passed to the QGT is correct
         qgt = sr.lhs_constructor(vstate, step_value)
         assert qgt.diag_shift == expected_diag_shift(step_value)
+
+
+def test_schedule_err():
+    sr = nk.optimizer.SR(diag_shift=lambda _: 0.01)
+
+    with pytest.raises(TypeError):
+        sr(None, None)
+
+    sr = nk.optimizer.SR(diag_scale=lambda _: 0.01)
+
+    with pytest.raises(TypeError):
+        sr(None, None)
+
+
+def test_repr():
+    sr = nk.optimizer.SR(diag_shift=lambda _: 0.01, diag_scale=lambda _: 0.01)
+    assert "SR" in repr(sr)

--- a/test/optimizer/test_sr_api.py
+++ b/test/optimizer/test_sr_api.py
@@ -86,3 +86,36 @@ def test_qgt_partial_onthefly():
     for k, v in args.items():
         assert k in QGT.keywords
         assert QGT.keywords[k] == v
+
+
+@pytest.mark.parametrize(
+    "diag_shift", [0.01, lambda _: 0.01, lambda x: 1 / x, "pytree"]
+)
+def test_diag_shift_schedule(diag_shift):
+    # construct a vstate
+    N = 5
+    hi = nk.hilbert.Spin(1 / 2, N)
+    vstate = nk.vqs.MCState(
+        nk.sampler.MetropolisLocal(hi),
+        nk.models.RBM(alpha=1),
+    )
+    vstate.init_parameters()
+    vstate.sample()
+
+    if isinstance(diag_shift, str):
+        sr = nk.optimizer.SR(diag_shift=vstate.parameters)
+        expected_diag_shift = lambda _: vstate.parameters
+    else:
+        sr = nk.optimizer.SR(diag_shift=diag_shift)
+        if isinstance(diag_shift, Callable):
+            expected_diag_shift = diag_shift
+        else:
+            expected_diag_shift = lambda _: diag_shift
+
+    for step_value in [10, 20.0]:
+        # ensure that this call is valid
+        grad = sr(vstate, vstate.parameters, step_value)
+
+        # check that the diag_shift passed to the QGT is correct
+        qgt = sr.lhs_constructor(vstate, step_value)
+        assert qgt.diag_shift == expected_diag_shift(step_value)


### PR DESCRIPTION
Remake of #1142, with a workaround in order not to throw a warning at every iteration. 

This could later be slightly extended to also support `diag_scale` from the other @attila-i-szabo 's PR. This forces preconditions to accept a third argument, but they can ignore it and it can be not passed around so that SR and everything else can still be used in custom loops without breaking user code.

I also plan in the future to migrate our preconditions to a stateful interface like optax optimisers, but for now I'd like to make minimal changes...

Only tests are missing. If someone wants to speed up this being merged, push some tests because I have little time right now.