### PR TITLE
Support sparse matrices in LocalOperator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,17 +15,17 @@
 * Parameters of models {class}`netket.models.GCNN` and layers {class}`netket.nn.DenseSymm` and {class}`netket.nn.DenseEquivariant` are stored as an array of shape '[features,in_features,mask_size]'. Masked parameters are now excluded from the model instead of multiplied by zero [#1387](https://github.com/netket/netket/pull/1387).
 
 ### Improvements
-* The underlying extension API for Autoregressive models that can be used with Ancestral/Autoregressive samplers has been simplified and stabilized and will be documented as part of the public API. For most models, you should now inherit from `AbstractARNN` and define `conditionals_log_psi`. For additional performance, implementers can also redefine `__call__` and `conditional` but this should not be needed in general. This will cause some breaking changes if you were relying on the old undocumented interface [#1361](https://github.com/netket/netket/pull/1361).
-* {class}`nk.operator.PauliStrings` now works with non-homogeneous Hilbert spaces, such as those obtained by taking the tensor product of multiple Hilbert spaces.
-* When multiplying an operator by it's conjugate transpose NetKet does not return anymore a lazy `Squared` object if the operator is hermitian. This avoids checking if the object is hermitian which greatly speeds up algebric manipulations of operators, and returns more unbiased epectation values [#1423](https://github.com/netket/netket/pull/1423). 
+* The underlying extension API for Autoregressive models that can be used with Ancestral/Autoregressive samplers has been simplified and stabilized and will be documented as part of the public API. For most models, you should now inherit from {class}`netket.models.AbstractARNN` and define the method {meth}`~netket.models.AbstractARNN.conditionals_log_psi`. For additional performance, implementers can also redefine {meth}`~netket.models.AbstractARNN.__call__` and {meth}`~netket.models.AbstractARNN.conditional` but this should not be needed in general. This will cause some breaking changes if you were relying on the old undocumented interface [#1361](https://github.com/netket/netket/pull/1361).
+* {class}`netket.operator.PauliStrings` now works with non-homogeneous Hilbert spaces, such as those obtained by taking the tensor product of multiple Hilbert spaces [#1411](https://github.com/netket/netket/pull/1411).
+* The {class}`netket.operator.LocalOperator` now keep sparse matrices sparse, leading to faster algebraic manipulations of those objects. The overall computational and memory cost is, however, equivalent, when running VMC calculations. All pre-constructed operators such as {func}`netket.operator.spin.sigmax` and {func}`netket.operator.boson.create` now build sparse-operators [#1422](https://github.com/netket/netket/pull/1422).
+* When multiplying an operator by it's conjugate transpose NetKet does not return anymore a lazy {class}`~netket.operator.Squared` object if the operator is hermitian. This avoids checking if the object is hermitian which greatly speeds up algebric manipulations of operators, and returns more unbiased epectation values [#1423](https://github.com/netket/netket/pull/1423). 
 
 ### Bug Fixes
-* Fixed a bug where {meth}`nk.hilbert.Particle.random_state` could not be jit-compiled, and therefore could not be used in the sampling [#1401](https://github.com/netket/netket/pull/1401).
+* Fixed a bug where {meth}`netket.hilbert.Particle.random_state` could not be jit-compiled, and therefore could not be used in the sampling [#1401](https://github.com/netket/netket/pull/1401).
 
 ### Deprecations
-* `AbstractARNN._conditional` has been removed from the API, and its use will throw a deprecation warning. Update your ARNN models accordingly! [#1361](https://github.com/netket/netket/pull/1361).
-* Several undocumented internal methods from `nk.models.ARNN` have been removed [#1361](https://github.com/netket/netket/pull/1361).
-* Parameter loading for  [#1361](https://github.com/netket/netket/pull/1361).
+* {meth}`netket.models.AbstractARNN._conditional` has been removed from the API, and its use will throw a deprecation warning. Update your ARNN models accordingly! [#1361](https://github.com/netket/netket/pull/1361).
+* Several undocumented internal methods from {class}`netket.models.AbstractARNN` have been removed [#1361](https://github.com/netket/netket/pull/1361).
 
 
 ## NetKet 3.6 (🏔️ 6 November 2022)
@@ -33,12 +33,13 @@
 ### New features
 * Added a new 'Full statevector' model {class}`netket.models.LogStateVector` that stores the exponentially large state and can be used as an exact ansatz [#1324](https://github.com/netket/netket/pull/1324).
 * Added a new experimental {class}`~netket.experimental.driver.TDVPSchmitt` driver, implementing the signal-to-noise ratio TDVP regularisation by Schmitt and Heyl [#1306](https://github.com/netket/netket/pull/1306).
+* Added a new experimental {class}`~netket.experimental.driver.TDVPSchmitt` driver, implementing the signal-to-noise ratio TDVP regularisation by Schmitt and Heyl [#1306](https://github.com/netket/netket/pull/1306).
 * QGT classes accept a `chunk_size` parameter that overrides the `chunk_size` set by the variational state object [#1347](https://github.com/netket/netket/pull/1347).
 * {func}`~netket.optimizer.qgt.QGTJacobianPyTree` and {func}`~netket.optimizer.qgt.QGTJacobianDense` support diagonal entry regularisation with constant and scale-invariant contributions. They accept a new `diag_scale` argument to pass the scale-invariant component [#1352](https://github.com/netket/netket/pull/1352).
 * {func}`~netket.optimizer.SR` preconditioner now supports scheduling of the diagonal shift and scale regularisations [#1364](https://github.com/netket/netket/pull/1364). 
 
 ### Improvements
-* {meth}`~netket.vqs.ExactState.expect_and_grad` now returns a `nk.stats.Stats` object that also contains the variance, as `MCState` does [#1325](https://github.com/netket/netket/pull/1325).
+* {meth}`~netket.vqs.ExactState.expect_and_grad` now returns a {class}`netket.stats.Stats` object that also contains the variance, as {class}`~netket.vqs.MCState` does [#1325](https://github.com/netket/netket/pull/1325).
 * Experimental RK solvers now store the error of the last timestep in the integrator state [#1328](https://github.com/netket/netket/pull/1328).
 * {class}`~netket.operator.PauliStrings` can now be constructed by passing a single string, instead of the previous requirement of a list of strings [#1331](https://github.com/netket/netket/pull/1331).
 * {class}`~flax.core.frozen_dict.FrozenDict` can now be logged to netket's loggers, meaning that one does no longer need to unfreeze the parameters before logging them [#1338](https://github.com/netket/netket/pull/1338).
@@ -48,7 +49,8 @@
 
 
 ### Bug Fixes
-* {meth}`netket.vqs.ExactState.expect_and_grad` returned a scalar while {meth}`~netket.vqs.ExactState.expect` returned a {class}`nk.stats.Stats` object with 0 error. The inconsistency has been addressed and now they both return a `Stats` object. This changes the format of the files logged when running `VMC`, which will now store the average under `Mean` instead of `value` [#1325](https://github.com/netket/netket/pull/1325).
+* {meth}`netket.vqs.ExactState.expect_and_grad` returned a scalar while {meth}`~netket.vqs.ExactState.expect` returned a {class}`netket.stats.Stats` object with 0 error. The inconsistency has been addressed and now they both return a `Stats` object. This changes the format of the files logged when running `VMC`, which will now store the average under `Mean` instead of `value` [#1325](https://github.com/netket/netket/pull/1325).
+* {func}`netket.optimizer.qgt.QGTJacobianDense` now returns the correct output for models with mixed real and complex parameters [#1397](https://github.com/netket/netket/pull/1397)
 
 ### Deprecations
 * The `rescale_shift` argument of {func}`~netket.optimizer.qgt.QGTJacobianPyTree` and {func}`~netket.optimizer.qgt.QGTJacobianDense` is deprecated inf avour the more flexible syntax with `diag_scale`. `rescale_shift=False` should be removed. `rescale_shift=True` should be replaced with `diag_scale=old_diag_shift`. [#1352](https://github.com/netket/netket/pull/1352).
@@ -66,7 +68,7 @@
 ## NetKet 3.5.1 (Bug Fixes)
 
 ### New features
-* Added a new configuration option `nk.config.netket_experimental_disable_ode_jit` to disable jitting of the ODE solvers. This can be useful to avoid hangs that might happen when working on GPUs with some particular systems [#1304](https://github.com/netket/netket/pull/1304).
+* Added a new configuration option `netket.config.netket_experimental_disable_ode_jit` to disable jitting of the ODE solvers. This can be useful to avoid hangs that might happen when working on GPUs with some particular systems [#1304](https://github.com/netket/netket/pull/1304).
 
 ### Bug Fixes
 * Continuous operatorors now work correctly when `chunk_size != None`. This was broken in v3.5 [#1316](https://github.com/netket/netket/pull/1316).
@@ -85,7 +87,7 @@ A new, more accurate, estimation of the autocorrelation time has been introduced
 
 ### New features
 
-* The method {meth}`~nk.vqs.MCState.local_estimators` has been added, which returns the local estimators `O_loc(s) = 〈s|O|ψ〉 / 〈s|ψ〉` (which are known as local energies if `O` is the Hamiltonian). [#1179](https://github.com/netket/netket/pull/1179)
+* The method {meth}`~netket.vqs.MCState.local_estimators` has been added, which returns the local estimators `O_loc(s) = 〈s|O|ψ〉 / 〈s|ψ〉` (which are known as local energies if `O` is the Hamiltonian). [#1179](https://github.com/netket/netket/pull/1179)
 * The permutation equivariant {class}`nk.models.DeepSetRelDistance` for use with particles in periodic potentials has been added together with an example. [#1199](https://github.com/netket/netket/pull/1199)
 * The class {class}`HDF5Log` has been added to the experimental submodule. This logger writes log data and variational state variables into a single HDF5 file. [#1200](https://github.com/netket/netket/issues/1200)
 * Added a new method {meth}`~nk.logging.RuntimeLog.serialize` to store the content of the logger to disk [#1255](https://github.com/netket/netket/issues/1255).
@@ -266,7 +268,7 @@ A new, more accurate, estimation of the autocorrelation time has been introduced
 ### Breaking Changes
 * The default initializer for `netket.models.GCNN` has been changed to from `jax.nn.selu` to `netket.nn.reim_selu` [#892](https://github.com/netket/netket/pull/892)
 * `netket.nn.initializers` has been deprecated in favor of `jax.nn.initializers` [#935](https://github.com/netket/netket/pull/935).
-* Subclasses of `AbstractARNN` must define the field `machine_pow` [#940](https://github.com/netket/netket/pull/940)
+* Subclasses of {class}`netket.models.AbstractARNN` must define the field `machine_pow` [#940](https://github.com/netket/netket/pull/940)
 * `nk.hilbert.HilbertIndex` and `nk.operator.spin.DType` are now unexported (they where never intended to be visible).  [#904](https://github.com/netket/netket/pull/904)
 * `AbstractOperator`s have been renamed `DiscreteOperator`s. `AbstractOperator`s still exist, but have almost no functionality and they are intended as the base class for more arbitrary (eg. continuous space) operators. If you have defined a custom operator inheriting from `AbstractOperator` you should change it to derive from `DiscreteOperator`. [#929](https://github.com/netket/netket/pull/929)
 

--- a/netket/operator/_local_operator.py
+++ b/netket/operator/_local_operator.py
@@ -70,10 +70,15 @@ class LocalOperator(DiscreteOperator):
         specified) a constant level shift.
 
         Args:
-           hilbert (netket.AbstractHilbert): Hilbert space the operator acts on.
-           operators (list(numpy.array) or numpy.array): A list of operators, in matrix form.
-           acting_on (list(numpy.array) or numpy.array): A list of sites, which the corresponding operators act on.
-           constant (float): Level shift for operator. Default is 0.0.
+           hilbert: Hilbert space the operator acts on.
+           operators: A list of operators, in matrix form. Supports numpy dense or scipy
+           sparse format
+           acting_on: A list of list of sites, which the corresponding operators act on. This
+                should be constructed such that :code:`operators[i]` acts on the sites :code:`acting_on[i]`.
+                If operators is not a list of operators, acting_on should just be the list of
+                corresponding sites.
+           constant: Constant diagonal shift of the operator, equivalent to
+                :math:`+\text{c}\hat{I}`. Default is 0.0.
 
         Examples:
            Constructs a ``LocalOperator`` without any operators.

--- a/netket/operator/_local_operator.py
+++ b/netket/operator/_local_operator.py
@@ -20,6 +20,7 @@ from textwrap import dedent
 
 import numpy as np
 import numba
+from scipy.sparse import issparse
 
 from netket.hilbert import AbstractHilbert
 from netket.utils.types import DType, Array
@@ -37,7 +38,10 @@ from ._local_operator_compile_helpers import pack_internals
 
 
 def is_hermitian(a: np.ndarray, rtol=1e-05, atol=1e-08) -> bool:
-    return np.allclose(a, a.T.conj(), rtol=rtol, atol=atol)
+    if issparse(a):
+        return np.allclose(a.todense(), a.T.conj().todense(), rtol=rtol, atol=atol)
+    else:
+        return np.allclose(a, a.T.conj(), rtol=rtol, atol=atol)
 
 
 def _is_sorted(a):

--- a/netket/operator/_local_operator_compile_helpers.py
+++ b/netket/operator/_local_operator_compile_helpers.py
@@ -19,6 +19,7 @@ operators.
 
 import numpy as np
 import numba
+from scipy import sparse
 
 from netket.hilbert import AbstractHilbert
 from netket.utils.types import DType
@@ -101,9 +102,10 @@ def pack_internals(
             basis[i, s] = ba
             ba *= hilbert.shape[aon[aon_size - s - 1]]
 
-        # eventually could support sparse matrices
-        # if isinstance(op, sparse.spmatrix):
-        #    op = op.todense()
+        if sparse.issparse(op):
+            # TODO: exploit the sparse structure in here.
+            #    op = op.todense()
+            op = op.todense()
 
         _append_matrix(
             op,

--- a/netket/operator/_local_operator_compile_helpers.py
+++ b/netket/operator/_local_operator_compile_helpers.py
@@ -125,6 +125,9 @@ def pack_internals(
 
     max_conn_size = 1 if nonzero_diagonal else 0
     for op in operators:
+        # TODO: exploit the sparse structure in here.
+        if sparse.issparse(op):
+            op = op.todense()
         nnz_mat = np.abs(op) > mel_cutoff
         nnz_mat[np.diag_indices(nnz_mat.shape[0])] = False
         nnz_rows = np.sum(nnz_mat, axis=1)

--- a/netket/operator/boson.py
+++ b/netket/operator/boson.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from scipy import sparse as _sparse
+
 from netket.utils.types import DType as _DType
 
 from netket.hilbert import AbstractHilbert as _AbstractHilbert
@@ -42,6 +44,7 @@ def destroy(
 
     D = np.array([np.sqrt(m) for m in np.arange(1, N)])
     mat = np.diag(D, 1)
+    mat = _sparse.coo_matrix(mat)
     return _LocalOperator(hilbert, mat, [site], dtype=dtype)
 
 
@@ -68,6 +71,7 @@ def create(
 
     D = np.array([np.sqrt(m) for m in np.arange(1, N)])
     mat = np.diag(D, -1)
+    mat = _sparse.coo_matrix(mat)
     return _LocalOperator(hilbert, mat, [site], dtype=dtype)
 
 
@@ -94,6 +98,7 @@ def number(
 
     D = np.array([m for m in np.arange(0, N)])
     mat = np.diag(D, 0)
+    mat = _sparse.coo_matrix(mat)
     return _LocalOperator(hilbert, mat, [site], dtype=dtype)
 
 
@@ -126,4 +131,5 @@ def proj(
     D = np.array([0 for m in np.arange(0, N)])
     D[n] = 1
     mat = np.diag(D, 0)
+    mat = _sparse.coo_matrix(mat)
     return _LocalOperator(hilbert, mat, [site], dtype=dtype)

--- a/netket/operator/spin.py
+++ b/netket/operator/spin.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from scipy import sparse as _sparse
+
 from netket.utils.types import DType as _DType
 
 from netket.hilbert import AbstractHilbert as _AbstractHilbert
@@ -40,6 +42,7 @@ def sigmax(
 
     D = [np.sqrt((S + 1) * 2 * a - a * (a + 1)) for a in np.arange(1, N)]
     mat = np.diag(D, 1) + np.diag(D, -1)
+    mat = _sparse.coo_matrix(mat)
     return _LocalOperator(hilbert, mat, [site], dtype=dtype)
 
 
@@ -78,6 +81,7 @@ def sigmay(
 
     D = np.array([1j * np.sqrt((S + 1) * 2 * a - a * (a + 1)) for a in np.arange(1, N)])
     mat = np.diag(D, -1) + np.diag(-D, 1)
+    mat = _sparse.coo_matrix(mat)
     return _LocalOperator(hilbert, mat, [site], dtype=dtype)
 
 
@@ -102,6 +106,7 @@ def sigmaz(
 
     D = np.array([2 * m for m in np.arange(S, -(S + 1), -1)])
     mat = np.diag(D, 0)
+    mat = _sparse.coo_matrix(mat)
     return _LocalOperator(hilbert, mat, [site], dtype=dtype)
 
 
@@ -127,6 +132,7 @@ def sigmam(
     S2 = (S + 1) * S
     D = np.array([np.sqrt(S2 - m * (m - 1)) for m in np.arange(S, -S, -1)])
     mat = np.diag(D, -1)
+    mat = _sparse.coo_matrix(mat)
     return _LocalOperator(hilbert, mat, [site], dtype=dtype)
 
 
@@ -152,4 +158,5 @@ def sigmap(
     S2 = (S + 1) * S
     D = np.array([np.sqrt(S2 - m * (m + 1)) for m in np.arange(S - 1, -(S + 1), -1)])
     mat = np.diag(D, 1)
+    mat = _sparse.coo_matrix(mat)
     return _LocalOperator(hilbert, mat, [site], dtype=dtype)

--- a/netket/sampler/rules/custom_numpy.py
+++ b/netket/sampler/rules/custom_numpy.py
@@ -130,6 +130,7 @@ def _choose_and_return(σp, x_prime, mels, sections, log_prob_corr, rnd_uniform)
 
 def _check_operators(operators):
     for op in operators:
+        op = op.todense()
         assert op.imag.max() < 1.0e-10
         assert op.min() >= 0
         assert np.allclose(op.sum(axis=0), 1.0)

--- a/test/operator/test_local_operator.py
+++ b/test/operator/test_local_operator.py
@@ -58,12 +58,12 @@ generic_operators["sigma +/-"] = (sm_hat, sp_hat)
 def assert_same_matrices(matl, matr, eps=1.0e-6):
     if isinstance(matl, AbstractOperator):
         matl = matl.to_dense()
-    elif isinstance(matl, sparse.csr_matrix):
+    elif sparse.issparse(matl):
         matl = matl.todense()
 
     if isinstance(matr, AbstractOperator):
         matr = matr.to_dense()
-    elif isinstance(matr, sparse.csr_matrix):
+    elif sparse.issparse(matr):
         matr = matr.todense()
 
     np.testing.assert_allclose(matl, matr, atol=eps, rtol=eps)


### PR DESCRIPTION
This PR significantly speeds up the construction of LocalOperators.

TODO:
 - Add logic to `_setup` to support sparse matrices (that converts the symbolic representation of LocaLoperators to our internal one)
 - Maybe convert all `operator.spin.sigmax/y/z` to use sparse matrices internally.
 - tests

I would need someone to bring this to the finish line.