### PR TITLE
Reducing Parameters of Mask GCNN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@
 
 ## NetKet 3.7 (⚙️ In development)
 
+### New features
+* Input and hidden layer masks can now be specified for {class}`netket.models.GCNN` [#1387](https://github.com/netket/netket/pull/1387).
+
+### Breaking Changes
+* Parameters of models {class}`netket.models.GCNN` and layers {class}`netket.nn.DenseSymm` and {class}`netket.nn.DenseEquivariant` are stored as an array of shape '[features,in_features,mask_size]'. Masked parameters are now excluded from the model instead of multiplied by zero [#1387](https://github.com/netket/netket/pull/1387).
+
+
 ### Improvements
 * The underlying extension API for Autoregressive models that can be used with Ancestral/Autoregressive samplers has been simplified and stabilized and will be documented as part of the public API. For most models, you should now inherit from `AbstractARNN` and define `conditionals_log_psi`. For additional performance, implementers can also redefine `__call__` and `conditional` but this should not be needed in general. This will cause some breaking changes if you were relying on the old undocumented interface [#1361](https://github.com/netket/netket/pull/1361).
 
@@ -13,6 +20,7 @@
 ### Deprecations
 * `AbstractARNN._conditional` has been removed from the API, and its use will throw a deprecation warning. Update your ARNN models accordingly! [#1361](https://github.com/netket/netket/pull/1361).
 * Several undocumented internal methods from `nk.models.ARNN` have been removed [#1361](https://github.com/netket/netket/pull/1361).
+* Parameter loading for  [#1361](https://github.com/netket/netket/pull/1361).
 
 
 ## NetKet 3.6 (🏔️ 6 November 2022)

--- a/netket/models/equivariant.py
+++ b/netket/models/equivariant.py
@@ -76,6 +76,10 @@ class GCNN_FFT(nn.Module):
     """The nonlinear activation function between hidden layers."""
     output_activation: Any = identity
     """The nonlinear activation before the output. Defaults to the identity."""
+    input_mask: Optional[Array]
+    """mask for input to hidden weights"""
+    hidden_mask: Optional[Array]
+    """mask for hidden to hidden weights"""
     equal_amplitudes: bool = False
     """If true forces all basis states to have the same amplitude by setting `Re[logψ] = 0`"""
     use_bias: bool = True
@@ -103,6 +107,7 @@ class GCNN_FFT(nn.Module):
             kernel_init=self.kernel_init,
             bias_init=self.bias_init,
             precision=self.precision,
+            mask=self.input_mask,
         )
 
         self.equivariant_layers = [
@@ -115,6 +120,7 @@ class GCNN_FFT(nn.Module):
                 precision=self.precision,
                 kernel_init=self.kernel_init,
                 bias_init=self.bias_init,
+                mask=self.hidden_mask,
             )
             for layer in range(self.layers - 1)
         ]
@@ -189,6 +195,10 @@ class GCNN_Irrep(nn.Module):
     """The nonlinear activation function between hidden layers."""
     output_activation: Any = identity
     """The nonlinear activation before the output."""
+    input_mask: Optional[Array]
+    """mask for input to hidden weights"""
+    hidden_mask: Optional[Array]
+    """mask for hidden to hidden weights"""
     equal_amplitudes: bool = False
     """If true forces all basis states to have the same amplitude by setting `Re[logψ] = 0`"""
     use_bias: bool = True
@@ -215,6 +225,7 @@ class GCNN_Irrep(nn.Module):
             kernel_init=self.kernel_init,
             bias_init=self.bias_init,
             precision=self.precision,
+            mask=self.input_mask,
         )
 
         self.equivariant_layers = [
@@ -226,6 +237,7 @@ class GCNN_Irrep(nn.Module):
                 precision=self.precision,
                 kernel_init=self.kernel_init,
                 bias_init=self.bias_init,
+                mask=self.hidden_mask,
             )
             for layer in range(self.layers - 1)
         ]
@@ -287,6 +299,10 @@ class GCNN_Parity_FFT(nn.Module):
     """The nonlinear activation function between hidden layers."""
     output_activation: Any = identity
     """The nonlinear activation before the output."""
+    input_mask: Optional[Array]
+    """mask for input to hidden weights"""
+    hidden_mask: Optional[Array]
+    """mask for hidden to hidden weights"""
     equal_amplitudes: bool = False
     """If true forces all basis states to have the same amplitude by setting Re[psi] = 0"""
     use_bias: bool = True
@@ -328,6 +344,7 @@ class GCNN_Parity_FFT(nn.Module):
             kernel_init=self.kernel_init,
             bias_init=self.bias_init,
             precision=self.precision,
+            mask=self.input_mask,
         )
 
         self.equivariant_layers = [
@@ -340,6 +357,7 @@ class GCNN_Parity_FFT(nn.Module):
                 precision=self.precision,
                 kernel_init=self.kernel_init,
                 bias_init=self.bias_init,
+                mask=self.hidden_mask,
             )
             for layer in range(self.layers - 1)
         ]
