### PR TITLE
Raise exception when `LocalOperator` finds duplicate sites in `acting_on`

### DIFF
--- a/netket/operator/_local_operator_helpers.py
+++ b/netket/operator/_local_operator_helpers.py
@@ -87,7 +87,9 @@ def canonicalize_input(
 
         for i, aon in enumerate(acting_on):
             if len(aon) != len(set(aon)):
-                raise ValueError(f"The operator at index {i} acts on duplicated sites {aon}")
+                raise ValueError(
+                    f"The operator at index {i} acts on duplicated sites {aon}"
+                )
 
     acting_on = [tuple(aon) for aon in acting_on]
     # operators = [np.asarray(operator) for operator in operators]

--- a/netket/operator/_local_operator_helpers.py
+++ b/netket/operator/_local_operator_helpers.py
@@ -85,6 +85,10 @@ def canonicalize_input(
         if max(map(max, acting_on)) >= hilbert.size or min(map(min, acting_on)) < 0:
             raise ValueError("An operator acts on an invalid set of sites.")
 
+        for i, aon in enumerate(acting_on):
+            if len(aon) != len(set(aon)):
+                raise ValueError(f"The operator at index {i} acts on duplicated sites {aon}")
+
     acting_on = [tuple(aon) for aon in acting_on]
     # operators = [np.asarray(operator) for operator in operators]
     operators = [_standardize_matrix_input_type(op) for op in operators]

--- a/test/operator/test_local_operator.py
+++ b/test/operator/test_local_operator.py
@@ -513,3 +513,11 @@ def test_not_recompiling():
     assert not op._initialized
     op.get_conn_padded(hi.numbers_to_states(1))
     assert op._initialized
+
+
+def test_duplicate_sites():
+    hi = nk.hilbert.Spin(s=1 / 2, N=2)
+    mat = np.random.rand(4, 4)
+    # The operator at index 0 acts on duplicated sites [0, 0]
+    with raises(ValueError):
+        nk.operator.LocalOperator(hi, mat, [0, 0])


### PR DESCRIPTION
We should raise an exception when two sites are duplicated in a term of `acting_on`. For example, it's nonsense to apply a 4x4 matrix on the sites `[0, 0]`, and the user should apply a 2x2 matrix on the site `[0]` instead. Currently it silently produces unexpected result. It also affects `GraphOperator` when there is an edge starting and ending at the same vertex in the graph.