### PR TITLE
Allow for product of continuous Hilbert spaces

### DIFF
--- a/netket/experimental/hilbert/spin_orbital_fermions.py
+++ b/netket/experimental/hilbert/spin_orbital_fermions.py
@@ -18,7 +18,7 @@ import numpy as np
 from fractions import Fraction
 
 from netket.hilbert.fock import Fock
-from netket.hilbert.tensor_hilbert import TensorHilbert
+from netket.hilbert.tensor_hilbert_discrete import TensorDiscreteHilbert
 from netket.hilbert.homogeneous import HomogeneousHilbert
 
 
@@ -92,7 +92,7 @@ class SpinOrbitalFermions(HomogeneousHilbert):
             spin_hilberts = [
                 Fock(n_max=1, N=n_orbitals, n_particles=Nf) for Nf in n_fermions
             ]
-            hilbert = TensorHilbert(*spin_hilberts)
+            hilbert = TensorDiscreteHilbert(*spin_hilberts)
 
         self._fock = hilbert
         """Internal representation of this Hilbert space (Fock or TensorHilbert)."""

--- a/netket/hilbert/__init__.py
+++ b/netket/hilbert/__init__.py
@@ -25,9 +25,8 @@ from .fock import Fock
 from .qubit import Qubit
 from .particle import Particle
 
-from .tensor_hilbert import TensorHilbert, AbstractTensorHilbert
-from .tensor_hilbert_discrete import TensorDiscreteHilbert
-
+from .tensor_hilbert import TensorHilbert
+from . import tensor_hilbert_discrete
 
 from netket.utils import _hide_submodules
 

--- a/netket/hilbert/__init__.py
+++ b/netket/hilbert/__init__.py
@@ -25,7 +25,8 @@ from .fock import Fock
 from .qubit import Qubit
 from .particle import Particle
 
-from .tensor_hilbert import TensorHilbert
+from .tensor_hilbert import TensorHilbert, AbstractTensorHilbert
+from .tensor_hilbert_discrete import TensorDiscreteHilbert
 
 
 from netket.utils import _hide_submodules

--- a/netket/hilbert/abstract_hilbert.py
+++ b/netket/hilbert/abstract_hilbert.py
@@ -132,20 +132,20 @@ class AbstractHilbert(abc.ABC):
         return TensorHilbert(other, self)
 
     def _mul_sametype_(self, other: "AbstractHilbert") -> "AbstractHilbert":
-        """This function can be implemented by subclasses to 
+        """This function can be implemented by subclasses to
         specify how to multiply two Hilbert spaces of the same type.
-        
+
         This can be used as an optimization to avoid creating a TensorHilbert
         object when possible, instead returning a new Hilbert space type.
-        
-        If it is not possible to combine the two Hilbert spaces, 
+
+        If it is not possible to combine the two Hilbert spaces,
         it should return NotImplemented.
 
         Args:
             other: other Hilbert space to combine with.
 
         Returns:
-            An Hilbert space combining the two. 
+            An Hilbert space combining the two.
         """
         return NotImplemented
 

--- a/netket/hilbert/abstract_hilbert.py
+++ b/netket/hilbert/abstract_hilbert.py
@@ -123,7 +123,7 @@ class AbstractHilbert(abc.ABC):
 
         return TensorGenericHilbert(self, other)
 
-    def __rmul__(self, other: "AbstractHilbert") -> "TensorGenericHilbert":
+    def __rmul__(self, other: "AbstractHilbert") -> "AbstractHilbert":
         if not isinstance(other, AbstractHilbert):
             return NotImplemented
 

--- a/netket/hilbert/abstract_hilbert.py
+++ b/netket/hilbert/abstract_hilbert.py
@@ -110,6 +110,45 @@ class AbstractHilbert(abc.ABC):
         hash of this Hilbert space
         """
 
+    def __mul__(self, other: "AbstractHilbert"):
+        if not isinstance(other, AbstractHilbert):
+            return NotImplemented
+
+        if type(self) == type(other):
+            res = self._mul_sametype_(other)
+            if res is not NotImplemented:
+                return res
+
+        from .tensor_hilbert import TensorHilbert
+
+        return TensorHilbert(self, other)
+
+    def __rmul__(self, other: "AbstractHilbert"):
+        if not isinstance(other, AbstractHilbert):
+            return NotImplemented
+
+        from .tensor_hilbert import TensorHilbert
+
+        return TensorHilbert(other, self)
+
+    def _mul_sametype_(self, other: "AbstractHilbert") -> "AbstractHilbert":
+        """This function can be implemented by subclasses to 
+        specify how to multiply two Hilbert spaces of the same type.
+        
+        This can be used as an optimization to avoid creating a TensorHilbert
+        object when possible, instead returning a new Hilbert space type.
+        
+        If it is not possible to combine the two Hilbert spaces, 
+        it should return NotImplemented.
+
+        Args:
+            other: other Hilbert space to combine with.
+
+        Returns:
+            An Hilbert space combining the two. 
+        """
+        return NotImplemented
+
     def __eq__(self, other) -> bool:
         if isinstance(other, type(self)):
             return self._attrs == other._attrs

