### PR TITLE
fix bug in hilbert particle that random state is not jittable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * The underlying extension API for Autoregressive models that can be used with Ancestral/Autoregressive samplers has been simplified and stabilized and will be documented as part of the public API. For most models, you should now inherit from `AbstractARNN` and define `conditionals_log_psi`. For additional performance, implementers can also redefine `__call__` and `conditional` but this should not be needed in general. This will cause some breaking changes if you were relying on the old undocumented interface [#1361](https://github.com/netket/netket/pull/1361).
 
 ### Bug Fixes
+* Fixed a bug where {meth}`nk.hilbert.Particle.random_state` could not be jit-compiled, and therefore could not be used in the sampling [#1401](https://github.com/netket/netket/pull/1401).
 
 ### Deprecations
 * `AbstractARNN._conditional` has been removed from the API, and its use will throw a deprecation warning. Update your ARNN models accordingly! [#1361](https://github.com/netket/netket/pull/1361).

--- a/netket/hilbert/random/particle.py
+++ b/netket/hilbert/random/particle.py
@@ -64,7 +64,7 @@ def random_state(hilb: Particle, key, batches: int, *, dtype):
 
     key = jax.random.split(key, num=batches)
     sdim = len(hilb.extent)
-    n = int(jnp.ceil(hilb.n_particles ** (1 / sdim)))
+    n = int(np.ceil(hilb.n_particles ** (1 / sdim)))
     xs = jnp.linspace(0, min(hilb.extent), n)
     uniform = jnp.array(jnp.meshgrid(*(sdim * [xs]))).reshape(-1, sdim)
     uniform = jnp.tile(uniform, (batches, 1, 1))

--- a/test/hilbert/test_hilbert.py
+++ b/test/hilbert/test_hilbert.py
@@ -128,6 +128,8 @@ hilberts["ContinuousSpaceHilbert"] = nk.hilbert.Particle(
     N=5, L=(np.inf, 10.0), pbc=(False, True)
 )
 
+N=10
+hilberts["ContinuousHelium"] = nk.hilbert.Particle(N=N, L=(N / (0.3 * 2.9673),), pbc=True)
 
 all_hilbert_params = [pytest.param(hi, id=name) for name, hi in hilberts.items()]
 discrete_hilbert_params = [
@@ -179,6 +181,8 @@ def test_random_states_discrete(hi: DiscreteHilbert):
     assert hi.random_state(jax.random.PRNGKey(13), size=10).shape == (10, hi.size)
     # assert hi.random_state(jax.random.PRNGKey(13), size=(10,)).shape == (10, hi.size)
     # assert hi.random_state(jax.random.PRNGKey(13), size=(10, 2)).shape == (10, 2, hi.size)
+    np.testing.assert_allclose(hi.random_state(jax.random.PRNGKey(13)),
+        jax.jit(hi.random_state)(jax.random.PRNGKey(13)))
 
 
 @pytest.mark.parametrize("hi", homogeneous_hilbert_params)
@@ -208,6 +212,8 @@ def test_random_states_particle(hi: Particle):
     )
     assert hi.random_state(jax.random.PRNGKey(13), 10).shape == (10, hi.size)
     assert hi.random_state(jax.random.PRNGKey(13), size=10).shape == (10, hi.size)
+    np.testing.assert_allclose(hi.random_state(jax.random.PRNGKey(13)),
+        jax.jit(hi.random_state)(jax.random.PRNGKey(13)))
 
     # check that boundary conditions are fulfilled if any are given
     state = hi.random_state(jax.random.PRNGKey(13))

--- a/test/hilbert/test_hilbert.py
+++ b/test/hilbert/test_hilbert.py
@@ -128,8 +128,10 @@ hilberts["ContinuousSpaceHilbert"] = nk.hilbert.Particle(
     N=5, L=(np.inf, 10.0), pbc=(False, True)
 )
 
-N=10
-hilberts["ContinuousHelium"] = nk.hilbert.Particle(N=N, L=(N / (0.3 * 2.9673),), pbc=True)
+N = 10
+hilberts["ContinuousHelium"] = nk.hilbert.Particle(
+    N=N, L=(N / (0.3 * 2.9673),), pbc=True
+)
 
 all_hilbert_params = [pytest.param(hi, id=name) for name, hi in hilberts.items()]
 discrete_hilbert_params = [
@@ -181,8 +183,10 @@ def test_random_states_discrete(hi: DiscreteHilbert):
     assert hi.random_state(jax.random.PRNGKey(13), size=10).shape == (10, hi.size)
     # assert hi.random_state(jax.random.PRNGKey(13), size=(10,)).shape == (10, hi.size)
     # assert hi.random_state(jax.random.PRNGKey(13), size=(10, 2)).shape == (10, 2, hi.size)
-    np.testing.assert_allclose(hi.random_state(jax.random.PRNGKey(13)),
-        jax.jit(hi.random_state)(jax.random.PRNGKey(13)))
+    np.testing.assert_allclose(
+        hi.random_state(jax.random.PRNGKey(13)),
+        jax.jit(hi.random_state)(jax.random.PRNGKey(13)),
+    )
 
 
 @pytest.mark.parametrize("hi", homogeneous_hilbert_params)
@@ -212,8 +216,10 @@ def test_random_states_particle(hi: Particle):
     )
     assert hi.random_state(jax.random.PRNGKey(13), 10).shape == (10, hi.size)
     assert hi.random_state(jax.random.PRNGKey(13), size=10).shape == (10, hi.size)
-    np.testing.assert_allclose(hi.random_state(jax.random.PRNGKey(13)),
-        jax.jit(hi.random_state)(jax.random.PRNGKey(13)))
+    np.testing.assert_allclose(
+        hi.random_state(jax.random.PRNGKey(13)),
+        jax.jit(hi.random_state)(jax.random.PRNGKey(13)),
+    )
 
     # check that boundary conditions are fulfilled if any are given
     state = hi.random_state(jax.random.PRNGKey(13))


### PR DESCRIPTION
random state for hilbert is not jittable. It was previously not tested by our tests.

I frankly don't understand how this could be here, as it makes samplers unusable...
