### PR TITLE
Small bugfix in langevin sampler

### DIFF
--- a/netket/sampler/rules/langevin.py
+++ b/netket/sampler/rules/langevin.py
@@ -27,7 +27,7 @@ class LangevinRule(MetropolisRule):
     """
     Time step in the Langevin dynamics
     """
-    chunk_size: int = None
+    chunk_size: int = struct.field(pytree_node=False, default=None)
     """
     Chunk size for computing gradients of the ansatz
     """
@@ -89,7 +89,8 @@ def _langevin_step(
 
     def _single_grad(x):
         """Derivative of log_prob with respect to a single sample x"""
-        g = nkjax.grad(_log_prob)(x)
+        x = x.reshape(x.shape[-1])
+        g = nkjax.grad(lambda xi: _log_prob(xi).ravel()[0])(x)
         return g if jnp.iscomplexobj(r) else g.real
 
     grad_logp_r = nkjax.vmap_chunked(_single_grad, chunk_size=chunk_size)(r)

--- a/test/sampler/test_sampler.py
+++ b/test/sampler/test_sampler.py
@@ -113,6 +113,9 @@ samplers[
 ] = nk.sampler.MetropolisAdjustedLangevin(
     hi_particles, dt=0.1, n_sweeps=hi_particles.size
 )
+samplers[
+    "Metropolis(AdjustedLangevin): AdjustedLangevin chunk_size"
+] = nk.sampler.MetropolisAdjustedLangevin(hi_particles, dt=0.1, chunk_size=16)
 
 
 # The following fixture initialises a model and it's weights


### PR DESCRIPTION
Bug fixes to Langevin sampler:
- when providing chunk_size != None, we got a tracing error
- for some models the grad function failed due to a shape (1,)