--- a/netket/hilbert/abstract_hilbert.py
+++ b/netket/hilbert/abstract_hilbert.py
@@ -110,7 +110,7 @@ class AbstractHilbert(abc.ABC):
         hash of this Hilbert space
         """
 
-    def __mul__(self, other: "AbstractHilbert"):
+    def __mul__(self, other: "AbstractHilbert") -> "AbstractHilbert":
         if not isinstance(other, AbstractHilbert):
             return NotImplemented
 
@@ -119,17 +119,17 @@ class AbstractHilbert(abc.ABC):
             if res is not NotImplemented:
                 return res
 
-        from .tensor_hilbert import TensorHilbert
+        from .tensor_hilbert import TensorGenericHilbert
 
-        return TensorHilbert(self, other)
+        return TensorGenericHilbert(self, other)
 
-    def __rmul__(self, other: "AbstractHilbert"):
+    def __rmul__(self, other: "AbstractHilbert") -> "TensorGenericHilbert":
         if not isinstance(other, AbstractHilbert):
             return NotImplemented
 
-        from .tensor_hilbert import TensorHilbert
+        from .tensor_hilbert import TensorGenericHilbert
 
-        return TensorHilbert(other, self)
+        return TensorGenericHilbert(other, self)
 
     def _mul_sametype_(self, other: "AbstractHilbert") -> "AbstractHilbert":
         """This function can be implemented by subclasses to

--- a/netket/hilbert/discrete_hilbert.py
+++ b/netket/hilbert/discrete_hilbert.py
@@ -229,9 +229,9 @@ class DiscreteHilbert(AbstractHilbert):
 
             return TensorDiscreteHilbert(self, other)
         elif isinstance(other, AbstractHilbert):
-            from .tensor_hilbert import TensorHilbert
+            from .tensor_hilbert import TensorGenericHilbert
 
-            return TensorHilbert(self, other)
+            return TensorGenericHilbert(self, other)
 
         return NotImplemented
 

--- a/netket/hilbert/discrete_hilbert.py
+++ b/netket/hilbert/discrete_hilbert.py
@@ -224,9 +224,16 @@ class DiscreteHilbert(AbstractHilbert):
             if res is not NotImplemented:
                 return res
 
-        from .tensor_hilbert import TensorHilbert
+        if isinstance(other, DiscreteHilbert):
+            from .tensor_hilbert_discrete import TensorDiscreteHilbert
 
-        return TensorHilbert(self, other)
+            return TensorDiscreteHilbert(self, other)
+        elif isinstance(other, AbstractHilbert):
+            from .tensor_hilbert import TensorHilbert
+
+            return TensorHilbert(self, other)
+
+        return NotImplemented
 
     def __pow__(self, n):
         return reduce(lambda x, y: x * y, [self for _ in range(n)])

--- a/netket/hilbert/discrete_hilbert.py
+++ b/netket/hilbert/discrete_hilbert.py
@@ -50,7 +50,7 @@ class DiscreteHilbert(AbstractHilbert):
             shape: The local dimension of the Hilbert space for each degree
                 of freedom.
         """
-        self._shape = shape
+        self._shape = tuple(shape)
 
         super().__init__()
 

--- a/netket/hilbert/random/tensor_hilbert.py
+++ b/netket/hilbert/random/tensor_hilbert.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Union
-
 import jax
 from jax import numpy as jnp
 

--- a/netket/hilbert/random/tensor_hilbert.py
+++ b/netket/hilbert/random/tensor_hilbert.py
@@ -12,15 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Union
+
 import jax
 from jax import numpy as jnp
 
-from netket.hilbert import TensorHilbert
+from netket.hilbert import AbstractTensorHilbert
 from netket.utils.dispatch import dispatch
 
 
 @dispatch
-def random_state(hilb: TensorHilbert, key, batches: int, *, dtype):
+def random_state(hilb: AbstractTensorHilbert, key, batches: int, *, dtype):
     keys = jax.random.split(key, hilb._n_hilbert_spaces)
 
     vs = [
@@ -50,7 +52,7 @@ def _make_subfun(hilb, i, sub_hi):
 
 
 @dispatch
-def flip_state_scalar(hilb: TensorHilbert, key, state, index):
+def flip_state_scalar(hilb: AbstractTensorHilbert, key, state, index):
 
     subfuns = []
     for (i, sub_hi) in enumerate(hilb._hilbert_spaces):

--- a/netket/hilbert/random/tensor_hilbert.py
+++ b/netket/hilbert/random/tensor_hilbert.py
@@ -15,12 +15,12 @@
 import jax
 from jax import numpy as jnp
 
-from netket.hilbert import AbstractTensorHilbert
+from netket.hilbert import TensorHilbert
 from netket.utils.dispatch import dispatch
 
 
 @dispatch
-def random_state(hilb: AbstractTensorHilbert, key, batches: int, *, dtype):
+def random_state(hilb: TensorHilbert, key, batches: int, *, dtype):
     keys = jax.random.split(key, hilb._n_hilbert_spaces)
 
     vs = [
@@ -50,7 +50,7 @@ def _make_subfun(hilb, i, sub_hi):
 
 
 @dispatch
-def flip_state_scalar(hilb: AbstractTensorHilbert, key, state, index):
+def flip_state_scalar(hilb: TensorHilbert, key, state, index):
 
     subfuns = []
     for (i, sub_hi) in enumerate(hilb._hilbert_spaces):

--- a/netket/hilbert/tensor_hilbert.py
+++ b/netket/hilbert/tensor_hilbert.py
@@ -12,17 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, List, Union
+from typing import Optional, List, Union, Iterable, Tuple
+from functools import reduce
 
 import numpy as np
 import jax.numpy as jnp
 
-from .discrete_hilbert import DiscreteHilbert, _is_indexable
+from .abstract_hilbert import AbstractHilbert
 
 
-# TODO: Make parametric class
-class TensorHilbert(DiscreteHilbert):
-    r"""Tensor product of several Discrete sub-spaces, representing the space
+class AbstractTensorHilbert:
+    r"""Abstract base class for the tensor product of several sub-spaces,
+    representing the space
 
     In general you should not construct this object directly, but you should
     simply multiply different hilbert spaces together. In this case, Python's
@@ -42,12 +43,20 @@ class TensorHilbert(DiscreteHilbert):
 
     """
 