@@ -463,6 +481,10 @@ class GCNN_Parity_Irrep(nn.Module):
     """The nonlinear activation function between hidden layers."""
     output_activation: Any = identity
     """The nonlinear activation before the output."""
+    input_mask: Optional[Array]
+    """mask for input to hidden weights"""
+    hidden_mask: Optional[Array]
+    """mask for hidden to hidden weights"""
     equal_amplitudes: bool = False
     """If true forces all basis states to have the same amplitude by setting Re[psi] = 0"""
     use_bias: bool = True
@@ -503,6 +525,7 @@ class GCNN_Parity_Irrep(nn.Module):
             kernel_init=self.kernel_init,
             bias_init=self.bias_init,
             precision=self.precision,
+            mask=self.input_mask,
         )
 
         self.equivariant_layers = [
@@ -514,6 +537,7 @@ class GCNN_Parity_Irrep(nn.Module):
                 precision=self.precision,
                 kernel_init=self.kernel_init,
                 bias_init=self.bias_init,
+                mask=self.hidden_mask,
             )
             for layer in range(self.layers - 1)
         ]

--- a/netket/models/equivariant.py
+++ b/netket/models/equivariant.py
@@ -682,7 +682,7 @@ def GCNN(
             Necessary when network parameters are real but some `characters` are negative.
         input_mask: Optional array of shape [n_sites] that used to restrict the convolutional
         kernel in the input :math:'\rightarrow' hidden weights. Only parameters with mask :math:'\ne 0' are used.
-        hidden_mask: Optional array of shape [n_symm] that used to restrict the convolutional
+        hidden_mask: Optional array of shape `(n_symm,)` that used to restrict the convolutional
         kernel in the hidden :math:'\rightarrow' hidden. Only parameters with mask :math:'\ne 0' are used.
 
     """

--- a/netket/models/equivariant.py
+++ b/netket/models/equivariant.py
@@ -78,11 +78,11 @@ class GCNN_FFT(nn.Module):
     """The nonlinear activation before the output. Defaults to the identity."""
     input_mask: Array = None
     """Optional array of shape `(n_sites,)` used to restrict the convolutional
-        kernel. Only parameters with mask :math:'\ne 0' are used. For best performance a 
+        kernel. Only parameters with mask :math:'\ne 0' are used. For best performance a
         boolean mask should be used."""
     hidden_mask: Array = None
-    """Optional array of shape `(n_symm,)` where `(n_symm,)` = `len(graph.automorphisms())` 
-        used to restrict the convolutional kernel. Only parameters with mask :math:'\ne 0' are used. 
+    """Optional array of shape `(n_symm,)` where `(n_symm,)` = `len(graph.automorphisms())`
+        used to restrict the convolutional kernel. Only parameters with mask :math:'\ne 0' are used.
         For best performance a boolean mask should be used"""
     equal_amplitudes: bool = False
     """If true forces all basis states to have the same amplitude by setting `Re[logψ] = 0`"""
@@ -201,11 +201,11 @@ class GCNN_Irrep(nn.Module):
     """The nonlinear activation before the output."""
     input_mask: Array = None
     """Optional array of shape `(n_sites,)` used to restrict the convolutional
-        kernel. Only parameters with mask :math:'\ne 0' are used. For best performance a 
+        kernel. Only parameters with mask :math:'\ne 0' are used. For best performance a
         boolean mask should be used."""
     hidden_mask: Array = None
-    """Optional array of shape `(n_symm,)` where `(n_symm,)` = `len(graph.automorphisms())` 
-        used to restrict the convolutional kernel. Only parameters with mask :math:'\ne 0' are used. 
+    """Optional array of shape `(n_symm,)` where `(n_symm,)` = `len(graph.automorphisms())`
+        used to restrict the convolutional kernel. Only parameters with mask :math:'\ne 0' are used.
         For best performance a boolean mask should be used"""
     equal_amplitudes: bool = False
     """If true forces all basis states to have the same amplitude by setting `Re[logψ] = 0`"""
@@ -309,11 +309,11 @@ class GCNN_Parity_FFT(nn.Module):
     """The nonlinear activation before the output."""
     input_mask: Array = None
     """Optional array of shape `(n_sites,)` used to restrict the convolutional
-        kernel. Only parameters with mask :math:'\ne 0' are used. For best performance a 
+        kernel. Only parameters with mask :math:'\ne 0' are used. For best performance a
         boolean mask should be used."""
     hidden_mask: Array = None
-    """Optional array of shape `(n_symm,)` where `(n_symm,)` = `len(graph.automorphisms())` 
-        used to restrict the convolutional kernel. Only parameters with mask :math:'\ne 0' are used. 
+    """Optional array of shape `(n_symm,)` where `(n_symm,)` = `len(graph.automorphisms())`
+        used to restrict the convolutional kernel. Only parameters with mask :math:'\ne 0' are used.
         For best performance a boolean mask should be used"""
     equal_amplitudes: bool = False
     """If true forces all basis states to have the same amplitude by setting Re[psi] = 0"""
@@ -496,11 +496,11 @@ class GCNN_Parity_Irrep(nn.Module):
     """The nonlinear activation before the output."""
     input_mask: Array = None
     """Optional array of shape `(n_sites,)` used to restrict the convolutional
-        kernel. Only parameters with mask :math:'\ne 0' are used. For best performance a 
+        kernel. Only parameters with mask :math:'\ne 0' are used. For best performance a
         boolean mask should be used."""
     hidden_mask: Array = None
-    """Optional array of shape `(n_symm,)` where `(n_symm,)` = `len(graph.automorphisms())` 
-        used to restrict the convolutional kernel. Only parameters with mask :math:'\ne 0' are used. 
+    """Optional array of shape `(n_symm,)` where `(n_symm,)` = `len(graph.automorphisms())`
+        used to restrict the convolutional kernel. Only parameters with mask :math:'\ne 0' are used.
         For best performance a boolean mask should be used"""
     equal_amplitudes: bool = False
     """If true forces all basis states to have the same amplitude by setting Re[psi] = 0"""

--- a/netket/models/equivariant.py
+++ b/netket/models/equivariant.py
@@ -680,7 +680,7 @@ def GCNN(
         bias_init: Initializer for the biases of all layers.
         complex_output: If True, ensures that the network output is always complex.
             Necessary when network parameters are real but some `characters` are negative.
-        input_mask: Optional array of shape [n_sites] that used to restrict the convolutional
+        input_mask: Optional array of shape `(n_sites,)` used to restrict the convolutional
         kernel in the input :math:'\rightarrow' hidden weights. Only parameters with mask :math:'\ne 0' are used.
         hidden_mask: Optional array of shape `(n_symm,)` that used to restrict the convolutional
         kernel in the hidden :math:'\rightarrow' hidden. Only parameters with mask :math:'\ne 0' are used.

--- a/netket/models/equivariant.py
+++ b/netket/models/equivariant.py
@@ -624,6 +624,8 @@ def GCNN(
     parity=None,
     param_dtype=np.float64,
     complex_output=True,
+    input_mask=None,
+    hidden_mask=None,
     **kwargs,
 ):
     r"""Implements a Group Convolutional Neural Network (G-CNN) that outputs a wavefunction
@@ -678,9 +680,17 @@ def GCNN(
         bias_init: Initializer for the biases of all layers.
         complex_output: If True, ensures that the network output is always complex.
             Necessary when network parameters are real but some `characters` are negative.
-
+        input_mask: Optional array of shape [n_sites] that used to restrict the convolutional
+        kernel in the input :math:'\rightarrow' hidden weights. Only parameters with mask :math:'\ne 0' are used.
+        hidden_mask: Optional array of shape [n_symm] that used to restrict the convolutional
+        kernel in the hidden :math:'\rightarrow' hidden. Only parameters with mask :math:'\ne 0' are used.
 
     """
+
+    if input_mask is not None:
+        input_mask = HashableArray(input_mask)
+    if hidden_mask is not None:
+        hidden_mask = HashableArray(hidden_mask)
 
     if isinstance(symmetries, Lattice) and (
         point_group is not None or symmetries._point_group is not None

--- a/netket/models/equivariant.py
+++ b/netket/models/equivariant.py
@@ -77,9 +77,13 @@ class GCNN_FFT(nn.Module):
     output_activation: Any = identity
     """The nonlinear activation before the output. Defaults to the identity."""
     input_mask: Array = None
-    """mask for input to hidden weights"""
+    """Optional array of shape `(n_sites,)` used to restrict the convolutional
+        kernel. Only parameters with mask :math:'\ne 0' are used. For best performance a 
+        boolean mask should be used."""
     hidden_mask: Array = None
-    """mask for hidden to hidden weights"""
+    """Optional array of shape `(n_symm,)` where `(n_symm,)` = `len(graph.automorphisms())` 
+        used to restrict the convolutional kernel. Only parameters with mask :math:'\ne 0' are used. 
+        For best performance a boolean mask should be used"""
     equal_amplitudes: bool = False
     """If true forces all basis states to have the same amplitude by setting `Re[logψ] = 0`"""
     use_bias: bool = True
@@ -196,9 +200,13 @@ class GCNN_Irrep(nn.Module):
     output_activation: Any = identity
     """The nonlinear activation before the output."""
     input_mask: Array = None
-    """mask for input to hidden weights"""
+    """Optional array of shape `(n_sites,)` used to restrict the convolutional
+        kernel. Only parameters with mask :math:'\ne 0' are used. For best performance a 
+        boolean mask should be used."""
     hidden_mask: Array = None
-    """mask for hidden to hidden weights"""
+    """Optional array of shape `(n_symm,)` where `(n_symm,)` = `len(graph.automorphisms())` 
+        used to restrict the convolutional kernel. Only parameters with mask :math:'\ne 0' are used. 
+        For best performance a boolean mask should be used"""
     equal_amplitudes: bool = False
     """If true forces all basis states to have the same amplitude by setting `Re[logψ] = 0`"""
     use_bias: bool = True
@@ -300,9 +308,13 @@ class GCNN_Parity_FFT(nn.Module):
     output_activation: Any = identity
     """The nonlinear activation before the output."""
     input_mask: Array = None
-    """mask for input to hidden weights"""
+    """Optional array of shape `(n_sites,)` used to restrict the convolutional
+        kernel. Only parameters with mask :math:'\ne 0' are used. For best performance a 
+        boolean mask should be used."""
     hidden_mask: Array = None
-    """mask for hidden to hidden weights"""
+    """Optional array of shape `(n_symm,)` where `(n_symm,)` = `len(graph.automorphisms())` 
+        used to restrict the convolutional kernel. Only parameters with mask :math:'\ne 0' are used. 
+        For best performance a boolean mask should be used"""
     equal_amplitudes: bool = False
     """If true forces all basis states to have the same amplitude by setting Re[psi] = 0"""
     use_bias: bool = True
@@ -483,9 +495,13 @@ class GCNN_Parity_Irrep(nn.Module):
     output_activation: Any = identity
     """The nonlinear activation before the output."""
     input_mask: Array = None
-    """mask for input to hidden weights"""
+    """Optional array of shape `(n_sites,)` used to restrict the convolutional
+        kernel. Only parameters with mask :math:'\ne 0' are used. For best performance a 
+        boolean mask should be used."""
     hidden_mask: Array = None
-    """mask for hidden to hidden weights"""
+    """Optional array of shape `(n_symm,)` where `(n_symm,)` = `len(graph.automorphisms())` 
+        used to restrict the convolutional kernel. Only parameters with mask :math:'\ne 0' are used. 
+        For best performance a boolean mask should be used"""
     equal_amplitudes: bool = False
     """If true forces all basis states to have the same amplitude by setting Re[psi] = 0"""
     use_bias: bool = True
@@ -681,9 +697,11 @@ def GCNN(
         complex_output: If True, ensures that the network output is always complex.
             Necessary when network parameters are real but some `characters` are negative.
         input_mask: Optional array of shape `(n_sites,)` used to restrict the convolutional
-        kernel in the input :math:'\rightarrow' hidden weights. Only parameters with mask :math:'\ne 0' are used.
-        hidden_mask: Optional array of shape `(n_symm,)` that used to restrict the convolutional
-        kernel in the hidden :math:'\rightarrow' hidden. Only parameters with mask :math:'\ne 0' are used.
+        kernel. Only parameters with mask :math:'\ne 0' are used. For best performance a
+        boolean mask should be used.
+        hidden_mask: Optional array of shape `(n_symm,)` where `(n_symm,)` = `len(graph.automorphisms())`
+        used to restrict the convolutional kernel. Only parameters with mask :math:'\ne 0' are used.
+        For best performance a boolean mask should be used.
 
     """
 

--- a/netket/models/equivariant.py
+++ b/netket/models/equivariant.py
@@ -23,7 +23,7 @@ from jax.nn.initializers import zeros, lecun_normal
 from jax.scipy.special import logsumexp
 
 from netket.utils import HashableArray, warn_deprecation, deprecate_dtype
-from netket.utils.types import NNInitFunc
+from netket.utils.types import NNInitFunc, Array
 from netket.utils.group import PermutationGroup
 from netket.graph import Graph, Lattice
 from netket.jax import logsumexp_cplx, is_complex_dtype
@@ -76,9 +76,9 @@ class GCNN_FFT(nn.Module):
     """The nonlinear activation function between hidden layers."""
     output_activation: Any = identity
     """The nonlinear activation before the output. Defaults to the identity."""
-    input_mask: Optional[Array]
+    input_mask: Array = None
     """mask for input to hidden weights"""
-    hidden_mask: Optional[Array]
+    hidden_mask: Array = None
     """mask for hidden to hidden weights"""
     equal_amplitudes: bool = False
     """If true forces all basis states to have the same amplitude by setting `Re[logψ] = 0`"""
@@ -195,9 +195,9 @@ class GCNN_Irrep(nn.Module):
     """The nonlinear activation function between hidden layers."""
     output_activation: Any = identity
     """The nonlinear activation before the output."""
-    input_mask: Optional[Array]
+    input_mask: Array = None
     """mask for input to hidden weights"""
-    hidden_mask: Optional[Array]
+    hidden_mask: Array = None
     """mask for hidden to hidden weights"""
     equal_amplitudes: bool = False
     """If true forces all basis states to have the same amplitude by setting `Re[logψ] = 0`"""
@@ -299,9 +299,9 @@ class GCNN_Parity_FFT(nn.Module):
     """The nonlinear activation function between hidden layers."""
     output_activation: Any = identity
     """The nonlinear activation before the output."""
-    input_mask: Optional[Array]
+    input_mask: Array = None
     """mask for input to hidden weights"""
-    hidden_mask: Optional[Array]
+    hidden_mask: Array = None
     """mask for hidden to hidden weights"""
     equal_amplitudes: bool = False
     """If true forces all basis states to have the same amplitude by setting Re[psi] = 0"""
@@ -373,6 +373,7 @@ class GCNN_Parity_FFT(nn.Module):
                 precision=self.precision,
                 kernel_init=self.kernel_init,
                 bias_init=self.bias_init,
+                mask=self.hidden_mask,
             )
             for layer in range(self.layers - 1)
         ]
