### PR TITLE
MinSR algorithm

### DIFF
--- a/netket/experimental/vqs/MinSR.py
+++ b/netket/experimental/vqs/MinSR.py
@@ -190,7 +190,7 @@ def grad_MinSR(
 
     NTK = jnp.linalg.pinv(NTK, rcond=r_cond, hermitian=True)
 
-    elocs = jnp.matmul(jnp.conj(NTK), jnp.conj(elocs))
+    elocs = jnp.matmul(NTK, elocs)
 
     def centered_apply(w, σ):
         out = model_apply_fun({"params": w, **model_state}, σ)
@@ -208,7 +208,7 @@ def grad_MinSR(
     )
 
     Ō_grad = vjp_fun_chunked(
-        elocs,
+        elocs.conj(),
     )[0]
 
     return tree_map(lambda x: mpi.mpi_sum_jax(x)[0], Ō_grad)

--- a/netket/experimental/vqs/MinSR.py
+++ b/netket/experimental/vqs/MinSR.py
@@ -141,7 +141,7 @@ def expect_and_MinSR_chunked(
                 )
             )
 
-    NTK = jnp.linalg.pinv(NTK.conj() / n_samples, rcond=r_cond, hermitian=True)
+    NTK = jnp.linalg.pinv(NTK.real / n_samples, rcond=r_cond, hermitian=True)
 
     O_loc = jnp.matmul(NTK, O_loc)
 