-    def __init__(self, *hilb_spaces: DiscreteHilbert):
-        r"""Constructs a tensor Hilbert space
+    def __init__(self, hilb_spaces: Iterable[AbstractHilbert], *args, **kwargs):
+        r"""Constructs a tensor Hilbert space.
 
         Args:
             *hilb: An iterable object containing at least 1 hilbert space.
         """
+        # Flatten "TensorHilberts" found inside hilb_spaces
+        _hilb_spaces_flat = []
+        for hi in hilb_spaces:
+            if isinstance(hi, AbstractTensorHilbert):
+                _hilb_spaces_flat.extend(hi.subspaces)
+            else:
+                _hilb_spaces_flat.append(hi)
+        hilb_spaces = _hilb_spaces_flat
 
         self._hilbert_spaces = hilb_spaces
         self._n_hilbert_spaces = len(hilb_spaces)
@@ -56,142 +65,46 @@ class TensorHilbert(DiscreteHilbert):
         )
 
         self._sizes = tuple([hi.size for hi in hilb_spaces])
-        shape = np.concatenate([hi.shape for hi in hilb_spaces])
         self._cum_sizes = np.cumsum(self._sizes)
         self._cum_indices = np.concatenate([[0], self._cum_sizes])
         self._size = sum(self._sizes)
         self._delta_indices_i = np.array(
             [self._cum_indices[i] for i in self._hilbert_i]
         )
-
-        # pre-compute indexing data iff the tensor space is still indexable
-        if all(hi.is_indexable for hi in hilb_spaces) and _is_indexable(shape):
-            self._ns_states = [hi.n_states for hi in self._hilbert_spaces]
-            self._ns_states_r = np.flip(self._ns_states)
-            self._cum_ns_states = np.concatenate([[0], np.cumprod(self._ns_states)])
-            self._cum_ns_states_r = np.flip(
-                np.cumprod(np.concatenate([[1], np.flip(self._ns_states)]))[:-1]
-            )
-            self._n_states = np.prod(self._ns_states)
-
-        super().__init__(shape=shape)
+        super().__init__(
+            *args, **kwargs
+        )  # forwards all unused arguments so that this class is a mixin.
 
     @property
     def size(self) -> int:
         return self._size
 
     @property
-    def is_finite(self):
-        return all([hi.is_finite for hi in self._hilbert_spaces])
+    def subspaces(self) -> Tuple[AbstractHilbert, ...]:
+        """Tuplec ontaining all the subspaces of this tensor product of
+        Hilbert spaces.
+        """
+        return self._hilbert_spaces
 
-    def _sub_index(self, i):
+    def _sub_index(self, i: int) -> int:
+        """Internal function computing the subspace index for the given site
+        i.
+
+        Arguments:
+            i: Index of a site in :math:`[0, N)`.
+        Returns:
+            The index `j` such that self.subspaces[j] is the Hilbert space
+            containing site `i`.
+        """
         for (j, sz) in enumerate(self._cum_sizes):
             if i < sz:
                 return j
-
-    # def size_at_index(self, i):
-    #    # j = self._sub_index(i)
-    #    # return self._hilbert_spaces[j].size_at_index(i-self._cum_indices[j-1])
-    #    return self._hilbert_spaces[self._hilbert_i[i]].size_at_index(
-    #        i - self._delta_indices_i[i]
-    #    )
-
-    def states_at_index(self, i):
-        # j = self._sub_index(i)
-        # return self._hilbert_spaces[j].states_at_index(i-self._cum_indices[j-1])
-        return self._hilbert_spaces[self._hilbert_i[i]].states_at_index(
-            i - self._delta_indices_i[i]
-        )
-
-    @property
-    def n_states(self) -> int:
-        if not self.is_indexable:
-            raise RuntimeError("The hilbert space is too large to be indexed.")
-        return self._n_states
-
-    def _numbers_to_states(self, numbers, out):
-        # !!! WARNING
-        # This code assumes that states are stored in a MSB
-        # (Most Significant Bit) format.
-        # We assume that the rightmost-half indexes the LSBs
-        # and the leftmost-half indexes the MSBs
-        # HilbertIndex-generated states respect this, as they are:
-        # 0 -> [0,0,0,0]
-        # 1 -> [0,0,0,1]
-        # 2 -> [0,0,1,0]
-        # etc...
-
-        rem = numbers
-        for (i, dim) in enumerate(self._ns_states_r):
-            rem, loc_numbers = np.divmod(rem, dim)
-            hi_i = self._n_hilbert_spaces - (i + 1)
-            self._hilbert_spaces[hi_i].numbers_to_states(
-                loc_numbers, out=out[:, self._cum_indices[hi_i] : self._cum_sizes[hi_i]]
-            )
-
-        return out
-
-    def _states_to_numbers(self, states, out):
-        out[:] = 0
-
-        temp = out.copy()
-
-        # !!! WARNING
-        # See note above in numbers_to_states
-
-        for (i, dim) in enumerate(self._cum_ns_states_r):
-            self._hilbert_spaces[i].states_to_numbers(
-                states[:, self._cum_indices[i] : self._cum_sizes[i]], out=temp
-            )
-            out += temp * dim
-
-        return out
-
-    def states_to_local_indices(self, x):
-        out = jnp.empty_like(x, dtype=jnp.int32)
-        for (i, hilb_i) in enumerate(self._hilbert_spaces):
-            out = out.at[..., self._cum_indices[i] : self._cum_sizes[i]].set(
-                hilb_i.states_to_local_indices(
-                    x[..., self._cum_indices[i] : self._cum_sizes[i]]
-                )
-            )
-        return out
-
-    def __repr__(self):
-        if len(self._hilbert_spaces) == 1:
-            return f"TensorHilbert({self._hilbert_spaces[0]})"
-
-        _str = "{}".format(self._hilbert_spaces[0])
-        for hi in self._hilbert_spaces[1:]:
-            _str += "⊗{}".format(hi)
-
-        return _str
 
     @property
     def _attrs(self):
         return self._hilbert_spaces
 
-    def __mul__(self, other):
-        spaces_l = self._hilbert_spaces[:-1]
-        space_center_l = self._hilbert_spaces[-1]
-
-        if isinstance(other, TensorHilbert):
-            space_center_r = other._hilbert_spaces[0]
-            spaces_r = other._hilbert_spaces[1:]
-        else:
-            space_center_r = other
-            spaces_r = tuple()
-
-        # Attempt to 'merge' the two spaces at the interface.
-        spaces_center = space_center_l * space_center_r
-        if isinstance(spaces_center, TensorHilbert):
-            spaces_center = (space_center_l, space_center_r)
-        else:
-            spaces_center = (spaces_center,)
-
-        return TensorHilbert(*spaces_l, *spaces_center, *spaces_r)
-
-    def ptrace(self, sites: Union[int, List]) -> Optional[DiscreteHilbert]:
+    def ptrace(self, sites: Union[int, List]) -> Optional[AbstractHilbert]:
         if isinstance(sites, int):
             sites = [sites]
 
@@ -231,3 +144,46 @@ class TensorHilbert(DiscreteHilbert):
                     hilb = hilb * h
 
                 return hilb
+
+    def __repr__(self):
+        if len(self._hilbert_spaces) == 1:
+            return f"{type(self).__name__}({self._hilbert_spaces[0]})"
+
+        _str = "{}".format(self._hilbert_spaces[0])
+        for hi in self._hilbert_spaces[1:]:
+            _str += "⊗{}".format(hi)
+
+        return _str
+
+
+class TensorHilbert(AbstractTensorHilbert, AbstractHilbert):
+    def __init__(self, *hilb_spaces: AbstractHilbert):
+        r"""Constructs a tensor Hilbert space
+
+        Args:
+            *hilb: An iterable object containing at least 1 hilbert space.
+        """
+        print("init  tensor general")
+
+    def __init__(self, *hilb_spaces: AbstractHilbert):
+        super().__init__(hilb_spaces)
+
+    def __mul__(self, other):
+        spaces_l = self._hilbert_spaces[:-1]
+        space_center_l = self._hilbert_spaces[-1]
+
+        if isinstance(other, TensorHilbert):
+            space_center_r = other._hilbert_spaces[0]
+            spaces_r = other._hilbert_spaces[1:]
+        else:
+            space_center_r = other
+            spaces_r = tuple()
+
+        # Attempt to 'merge' the two spaces at the interface.
+        spaces_center = space_center_l * space_center_r
+        if isinstance(spaces_center, TensorHilbert):
+            spaces_center = (space_center_l, space_center_r)
+        else:
+            spaces_center = (spaces_center,)
+
+        return TensorHilbert(*spaces_l, *spaces_center, *spaces_r)

--- a/netket/hilbert/tensor_hilbert.py
+++ b/netket/hilbert/tensor_hilbert.py
@@ -13,10 +13,8 @@
 # limitations under the License.
 
 from typing import Optional, List, Union, Iterable, Tuple
-from functools import reduce
 
 import numpy as np
-import jax.numpy as jnp
 
 from .abstract_hilbert import AbstractHilbert
 
@@ -29,18 +27,8 @@ class AbstractTensorHilbert:
     simply multiply different hilbert spaces together. In this case, Python's
     `*` operator will be interpreted as a tensor product.
 
-    This Hilbert can be used as a replacement anywhere a Uniform Hilbert space
-    is not required.
-
-    Examples:
-        Couple a bosonic mode with spins
-
-        >>> from netket.hilbert import Spin, Fock
-        >>> Fock(3)*Spin(0.5, 5)
-        Fock(n_max=3, N=1)⊗Spin(s=1/2, N=5)
-        >>> type(_)
-        <class 'netket.hilbert.tensor_hilbert.TensorHilbert'>
-
+    This is an abstract mixing class that should be inherited from, together
+    with another class that inherits from `AbstractHilbert`.
     """
 
     def __init__(self, hilb_spaces: Iterable[AbstractHilbert], *args, **kwargs):
