### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,12 +56,13 @@ extra = [
     "h5py>=3.7.0",
     ]
 dev = [
+    "networkx>=2.4, <4",
+    "matplotlib>=3",
     "pytest>=6",
     "pytest-xdist[psutil]>=2",
     "pytest-cov>=2.10.1",
     "pytest-json-report>=1.3",
     "coverage>=5",
-    "networkx>=2.4, <4",
     "pre-commit>=2.7",
     "black==22.10.0",
     "flake8==6.0.0; python_version >= '3.8'",


### PR DESCRIPTION
flax recently removed matplotlib from its dependencies. We have some tests that depend on it.