@@ -481,9 +482,9 @@ class GCNN_Parity_Irrep(nn.Module):
     """The nonlinear activation function between hidden layers."""
     output_activation: Any = identity
     """The nonlinear activation before the output."""
-    input_mask: Optional[Array]
+    input_mask: Array = None
     """mask for input to hidden weights"""
-    hidden_mask: Optional[Array]
+    hidden_mask: Array = None
     """mask for hidden to hidden weights"""
     equal_amplitudes: bool = False
     """If true forces all basis states to have the same amplitude by setting Re[psi] = 0"""
@@ -552,6 +553,7 @@ class GCNN_Parity_Irrep(nn.Module):
                 precision=self.precision,
                 kernel_init=self.kernel_init,
                 bias_init=self.bias_init,
+                mask=self.hidden_mask,
             )
             for layer in range(self.layers - 1)
         ]

--- a/netket/nn/symmetric_linear.py
+++ b/netket/nn/symmetric_linear.py
@@ -108,7 +108,7 @@ class DenseSymmMatrix(Module):
             )
         else:
             bias = None
-        
+
         if self.mask is not None:
             kernel_params = self.param(
                 "kernel",
@@ -117,8 +117,10 @@ class DenseSymmMatrix(Module):
                 self.param_dtype,
             )
 
