### PR TITLE
Fix flaky test

### DIFF
--- a/test/variational/test_variational.py
+++ b/test/variational/test_variational.py
@@ -43,25 +43,25 @@ RBMModPhase = partial(nk.models.RBMModPhase, hidden_bias_init=standard_init)
 
 nk.models.RBM(
     alpha=1,
-    dtype=complex,
+    param_dtype=complex,
     kernel_init=normal(stddev=0.1),
     hidden_bias_init=normal(stddev=0.1),
 )
 machines["model:(R->R)"] = RBM(
     alpha=1,
-    dtype=float,
+    param_dtype=float,
     kernel_init=normal(stddev=0.1),
     hidden_bias_init=normal(stddev=0.1),
 )
 machines["model:(R->C)"] = RBMModPhase(
     alpha=1,
-    dtype=float,
+    param_dtype=float,
     kernel_init=normal(stddev=0.1),
     hidden_bias_init=normal(stddev=0.1),
 )
 machines["model:(C->C)"] = RBM(
     alpha=1,
-    dtype=complex,
+    param_dtype=complex,
     kernel_init=normal(stddev=0.1),
     hidden_bias_init=normal(stddev=0.1),
 )

--- a/test/variational/test_variational.py
+++ b/test/variational/test_variational.py
@@ -68,8 +68,8 @@ machines["model:(C->C)"] = RBM(
 machines["model:(C->C,nonholo)"] = nk.models.RBM(
     alpha=1,
     param_dtype=complex,
-    activation=lambda x: nk.nn.log_cosh(0.3*x*x+0.6*x.conj())
-    )
+    activation=lambda x: nk.nn.log_cosh(0.3 * x * x + 0.6 * x.conj()),
+)
 
 operators = {}
 


### PR DESCRIPTION
No idea why, but on the GitHub runner python 3.10 this test keeps failing. I never reproduced locally so I think it's not a real failure. Simplyfying the test to avoid.