### PR TITLE
Chunking apply_fun for MCState.to_array

### DIFF
--- a/netket/nn/utils.py
+++ b/netket/nn/utils.py
@@ -152,12 +152,13 @@ def to_matrix(
     params: PyTree,
     *,
     normalize: bool = True,
+    chunk_size: Optional[int] = None,
 ) -> Array:
 
     if not hilbert.is_indexable:
         raise RuntimeError("The hilbert space is not indexable")
 
-    psi = to_array(hilbert, machine, params, normalize=False)
+    psi = to_array(hilbert, machine, params, normalize=False, chunk_size=chunk_size)
 
     L = hilbert.physical.n_states
     rho = psi.reshape((L, L))

--- a/netket/nn/utils.py
+++ b/netket/nn/utils.py
@@ -20,6 +20,7 @@ import jax
 from jax import numpy as jnp
 import numpy as np
 
+from netket import jax as nkjax
 from netket.utils import get_afun_if_module, mpi, module_version
 from netket.utils.types import Array
 from netket.hilbert import DiscreteHilbert
@@ -92,7 +93,7 @@ def _to_array_rank(apply_fun, variables, σ_rank, n_states, normalize, allgather
     """
     
     if chunk_size is not None:
-        apply_fun = nk.jax.apply_chunked(apply_fun, in_axes=(None, 0), chunk_size=chunk_size)
+        apply_fun = nkjax.apply_chunked(apply_fun, in_axes=(None, 0), chunk_size=chunk_size)
 
     
     # number of 'fake' states, in the last rank.

--- a/netket/nn/utils.py
+++ b/netket/nn/utils.py
@@ -52,7 +52,9 @@ def split_array_mpi(array):
     return array[states_per_rank[mpi.rank]]
 
 
-def to_array(hilbert, apply_fun, variables, normalize=True, allgather=True, chunk_size=None):
+def to_array(
+    hilbert, apply_fun, variables, normalize=True, allgather=True, chunk_size=None
+):
     """
     Computes `apply_fun(variables, states)` on all states of `hilbert` and returns
       the results as a vector.
@@ -78,11 +80,15 @@ def to_array(hilbert, apply_fun, variables, normalize=True, allgather=True, chun
 
     xs = hilbert.numbers_to_states(states_per_rank[mpi.rank])
 
-    return _to_array_rank(apply_fun, variables, xs, n_states, normalize, allgather, chunk_size)
+    return _to_array_rank(
+        apply_fun, variables, xs, n_states, normalize, allgather, chunk_size
+    )
 
 
 @partial(jax.jit, static_argnums=(0, 3, 4, 5, 6))
-def _to_array_rank(apply_fun, variables, σ_rank, n_states, normalize, allgather, chunk_size):
+def _to_array_rank(
+    apply_fun, variables, σ_rank, n_states, normalize, allgather, chunk_size
+):
     """
     Computes apply_fun(variables, σ_rank) and gathers all results across all ranks.
     The input σ_rank should be a slice of all states in the hilbert space of equal
@@ -91,11 +97,12 @@ def _to_array_rank(apply_fun, variables, σ_rank, n_states, normalize, allgather
     Args:
         n_states: total number of elements in the hilbert space.
     """
-    
-    if chunk_size is not None:
-        apply_fun = nkjax.apply_chunked(apply_fun, in_axes=(None, 0), chunk_size=chunk_size)
 
-    
+    if chunk_size is not None:
+        apply_fun = nkjax.apply_chunked(
+            apply_fun, in_axes=(None, 0), chunk_size=chunk_size
+        )
+
     # number of 'fake' states, in the last rank.
     n_fake_states = σ_rank.shape[0] * mpi.n_nodes - n_states
 

--- a/netket/vqs/exact/state.py
+++ b/netket/vqs/exact/state.py
@@ -283,6 +283,7 @@ class ExactState(VariationalState):
                 self.variables,
                 normalize=normalize,
                 allgather=allgather,
+                chunk_size=self.chunk_size, 
             )
 
         if normalize:
@@ -294,6 +295,7 @@ class ExactState(VariationalState):
                 self.variables,
                 normalize=normalize,
                 allgather=allgather,
+                chunk_size=self.chunk_size,
             )
 
         return arr