-            kernel = jnp.zeros([self.features, in_features, self.n_sites],self.param_dtype)
-            kernel = kernel.at[:,:,self.kernel_indices].set(kernel_params)
+            kernel = jnp.zeros(
+                [self.features, in_features, self.n_sites], self.param_dtype
+            )
+            kernel = kernel.at[:, :, self.kernel_indices].set(kernel_params)
         else:
             kernel = self.param(
                 "kernel",
@@ -229,13 +231,16 @@ class DenseSymmFFT(Module):
                 self.param_dtype,
             )
 
-            kernel = jnp.zeros([self.features, in_features, self.n_cells*self.sites_per_cell],self.param_dtype)
-            kernel = kernel.at[:,:,self.kernel_indices].set(kernel_params)
+            kernel = jnp.zeros(
+                [self.features, in_features, self.n_cells * self.sites_per_cell],
+                self.param_dtype,
+            )
+            kernel = kernel.at[:, :, self.kernel_indices].set(kernel_params)
         else:
             kernel = self.param(
                 "kernel",
                 self.kernel_init,
-                (self.features, in_features, self.n_cells*self.sites_per_cell),
+                (self.features, in_features, self.n_cells * self.sites_per_cell),
                 self.param_dtype,
             )
 
@@ -344,13 +349,16 @@ class DenseEquivariantFFT(Module):
                 self.param_dtype,
             )
 
