### PR TITLE
use complex-aware activations as default for arnn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Bug Fixes
 * {class}`nk.vqs.ExactState` `expect_and_grad` returned a scalar while `expect` returned a {class}`nk.stats.Stats` object with 0 error. The inconsistency has been addressed and now they both return a `Stats` object. This changes the format of the files logged when running `VMC`, which will now store the average under `Mean` instead of `value` [#1325](https://github.com/netket/netket/pull/1325).
+* Autoregressive networks had a default activation function (`selu`) that did not act on the imaginary part of the inputs. We now changed that, and the activation function is `reim_selu`, which acts independently on the real and imaginary part. This changes nothing for real parameters, but improves the defaults for complex ones [#1371](https://github.com/netket/netket/pull/1371).
 
 ### Deprecations
 * The `rescale_shift` argument of `nk.optimizer.qgt.QGTJacobianPyTree` and `QGTJacobianDense` is deprecated inf avour the more flexible syntax with `diag_scale`. `rescale_shift=False` should be removed. `rescale_shift=True` should be replaced with `diag_scale=old_diag_shift`. [#1352](https://github.com/netket/netket/pull/1352).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,17 +6,17 @@
 ## NetKet 3.6 (In development)
 
 ### New features
-* Added a new 'Full statevector' model {class}`nk.models.LogStateVector` that stores the exponentially large state and can be used as an exact ansatz [#1324](https://github.com/netket/netket/pull/1324).
-* Added a new `nkx.driver.TDVPSchmitt` driver, implementing the signal-to-noise ratio TDVP regularisation by Schmitt and Heyl [#1306](https://github.com/netket/netket/pull/1306).
+* Added a new 'Full statevector' model {class}`netket.models.LogStateVector` that stores the exponentially large state and can be used as an exact ansatz [#1324](https://github.com/netket/netket/pull/1324).
+* Added a new {class}`netket.experimental.driver.TDVPSchmitt` driver, implementing the signal-to-noise ratio TDVP regularisation by Schmitt and Heyl [#1306](https://github.com/netket/netket/pull/1306).
 * QGT classes accept a `chunk_size` parameter that overrides the `chunk_size` set by the variational state object [#1347](https://github.com/netket/netket/pull/1347).
-* `nk.optimizer.qgt.QGTJacobianPyTree` and `QGTJacobianDense` support diagonal entry regularisation with constant and scale-invariant contributions. They accept a new `diag_scale` argument to pass the scale-invariant component [#1352](https://github.com/netket/netket/pull/1352).
+* {func}`~netket.optimizer.qgt.QGTJacobianPyTree` and {func}`~netket.optimizer.qgt.QGTJacobianDense` support diagonal entry regularisation with constant and scale-invariant contributions. They accept a new `diag_scale` argument to pass the scale-invariant component [#1352](https://github.com/netket/netket/pull/1352).
 
 ### Bug Fixes
-* {class}`nk.vqs.ExactState` `expect_and_grad` returned a scalar while `expect` returned a {class}`nk.stats.Stats` object with 0 error. The inconsistency has been addressed and now they both return a `Stats` object. This changes the format of the files logged when running `VMC`, which will now store the average under `Mean` instead of `value` [#1325](https://github.com/netket/netket/pull/1325).
+* {meth}`netket.vqs.ExactState.expect_and_grad` returned a scalar while `expect` returned a {class}`nk.stats.Stats` object with 0 error. The inconsistency has been addressed and now they both return a `Stats` object. This changes the format of the files logged when running `VMC`, which will now store the average under `Mean` instead of `value` [#1325](https://github.com/netket/netket/pull/1325).
 * Autoregressive networks had a default activation function (`selu`) that did not act on the imaginary part of the inputs. We now changed that, and the activation function is `reim_selu`, which acts independently on the real and imaginary part. This changes nothing for real parameters, but improves the defaults for complex ones [#1371](https://github.com/netket/netket/pull/1371).
 
 ### Deprecations
-* The `rescale_shift` argument of `nk.optimizer.qgt.QGTJacobianPyTree` and `QGTJacobianDense` is deprecated inf avour the more flexible syntax with `diag_scale`. `rescale_shift=False` should be removed. `rescale_shift=True` should be replaced with `diag_scale=old_diag_shift`. [#1352](https://github.com/netket/netket/pull/1352).
+* The `rescale_shift` argument of {class}`~netket.optimizer.qgt.QGTJacobianPyTree` and `QGTJacobianDense` is deprecated inf avour the more flexible syntax with `diag_scale`. `rescale_shift=False` should be removed. `rescale_shift=True` should be replaced with `diag_scale=old_diag_shift`. [#1352](https://github.com/netket/netket/pull/1352).
 
 
 ## NetKet 3.5.1 (Bug Fixes)

--- a/netket/models/autoreg.py
+++ b/netket/models/autoreg.py
@@ -25,6 +25,7 @@ from plum import dispatch
 from netket.hilbert.homogeneous import HomogeneousHilbert
 from netket.nn import MaskedConv1D, MaskedConv2D, MaskedDense1D
 from netket.nn.masked_linear import default_kernel_init
+from netket.nn import activation as nkactivation
 from netket.utils.types import Array, DType, NNInitFunc
 from netket.utils import deprecate_dtype
 
@@ -106,8 +107,8 @@ class ARNNDense(AbstractARNN):
     features: Union[Iterable[int], int]
     """output feature density in each layer. If a single number is given,
     all layers except the last one will have the same number of features."""
-    activation: Callable[[Array], Array] = jax.nn.selu
-    """the nonlinear activation function between hidden layers (default: selu)."""
+    activation: Callable[[Array], Array] = nkactivation.reim_selu
+    """the nonlinear activation function between hidden layers (default: reim_selu)."""
     use_bias: bool = True
     """whether to add a bias to the output (default: True)."""
     param_dtype: DType = jnp.float64
@@ -162,8 +163,8 @@ class ARNNConv1D(AbstractARNN):
     """length of the convolutional kernel."""
     kernel_dilation: int = 1
     """dilation factor of the convolution kernel (default: 1)."""
-    activation: Callable[[Array], Array] = jax.nn.selu
-    """the nonlinear activation function between hidden layers (default: selu)."""
+    activation: Callable[[Array], Array] = nkactivation.reim_selu
+    """the nonlinear activation function between hidden layers (default: reim_selu)."""
     use_bias: bool = True
     """whether to add a bias to the output (default: True)."""
     param_dtype: DType = jnp.float64
@@ -220,8 +221,8 @@ class ARNNConv2D(AbstractARNN):
     kernel_dilation: Tuple[int, int] = (1, 1)
     """a sequence of 2 integers, giving the dilation factor to
     apply in each spatial dimension of the convolution kernel (default: 1)."""
-    activation: Callable[[Array], Array] = jax.nn.selu
-    """the nonlinear activation function between hidden layers (default: selu)."""
+    activation: Callable[[Array], Array] = nkactivation.reim_selu
+    """the nonlinear activation function between hidden layers (default: reim_selu)."""
     use_bias: bool = True
     """whether to add a bias to the output (default: True)."""
     param_dtype: DType = jnp.float64

--- a/netket/models/fast_autoreg.py
+++ b/netket/models/fast_autoreg.py
@@ -15,7 +15,6 @@
 from math import sqrt
 from typing import Any, Callable, Iterable, Tuple, Union
 
-import jax
 from jax import numpy as jnp
 from jax.nn.initializers import zeros
 from plum import dispatch

--- a/netket/models/fast_autoreg.py
+++ b/netket/models/fast_autoreg.py
@@ -28,6 +28,7 @@ from netket.models.autoreg import (
     _reshape_inputs,
 )
 from netket.nn import FastMaskedConv1D, FastMaskedConv2D, FastMaskedDense1D
+from netket.nn import activation as nkactivation
 from netket.nn.masked_linear import default_kernel_init
 from netket.utils.types import Array, DType, NNInitFunc
 from netket.utils import deprecate_dtype
@@ -49,8 +50,8 @@ class FastARNNDense(AbstractARNN):
     features: Union[Iterable[int], int]
     """output feature density in each layer. If a single number is given,
     all layers except the last one will have the same number of features."""
-    activation: Callable[[Array], Array] = jax.nn.selu
-    """the nonlinear activation function between hidden layers (default: selu)."""
+    activation: Callable[[Array], Array] = nkactivation.reim_selu
+    """the nonlinear activation function between hidden layers (default: reim_selu)."""
     use_bias: bool = True
     """whether to add a bias to the output (default: True)."""
     param_dtype: DType = jnp.float64
@@ -113,8 +114,8 @@ class FastARNNConv1D(AbstractARNN):
     """length of the convolutional kernel."""
     kernel_dilation: int = 1
     """dilation factor of the convolution kernel (default: 1)."""
-    activation: Callable[[Array], Array] = jax.nn.selu
-    """the nonlinear activation function between hidden layers (default: selu)."""
+    activation: Callable[[Array], Array] = nkactivation.reim_selu
+    """the nonlinear activation function between hidden layers (default: reim_selu)."""
     use_bias: bool = True
     """whether to add a bias to the output (default: True)."""
     param_dtype: DType = jnp.float64
@@ -178,8 +179,8 @@ class FastARNNConv2D(AbstractARNN):
     kernel_dilation: Tuple[int, int] = (1, 1)
     """a sequence of 2 integers, giving the dilation factor to
     apply in each spatial dimension of the convolution kernel (default: 1)."""
-    activation: Callable[[Array], Array] = jax.nn.selu
-    """the nonlinear activation function between hidden layers (default: selu)."""
+    activation: Callable[[Array], Array] = nkactivation.reim_selu
+    """the nonlinear activation function between hidden layers (default: reim_selu)."""
     use_bias: bool = True
     """whether to add a bias to the output (default: True)."""
     param_dtype: DType = jnp.float64


### PR DESCRIPTION
Up to now we had an activation that was not doing nothing on the imaginary part of the input. This PR uses the `reim_` version. It does not change behaviour for real parameters, it does change the behaviour for complex but the old behaviour was clearly wrong so this is in a sense a bug fix