--- a/netket/vqs/exact/state.py
+++ b/netket/vqs/exact/state.py
@@ -283,7 +283,7 @@ class ExactState(VariationalState):
                 self.variables,
                 normalize=normalize,
                 allgather=allgather,
-                chunk_size=self.chunk_size, 
+                chunk_size=self.chunk_size,
             )
 
         if normalize:

--- a/netket/vqs/mc/mc_state/state.py
+++ b/netket/vqs/mc/mc_state/state.py
@@ -653,9 +653,12 @@ class MCState(VariationalState):
     def to_array(self, normalize: bool = True) -> jnp.ndarray:
 
         return nn.to_array(
-            self.hilbert, self._apply_fun, self.variables, normalize=normalize, chunk_size=self.chunk_size
+            self.hilbert,
+            self._apply_fun,
+            self.variables,
+            normalize=normalize,
+            chunk_size=self.chunk_size,
         )
-
 
     def __repr__(self):
         return (

--- a/netket/vqs/mc/mc_state/state.py
+++ b/netket/vqs/mc/mc_state/state.py
@@ -651,9 +651,12 @@ class MCState(VariationalState):
         return qgt_T(self)
 
     def to_array(self, normalize: bool = True) -> jnp.ndarray:
+       
         return nn.to_array(
-            self.hilbert, self._apply_fun, self.variables, normalize=normalize
+            self.hilbert, nk.jax.apply_chunked(self._apply_fun, in_axes=(None, 0), chunk_size=self.chunk_size), self.variables, normalize=normalize
         )
+        
+        
 
     def __repr__(self):
         return (

--- a/netket/vqs/mc/mc_state/state.py
+++ b/netket/vqs/mc/mc_state/state.py
@@ -651,12 +651,11 @@ class MCState(VariationalState):
         return qgt_T(self)
 
     def to_array(self, normalize: bool = True) -> jnp.ndarray:
-       
+
         return nn.to_array(
-            self.hilbert, nk.jax.apply_chunked(self._apply_fun, in_axes=(None, 0), chunk_size=self.chunk_size), self.variables, normalize=normalize
+            self.hilbert, nkjax.apply_chunked(self._apply_fun, in_axes=(None, 0), chunk_size=self.chunk_size), self.variables, normalize=normalize
         )
-        
-        
+
 
     def __repr__(self):
         return (

--- a/netket/vqs/mc/mc_state/state.py
+++ b/netket/vqs/mc/mc_state/state.py
@@ -653,7 +653,7 @@ class MCState(VariationalState):
     def to_array(self, normalize: bool = True) -> jnp.ndarray:
 
         return nn.to_array(
-            self.hilbert, nkjax.apply_chunked(self._apply_fun, in_axes=(None, 0), chunk_size=self.chunk_size), self.variables, normalize=normalize
+            self.hilbert, self._apply_fun, self.variables, normalize=normalize, chunk_size=self.chunk_size
         )
 
 

--- a/test/nn/test_utils.py
+++ b/test/nn/test_utils.py
@@ -55,9 +55,9 @@ def vstate(request):
 @pytest.mark.parametrize("normalize", [True, False])
 @pytest.mark.parametrize("chunk_size", [None, 4])
 def test_to_array(vstate, normalize, chunk_size):
-    
+
     vstate.chunk_size = chunk_size
-    
+
     psi = vstate.to_array(normalize=normalize)
 
     if normalize:

--- a/test/nn/test_utils.py
+++ b/test/nn/test_utils.py
@@ -53,7 +53,11 @@ def vstate(request):
 
 
 @pytest.mark.parametrize("normalize", [True, False])
-def test_to_array(vstate, normalize):
+@pytest.mark.parametrize("chunk_size", [None, 4])
+def test_to_array(vstate, normalize, chunk_size):
+    
+    vstate.chunk_size = chunk_size
+    
     psi = vstate.to_array(normalize=normalize)
 
     if normalize:


### PR DESCRIPTION
`MCState.to_array()` cannot be used to instantiate the wave function over the full Hilbert space for systems with fairly large size (but that should be still accessible) due to a large memory usage. The modification in `MCState.to_array()` consists in the possibility of computing the wave function over chunks of the Hilbert space of size `MCState.chunk_size` that are then combined to get the complete state vector. 