-            kernel = jnp.zeros([self.features, in_features, self.n_point*self.n_cells],self.param_dtype)
-            kernel = kernel.at[:,:,self.kernel_indices].set(kernel_params)
+            kernel = jnp.zeros(
+                [self.features, in_features, self.n_point * self.n_cells],
+                self.param_dtype,
+            )
+            kernel = kernel.at[:, :, self.kernel_indices].set(kernel_params)
         else:
             kernel = self.param(
                 "kernel",
                 self.kernel_init,
-                (self.features, in_features, self.n_point*self.n_cells),
+                (self.features, in_features, self.n_point * self.n_cells),
                 self.param_dtype,
             )
 
@@ -534,8 +542,10 @@ class DenseEquivariantIrrep(Module):
                 self.param_dtype,
             )
 
-            kernel = jnp.zeros([self.features, in_features, self.n_symm],self.param_dtype)
-            kernel = kernel.at[:,:,self.kernel_indices].set(kernel_params)
+            kernel = jnp.zeros(
+                [self.features, in_features, self.n_symm], self.param_dtype
+            )
+            kernel = kernel.at[:, :, self.kernel_indices].set(kernel_params)
         else:
             kernel = self.param(
                 "kernel",
@@ -617,8 +627,10 @@ class DenseEquivariantMatrix(Module):
                 self.param_dtype,
             )
 
