### PR TITLE
Enfore at least float type in BoseHubbard operator

### DIFF
--- a/netket/operator/_bose_hubbard.py
+++ b/netket/operator/_bose_hubbard.py
@@ -80,6 +80,7 @@ class BoseHubbard(SpecialHamiltonian):
             dtype = jnp.promote_types(_dtype(U), _dtype(V))
             dtype = jnp.promote_types(dtype, _dtype(J))
             dtype = jnp.promote_types(dtype, _dtype(mu))
+        dtype = jnp.promote_types(float, dtype)
         dtype = np.empty((), dtype=dtype).dtype
         self._dtype = dtype
 


### PR DESCRIPTION
When supplying integer parameters to Bose-Hubbard operator (e.g. `J = 1` vs `J = 1.0`) the inferred dtype is integer. However, the Bose-Hubbard operator (matrix elements) is inherently irrational, since jumping operators are the square root of particle number.