### PR TITLE
Add Langevin rule and MetropolisAdjustedLangevin

### DIFF
--- a/docs/api/sampler.md
+++ b/docs/api/sampler.md
@@ -116,6 +116,7 @@ Sampler. Rules with `Numpy` in their name can only be used with
   rules.ExchangeRule
   rules.HamiltonianRule
   rules.GaussianRule
+  rules.LangevinRule
   rules.HamiltonianRuleNumpy
   rules.CustomRuleNumpy
 

--- a/docs/api/sampler.md
+++ b/docs/api/sampler.md
@@ -84,6 +84,8 @@ This is a list of shorthands that allow to construct a {class}`~netket.sampler.M
    MetropolisLocal
    MetropolisExchange
    MetropolisHamiltonian
+   MetropolisGaussian
+   MetropolisAdjustedLangevin
 ```
 
 ```{eval-rst}

--- a/netket/sampler/__init__.py
+++ b/netket/sampler/__init__.py
@@ -31,6 +31,7 @@ from .metropolis import (
     MetropolisSamplerState,
     MetropolisHamiltonian,
     MetropolisGaussian,
+    MetropolisAdjustedLangevin,
     sample_next,
 )
 

--- a/netket/sampler/metropolis.py
+++ b/netket/sampler/metropolis.py
@@ -596,3 +596,30 @@ def MetropolisGaussian(hilbert, sigma=1.0, **kwargs) -> MetropolisSampler:
 
     rule = GaussianRule(sigma)
     return MetropolisSampler(hilbert, rule, **kwargs)
+
+
+def MetropolisAdjustedLangevin(
+    hilbert, dt=0.001, chunk_size=None, **kwargs
+) -> MetropolisSampler:
+    """This sampler acts on all particle positions simultaneously
+    and takes a Langevin step.
+
+    Args:
+        hilbert: The continuous Hilbert space to sample.
+        dt: Time step size for the Langevin dynamics (noise with variance 2*dt).
+        chunk_size: Chunk size to compute the gradients of the log probability.
+        n_chains: The total number of independent Markov chains across all MPI ranks. Either specify this or `n_chains_per_rank`.
+        n_chains_per_rank: Number of independent chains on every MPI rank (default = 16).
+        n_sweeps: Number of sweeps for each step along the chain. Defaults to the number of sites in the Hilbert space.
+                This is equivalent to subsampling the Markov chain.
+        reset_chains: If True, resets the chain state when `reset` is called on every new sampling (default = False).
+        machine_pow: The power to which the machine should be exponentiated to generate the pdf (default = 2).
+        dtype: The dtype of the states sampled (default = np.float64).
+    """
+    if not isinstance(hilbert, ContinuousHilbert):
+        raise ValueError("This sampler only works for Continuous Hilbert spaces.")
+
+    from .rules import LangevinRule
+
+    rule = LangevinRule(dt=dt, chunk_size=chunk_size)
+    return MetropolisSampler(hilbert, rule, **kwargs)

--- a/netket/sampler/metropolis.py
+++ b/netket/sampler/metropolis.py
@@ -601,8 +601,14 @@ def MetropolisGaussian(hilbert, sigma=1.0, **kwargs) -> MetropolisSampler:
 def MetropolisAdjustedLangevin(
     hilbert, dt=0.001, chunk_size=None, **kwargs
 ) -> MetropolisSampler:
-    """This sampler acts on all particle positions simultaneously
-    and takes a Langevin step [1].
+    r"""This sampler acts on all particle positions simultaneously
+    and takes a Langevin step [1]:
+
+    .. math::
+       x_{t+dt} = x_t + dt \nabla_x \log p(x) \vert_{x=x_t} + \sqrt{2 dt}\eta,
+
+    where  :math:`\eta` is normal distributed noise :math:`\eta \sim \mathcal{N}(0,1)`.
+    This sampler only works for continuous Hilbert spaces.
 
     [1]: https://en.wikipedia.org/wiki/Metropolis-adjusted_Langevin_algorithm
 

--- a/netket/sampler/metropolis.py
+++ b/netket/sampler/metropolis.py
@@ -602,7 +602,9 @@ def MetropolisAdjustedLangevin(
     hilbert, dt=0.001, chunk_size=None, **kwargs
 ) -> MetropolisSampler:
     """This sampler acts on all particle positions simultaneously
-    and takes a Langevin step.
+    and takes a Langevin step [1].
+
+    [1]: https://en.wikipedia.org/wiki/Metropolis-adjusted_Langevin_algorithm
 
     Args:
         hilbert: The continuous Hilbert space to sample.

--- a/netket/sampler/rules/__init__.py
+++ b/netket/sampler/rules/__init__.py
@@ -18,6 +18,7 @@ from .local import LocalRule
 from .exchange import ExchangeRule
 from .hamiltonian import HamiltonianRule
 from .continuous_gaussian import GaussianRule
+from .langevin import LangevinRule
 
 # numpy backend
 from .local_numpy import LocalRuleNumpy

--- a/netket/sampler/rules/langevin.py
+++ b/netket/sampler/rules/langevin.py
@@ -13,6 +13,11 @@ import netket.jax as nkjax
 class LangevinRule(MetropolisRule):
     r"""
     A transition rule that uses Langevin dynamics to update samples.
+
+    .. math::
+       x_{t+dt} = x_t + dt \nabla_x \log p(x) \vert_{x=x_t} + \sqrt{2 dt}\eta,
+
+    where  :math:`\eta` is normal distributed noise :math:`\eta \sim \mathcal{N}(0,1)`.
     """
 
     dt: float = 0.001

--- a/netket/sampler/rules/langevin.py
+++ b/netket/sampler/rules/langevin.py
@@ -1,0 +1,103 @@
+import jax
+import jax.numpy as jnp
+import numpy as np
+from functools import partial
+
+from flax import struct
+
+from .base import MetropolisRule
+import netket.jax as nkjax
+
+
+@struct.dataclass
+class LangevinRule(MetropolisRule):
+    r"""
+    A transition rule that uses Langevin dynamics to update samples.
+    """
+
+    dt: float = 0.001
+    """
+    Time step in the Langevin dynamics
+    """
+    chunk_size: int = None
+    """
+    Chunk size for computing gradients of the ansatz
+    """
+
+    def transition(rule, sampler, machine, parameters, state, key, r):
+        if jnp.issubdtype(r.dtype, jnp.complexfloating):
+            raise TypeError("LangevinRule does not work with complex basis elements.")
+
+        n_chains = r.shape[0]
+        hilb = sampler.hilbert
+
+        pbc = np.array(hilb.n_particles * hilb.pbc, dtype=r.dtype)
+        boundary = np.tile(pbc, (n_chains, 1))
+
+        Ls = np.array(hilb.n_particles * hilb.extent, dtype=r.dtype)
+        modulus = np.where(np.equal(pbc, False), jnp.inf, Ls)
+
+        # one langevin step
+        rp, log_corr = _langevin_step(
+            key,
+            r,
+            machine.apply,
+            parameters,
+            sampler.machine_pow,
+            rule.dt,
+            chunk_size=rule.chunk_size,
+            return_log_corr=True,
+        )
+
+        rp = jnp.where(np.equal(boundary, False), rp, rp % modulus)
+
+        return rp, log_corr
+
+    def __repr__(self):
+        return "LangevinRule(dt={})".format(self.dt)
+
+
+@partial(jax.jit, static_argnames=("axis",))
+def _norm_sqr(x, axis=None):
+    return jnp.sum(x**2, axis=axis)
+
+
+@partial(jax.jit, static_argnames=("apply_fun", "chunk_size", "return_log_corr"))
+def _langevin_step(
+    key,
+    r,
+    apply_fun,
+    parameters,
+    machine_pow,
+    dt,
+    chunk_size=None,
+    return_log_corr=True,
+):
+    """Single step of samples with Langevin dynamics"""
+
+    n_chains, hilb_size = r.shape
+
+    # steps with Langevin dynamics
+    noise_vec = jax.random.normal(key, shape=(n_chains, hilb_size), dtype=r.dtype)
+
+    def _log_prob(x):
+        """Conversion to a log probability"""
+        return machine_pow * apply_fun(parameters, x).real
+
+    def _single_grad(x):
+        """Derivative of log_prob with respect to a single sample x"""
+        g = nkjax.grad(_log_prob)(x)
+        return g if jnp.iscomplexobj(r) else g.real
+
+    grad_logp_r = nkjax.vmap_chunked(_single_grad, chunk_size=chunk_size)(r)
+
+    rp = r + dt * grad_logp_r + jnp.sqrt(2 * dt) * noise_vec
+
+    if not return_log_corr:
+        return rp
+    else:
+        log_q_xp = -0.5 * _norm_sqr(noise_vec, axis=-1)
+        grad_logp_rp = nkjax.vmap_chunked(_single_grad, chunk_size=chunk_size)(rp)
+        log_q_x = -_norm_sqr(r - rp - dt * grad_logp_rp, axis=-1) / (4 * dt)
+
+        return rp, log_q_x - log_q_xp

--- a/test/sampler/test_sampler.py
+++ b/test/sampler/test_sampler.py
@@ -108,6 +108,11 @@ hi_particles = nk.hilbert.Particle(N=3, L=jnp.inf, pbc=False)
 samplers["Metropolis(Gaussian): Gaussian"] = nk.sampler.MetropolisGaussian(
     hi_particles, sigma=1.0, n_sweeps=hi_particles.size * 10
 )
+samplers[
+    "Metropolis(AdjustedLangevin): AdjustedLangevin"
+] = nk.sampler.MetropolisAdjustedLangevin(
+    hi_particles, dt=0.1, n_sweeps=hi_particles.size
+)
 
 
 # The following fixture initialises a model and it's weights


### PR DESCRIPTION
This PR adds the Langevin sampler, where Metropolis rejection is used for finite sample sizes (@gpescia ). See e.g. wiki: https://en.wikipedia.org/wiki/Metropolis-adjusted_Langevin_algorithm