@@ -58,7 +46,7 @@ class AbstractTensorHilbert:
                 _hilb_spaces_flat.append(hi)
         hilb_spaces = _hilb_spaces_flat
 
-        self._hilbert_spaces = hilb_spaces
+        self._hilbert_spaces = tuple(hilb_spaces)
         self._n_hilbert_spaces = len(hilb_spaces)
         self._hilbert_i = np.concatenate(
             [[i for _ in range(hi.size)] for (i, hi) in enumerate(hilb_spaces)]
@@ -157,14 +145,6 @@ class AbstractTensorHilbert:
 
 
 class TensorHilbert(AbstractTensorHilbert, AbstractHilbert):
-    def __init__(self, *hilb_spaces: AbstractHilbert):
-        r"""Constructs a tensor Hilbert space
-
-        Args:
-            *hilb: An iterable object containing at least 1 hilbert space.
-        """
-        print("init  tensor general")
-
     def __init__(self, *hilb_spaces: AbstractHilbert):
         super().__init__(hilb_spaces)
 

--- a/netket/hilbert/tensor_hilbert.py
+++ b/netket/hilbert/tensor_hilbert.py
@@ -39,10 +39,11 @@ class TensorHilbert(ABC):
     """
 
     def __new__(cls, *args, **kwargs):
-        # This logic overrides the constructor, such that if someone tries to 
+        # This logic overrides the constructor, such that if someone tries to
         # construct this class directly by calling `TensorHilbert(...)`
         # it will construct either a DiscreteHilbert or TensorDiscreteHilbert
         from .tensor_hilbert_discrete import TensorDiscreteHilbert, DiscreteHilbert
+
         if cls is TensorHilbert:
             if all(isinstance(hi, DiscreteHilbert) for hi in args):
                 cls = TensorDiscreteHilbert
@@ -167,9 +168,11 @@ class TensorHilbert(ABC):
 class TensorGenericHilbert(TensorHilbert, AbstractHilbert):
     def __init__(self, *hilb_spaces: AbstractHilbert):
         if not all(isinstance(hi, AbstractHilbert) for hi in hilb_spaces):
-            raise TypeError("Arguments to TensorHilbert must all be subtypes of "
-                            "AbstractHilbert. However the types are:\n\n"
-                            f"{list(type(hi) for hi in hilb_spaces)}\n")
+            raise TypeError(
+                "Arguments to TensorHilbert must all be subtypes of "
+                "AbstractHilbert. However the types are:\n\n"
+                f"{list(type(hi) for hi in hilb_spaces)}\n"
+            )
         super().__init__(hilb_spaces)
 
     def __mul__(self, other):

--- a/netket/hilbert/tensor_hilbert_discrete.py
+++ b/netket/hilbert/tensor_hilbert_discrete.py
@@ -47,9 +47,11 @@ class TensorDiscreteHilbert(TensorHilbert, DiscreteHilbert):
             *hilb: An iterable object containing at least 1 hilbert space.
         """
         if not all(isinstance(hi, DiscreteHilbert) for hi in hilb_spaces):
-            raise TypeError("Arguments to TensorDiscreteHilbert must all be "
-                            "subtypes of DiscreteHilbert. However the types are:\n\n"
-                            f"{list(type(hi) for hi in hilb_spaces)}\n")
+            raise TypeError(
+                "Arguments to TensorDiscreteHilbert must all be "
+                "subtypes of DiscreteHilbert. However the types are:\n\n"
+                f"{list(type(hi) for hi in hilb_spaces)}\n"
+            )
 
         shape = np.concatenate([hi.shape for hi in hilb_spaces])
 

--- a/netket/hilbert/tensor_hilbert_discrete.py
+++ b/netket/hilbert/tensor_hilbert_discrete.py
@@ -16,10 +16,10 @@ import numpy as np
 import jax.numpy as jnp
 
 from .discrete_hilbert import DiscreteHilbert, _is_indexable
-from .tensor_hilbert import AbstractTensorHilbert
+from .tensor_hilbert import TensorHilbert
 
 
-class TensorDiscreteHilbert(AbstractTensorHilbert, DiscreteHilbert):
+class TensorDiscreteHilbert(TensorHilbert, DiscreteHilbert):
     r"""Tensor product of several Discrete sub-spaces, representing the space
 
     In general you should not construct this object directly, but you should
@@ -46,6 +46,11 @@ class TensorDiscreteHilbert(AbstractTensorHilbert, DiscreteHilbert):
         Args:
             *hilb: An iterable object containing at least 1 hilbert space.
         """
+        if not all(isinstance(hi, DiscreteHilbert) for hi in hilb_spaces):
+            raise TypeError("Arguments to TensorDiscreteHilbert must all be "
+                            "subtypes of DiscreteHilbert. However the types are:\n\n"
+                            f"{list(type(hi) for hi in hilb_spaces)}\n")
+
         shape = np.concatenate([hi.shape for hi in hilb_spaces])
 
         super().__init__(hilb_spaces, shape=shape)

--- a/netket/hilbert/tensor_hilbert_discrete.py
+++ b/netket/hilbert/tensor_hilbert_discrete.py
@@ -1,0 +1,151 @@
+# Copyright 2021 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional, List, Union
+
+import numpy as np
+import jax.numpy as jnp
+
+from .discrete_hilbert import DiscreteHilbert, _is_indexable
+from .tensor_hilbert import AbstractTensorHilbert
+
+
+class TensorDiscreteHilbert(AbstractTensorHilbert, DiscreteHilbert):
+    r"""Tensor product of several Discrete sub-spaces, representing the space
+
+    In general you should not construct this object directly, but you should
+    simply multiply different hilbert spaces together. In this case, Python's
+    `*` operator will be interpreted as a tensor product.
+
+    This Hilbert can be used as a replacement anywhere a Uniform Hilbert space
+    is not required.
+
+    Examples:
+        Couple a bosonic mode with spins
+
+        >>> from netket.hilbert import Spin, Fock
+        >>> Fock(3)*Spin(0.5, 5)
+        Fock(n_max=3, N=1)⊗Spin(s=1/2, N=5)
+        >>> type(_)
+        <class 'netket.hilbert.tensor_hilbert.TensorHilbert'>
+
+    """
+
+    def __init__(self, *hilb_spaces: DiscreteHilbert):
+        r"""Constructs a tensor Hilbert space
+
+        Args:
+            *hilb: An iterable object containing at least 1 hilbert space.
+        """
+        shape = np.concatenate([hi.shape for hi in hilb_spaces])
+
+        super().__init__(hilb_spaces, shape=shape)
+
+        # pre-compute indexing data iff the tensor space is still indexable
+        if all(hi.is_indexable for hi in hilb_spaces) and _is_indexable(shape):
+            self._ns_states = [hi.n_states for hi in self._hilbert_spaces]
+            self._ns_states_r = np.flip(self._ns_states)
+            self._cum_ns_states = np.concatenate([[0], np.cumprod(self._ns_states)])
+            self._cum_ns_states_r = np.flip(
+                np.cumprod(np.concatenate([[1], np.flip(self._ns_states)]))[:-1]
+            )
+            self._n_states = np.prod(self._ns_states)
+
+    @property
+    def is_finite(self):
+        return all([hi.is_finite for hi in self._hilbert_spaces])
+
+    def states_at_index(self, i):
+        # j = self._sub_index(i)
+        # return self._hilbert_spaces[j].states_at_index(i-self._cum_indices[j-1])
+        return self._hilbert_spaces[self._hilbert_i[i]].states_at_index(
+            i - self._delta_indices_i[i]
+        )
+
+    @property
+    def n_states(self) -> int:
+        if not self.is_indexable:
+            raise RuntimeError("The hilbert space is too large to be indexed.")
+        return self._n_states
+
+    def _numbers_to_states(self, numbers, out):
+        # !!! WARNING
+        # This code assumes that states are stored in a MSB
+        # (Most Significant Bit) format.
+        # We assume that the rightmost-half indexes the LSBs
+        # and the leftmost-half indexes the MSBs
+        # HilbertIndex-generated states respect this, as they are:
+        # 0 -> [0,0,0,0]
+        # 1 -> [0,0,0,1]
+        # 2 -> [0,0,1,0]
+        # etc...
+
+        rem = numbers
+        for (i, dim) in enumerate(self._ns_states_r):
+            rem, loc_numbers = np.divmod(rem, dim)
+            hi_i = self._n_hilbert_spaces - (i + 1)
+            self._hilbert_spaces[hi_i].numbers_to_states(
+                loc_numbers, out=out[:, self._cum_indices[hi_i] : self._cum_sizes[hi_i]]
+            )
+
+        return out
+
+    def _states_to_numbers(self, states, out):
+        out[:] = 0
+
+        temp = out.copy()
+
+        # !!! WARNING
+        # See note above in numbers_to_states
+
+        for (i, dim) in enumerate(self._cum_ns_states_r):
+            self._hilbert_spaces[i].states_to_numbers(
+                states[:, self._cum_indices[i] : self._cum_sizes[i]], out=temp
+            )
+            out += temp * dim
+
+        return out
+
+    def states_to_local_indices(self, x):
+        out = jnp.empty_like(x, dtype=jnp.int32)
+        for (i, hilb_i) in enumerate(self._hilbert_spaces):
+            out = out.at[..., self._cum_indices[i] : self._cum_sizes[i]].set(
+                hilb_i.states_to_local_indices(
+                    x[..., self._cum_indices[i] : self._cum_sizes[i]]
+                )
+            )
+        return out
+
+    def __mul__(self, other):
+        if not isinstance(other, DiscreteHilbert):
+            return NotImplemented
+
+        spaces_l = self._hilbert_spaces[:-1]
+        space_center_l = self._hilbert_spaces[-1]
+
+        if isinstance(other, TensorDiscreteHilbert):
+            space_center_r = other._hilbert_spaces[0]
+            spaces_r = other._hilbert_spaces[1:]
+        else:
+            space_center_r = other
+            spaces_r = tuple()
+
+        # Attempt to 'merge' the two spaces at the interface.
+        spaces_center = space_center_l * space_center_r
+        if isinstance(spaces_center, TensorDiscreteHilbert):
+            spaces_center = (space_center_l, space_center_r)
+        else:
+            spaces_center = (spaces_center,)
+
+        return TensorDiscreteHilbert(*spaces_l, *spaces_center, *spaces_r)

--- a/netket/hilbert/tensor_hilbert_discrete.py
+++ b/netket/hilbert/tensor_hilbert_discrete.py
@@ -32,11 +32,15 @@ class TensorDiscreteHilbert(TensorHilbert, DiscreteHilbert):
     Examples:
         Couple a bosonic mode with spins
 
+        >>> import netket as nk
         >>> from netket.hilbert import Spin, Fock
-        >>> Fock(3)*Spin(0.5, 5)
+        >>> hi = Fock(3)*Spin(0.5, 5)
+        >>> print(hi)
         Fock(n_max=3, N=1)⊗Spin(s=1/2, N=5)
-        >>> type(_)
-        <class 'netket.hilbert.tensor_hilbert.TensorHilbert'>
+        >>> isinstance(hi, nk.hilbert.TensorHilbert)
+        True
+        >>> type(hi)
+        <class 'netket.hilbert.tensor_hilbert_discrete.TensorDiscreteHilbert'>
 
     """
 

--- a/netket/hilbert/tensor_hilbert_discrete.py
+++ b/netket/hilbert/tensor_hilbert_discrete.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, List, Union
-
 import numpy as np
 import jax.numpy as jnp
 

--- a/test/hilbert/test_hilbert.py
+++ b/test/hilbert/test_hilbert.py
@@ -540,6 +540,24 @@ def test_tensor_combination():
     assert isinstance(repr(hit3), str)
     assert hit3 == nk.hilbert.TensorHilbert(hit, hi3)
 
+    hit3 = Spin(s=1 / 2, N=2) * hi3
+    assert isinstance(hit3, nk.hilbert.TensorHilbert)
+    assert len(hit3._hilbert_spaces) == 2
+    assert isinstance(repr(hit3), str)
+    assert hit3 == nk.hilbert.TensorHilbert(Spin(s=1 / 2, N=2), hi3)
+
+    hit3 = Spin(s=1 / 2, N=2) * nk.hilbert.TensorHilbert(hi3)
+    assert isinstance(hit3, nk.hilbert.TensorHilbert)
+    assert len(hit3._hilbert_spaces) == 2
+    assert isinstance(repr(hit3), str)
+    assert hit3 == nk.hilbert.TensorHilbert(Spin(s=1 / 2, N=2), hi3)
+
+    hit3 = nk.hilbert.TensorHilbert(hi3) * nk.hilbert.TensorHilbert(hi3)
+    assert isinstance(hit3, nk.hilbert.TensorHilbert)
+    assert len(hit3._hilbert_spaces) == 2
+    assert isinstance(repr(hit3), str)
+    assert hit3 == nk.hilbert.TensorHilbert(hi3, hi3)
+
     hit = hi3 * hi3
     assert isinstance(hit, nk.hilbert.TensorHilbert)
     assert len(hit._hilbert_spaces) == 2
@@ -570,6 +588,22 @@ def test_tensor_combination():
     assert len(hit._hilbert_spaces) == 1
     assert isinstance(repr(hit), str)
 
+def test_errors():
+    hi = Spin(s=1 / 2, N=2) 
+    with pytest.raises(TypeError):
+        1 * hi
+    with pytest.raises(TypeError):
+        hi * 1
+
+    hi = nk.hilbert.Particle(N=5, L=(np.inf, 10.0), pbc=(False, True))
+    with pytest.raises(TypeError):
+        1 * hi
+    with pytest.raises(TypeError):
+        hi * 1
+
+def test_pow():
+    hi = Spin(s=1 / 2, N=2) 
+    assert hi**5 == Spin(1/2, N=10)
 
 def test_constrained_eq_hash():
     hi1 = nk.hilbert.Spin(0.5, 4, total_sz=0)

--- a/test/hilbert/test_hilbert.py
+++ b/test/hilbert/test_hilbert.py
@@ -588,8 +588,9 @@ def test_tensor_combination():
     assert len(hit._hilbert_spaces) == 1
     assert isinstance(repr(hit), str)
 
+
 def test_errors():
-    hi = Spin(s=1 / 2, N=2) 
+    hi = Spin(s=1 / 2, N=2)
     with pytest.raises(TypeError):
         1 * hi
     with pytest.raises(TypeError):
@@ -601,9 +602,11 @@ def test_errors():
     with pytest.raises(TypeError):
         hi * 1
 
+
 def test_pow():
-    hi = Spin(s=1 / 2, N=2) 
-    assert hi**5 == Spin(1/2, N=10)
+    hi = Spin(s=1 / 2, N=2)
+    assert hi**5 == Spin(1 / 2, N=10)
+
 
 def test_constrained_eq_hash():
     hi1 = nk.hilbert.Spin(0.5, 4, total_sz=0)

--- a/test/hilbert/test_hilbert.py
+++ b/test/hilbert/test_hilbert.py
@@ -524,17 +524,51 @@ def test_tensor_combination():
     assert np.allclose(hit.shape, np.hstack([hi1.shape, hi2.shape]))
     assert hit.n_states == hi1.n_states * hi2.n_states
     assert len(hit._hilbert_spaces) == 5
-    repr(hit)
+    assert isinstance(repr(hit), str)
 
     hi3 = nk.hilbert.Particle(N=5, L=(np.inf, 10.0), pbc=(False, True))
     hit2 = hi1 * hi3
     assert isinstance(hit2, nk.hilbert.TensorHilbert)
     assert np.allclose(hit2.size, hi1.size + hi3.size)
     assert len(hit2._hilbert_spaces) == 4
+    assert isinstance(repr(hit2), str)
+    assert hit2 == nk.hilbert.TensorHilbert(hi1, hi3)
 
     hit3 = hit * hi3
     assert isinstance(hit3, nk.hilbert.TensorHilbert)
     assert len(hit3._hilbert_spaces) == 6
+    assert isinstance(repr(hit3), str)
+    assert hit3 == nk.hilbert.TensorHilbert(hit, hi3)
+
+    hit = hi3 * hi3
+    assert isinstance(hit, nk.hilbert.TensorHilbert)
+    assert len(hit._hilbert_spaces) == 2
+    assert isinstance(repr(hit), str)
+    assert hit == nk.hilbert.TensorHilbert(hi3, hi3)
+
+    hit = (hi3 * hi3) * hi3
+    assert isinstance(hit, nk.hilbert.TensorHilbert)
+    assert len(hit._hilbert_spaces) == 3
+    assert isinstance(repr(hit), str)
+    assert hit == nk.hilbert.TensorHilbert(hi3 * hi3, hi3)
+
+    hit = hi3 * (hi3 * hi3)
+    assert isinstance(hit, nk.hilbert.TensorHilbert)
+    assert len(hit._hilbert_spaces) == 3
+    assert isinstance(repr(hit), str)
+    assert hit == nk.hilbert.TensorHilbert(hi3, hi3 * hi3)
+
+    hit = nk.hilbert.TensorHilbert(Spin(s=1 / 2, N=2))
+    assert isinstance(hit, nk.hilbert._tensor_hilbert_discrete.TensorDiscreteHilbert)
+    assert len(hit._hilbert_spaces) == 1
+    assert isinstance(repr(hit), str)
+
+    hit = nk.hilbert.TensorHilbert(
+        nk.hilbert.Particle(N=5, L=(np.inf, 10.0), pbc=(False, True))
+    )
+    assert isinstance(hit, nk.hilbert._tensor_hilbert.TensorGenericHilbert)
+    assert len(hit._hilbert_spaces) == 1
+    assert isinstance(repr(hit), str)
 
 
 def test_constrained_eq_hash():

--- a/test/hilbert/test_hilbert.py
+++ b/test/hilbert/test_hilbert.py
@@ -512,14 +512,15 @@ def test_no_particles():
 def test_tensor_no_recursion():
     # Issue https://github.com/netket/netket/issues/1101
     hi = nk.hilbert.Fock(3) * nk.hilbert.Spin(0.5, 2, total_sz=0.0)
-    assert isinstance(hi, nk.hilbert.TensorDiscreteHilbert)
+    assert isinstance(hi, nk.hilbert.TensorHilbert)
 
 
 def test_tensor_combination():
     hi1 = Spin(s=1 / 2, N=2) * Spin(s=1, N=2) * Fock(n_max=3, N=1)
     hi2 = Fock(n_max=3, N=1) * Spin(s=1, N=2) * Spin(s=1 / 2, N=2)
     hit = hi1 * hi2
-    assert isinstance(hit, nk.hilbert.TensorDiscreteHilbert)
+    assert isinstance(hit, nk.hilbert.TensorHilbert)
+    assert isinstance(hit, nk.hilbert._tensor_hilbert_discrete.TensorDiscreteHilbert)
     assert np.allclose(hit.shape, np.hstack([hi1.shape, hi2.shape]))
     assert hit.n_states == hi1.n_states * hi2.n_states
     assert len(hit._hilbert_spaces) == 5


### PR DESCRIPTION
Right now we can only combine discrete Hilbert spaces, not continuous.

This PR extracts the common logic of tensorHilbert in a new `AbstractTensorHiblert` class, and creates two implementations
 - `TensorHilbert` which is a combination of continuous Hilbert spaces, with no special new methods added
 - `TensorDiscreteHilbert` which combines discrete spaces and is discrete itself, possibly even indexable.
I've cleaned up the logic used in multiplying hilbert spaces so that you always get the correct type (a `TensorDiscrete` as long as you only have discrete spaces, the continuous one otherwise)

I'm unsure about the naming, and I'd like some feedback about how to name those three objects (`AbstractTensorHilbert`, `TensorHilbert` and `TensorDiscreteHilbert`).

In theory one should never have to construct directly a `Tensor***Hilbert`, but might only want to check for `AbstractTensorHilbert` in some cases.

This also renames `TensorHilbert` to `TensorDiscreteHilbert` which might break some user code, though I suspect few are using this directly (@jwnys ?)