### PR TITLE
Add new transition rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 ### New features
 * {class}`netket.hilbert.TensorHilbert` has been generalised and now works with both discrete, continuous or a combination of discrete and continuous hilbert spaces [#1437](https://github.com/netket/netket/pull/1437).
 * NetKet is now compatible with Numba 0.57 and therefore with Python 3.11 [#1462](https://github.com/netket/netket/pull/1462).
+* The new Metropolis sampling transition proposal rules {func}`netket.sampler.rules.MultipleRules` has been added, which can be used to pick from different transition proposals according to a certain probability distribution. 
+* The new Metropolis sampling transition proposal rules {func}`netket.sampler.rules.TensorRule` has been added, which can be used to combine different transition proposals acting on different subspaces of the Hilbert space together.
+* The new Metropolis sampling transition proposal rules {func}`netket.sampler.rules.FixedRule` has been added, which does not change the configuration.
 
 ### Bug Fixes
 * Fix issue [#1435](https://github.com/netket/netket/issues/1435), where a 0-tangent originating from integer samples was not correctly handled by {func}`nk.jax.vjp` [#1436](https://github.com/netket/netket/pull/1436).

--- a/docs/api/sampler.md
+++ b/docs/api/sampler.md
@@ -133,7 +133,7 @@ There are also a few additional rules that can be used to compose other rules to
   :toctree: _generated/samplers
 
   rules.TensorRule
-  rules.WeightedRule
+  rules.MultipleRules
 
 ```
 

--- a/docs/api/sampler.md
+++ b/docs/api/sampler.md
@@ -115,12 +115,25 @@ Sampler. Rules with `Numpy` in their name can only be used with
 
   rules.MetropolisRule
   rules.LocalRule
+  rules.CustomRuleNumpy
   rules.ExchangeRule
+  rules.FixedRule
   rules.HamiltonianRule
+  rules.HamiltonianRuleNumpy
   rules.GaussianRule
   rules.LangevinRule
-  rules.HamiltonianRuleNumpy
-  rules.CustomRuleNumpy
+
+```
+
+There are also a few additional rules that can be used to compose other rules together.
+```
+.. currentmodule:: netket.sampler
+
+.. autosummary::
+  :toctree: _generated/samplers
+
+  rules.TensorRule
+  rules.WeightedRule
 
 ```
 

--- a/netket/sampler/rules/__init__.py
+++ b/netket/sampler/rules/__init__.py
@@ -21,7 +21,7 @@ from .hamiltonian import HamiltonianRule
 from .continuous_gaussian import GaussianRule
 from .langevin import LangevinRule
 from .tensor import tensorRule as TensorRule
-from .weighted import weightedRule as WeightedRule
+from .weighted import multipleRules as MultipleRules
 
 # numpy backend
 from .local_numpy import LocalRuleNumpy

--- a/netket/sampler/rules/__init__.py
+++ b/netket/sampler/rules/__init__.py
@@ -21,7 +21,7 @@ from .hamiltonian import HamiltonianRule
 from .continuous_gaussian import GaussianRule
 from .langevin import LangevinRule
 from .tensor import tensorRule as TensorRule
-from .weighted import multipleRules as MultipleRules
+from .multiple import multipleRules as MultipleRules
 
 # numpy backend
 from .local_numpy import LocalRuleNumpy

--- a/netket/sampler/rules/__init__.py
+++ b/netket/sampler/rules/__init__.py
@@ -20,6 +20,7 @@ from .exchange import ExchangeRule
 from .hamiltonian import HamiltonianRule
 from .continuous_gaussian import GaussianRule
 from .langevin import LangevinRule
+from .tensor import tensorRule as TensorRule
 
 # numpy backend
 from .local_numpy import LocalRuleNumpy

--- a/netket/sampler/rules/__init__.py
+++ b/netket/sampler/rules/__init__.py
@@ -21,6 +21,7 @@ from .hamiltonian import HamiltonianRule
 from .continuous_gaussian import GaussianRule
 from .langevin import LangevinRule
 from .tensor import tensorRule as TensorRule
+from .weighted import weightedRule as WeightedRule
 
 # numpy backend
 from .local_numpy import LocalRuleNumpy

--- a/netket/sampler/rules/fixed.py
+++ b/netket/sampler/rules/fixed.py
@@ -12,20 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from flax import struct
+
 from .base import MetropolisRule
 
-from .fixed import FixedRule
-from .local import LocalRule
-from .exchange import ExchangeRule
-from .hamiltonian import HamiltonianRule
-from .continuous_gaussian import GaussianRule
-from .langevin import LangevinRule
 
-# numpy backend
-from .local_numpy import LocalRuleNumpy
-from .hamiltonian_numpy import HamiltonianRuleNumpy
-from .custom_numpy import CustomRuleNumpy
+@struct.dataclass
+class FixedRule(MetropolisRule):
+    r"""
+    A transition rule relaxing and doing nothing.
 
-from netket.utils import _hide_submodules
+    You can use it to make a CombinedRule not act on a certain subspace at all.
+    """
 
-_hide_submodules(__name__)
+    def transition(rule, sampler, machine, parameters, state, key, σ):
+        return σ, None
+
+    def __repr__(self):
+        return "FixedRule()"

--- a/netket/sampler/rules/multiple.py
+++ b/netket/sampler/rules/multiple.py
@@ -50,7 +50,9 @@ def multipleRules(
             f"{jnp.sum(probabilities)}."
         )
 
-    if not isinstance(rules, (tuple, list)) or not all(isinstance(r, MetropolisRule) for r in rules):
+    if not isinstance(rules, (tuple, list)) or not all(
+        isinstance(r, MetropolisRule) for r in rules
+    ):
         raise TypeError(
             "The first argument (rules) must be a tuple of `MetropolisRule` "
             f"rules, but you have passed {type(rules)}."
@@ -134,7 +136,10 @@ class MultipleRules(MetropolisRule):
         # if not all log_prob_corr are 0, convert the Nones to 0s
         if any(x is not None for x in log_prob_corrs):
             log_prob_corrs = jnp.stack(
-                [x if x is not None else jnp.zeros((sampler.n_chains_per_rank,)) for x in log_prob_corrs]
+                [
+                    x if x is not None else jnp.zeros((sampler.n_chains_per_rank,))
+                    for x in log_prob_corrs
+                ]
             )
             log_prob_corr = batch_select(log_prob_corrs, indices)
         else:

--- a/netket/sampler/rules/multiple.py
+++ b/netket/sampler/rules/multiple.py
@@ -50,7 +50,7 @@ def multipleRules(
             f"{jnp.sum(probabilities)}."
         )
 
-    if not isinstance(rules, (tuple, list)):
+    if not isinstance(rules, (tuple, list)) or not all(isinstance(r, MetropolisRule) for r in rules):
         raise TypeError(
             "The first argument (rules) must be a tuple of `MetropolisRule` "
             f"rules, but you have passed {type(rules)}."
@@ -134,7 +134,7 @@ class MultipleRules(MetropolisRule):
         # if not all log_prob_corr are 0, convert the Nones to 0s
         if any(x is not None for x in log_prob_corrs):
             log_prob_corrs = jnp.stack(
-                [x if x is not None else 0 for x in log_prob_corrs]
+                [x if x is not None else jnp.zeros((sampler.n_chains_per_rank,)) for x in log_prob_corrs]
             )
             log_prob_corr = batch_select(log_prob_corrs, indices)
         else:

--- a/netket/sampler/rules/tensor.py
+++ b/netket/sampler/rules/tensor.py
@@ -63,7 +63,7 @@ def tensorRule(
             f"has {len(hilbert.subspaces)} subpsaces, but you specified {len(rules)}."
         )
 
-    return TensorRule(hilbert, rules)
+    return TensorRule(hilbert, tuple(rules))
 
 
 @struct.dataclass
@@ -115,7 +115,7 @@ class TensorRule(MetropolisRule):
             _sampler = sampler.replace(hilbert=self.hilbert.subspaces[i])
             _state = sampler_state.replace(rule_state=sampler_state.rule_state[i])
 
-            rule_states.append(self.rules.reset(_sampler, machine, params, _state))
+            rule_states.append(self.rules[i].reset(_sampler, machine, params, _state))
         return tuple(rule_states)
 
     def transition(self, sampler, machine, parameters, state, key, σ):

--- a/netket/sampler/rules/tensor.py
+++ b/netket/sampler/rules/tensor.py
@@ -51,7 +51,9 @@ def tensorRule(
             "which is constructed as a product of different Hilbert spaces."
         )
 
-    if not isinstance(rules, (tuple, list)) or not all(isinstance(r, MetropolisRule) for r in rules):
+    if not isinstance(rules, (tuple, list)) or not all(
+        isinstance(r, MetropolisRule) for r in rules
+    ):
         raise TypeError(
             "The second argument (rules) must be a tuple of `MetropolisRule` "
             f"rules, but you have passed {type(rules)}."

--- a/netket/sampler/rules/tensor.py
+++ b/netket/sampler/rules/tensor.py
@@ -1,0 +1,147 @@
+# Copyright 2023 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, Optional, Tuple
+
+import jax
+import jax.numpy as jnp
+
+from flax import struct
+from flax import linen as nn
+
+from netket import config
+from netket.hilbert import TensorHilbert
+from netket.utils.types import PyTree, PRNGKeyT
+
+# Necessary for the type annotation to work
+if config.netket_sphinx_build:
+    from netket import sampler
+
+from .base import MetropolisRule
+
+
+def tensorRule(
+    hilbert: TensorHilbert, rules: Tuple[MetropolisRule, ...]
+) -> "TensorRule":
+    r"""A Metropolis sampling rule that can be used to combine different rules acting
+    on different subspaces of the same tensor-hilbert space.
+
+    It should be constructed by passing a `TensorHilbert` space as a first argument
+    and a list of rules as a second argument. Each `rule[i]` will be used to generate
+    a transition for the `i`-th subspace of the tensor hilbert space.
+
+    Args:
+        hilbert: The tensor hilbert space on which the rule acts.
+        rules: A list of rules, one for each subspace of the tensor hilbert space.
+    """
+    if not isinstance(hilbert, TensorHilbert):
+        raise TypeError(
+            "The Hilbert space of a `CombinedRule` must be a TensorHilbert,"
+            "which is constructed as a product of different Hilbert spaces."
+        )
+
+    if not isinstance(rules, (tuple, list)):
+        raise TypeError(
+            "The second argument (rules) must be a tuple of `MetropolisRule` "
+            f"rules, but you have passed {type(rules)}."
+        )
+
+    if len(hilbert.subspaces) != len(rules):
+        raise ValueError(
+            "Length mismatch between the rules and the hilbert space: Hilbert "
+            f"has {len(hilbert.subspaces)} subpsaces, but you specified {len(rules)}."
+        )
+
+    return TensorRule(hilbert, rules)
+
+
+@struct.dataclass
+class TensorRule(MetropolisRule):
+    r"""A Metropolis sampling rule that can be used to combine different rules acting
+    on different subspaces of the same tensor-hilbert space.
+
+    It should be constructed by passing a `TensorHilbert` space as a first argument
+    and a list of rules as a second argument. Each `rule[i]` will be used to generate
+    a transition for the `i`-th subspace of the tensor hilbert space.
+
+    Args:
+        hilbert: The tensor hilbert space on which the rule acts.
+        rules: A list of rules, one for each subspace of the tensor hilbert space.
+    """
+    hilbert: TensorHilbert = struct.field(pytree_node=False)
+    rules: Tuple[MetropolisRule, ...]
+
+    def init_state(
+        self,
+        sampler: "sampler.MetropolisSampler",  # noqa: F821
+        machine: nn.Module,
+        params: PyTree,
+        key: PRNGKeyT,
+    ) -> Optional[Any]:
+        N = self.hilbert._n_hilbert_spaces
+        keys = jax.random.split(key, N)
+        return tuple(
+            self.rules[i].init_state(
+                sampler.replace(hilbert=self.hilbert.subspaces[i]),
+                machine,
+                params,
+                keys[i],
+            )
+            for i in range(N)
+        )
+
+    def reset(
+        self,
+        sampler: "sampler.MetropolisSampler",  # noqa: F821
+        machine: nn.Module,
+        params: PyTree,
+        sampler_state: "sampler.SamplerState",  # noqa: F821
+    ) -> Optional[Any]:
+        rule_states = []
+        for i in range(self.hilbert._n_hilbert_spaces):
+            # construct temporary sampler and rule state with correct sub-hilbert and
+            # sampler-state objects.
+            _sampler = sampler.replace(hilbert=self.hilbert.subspaces[i])
+            _state = sampler_state.replace(rule_state=sampler_state.rule_state[i])
+
+            rule_states.append(self.rules.reset(_sampler, machine, params, _state))
+        return tuple(rule_states)
+
+    def transition(self, sampler, machine, parameters, state, key, σ):
+        keys = jax.random.split(key, self.hilbert._n_hilbert_spaces)
+
+        σps = []
+        log_prob_corr = []
+        for i in range(self.hilbert._n_hilbert_spaces):
+            σ_i = σ[..., self.hilbert._cum_indices[i] : self.hilbert._cum_sizes[i]]
+
+            # construct temporary sampler and rule state with correct sub-hilbert and
+            # sampler-state objects.
+            _sampler = sampler.replace(hilbert=self.hilbert.subspaces[i])
+            _state = state.replace(rule_state=state.rule_state[i])
+
+            σps_i, log_prob_corr_i = self.rules[i].transition(
+                _sampler, machine, parameters, _state, keys[i], σ_i
+            )
+
+            σps.append(σps_i)
+            if log_prob_corr_i is not None:
+                log_prob_corr.append(log_prob_corr_i)
+
+        σp = jnp.concatenate(σps, axis=-1)
+        log_prob_corr = sum(log_prob_corr) if len(log_prob_corr) > 0 else None
+        return σp, log_prob_corr
+
+    def __repr__(self):
+        return "TensorRule(hilbert={self.hilbert}, rules={self.rules})"

--- a/netket/sampler/rules/tensor.py
+++ b/netket/sampler/rules/tensor.py
@@ -51,7 +51,7 @@ def tensorRule(
             "which is constructed as a product of different Hilbert spaces."
         )
 
-    if not isinstance(rules, (tuple, list)):
+    if not isinstance(rules, (tuple, list)) or not all(isinstance(r, MetropolisRule) for r in rules):
         raise TypeError(
             "The second argument (rules) must be a tuple of `MetropolisRule` "
             f"rules, but you have passed {type(rules)}."

--- a/netket/sampler/rules/weighted.py
+++ b/netket/sampler/rules/weighted.py
@@ -1,0 +1,148 @@
+# Copyright 2023 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, Optional, Tuple
+
+import jax
+import jax.numpy as jnp
+
+from flax import struct
+from flax import linen as nn
+
+from netket import config
+from netket.hilbert import TensorHilbert
+from netket.utils.types import Array, PyTree, PRNGKeyT
+
+# Necessary for the type annotation to work
+if config.netket_sphinx_build:
+    from netket import sampler
+
+from .base import MetropolisRule
+
+
+def weightedRule(
+    rules: Tuple[MetropolisRule, ...], probabilities: Array
+) -> MetropolisRule:
+    r"""A Metropolis sampling rule that can be used to pick a rule from a list of rules
+    with a given probability.
+
+    Each `rule[i]` will be selected with a probability `probabilities[i]`.
+
+    Args:
+        rules: A list of rules, one for each subspace of the tensor hilbert space.
+        probabilities: A list of probabilities, one for each rule.
+    """
+    if not isinstance(probabilities, jax.Array):
+        probabilities = jnp.array(probabilities)
+
+    if not jnp.allclose(jnp.sum(probabilities), 1.0):
+        raise ValueError(
+            "The probabilities must sum to 1, but they sum to "
+            f"{jnp.sum(probabilities)}."
+        )
+
+    if not isinstance(rules, (tuple, list)):
+        raise TypeError(
+            "The first argument (rules) must be a tuple of `MetropolisRule` "
+            f"rules, but you have passed {type(rules)}."
+        )
+
+    if len(probabilities) != len(rules):
+        raise ValueError(
+            "Length mismatch between the probabilities and the rules: probabilities "
+            f"has length {len(probabilities)} , rules has length {len(rules)}."
+        )
+
+    return WeightedRule(rules, probabilities)
+
+
+@struct.dataclass
+class WeightedRule(MetropolisRule):
+    r"""A Metropolis sampling rule that can be used to pick a rule from a list of rules
+    with a given probability.
+
+    Each `rule[i]` will be selected with a probability `probabilities[i]`.
+    """
+    rules: Tuple[MetropolisRule, ...]
+    probabilities: Array
+
+    def init_state(
+        self,
+        sampler: "sampler.MetropolisSampler",  # noqa: F821
+        machine: nn.Module,
+        params: PyTree,
+        key: PRNGKeyT,
+    ) -> Optional[Any]:
+        N = len(self.probabilities)
+        keys = jax.random.split(key, N)
+        return tuple(
+            self.rules[i].init_state(sampler, machine, params, keys[i])
+            for i in range(N)
+        )
+
+    def reset(
+        self,
+        sampler: "sampler.MetropolisSampler",  # noqa: F821
+        machine: nn.Module,
+        params: PyTree,
+        sampler_state: "sampler.SamplerState",  # noqa: F821
+    ) -> Optional[Any]:
+        rule_states = []
+        for i in range(len(self.probabilities)):
+            # construct temporary sampler and rule state with correct sub-hilbert and
+            # sampler-state objects.
+            _state = sampler_state.replace(rule_state=sampler_state.rule_state[i])
+            rule_states.append(self.rules[i].reset(sampler, machine, params, _state))
+        return tuple(rule_states)
+
+    def transition(self, sampler, machine, parameters, state, key, σ):
+        N = len(self.probabilities)
+        keys = jax.random.split(key, N + 1)
+
+        σps = []
+        log_prob_corrs = []
+        for i in range(N):
+            # construct temporary rule state with correct sampler-state objects
+            _state = state.replace(rule_state=state.rule_state[i])
+
+            σps_i, log_prob_corr_i = self.rules[i].transition(
+                sampler, machine, parameters, _state, keys[i], σ
+            )
+
+            σps.append(σps_i)
+            log_prob_corrs.append(log_prob_corr_i)
+
+        indices = jax.random.choice(
+            keys[-1],
+            N,
+            shape=(sampler.n_chains_per_rank,),
+            p=self.probabilities,
+        )
+
+        batch_select = jax.vmap(lambda σ, i: σ[i], in_axes=(1, 0), out_axes=0)
+        σp = batch_select(jnp.stack(σps), indices)
+
+        # if not all log_prob_corr are 0, convert the Nones to 0s
+        if any(x is not None for x in log_prob_corrs):
+            log_prob_corrs = jnp.stack(
+                [x if x is not None else 0 for x in log_prob_corrs]
+            )
+            log_prob_corr = batch_select(log_prob_corrs, indices)
+        else:
+            log_prob_corr = None
+
+        return σp, log_prob_corr
+
+    def __repr__(self):
+        return "WeightedRule(probabilities={self.probabilities}, rules={self.rules})"

--- a/netket/sampler/rules/weighted.py
+++ b/netket/sampler/rules/weighted.py
@@ -21,7 +21,6 @@ from flax import struct
 from flax import linen as nn
 
 from netket import config
-from netket.hilbert import TensorHilbert
 from netket.utils.types import Array, PyTree, PRNGKeyT
 
 # Necessary for the type annotation to work
@@ -31,7 +30,7 @@ if config.netket_sphinx_build:
 from .base import MetropolisRule
 
 
-def weightedRule(
+def multipleRules(
     rules: Tuple[MetropolisRule, ...], probabilities: Array
 ) -> MetropolisRule:
     r"""A Metropolis sampling rule that can be used to pick a rule from a list of rules
@@ -43,8 +42,7 @@ def weightedRule(
         rules: A list of rules, one for each subspace of the tensor hilbert space.
         probabilities: A list of probabilities, one for each rule.
     """
-    if not isinstance(probabilities, jax.Array):
-        probabilities = jnp.array(probabilities)
+    probabilities = jnp.asarray(probabilities)
 
     if not jnp.allclose(jnp.sum(probabilities), 1.0):
         raise ValueError(
@@ -64,11 +62,11 @@ def weightedRule(
             f"has length {len(probabilities)} , rules has length {len(rules)}."
         )
 
-    return WeightedRule(rules, probabilities)
+    return MultipleRules(rules, probabilities)
 
 
 @struct.dataclass
-class WeightedRule(MetropolisRule):
+class MultipleRules(MetropolisRule):
     r"""A Metropolis sampling rule that can be used to pick a rule from a list of rules
     with a given probability.
 
@@ -145,4 +143,4 @@ class WeightedRule(MetropolisRule):
         return σp, log_prob_corr
 
     def __repr__(self):
-        return "WeightedRule(probabilities={self.probabilities}, rules={self.rules})"
+        return "MultipleRules(probabilities={self.probabilities}, rules={self.rules})"

--- a/test/sampler/test_sampler.py
+++ b/test/sampler/test_sampler.py
@@ -97,9 +97,7 @@ samplers["Metropolis(Custom: Sx): Spin"] = nk.sampler.MetropolisCustom(
 )
 
 # MultipleRules sampler
-samplers[
-    "Metropolis(MultipleRules[Local,Local]): Spin"
-] = nk.sampler.MetropolisSampler(
+samplers["Metropolis(MultipleRules[Local,Local]): Spin"] = nk.sampler.MetropolisSampler(
     hi,
     nk.sampler.rules.MultipleRules(
         [nk.sampler.rules.LocalRule(), nk.sampler.rules.LocalRule()], [0.8, 0.2]
@@ -461,6 +459,7 @@ def test_throwing(model_and_weights):
 
         sampler.sample(ma, w, seed=SAMPLER_SEED)
 
+
 def test_setup_throwing_tensorrule():
     # TensorHilbert sampler
     hi = nk.hilbert.Spin(0.5, 4) * nk.hilbert.Fock(3)
@@ -477,10 +476,11 @@ def test_setup_throwing_tensorrule():
         nk.sampler.rules.TensorRule(hi, rule1)
     with pytest.raises(TypeError):
         # Not good types
-        nk.sampler.rules.TensorRule(hi, [rule1,2])
+        nk.sampler.rules.TensorRule(hi, [rule1, 2])
     with pytest.raises(ValueError):
         # length mismatch
         nk.sampler.rules.TensorRule(hi, [rule1, rule1, rule2])
+
 
 def test_setup_throwing_multiplerules():
     rule1 = nk.sampler.rules.LocalRule()

--- a/test/sampler/test_sampler.py
+++ b/test/sampler/test_sampler.py
@@ -117,6 +117,12 @@ samplers[
     "Metropolis(AdjustedLangevin): AdjustedLangevin chunk_size"
 ] = nk.sampler.MetropolisAdjustedLangevin(hi_particles, dt=0.1, chunk_size=16)
 
+# TensorHilbert sampler
+hi = nk.hilbert.Spin(0.5, 4) * nk.hilbert.Fock(3)
+samplers["Metropolis(TensorRule): Spin x Fock"] = nk.sampler.MetropolisSampler(
+    hi, nk.sampler.rules.TensorRule(hi, 
+        [nk.sampler.rules.LocalRule(), nk.sampler.rules.LocalRule()]))
+
 
 # The following fixture initialises a model and it's weights
 # for tests that require it.

--- a/test/sampler/test_sampler.py
+++ b/test/sampler/test_sampler.py
@@ -96,6 +96,25 @@ samplers["Metropolis(Custom: Sx): Spin"] = nk.sampler.MetropolisCustom(
     hi, move_operators=move_op
 )
 
+# MultipleRules sampler
+samplers[
+    "Metropolis(MultipleRules[Local,Local]): Spin"
+] = nk.sampler.MetropolisSampler(
+    hi,
+    nk.sampler.rules.MultipleRules(
+        [nk.sampler.rules.LocalRule(), nk.sampler.rules.LocalRule()], [0.8, 0.2]
+    ),
+)
+samplers[
+    "Metropolis(MultipleRules[Local,Hamiltonian]): Spin"
+] = nk.sampler.MetropolisSampler(
+    hi,
+    nk.sampler.rules.MultipleRules(
+        [nk.sampler.rules.LocalRule(), nk.sampler.rules.HamiltonianRule(ha)], [0.8, 0.2]
+    ),
+)
+
+
 # samplers["MetropolisPT(Custom: Sx): Spin"] = nkx.sampler.MetropolisCustomPt(hi, move_operators=move_op, n_replicas=4)
 
 samplers["Autoregressive: Spin 1/2"] = nk.sampler.ARDirectSampler(hi)
@@ -120,8 +139,21 @@ samplers[
 # TensorHilbert sampler
 hi = nk.hilbert.Spin(0.5, 4) * nk.hilbert.Fock(3)
 samplers["Metropolis(TensorRule): Spin x Fock"] = nk.sampler.MetropolisSampler(
-    hi, nk.sampler.rules.TensorRule(hi, 
-        [nk.sampler.rules.LocalRule(), nk.sampler.rules.LocalRule()]))
+    hi,
+    nk.sampler.rules.TensorRule(
+        hi, [nk.sampler.rules.LocalRule(), nk.sampler.rules.LocalRule()]
+    ),
+)
+
+# TensorHilbert sampler
+hi = nk.hilbert.Spin(0.5, 4) * nk.hilbert.Fock(3)
+ha = sum(nk.operator.spin.sigmax(nk.hilbert.Spin(0.5, 4), i) for i in range(4))
+samplers["Metropolis(TensorRule): Spin x Fock"] = nk.sampler.MetropolisSampler(
+    hi,
+    nk.sampler.rules.TensorRule(
+        hi, [nk.sampler.rules.HamiltonianRule(ha), nk.sampler.rules.LocalRule()]
+    ),
+)
 
 
 # The following fixture initialises a model and it's weights
@@ -428,6 +460,44 @@ def test_throwing(model_and_weights):
         ma, w = model_and_weights(hi)
 
         sampler.sample(ma, w, seed=SAMPLER_SEED)
+
+def test_setup_throwing_tensorrule():
+    # TensorHilbert sampler
+    hi = nk.hilbert.Spin(0.5, 4) * nk.hilbert.Fock(3)
+    ha = sum(nk.operator.spin.sigmax(nk.hilbert.Spin(0.5, 4), i) for i in range(4))
+
+    rule1 = nk.sampler.rules.HamiltonianRule(ha)
+    rule2 = nk.sampler.rules.LocalRule()
+
+    with pytest.raises(TypeError):
+        # Hilbert not TensorHilbert
+        nk.sampler.rules.TensorRule(nk.hilbert.Spin(0.5, 5), [rule1, rule1, rule2])
+    with pytest.raises(TypeError):
+        # not list of rules
+        nk.sampler.rules.TensorRule(hi, rule1)
+    with pytest.raises(TypeError):
+        # Not good types
+        nk.sampler.rules.TensorRule(hi, [rule1,2])
+    with pytest.raises(ValueError):
+        # length mismatch
+        nk.sampler.rules.TensorRule(hi, [rule1, rule1, rule2])
+
+def test_setup_throwing_multiplerules():
+    rule1 = nk.sampler.rules.LocalRule()
+    rule2 = nk.sampler.rules.LocalRule()
+
+    with pytest.raises(ValueError):
+        # length mismatch
+        nk.sampler.rules.MultipleRules([rule1, rule2], [0.5, 0.25, 0.25])
+    with pytest.raises(ValueError):
+        # not summing to 1
+        nk.sampler.rules.MultipleRules([rule1, rule2], [0.5, 0.25])
+    with pytest.raises(TypeError):
+        # wrong types
+        nk.sampler.rules.MultipleRules([rule1, 2], [0.5, 0.5])
+    with pytest.raises(TypeError):
+        # wrong types
+        nk.sampler.rules.MultipleRules(rule1, [0.5, 0.5])
 
 
 def test_exact_sampler(sampler):


### PR DESCRIPTION
Adds 
 - `WeightedRule` to pick from different transition rules according to a certain probability distribution (as asked in #1466), 
 - `TensorRule` to combine different transition rules acting on different subspaces of a `tensorHilbert`.
 -  `FixedRule`, which does nothing. Mainly useful to combine with other rules.

I don't really like `weighted rule` (some better proposals?) 

~I need to add tests...~ done