-            kernel = jnp.zeros([self.features, in_features, self.n_symm],self.param_dtype)
-            kernel = kernel.at[:,:,self.kernel_indices].set(kernel_params)
+            kernel = jnp.zeros(
+                [self.features, in_features, self.n_symm], self.param_dtype
+            )
+            kernel = kernel.at[:, :, self.kernel_indices].set(kernel_params)
         else:
             kernel = self.param(
                 "kernel",

--- a/netket/nn/symmetric_linear.py
+++ b/netket/nn/symmetric_linear.py
@@ -58,7 +58,7 @@ class DenseSymmMatrix(Module):
     """Whether to add a bias to the output (default: True)."""
     mask: Optional[HashableArray] = None
     """Optional array of shape `(n_sites,)` used to restrict the convolutional
-        kernel. Only parameters with mask :math:'\ne 0' are used. For best performance a 
+        kernel. Only parameters with mask :math:'\ne 0' are used. For best performance a
         boolean mask should be used"""
     param_dtype: Any = jnp.float64
     """The dtype of the weights."""
@@ -126,7 +126,6 @@ class DenseSymmMatrix(Module):
                 self.param_dtype,
             )
         x, kernel, bias = promote_dtype(x, kernel, bias, dtype=None)
-        dtype = x.dtype
 
         # Converts the convolutional kernel of shape (self.features, in_features, n_sites)
         # to a full dense kernel of shape (self.features, in_features, n_symm, n_sites).
@@ -163,7 +162,7 @@ class DenseSymmFFT(Module):
     """Whether to add a bias to the output (default: True)."""
     mask: Optional[HashableArray] = None
     """Optional array of shape `(n_sites,)` used to restrict the convolutional
-        kernel. Only parameters with mask :math:'\ne 0' are used. For best performance a 
+        kernel. Only parameters with mask :math:'\ne 0' are used. For best performance a
         boolean mask should be used"""
     param_dtype: DType = jnp.float64
     """The dtype of the weights."""
@@ -293,8 +292,8 @@ class DenseEquivariantFFT(Module):
     use_bias: bool = True
     """Whether to add a bias to the output (default: True)."""
     mask: Optional[HashableArray] = None
-    """Optional array of shape `(n_symm,)` where `(n_symm,)` = `len(graph.automorphisms())` 
-        used to restrict the convolutional kernel. Only parameters with mask :math:'\ne 0' are used. 
+    """Optional array of shape `(n_symm,)` where `(n_symm,)` = `len(graph.automorphisms())`
+        used to restrict the convolutional kernel. Only parameters with mask :math:'\ne 0' are used.
         For best performance a boolean mask should be used"""
     param_dtype: DType = jnp.float64
     """The dtype of the weights."""
@@ -431,8 +430,8 @@ class DenseEquivariantIrrep(Module):
     use_bias: bool = True
     """Whether to add a bias to the output (default: True)."""
     mask: Optional[HashableArray] = None
-    """Optional array of shape `(n_symm,)` where `(n_symm,)` = `len(graph.automorphisms())` 
-        used to restrict the convolutional kernel. Only parameters with mask :math:'\ne 0' are used. 
+    """Optional array of shape `(n_symm,)` where `(n_symm,)` = `len(graph.automorphisms())`
+        used to restrict the convolutional kernel. Only parameters with mask :math:'\ne 0' are used.
         For best performance a boolean mask should be used"""
 
     param_dtype: DType = jnp.float64
@@ -596,8 +595,8 @@ class DenseEquivariantMatrix(Module):
     use_bias: bool = True
     """Whether to add a bias to the output (default: True)."""
     mask: Optional[HashableArray] = None