--- a/netket/experimental/vqs/MinSR.py
+++ b/netket/experimental/vqs/MinSR.py
@@ -135,7 +135,7 @@ def expect_and_MinSR_chunked(
     
     for i in range(n_samples//jcs):
         for j in range(n_samples//jcs):
-            NTK.at[i*jcs:(i+1)*jcs,j*jcs:(j+1)*jcs].set(NeuralTangentKernel(model_apply_fun, parameters, ∇O_mean, σ[i*jcs:(i+1)*jcs], σ[j*jcs:(j+1)*jcs], "complex"))
+            NTK = NTK.at[i*jcs:(i+1)*jcs,j*jcs:(j+1)*jcs].set(NeuralTangentKernel(model_apply_fun, parameters, ∇O_mean, σ[i*jcs:(i+1)*jcs], σ[j*jcs:(j+1)*jcs], "complex"))
 
     NTK = jnp.linalg.pinv(NTK,rcond=r_cond)
     

--- a/netket/experimental/vqs/MinSR.py
+++ b/netket/experimental/vqs/MinSR.py
@@ -44,6 +44,18 @@ def expect_and_MinSR(  # noqa: F811
     *,
     mutable: CollectionFilter,
 ) -> Tuple[Stats, PyTree]:
+    
+    """Calculates the expectation value of an operator and the gradient update 
+    according to the MinSR algorithm in `Chen et al. <https://arxiv.org/pdf/2302.01941.pdf>`
+    
+    Args:
+        vstate: the variational state 
+        Ô : a hermitian operator
+        chunk_size : An integer over which expect and the final VJP are chunked
+    Returns:
+        A tuple containing the expectation value of Ô and the update according to MinSR
+    """
+    
     σ, args = get_local_kernel_arguments(vstate, Ô)
 
     local_estimator_fun = get_local_kernel(vstate, Ô, chunk_size)

--- a/netket/experimental/vqs/MinSR.py
+++ b/netket/experimental/vqs/MinSR.py
@@ -1,0 +1,123 @@
+# Copyright 2021 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import partial
+from typing import Any, Callable, Tuple
+import warnings
+
+import jax
+from jax import numpy as jnp
+from jax import tree_map
+from flax.core.scope import CollectionFilter
+
+from netket import jax as nkjax
+from netket.operator import AbstractOperator
+from netket.stats import Stats, statistics
+from netket.utils import mpi
+from netket.utils.types import PyTree
+
+from netket.vqs import expect_and_forces
+from netket.vqs.mc import (
+    get_local_kernel,
+    get_local_kernel_arguments,
+)
+
+from netket.jax._jacobian.neural_tangent_kernel import NeuralTangentKernelInverse
+from netket.vqs import MCState
+
+
+def expect_and_MinSR(  # noqa: F811
+    vstate: MCState,
+    Ô: AbstractOperator,
+    chunk_size: int,
+    *,
+    mutable: CollectionFilter,
+) -> Tuple[Stats, PyTree]:
+    σ, args = get_local_kernel_arguments(vstate, Ô)
+
+    local_estimator_fun = get_local_kernel(vstate, Ô, chunk_size)
+
+    Ō, Ō_grad, new_model_state = expect_and_MinSR_chunked(
+        chunk_size,
+        local_estimator_fun,
+        vstate._apply_fun,
+        mutable,
+        vstate.parameters,
+        vstate.model_state,
+        σ,
+        args,
+    )
+
+    if mutable is not False:
+        vstate.model_state = new_model_state
+
+    return Ō, Ō_grad
+
+
+@partial(jax.jit, static_argnums=(0, 1, 2, 3))
+def expect_and_MinSR_chunked(
+    chunk_size: int,
+    local_value_kernel_chunked: Callable,
+    model_apply_fun: Callable,
+    mutable: CollectionFilter,
+    parameters: PyTree,
+    model_state: PyTree,
+    σ: jnp.ndarray,
+    local_value_args: PyTree,
+) -> Tuple[PyTree, PyTree]:
+
+    σ_shape = σ.shape
+    if jnp.ndim(σ) != 2:
+        σ = σ.reshape((-1, σ_shape[-1]))
+
+    n_samples = σ.shape[0] * mpi.n_nodes
+
+    O_loc = local_value_kernel_chunked(
+        model_apply_fun,
+        {"params": parameters, **model_state},
+        σ,
+        local_value_args,
+        chunk_size=chunk_size,
+    )
+
+    Ō = statistics(O_loc.reshape(σ_shape[:-1]).T)
+
+    O_loc -= Ō.mean
+
+    NTKI = NeuralTangentKernelInverse(model_apply_fun, parameters, σ, "complex")
+
+    O_loc = jnp.matmul(NTKI, O_loc)
+
+    # Then compute the vjp.
+    # Code is a bit more complex than a standard one because we support
+    # mutable state (if it's there)
+    if mutable is False:
+        vjp_fun_chunked = nkjax.vjp_chunked(
+            lambda w, σ: model_apply_fun({"params": w, **model_state}, σ),
+            parameters,
+            σ,
+            conjugate=True,
+            chunk_size=chunk_size,
+            chunk_argnums=1,
+            nondiff_argnums=1,
+        )
+        new_model_state = None
+    else:
+        raise NotImplementedError
+
+    Ō_grad = vjp_fun_chunked(
+        jnp.conjugate(O_loc),
+    )[0]
+
+    return Ō, tree_map(lambda x: mpi.mpi_sum_jax(x)[0], Ō_grad), new_model_state

--- a/netket/experimental/vqs/MinSR.py
+++ b/netket/experimental/vqs/MinSR.py
@@ -141,7 +141,7 @@ def expect_and_MinSR_chunked(
                 )
             )
 
-    NTK = jnp.linalg.pinv(NTK.real / n_samples, rcond=r_cond, hermitian=True)
+    NTK = jnp.linalg.pinv(NTK / n_samples, rcond=r_cond, hermitian=True)
 
     O_loc = jnp.matmul(NTK, O_loc)
 

--- a/netket/experimental/vqs/MinSR.py
+++ b/netket/experimental/vqs/MinSR.py
@@ -116,7 +116,7 @@ def expect_and_MinSR_chunked(
         grad,
         parameters,
         σ,
-        conjugate=True,
+        conjugate=False,
         chunk_size=chunk_size,
         chunk_argnums=1,
         nondiff_argnums=1,
@@ -143,7 +143,7 @@ def expect_and_MinSR_chunked(
 
     NTK = jnp.linalg.pinv(NTK / n_samples, rcond=r_cond, hermitian=True)
 
-    O_loc = jnp.matmul(NTK, O_loc)
+    O_loc = jnp.matmul(NTK, jnp.conj(O_loc))
 
     def centered_apply(w, σ):
         out = model_apply_fun({"params": w, **model_state}, σ)
@@ -161,7 +161,7 @@ def expect_and_MinSR_chunked(
     )
 
     Ō_grad = vjp_fun_chunked(
-        jnp.conj(O_loc / n_samples),
+        O_loc / n_samples,
     )[0]
 
     return Ō, tree_map(lambda x: mpi.mpi_sum_jax(x)[0], Ō_grad), None

--- a/netket/experimental/vqs/MinSR.py
+++ b/netket/experimental/vqs/MinSR.py
@@ -194,6 +194,8 @@ def grad_MinSR(
     grad_mean: PyTree,
 ) -> Tuple[PyTree, PyTree]:
 
+    n_samples = len(σ)
+    
     NTK = jnp.linalg.pinv(NTK, rcond=r_cond, hermitian=True)
 
     elocs = jnp.matmul(NTK, elocs)

--- a/netket/experimental/vqs/MinSR.py
+++ b/netket/experimental/vqs/MinSR.py
@@ -143,7 +143,7 @@ def expect_and_MinSR_chunked(
 
     NTK = jnp.linalg.pinv(NTK / n_samples, rcond=r_cond, hermitian=True)
 
-    O_loc = jnp.matmul(NTK, jnp.conj(O_loc))
+    O_loc = jnp.matmul(jnp.conj(NTK), jnp.conj(O_loc))
 
     def centered_apply(w, σ):
         out = model_apply_fun({"params": w, **model_state}, σ)

--- a/netket/experimental/vqs/MinSR.py
+++ b/netket/experimental/vqs/MinSR.py
@@ -68,6 +68,7 @@ def expect_and_MinSR(  # noqa: F811
 
     Ō, elocs, grad_mean = expect_MinSR(
         chunk_size,
+        jacobian_chunk_size,
         local_estimator_fun,
         vstate._apply_fun,
         vstate.parameters,
@@ -77,7 +78,6 @@ def expect_and_MinSR(  # noqa: F811
     )
 
     NTK = compute_NTK(
-        chunk_size,
         jacobian_chunk_size,
         vstate._apply_fun,
         vstate.parameters,
@@ -87,7 +87,7 @@ def expect_and_MinSR(  # noqa: F811
     )
 
     Ō_grad = grad_MinSR(
-        chunk_size,
+        jacobian_chunk_size,
         r_cond,
         vstate._apply_fun,
         elocs,
@@ -100,9 +100,10 @@ def expect_and_MinSR(  # noqa: F811
     return Ō, Ō_grad
 
 
-@partial(jax.jit, static_argnums=(0, 1, 2))
+@partial(jax.jit, static_argnums=(0, 1, 2, 3))
 def expect_MinSR(
     chunk_size: int,
+    jcs: int,
     local_value_kernel_chunked: Callable,
     model_apply_fun: Callable,
     parameters: PyTree,
@@ -134,7 +135,7 @@ def expect_MinSR(
         parameters,
         σ,
         conjugate=False,
-        chunk_size=chunk_size,
+        chunk_size=jcs,
         chunk_argnums=1,
         nondiff_argnums=1,
     )
@@ -147,7 +148,6 @@ def expect_MinSR(
 
 
 def compute_NTK(
-    chunk_size: int,
     jcs: int,
     model_apply_fun: Callable,
     parameters: PyTree,
@@ -178,7 +178,7 @@ def compute_NTK(
 
 @partial(jax.jit, static_argnums=(0, 1, 2))
 def grad_MinSR(
-    chunk_size: int,
+    jcs: int,
     r_cond: float,
     model_apply_fun: Callable,
     elocs: jnp.ndarray,
@@ -202,7 +202,7 @@ def grad_MinSR(
         parameters,
         σ,
         conjugate=True,
-        chunk_size=chunk_size,
+        chunk_size=jcs,
         chunk_argnums=1,
         nondiff_argnums=1,
     )

--- a/netket/experimental/vqs/MinSR.py
+++ b/netket/experimental/vqs/MinSR.py
@@ -162,17 +162,21 @@ def compute_NTK(
     NTK = jnp.zeros([n_samples, n_samples], dtype="complex")
 
     for i in range(n_samples // jcs):
-        for j in range(n_samples // jcs):
-            NTK = NTK.at[i * jcs : (i + 1) * jcs, j * jcs : (j + 1) * jcs].set(
-                NeuralTangentKernel(
+        for j in range(i+1):
+            ntk_local = NeuralTangentKernel(
                     model_apply_fun,
                     parameters,
                     grad_mean,
                     σ[i * jcs : (i + 1) * jcs],
                     σ[j * jcs : (j + 1) * jcs],
                     "complex",
-                )
             )
+
+
+            NTK = NTK.at[i * jcs : (i + 1) * jcs, j * jcs : (j + 1) * jcs].set(ntk_local)
+
+            if not i == j:
+                NTK = NTK.at[j * jcs : (j + 1) * jcs, i * jcs : (i + 1) * jcs].set(ntk_local.T.conj())
 
     return NTK / n_samples
 

--- a/netket/experimental/vqs/MinSR.py
+++ b/netket/experimental/vqs/MinSR.py
@@ -77,7 +77,7 @@ def expect_and_MinSR(  # noqa: F811
     return Ō, Ō_grad
 
 
-@partial(jax.jit, static_argnums=(0, 1, 2, 3, 4))
+# @partial(jax.jit, static_argnums=(0, 1, 2, 3, 4))
 def expect_and_MinSR_chunked(
     chunk_size: int,
     jcs: int,
@@ -154,7 +154,7 @@ def expect_and_MinSR_chunked(
         centered_apply,
         parameters,
         σ,
-        conjugate=True,
+        conjugate=False,
         chunk_size=chunk_size,
         chunk_argnums=1,
         nondiff_argnums=1,

--- a/netket/experimental/vqs/MinSR.py
+++ b/netket/experimental/vqs/MinSR.py
@@ -145,7 +145,7 @@ def expect_MinSR(
         jnp.ones_like(O_loc),
     )[0]
 
-    return Ō, O_loc / n_samples, grad_mean
+    return Ō, O_loc / n_samples**0.5, grad_mean
 
 
 def compute_NTK(
@@ -199,7 +199,7 @@ def grad_MinSR(
     elocs = jnp.matmul(NTK, elocs)
 
     def forward(w, σ):
-        out = model_apply_fun({"params": w, **model_state}, σ)
+        out = model_apply_fun({"params": w, **model_state}, σ)/n_samples**0.5
 
         return out
 

--- a/netket/experimental/vqs/MinSR.py
+++ b/netket/experimental/vqs/MinSR.py
@@ -154,7 +154,7 @@ def expect_and_MinSR_chunked(
         centered_apply,
         parameters,
         σ,
-        conjugate=False,
+        conjugate=True,
         chunk_size=chunk_size,
         chunk_argnums=1,
         nondiff_argnums=1,

--- a/netket/experimental/vqs/MinSR.py
+++ b/netket/experimental/vqs/MinSR.py
@@ -143,7 +143,7 @@ def expect_and_MinSR_chunked(
 
     NTK = jnp.linalg.pinv(NTK / n_samples, rcond=r_cond, hermitian=True)
 
-    O_loc = jnp.matmul(jnp.conj(NTK), jnp.conj(O_loc))
+    O_loc = jnp.matmul(NTK, jnp.conj(O_loc))
 
     def centered_apply(w, σ):
         out = model_apply_fun({"params": w, **model_state}, σ)

--- a/netket/experimental/vqs/MinSR.py
+++ b/netket/experimental/vqs/MinSR.py
@@ -141,7 +141,7 @@ def expect_and_MinSR_chunked(
                 )
             )
 
-    NTK = jnp.linalg.pinv(NTK / n_samples, rcond=r_cond, hermitian=True)
+    NTK = jnp.linalg.pinv(NTK.conj() / n_samples, rcond=r_cond, hermitian=True)
 
     O_loc = jnp.matmul(NTK, O_loc)
 

--- a/netket/experimental/vqs/MinSR.py
+++ b/netket/experimental/vqs/MinSR.py
@@ -139,7 +139,7 @@ def expect_and_MinSR_chunked(
 
     NTK = jnp.linalg.pinv(NTK,rcond=r_cond)
     
-    O_loc = jnp.matmul(NTK, O_loc)
+    O_loc = jnp.matmul(NTK, O_loc, hermitian=True)
 
     def centered_apply(w, σ):
         out = model_apply_fun({"params": w, **model_state}, σ)

--- a/netket/experimental/vqs/MinSR.py
+++ b/netket/experimental/vqs/MinSR.py
@@ -77,7 +77,7 @@ def expect_and_MinSR(  # noqa: F811
     return Ō, Ō_grad
 
 
-# @partial(jax.jit, static_argnums=(0, 1, 2, 3, 4))
+@partial(jax.jit, static_argnums=(0, 1, 2, 3, 4))
 def expect_and_MinSR_chunked(
     chunk_size: int,
     jcs: int,
@@ -143,7 +143,7 @@ def expect_and_MinSR_chunked(
 
     NTK = jnp.linalg.pinv(NTK / n_samples, rcond=r_cond, hermitian=True)
 
-    O_loc = jnp.matmul(NTK, jnp.conj(O_loc))
+    O_loc = jnp.matmul(jnp.conj(NTK), jnp.conj(O_loc))
 
     def centered_apply(w, σ):
         out = model_apply_fun({"params": w, **model_state}, σ)

--- a/netket/jax/_jacobian/logic.py
+++ b/netket/jax/_jacobian/logic.py
@@ -31,9 +31,9 @@ from . import jacobian_dense
 from . import jacobian_pytree
 
 
-@partial(
-    jax.jit, static_argnames=("apply_fun", "mode", "chunk_size", "center", "dense")
-)
+#@partial(
+#    jax.jit, static_argnames=("apply_fun", "mode", "chunk_size", "center", "dense")
+#)
 def jacobian(
     apply_fun: Callable,
     params: PyTree,

--- a/netket/jax/_jacobian/logic.py
+++ b/netket/jax/_jacobian/logic.py
@@ -31,9 +31,9 @@ from . import jacobian_dense
 from . import jacobian_pytree
 
 
-#@partial(
-#    jax.jit, static_argnames=("apply_fun", "mode", "chunk_size", "center", "dense")
-#)
+@partial(
+    jax.jit, static_argnames=("apply_fun", "mode", "chunk_size", "center", "dense")
+)
 def jacobian(
     apply_fun: Callable,
     params: PyTree,

--- a/netket/jax/_jacobian/neural_tangent_kernel.py
+++ b/netket/jax/_jacobian/neural_tangent_kernel.py
@@ -60,6 +60,7 @@ def NeuralTangentKernel(
 
     Returns:
         The neural tangent kernel
+        
     """
 
     
@@ -96,6 +97,7 @@ def NeuralTangentKernelInverse(
 
     Returns:
         The pseudo-inverse of the neural tangent kernel 
+        
     """
     
   

--- a/netket/jax/_jacobian/neural_tangent_kernel.py
+++ b/netket/jax/_jacobian/neural_tangent_kernel.py
@@ -44,7 +44,7 @@ def OuterProduct(x: PyTree) -> Array:
 
 
 @partial(jax.jit, static_argnames=("apply_fun", "mode"))
-def NeuralTangentKernel(
+def NeuralTangentKernel(apply_fun: Callable, params: PyTree, samples: Array, mode: str) -> Array:
     
     r"""Computes the neural tangent kernel which is defined as follows
     
@@ -62,11 +62,7 @@ def NeuralTangentKernel(
         The neural tangent kernel
         
     """
-
-    
-    apply_fun: Callable, params: PyTree, samples: Array, mode: str
-) -> Array:
-    
+        
     jac = jacobian(apply_fun, params, samples, mode=mode, center=True)
     
     return OuterProduct(jac)
@@ -98,8 +94,7 @@ def NeuralTangentKernelInverse(
     Returns:
         The pseudo-inverse of the neural tangent kernel 
         
-    """
-    
+    """    
   
     jac = jacobian(apply_fun, params, samples, mode=mode, center=True)
     jac = OuterProduct(jac)

--- a/netket/jax/_jacobian/neural_tangent_kernel.py
+++ b/netket/jax/_jacobian/neural_tangent_kernel.py
@@ -48,7 +48,7 @@ def NeuralTangentKernel(
     apply_fun: Callable, params: PyTree, samples: Array, mode: str
 ) -> Array:
 
-    jac = jacobian(apply_fun, params, samples, mode=mode)
+    jac = jacobian(apply_fun, params, samples, mode=mode, center=True)
 
     return OuterProduct(jac)
 
@@ -62,7 +62,7 @@ def NeuralTangentKernelInverse(
     r_cond: float = 1e-12,
 ) -> Array:
 
-    jac = jacobian(apply_fun, params, samples, mode=mode)
+    jac = jacobian(apply_fun, params, samples, mode=mode, center=True)
 
     jac = OuterProduct(jac)
 

--- a/netket/jax/_jacobian/neural_tangent_kernel.py
+++ b/netket/jax/_jacobian/neural_tangent_kernel.py
@@ -47,10 +47,9 @@ def OuterProduct(x: PyTree) -> Array:
 def NeuralTangentKernel(
     apply_fun: Callable, params: PyTree, samples: Array, mode: str
 ) -> Array:
+    
+    return OuterProduct(jacobian(apply_fun, params, samples, mode=mode, center=True))
 
-    jac = jacobian(apply_fun, params, samples, mode=mode, center=True)
-
-    return OuterProduct(jac)
 
 
 @partial(jax.jit, static_argnames=("apply_fun", "mode", "r_cond"))
@@ -61,9 +60,7 @@ def NeuralTangentKernelInverse(
     mode: str,
     r_cond: float = 1e-12,
 ) -> Array:
-
-    jac = jacobian(apply_fun, params, samples, mode=mode, center=True)
-
-    jac = OuterProduct(jac)
+  
+    OuterProduct(jacobian(apply_fun, params, samples, mode=mode, center=True))
 
     return jnp.linalg.pinv(jac, rcond=r_cond, hermitian=True)

--- a/netket/jax/_jacobian/neural_tangent_kernel.py
+++ b/netket/jax/_jacobian/neural_tangent_kernel.py
@@ -45,7 +45,7 @@ def OuterProduct(x: PyTree, x2: PyTree) -> Array:
     return tree_reduce(add, tree_map(array_outer, x, x2))
 
 
-@partial(jax.jit, static_argnames=("apply_fun", "mode"))
+# @partial(jax.jit, static_argnames=("apply_fun", "mode"))
 def NeuralTangentKernel(
     apply_fun: Callable, params: PyTree, offset: PyTree, σ1: Array, σ2: Array, mode: str
 ) -> Array:

--- a/netket/jax/_jacobian/neural_tangent_kernel.py
+++ b/netket/jax/_jacobian/neural_tangent_kernel.py
@@ -48,10 +48,9 @@ def NeuralTangentKernel(
     apply_fun: Callable, params: PyTree, samples: Array, mode: str
 ) -> Array:
     
-    jac = jacobian(apply_fun, params, samples, mode=mode, center=True,dense=True)
-    jac = jac.reshape(jac.shape[0],-1)
+    jac = jacobian(apply_fun, params, samples, mode=mode, center=True)
     
-    return jnp.matmul(jac.conj(),jac.T) 
+    return OuterProduct(jac)
 
 
 
@@ -64,9 +63,7 @@ def NeuralTangentKernelInverse(
     r_cond: float = 1e-12,
 ) -> Array:
   
-    jac = jacobian(apply_fun, params, samples, mode=mode, center=True,dense=True)
-    jac = jac.reshape(jac.shape[0],-1)
-
-    jac = jnp.matmul(jac.conj(),jac.T)
+    jac = jacobian(apply_fun, params, samples, mode=mode, center=True)
+    jac = OuterProduct(jac)
 
     return jnp.linalg.pinv(jac, rcond=r_cond, hermitian=True)

--- a/netket/jax/_jacobian/neural_tangent_kernel.py
+++ b/netket/jax/_jacobian/neural_tangent_kernel.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from os import truncate
 from jax import numpy as jnp
 
 import jax
@@ -50,3 +51,19 @@ def NeuralTangentKernel(
     jac = jacobian(apply_fun, params, samples, mode=mode)
 
     return OuterProduct(jac)
+
+
+@partial(jax.jit, static_argnames=("apply_fun", "mode", "r_cond"))
+def NeuralTangentKernelInverse(
+    apply_fun: Callable,
+    params: PyTree,
+    samples: Array,
+    mode: str,
+    r_cond: float = 1e-12,
+) -> Array:
+
+    jac = jacobian(apply_fun, params, samples, mode=mode)
+
+    jac = OuterProduct(jac)
+
+    return jnp.linalg.pinv(jac, rcond=r_cond, hermitian=True)

--- a/netket/jax/_jacobian/neural_tangent_kernel.py
+++ b/netket/jax/_jacobian/neural_tangent_kernel.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from os import truncate
-from jax import numpy as jnp
+from jax import jvp, numpy as jnp
 
 import jax
 from netket.utils.types import Array, Callable, PyTree
@@ -69,7 +69,9 @@ def NeuralTangentKernel(
     """
 
     def subtract_mean(j, mean):
-        return tree_map(lambda x, y: x - jnp.expand_dims(y, 0), j, mean)
+        return tree_map(
+            lambda x, y: x[:, 0] + 1j * x[:, 1] - jnp.expand_dims(y, 0), j, mean
+        )
 
     jac = subtract_mean(jacobian(apply_fun, params, σ1, mode=mode), offset)
     jac2 = subtract_mean(jacobian(apply_fun, params, σ2, mode=mode), offset)

--- a/netket/jax/_jacobian/neural_tangent_kernel.py
+++ b/netket/jax/_jacobian/neural_tangent_kernel.py
@@ -45,7 +45,7 @@ def OuterProduct(x: PyTree, x2: PyTree) -> Array:
     return tree_reduce(add, tree_map(array_outer, x, x2))
 
 
-# @partial(jax.jit, static_argnames=("apply_fun", "mode"))
+@partial(jax.jit, static_argnames=("apply_fun", "mode"))
 def NeuralTangentKernel(
     apply_fun: Callable, params: PyTree, offset: PyTree, σ1: Array, σ2: Array, mode: str
 ) -> Array:

--- a/netket/jax/_jacobian/neural_tangent_kernel.py
+++ b/netket/jax/_jacobian/neural_tangent_kernel.py
@@ -1,0 +1,52 @@
+# Copyright 2021 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from jax import numpy as jnp
+
+import jax
+from netket.utils.types import Array, Callable, PyTree
+import netket.jax as nkjax
+from operator import add
+from jax.tree_util import tree_map, tree_reduce
+from functools import partial
+
+from .logic import jacobian
+
+
+def OuterProduct(x: PyTree) -> Array:
+    """Sums over A^T
+
+    Args:
+        x: A pytree of arrays with equal lengths dim0
+
+    Returns:
+        An array of shape [dim0,dim0] summed over all other dimensions
+        in the pytree arrays
+    """
+
+    def array_outer(x):
+        x = x.reshape(x.shape[0], -1)
+        return jnp.matmul(x.conj(), x.T)
+
+    return tree_reduce(add, tree_map(array_outer, x))
+
+
+@partial(jax.jit, static_argnames=("apply_fun", "mode"))
+def NeuralTangentKernel(
+    apply_fun: Callable, params: PyTree, samples: Array, mode: str
+) -> Array:
+
+    jac = jacobian(apply_fun, params, samples, mode=mode)
+
+    return OuterProduct(jac)

--- a/netket/jax/_jacobian/neural_tangent_kernel.py
+++ b/netket/jax/_jacobian/neural_tangent_kernel.py
@@ -48,7 +48,9 @@ def NeuralTangentKernel(
     apply_fun: Callable, params: PyTree, samples: Array, mode: str
 ) -> Array:
     
-    return OuterProduct(jacobian(apply_fun, params, samples, mode=mode, center=True))
+    jac = jacobian(apply_fun, params, samples, mode=mode, center=True,dense=True)
+    
+    return jnp.matmul(jac.conj(),jac.T) 
 
 
 
@@ -61,6 +63,8 @@ def NeuralTangentKernelInverse(
     r_cond: float = 1e-12,
 ) -> Array:
   
-    jac = OuterProduct(jacobian(apply_fun, params, samples, mode=mode, center=True))
+    jac = jacobian(apply_fun, params, samples, mode=mode, center=True,dense=True)
+
+    jac = jnp.matmul(jac.conj(),jac.T)
 
     return jnp.linalg.pinv(jac, rcond=r_cond, hermitian=True)

--- a/netket/jax/_jacobian/neural_tangent_kernel.py
+++ b/netket/jax/_jacobian/neural_tangent_kernel.py
@@ -59,7 +59,7 @@ def NeuralTangentKernel(
         r_cond: A value such that all eigenvalues v below r_cond*v_max are truncated 
 
     Returns:
-        The neural tangent kernel N_{s,s'}
+        The neural tangent kernel
     """
 
     
@@ -95,7 +95,7 @@ def NeuralTangentKernelInverse(
         r_cond: A value such that all eigenvalues v below r_cond*v_max are truncated 
 
     Returns:
-        The pseudo-inverse of the neural tangent kernel N^{-1}_{s,s'}
+        The pseudo-inverse of the neural tangent kernel 
     """
     
   

--- a/netket/jax/_jacobian/neural_tangent_kernel.py
+++ b/netket/jax/_jacobian/neural_tangent_kernel.py
@@ -26,10 +26,10 @@ from .logic import jacobian
 
 
 def OuterProduct(x: PyTree) -> Array:
-    """Sums over A^T
+    """Computes A A^T where A is stored as a pytree of parameters
 
     Args:
-        x: A pytree of arrays with equal lengths dim0
+        x: A pytree of arrays with equal first dimension dim0
 
     Returns:
         An array of shape [dim0,dim0] summed over all other dimensions
@@ -45,6 +45,24 @@ def OuterProduct(x: PyTree) -> Array:
 
 @partial(jax.jit, static_argnames=("apply_fun", "mode"))
 def NeuralTangentKernel(
+    
+    """Computes the neural tangent kernel which is defined as follows
+    
+    .. math ::
+        N_{s,s'} = \sum_{\theta} \frac{d log(\psi_s)}{d \theta} \frac{d log(\psi_s')}{d \theta}
+
+    Args:
+        apply_fun: A function that takes a basis state s as input and returns the log amplitude of the wavefunction
+        params: A PyTree with the differential parameters of apply_fun
+        samples: The samples s at which the neural tangent kernel is evaluated
+        mode: A specification of the differentiation properties of the function as detailed in :def:`netket.jax.jacobian`
+        r_cond: A value such that all eigenvalues v below r_cond*v_max are truncated 
+
+    Returns:
+        The neural tangent kernel N_{s,s'}
+    """
+
+    
     apply_fun: Callable, params: PyTree, samples: Array, mode: str
 ) -> Array:
     
@@ -62,6 +80,24 @@ def NeuralTangentKernelInverse(
     mode: str,
     r_cond: float = 1e-12,
 ) -> Array:
+    
+    
+    """Computes the pseudo-inverse of the neural tangent kernel which is defined as follows
+    
+    .. math ::
+        N_{s,s'} = \sum_{\theta} \frac{d log(\psi_s)}{d \theta} \frac{d log(\psi_s')}{d \theta}
+
+    Args:
+        apply_fun: A function that takes a basis state s as input and returns the log amplitude of the wavefunction
+        params: A PyTree with the differential parameters of apply_fun
+        samples: The samples s at which the neural tangent kernel is evaluated
+        mode: A specification of the differentiation properties of the function as detailed in :def:`netket.jax.jacobian`
+        r_cond: A value such that all eigenvalues v below r_cond*v_max are truncated 
+
+    Returns:
+        The pseudo-inverse of the neural tangent kernel N^{-1}_{s,s'}
+    """
+    
   
     jac = jacobian(apply_fun, params, samples, mode=mode, center=True)
     jac = OuterProduct(jac)

--- a/netket/jax/_jacobian/neural_tangent_kernel.py
+++ b/netket/jax/_jacobian/neural_tangent_kernel.py
@@ -26,18 +26,18 @@ from .logic import jacobian
 
 
 def OuterProduct(x: PyTree, x2: PyTree) -> Array:
-    r"""Computes A B^T where A and B are represent the pytrees of x and x2 
+    r"""Computes A B^T where A and B are represent the pytrees of x and x2
     flattened over all but the first dimension
 
     Args:
-        x: A pytree of arrays with equal first dimension 
-        x2: A pytree of arrays with dimensions to x outside of the first dimension 
+        x: A pytree of arrays with equal first dimension
+        x2: A pytree of arrays with dimensions to x outside of the first dimension
 
     Returns:
         An array of shape [len(x),len(x2)] where len measures the first dimension in the pytree
     """
 
-    def array_outer(x,x2):
+    def array_outer(x, x2):
         x = x.reshape(x.shape[0], -1)
         x2 = x2.reshape(x2.shape[0], -1)
         return jnp.matmul(x, x2.conj().T)
@@ -46,34 +46,32 @@ def OuterProduct(x: PyTree, x2: PyTree) -> Array:
 
 
 @partial(jax.jit, static_argnames=("apply_fun", "mode"))
-def NeuralTangentKernel(apply_fun: Callable, params: PyTree,  offset: PyTree, σ1: Array, σ2: Array, mode: str) -> Array:
-    
-    r"""Computes the neural tangent kernel with respect to two sets of samples σ1 and σ2 where the jacobians are offset 
-    
+def NeuralTangentKernel(
+    apply_fun: Callable, params: PyTree, offset: PyTree, σ1: Array, σ2: Array, mode: str
+) -> Array:
+
+    r"""Computes the neural tangent kernel with respect to two sets of samples σ1 and σ2 where the jacobians are offset
+
     .. math ::
         N_{s,s'} = \sum_{\theta} \frac{d log(\psi_s)}{d \theta} \frac{d log(\psi_s')}{d \theta}
 
     Args:
         apply_fun: A function that takes a basis state s as input and returns the log amplitude of the wavefunction
         params: A PyTree with the differential parameters of apply_fun
-        offset: An offset that is subtracted from each of the Jacobians.  
+        offset: An offset that is subtracted from each of the Jacobians.
         σ1, σ2: The samples at which the neural tangent kernel is evaluated
         mode: A specification of the differentiation properties of the function as detailed in :def:`netket.jax.jacobian`
-        r_cond: A value such that all eigenvalues v below r_cond*v_max are truncated 
+        r_cond: A value such that all eigenvalues v below r_cond*v_max are truncated
 
     Returns:
         The neural tangent kernel
-        
+
     """
-    
-    def subtract_mean(j,mean):
-        return tree_map(lambda x,y: x - jnp.expand_dims(y,0),j,mean)
-    
-            
-    jac = subtract_mean(jacobian(apply_fun, params, samples1, mode=mode, center=True),offset)
-    jac2 = subtract_mean(jacobian(apply_fun, params, samples2, mode=mode, center=True),offset)
-    
+
+    def subtract_mean(j, mean):
+        return tree_map(lambda x, y: x - jnp.expand_dims(y, 0), j, mean)
+
+    jac = subtract_mean(jacobian(apply_fun, params, σ1, mode=mode), offset)
+    jac2 = subtract_mean(jacobian(apply_fun, params, σ2, mode=mode), offset)
+
     return OuterProduct(jac, jac2)
-
-
-

--- a/netket/jax/_jacobian/neural_tangent_kernel.py
+++ b/netket/jax/_jacobian/neural_tangent_kernel.py
@@ -49,6 +49,7 @@ def NeuralTangentKernel(
 ) -> Array:
     
     jac = jacobian(apply_fun, params, samples, mode=mode, center=True,dense=True)
+    jac = jac.reshape(jac.shape[0],-1)
     
     return jnp.matmul(jac.conj(),jac.T) 
 
@@ -64,6 +65,7 @@ def NeuralTangentKernelInverse(
 ) -> Array:
   
     jac = jacobian(apply_fun, params, samples, mode=mode, center=True,dense=True)
+    jac = jac.reshape(jac.shape[0],-1)
 
     jac = jnp.matmul(jac.conj(),jac.T)
 

--- a/netket/jax/_jacobian/neural_tangent_kernel.py
+++ b/netket/jax/_jacobian/neural_tangent_kernel.py
@@ -26,7 +26,7 @@ from .logic import jacobian
 
 
 def OuterProduct(x: PyTree) -> Array:
-    """Computes A A^T where A is stored as a pytree of parameters
+    r"""Computes A A^T where A is stored as a pytree of parameters
 
     Args:
         x: A pytree of arrays with equal first dimension dim0
@@ -46,7 +46,7 @@ def OuterProduct(x: PyTree) -> Array:
 @partial(jax.jit, static_argnames=("apply_fun", "mode"))
 def NeuralTangentKernel(
     
-    """Computes the neural tangent kernel which is defined as follows
+    r"""Computes the neural tangent kernel which is defined as follows
     
     .. math ::
         N_{s,s'} = \sum_{\theta} \frac{d log(\psi_s)}{d \theta} \frac{d log(\psi_s')}{d \theta}
@@ -82,7 +82,7 @@ def NeuralTangentKernelInverse(
 ) -> Array:
     
     
-    """Computes the pseudo-inverse of the neural tangent kernel which is defined as follows
+    r"""Computes the pseudo-inverse of the neural tangent kernel which is defined as follows
     
     .. math ::
         N_{s,s'} = \sum_{\theta} \frac{d log(\psi_s)}{d \theta} \frac{d log(\psi_s')}{d \theta}

--- a/netket/jax/_jacobian/neural_tangent_kernel.py
+++ b/netket/jax/_jacobian/neural_tangent_kernel.py
@@ -61,6 +61,6 @@ def NeuralTangentKernelInverse(
     r_cond: float = 1e-12,
 ) -> Array:
   
-    OuterProduct(jacobian(apply_fun, params, samples, mode=mode, center=True))
+    jac = OuterProduct(jacobian(apply_fun, params, samples, mode=mode, center=True))
 
     return jnp.linalg.pinv(jac, rcond=r_cond, hermitian=True)


### PR DESCRIPTION
This is a draft of the MinSR algorithm relegated to `netket.experimental` for the time being. 

The MinSR algorithm involves contracting the Jacobian with itself over the parameter dimension to compute the neural tangent kernel (NTK). There is a memory cost N(Y + P^l) where N is the number of samples, Y is the size of the total hidden state across all layers, and P^l is the parameters per layer. This can be reduced by computing the NTK matrix in chunks using the argument `jacobian_chunk_size`. 