### PR TITLE
fix wrong U_Y matrix in tomography

### DIFF
--- a/netket/experimental/qsr/dataset.py
+++ b/netket/experimental/qsr/dataset.py
@@ -42,7 +42,7 @@ def _build_rotation(
     """
     localop = LocalOperator(hi, constant=1.0, dtype=dtype)
     U_X = 1.0 / (np.sqrt(2)) * np.asarray([[1.0, 1.0], [1.0, -1.0]])
-    U_Y = 1.0 / (np.sqrt(2)) * np.asarray([[1.0, -1j], [1.0, 1j]])
+    U_Y = 1.0 / (np.sqrt(2)) * np.asarray([[1.0, -1.0j], [1.0, 1.0j]])
 
     assert len(basis) == hi.size
 


### PR DESCRIPTION
This is only relevant if the basis is constructed using `XXXYZ` stringy strings.
But still, it was wrong.