-    """Optional array of shape `(n_symm,)` where `(n_symm,)` = `len(graph.automorphisms())` 
-        used to restrict the convolutional kernel. Only parameters with mask :math:'\ne 0' are used. 
+    """Optional array of shape `(n_symm,)` where `(n_symm,)` = `len(graph.automorphisms())`
+        used to restrict the convolutional kernel. Only parameters with mask :math:'\ne 0' are used.
         For best performance a boolean mask should be used"""
     param_dtype: Any = jnp.float64
     """The dtype of the weights."""

--- a/netket/nn/symmetric_linear.py
+++ b/netket/nn/symmetric_linear.py
@@ -789,7 +789,7 @@ def DenseEquivariant(
             is [n_batch,features,n_symm].
         use_bias: A bool specifying whether to add a bias to the output (default: True).
         input_mask: Optional array of shape [n_symm] that used to restrict the convolutional
-        kernel. Only parameters with mask :math:'\ne 0' are used.
+        kernel. Only parameters with mask :math:'\ne 0' are used. For best performance a boolean mask should be used.
         param_dtype: The datatype of the weights. Defaults to a 64bit float.
         precision: Optional argument specifying numerical precision of the computation.
             see :class:`jax.lax.Precision` for details.

--- a/netket/nn/symmetric_linear.py
+++ b/netket/nn/symmetric_linear.py
@@ -607,7 +607,7 @@ class DenseEquivariantMatrix(Module):
     def setup(self):
         self.n_symm = np.asarray(self.product_table).shape[0]
         if self.mask is not None:
-            self.kernel_indices = jnp.nonzero(self.mask)[0]
+            self.kernel_indices, = jnp.nonzero(self.mask)
 
     @compact
     def __call__(self, x: Array) -> Array:

--- a/netket/nn/symmetric_linear.py
+++ b/netket/nn/symmetric_linear.py
@@ -700,8 +700,8 @@ def DenseSymm(symmetries, point_group=None, mode="auto", shape=None, **kwargs):
         features: The number of output features. The full output shape
             is :code:`[n_batch,features,n_symm]`.
         use_bias: A bool specifying whether to add a bias to the output (default: True).
-        mask: An optional array of shape [n_sites] consisting of ones and zeros
-            that can be used to give the kernel a particular shape.
+        input_mask: Optional array of shape [n_sites] that used to restrict the convolutional
+        kernel. Only parameters with mask :math:'\ne 0' are used.
         param_dtype: The datatype of the weights. Defaults to a 64bit float.
         precision: Optional argument specifying numerical precision of the computation.
             see {class}`jax.lax.Precision` for details.
@@ -788,8 +788,8 @@ def DenseEquivariant(
         features: The number of output features. The full output shape
             is [n_batch,features,n_symm].
         use_bias: A bool specifying whether to add a bias to the output (default: True).
-        mask: An optional array of shape [n_sites] consisting of ones and zeros
-            that can be used to give the kernel a particular shape.
+        input_mask: Optional array of shape [n_symm] that used to restrict the convolutional
+        kernel. Only parameters with mask :math:'\ne 0' are used.
         param_dtype: The datatype of the weights. Defaults to a 64bit float.
         precision: Optional argument specifying numerical precision of the computation.
             see :class:`jax.lax.Precision` for details.

--- a/netket/nn/symmetric_linear.py
+++ b/netket/nn/symmetric_linear.py
@@ -108,24 +108,26 @@ class DenseSymmMatrix(Module):
             )
         else:
             bias = None
-
+        
         if self.mask is not None:
             kernel_params = self.param(
                 "kernel",
                 self.kernel_init,
                 (self.features, in_features, len(self.kernel_indices)),
-                self.dtype,
+                self.param_dtype,
             )
 
-            kernel = jnp.zeros([self.features, in_features, self.n_sites])
-            kernel = kernel.at[:, :, self.kernel_indices].set(kernel_params)
+            kernel = jnp.zeros([self.features, in_features, self.n_sites],self.param_dtype)
+            kernel = kernel.at[:,:,self.kernel_indices].set(kernel_params)
         else:
             kernel = self.param(
                 "kernel",
                 self.kernel_init,
                 (self.features, in_features, self.n_sites),
-                self.dtype,
+                self.param_dtype,
             )
+        x, kernel, bias = promote_dtype(x, kernel, bias, dtype=None)
+        dtype = x.dtype
 
         # Converts the convolutional kernel of shape (self.features, in_features, n_sites)
         # to a full dense kernel of shape (self.features, in_features, n_symm, n_sites).
@@ -224,18 +226,22 @@ class DenseSymmFFT(Module):
                 "kernel",
                 self.kernel_init,
                 (self.features, in_features, len(self.kernel_indices)),
-                self.dtype,
+                self.param_dtype,
             )
 
-            kernel = jnp.zeros([self.features, in_features, self.n_sites])
-            kernel = kernel.at[:, :, self.kernel_indices].set(kernel_params)
+            kernel = jnp.zeros([self.features, in_features, self.n_cells*self.sites_per_cell],self.param_dtype)
+            kernel = kernel.at[:,:,self.kernel_indices].set(kernel_params)
         else:
             kernel = self.param(
                 "kernel",
                 self.kernel_init,
-                (self.features, in_features, self.n_sites),
-                self.dtype,
+                (self.features, in_features, self.n_cells*self.sites_per_cell),
+                self.param_dtype,
             )
+
+        x, kernel, bias = promote_dtype(x, kernel, bias, dtype=None)
+        dtype = x.dtype
+
         # Converts the convolutional kernel of shape (features, in_features, n_sites)
         # to the expanded kernel of shape (features, in_features, sites_per_cell,
         # n_point, *shape) used in FFT-based group convolutions.
@@ -335,17 +341,17 @@ class DenseEquivariantFFT(Module):
                 "kernel",
                 self.kernel_init,
                 (self.features, in_features, len(self.kernel_indices)),
-                self.dtype,
+                self.param_dtype,
             )
 
-            kernel = jnp.zeros([self.features, in_features, self.n_sites])
-            kernel = kernel.at[:, :, self.kernel_indices].set(kernel_params)
+            kernel = jnp.zeros([self.features, in_features, self.n_point*self.n_cells],self.param_dtype)
+            kernel = kernel.at[:,:,self.kernel_indices].set(kernel_params)
         else:
             kernel = self.param(
                 "kernel",
                 self.kernel_init,
-                (self.features, in_features, self.n_sites),
-                self.dtype,
+                (self.features, in_features, self.n_point*self.n_cells),
+                self.param_dtype,
             )
 
         x, kernel, bias = promote_dtype(x, kernel, bias, dtype=None)
@@ -525,17 +531,17 @@ class DenseEquivariantIrrep(Module):
                 "kernel",
                 self.kernel_init,
                 (self.features, in_features, len(self.kernel_indices)),
-                self.dtype,
+                self.param_dtype,
             )
 
-            kernel = jnp.zeros([self.features, in_features, self.n_sites])
-            kernel = kernel.at[:, :, self.kernel_indices].set(kernel_params)
+            kernel = jnp.zeros([self.features, in_features, self.n_symm],self.param_dtype)
+            kernel = kernel.at[:,:,self.kernel_indices].set(kernel_params)
         else:
             kernel = self.param(
                 "kernel",
                 self.kernel_init,
-                (self.features, in_features, self.n_sites),
-                self.dtype,
+                (self.features, in_features, self.n_symm),
+                self.param_dtype,
             )
 
         x, kernel, bias = promote_dtype(x, kernel, bias, dtype=None)
@@ -608,17 +614,17 @@ class DenseEquivariantMatrix(Module):
                 "kernel",
                 self.kernel_init,
                 (self.features, in_features, len(self.kernel_indices)),
-                self.dtype,
+                self.param_dtype,
             )
 
-            kernel = jnp.zeros([self.features, in_features, self.n_sites])
-            kernel = kernel.at[:, :, self.kernel_indices].set(kernel_params)
+            kernel = jnp.zeros([self.features, in_features, self.n_symm],self.param_dtype)
+            kernel = kernel.at[:,:,self.kernel_indices].set(kernel_params)
         else:
             kernel = self.param(
                 "kernel",
                 self.kernel_init,
-                (self.features, in_features, self.n_sites),
-                self.dtype,
+                (self.features, in_features, self.n_symm),
+                self.param_dtype,
             )
 
         if self.use_bias:


### PR DESCRIPTION
This PR does two things.

1. Allows masks to be passed through the GCNN constructor 
2. Reduces the parameters in the module to include only the "unmasked" parameters. This is useful for `QGTJacobianPyTree`, where you need `n_parameters*n_samples` to fit into memory 

Here's an example of a GCNN with 2nd nearest neighbor convolutions on the square lattice:

```
#3 x 3 convolutional filter
input_mask = np.zeros([3,3])
for i in range(-1,2):
  for j in range(-1,2):
    input_mask[i][j] = 1
input_mask = input_mask.ravel()

# repeat mask over point group for hidden mask
hidden_mask = np.repeat(np.expand_dims(input_mask,1),repeats=8,axis=1).ravel()

g = nk.graph.Square(8)
ma = GCNN(symmetries=g,parity=1,input_mask=input_mask,hidden_mask=hidden_mask...)
```

I'd like to make this a bit more user friendly if possible 

