### PR TITLE
[MPI] add a token-aware tree map

### DIFF
--- a/netket/experimental/qsr/logic_helpers.py
+++ b/netket/experimental/qsr/logic_helpers.py
@@ -49,7 +49,7 @@ def _avg_O(afun, pars, model_state, sigma):
     sigma = sigma.reshape((-1, sigma.shape[-1]))
     _, vjp = nkjax.vjp(lambda W: afun({"params": W, **model_state}, sigma), pars)
     (O_avg,) = vjp(jnp.ones(sigma.shape[0]) / sigma.shape[0])
-    return jax.tree_map(lambda x: mpi.mpi_mean_jax(x)[0], O_avg)
+    return mpi.mpi_tree_map(mpi.mpi_mean_jax, O_avg)[0]
 
 
 @dispatch
@@ -84,7 +84,7 @@ def _avg_O_exact(hilbert: AbstractHilbert, afun, pars, model_state):
     psi_2 = jnp.abs(jnp.exp(afun({"params": pars, **model_state}, sigma))) ** 2
     psi_2 /= jnp.sum(psi_2)
     (O_avg,) = vjp(psi_2)
-    return jax.tree_map(lambda x: mpi.mpi_mean_jax(x)[0], O_avg)
+    return mpi.mpi_tree_map(mpi.mpi_mean_jax, O_avg)[0]
 
 
 @dispatch
@@ -181,7 +181,7 @@ def _grad_local_value_rotated(log_psi, pars, model_state, sigma_p, mel, secs):
 
     (O_avg,) = vjp(jnp.ones_like(log_val_rotated) / log_val_rotated.size)
 
-    O_avg = jax.tree_map(lambda x: mpi.mpi_mean_jax(x)[0], O_avg)
+    O_avg = mpi.mpi_tree_map(mpi.mpi_mean_jax, O_avg)[0]
 
     return log_val_rotated, O_avg
 

--- a/netket/jax/utils.py
+++ b/netket/jax/utils.py
@@ -310,7 +310,7 @@ def PRNGKey(
     else:
         key = seed
 
-    key = jax.tree_map(lambda k: mpi.mpi_bcast_jax(k, root=root, comm=comm)[0], key)
+    key = mpi.mpi_tree_map(mpi.mpi_bcast_jax, key, root=root, comm=comm)[0]
 
     return key
 
@@ -333,7 +333,7 @@ def mpi_split(key, *, root=0, comm=MPI_jax_comm) -> PRNGKeyT:
     # on all MPI nodes?
     keys = jax.random.split(key, mpi.n_nodes)
 
-    keys = jax.tree_map(lambda k: mpi.mpi_bcast_jax(k, root=root)[0], keys)
+    keys = mpi.mpi_tree_map(mpi.mpi_bcast_jax, keys, root=root, comm=comm)[0]
 
     return keys[mpi.rank]
 

--- a/netket/optimizer/qgt/qgt_jacobian_pytree_logic.py
+++ b/netket/optimizer/qgt/qgt_jacobian_pytree_logic.py
@@ -41,7 +41,7 @@ def _vjp(oks: PyTree, w: Array) -> PyTree:
     Compute the vector-matrix product between the vector w and the pytree jacobian oks
     """
     res = jax.tree_map(partial(jnp.tensordot, w, axes=w.ndim), oks)
-    return jax.tree_map(lambda x: mpi.mpi_sum_jax(x)[0], res)  # MPI
+    return mpi.mpi_tree_map(mpi.mpi_sum_jax, res)[0]  # MPI
 
 
 def _mat_vec(v: PyTree, oks: PyTree) -> PyTree:

--- a/netket/optimizer/qgt/qgt_jacobian_pytree_logic.py
+++ b/netket/optimizer/qgt/qgt_jacobian_pytree_logic.py
@@ -41,7 +41,7 @@ def _vjp(oks: PyTree, w: Array) -> PyTree:
     Compute the vector-matrix product between the vector w and the pytree jacobian oks
     """
     res = jax.tree_map(partial(jnp.tensordot, w, axes=w.ndim), oks)
-    return mpi.mpi_tree_map(mpi.mpi_sum_jax, res)[0]  # MPI
+    return mpi.mpi_tree_sum(res)  # MPI
 
 
 def _mat_vec(v: PyTree, oks: PyTree) -> PyTree:

--- a/netket/optimizer/qgt/qgt_onthefly_logic.py
+++ b/netket/optimizer/qgt/qgt_onthefly_logic.py
@@ -52,7 +52,7 @@ def _mat_vec(jvp_fn, v, diag_shift, pdf=None):
     # Oᴴw = (wᴴO)ᴴ = (w* O)* since 1D arrays are not transposed
     # vjp_fn packages output into a length-1 tuple
     (res,) = tree_conj(vjp_fn(w.conjugate()))
-    res = jax.tree_map(lambda x: mpi.mpi_sum_jax(x)[0], res)
+    res = mpi.mpi_tree_map(mpi.mpi_sum_jax, res)[0]
 
     return tree_axpy(diag_shift, v, res)  # res + diag_shift * v
 
@@ -125,7 +125,7 @@ def _Odagger_DeltaO_v(forward_fn, params, samples, v, pdf=None):
         w_ = pdf_ * (w_ - mpi.mpi_sum_jax(pdf_ @ w_)[0])
         w = chunk_fn(w_)
     res = _OH_w(forward_fn, params, samples, w)
-    return jax.tree_map(lambda x: mpi.mpi_sum_jax(x)[0], res)  # MPI
+    return mpi.mpi_tree_map(mpi.mpi_sum_jax, res)[0]  # MPI
 
 
 # @partial(jax.jit, static_argnums=1)

--- a/netket/optimizer/qgt/qgt_onthefly_logic.py
+++ b/netket/optimizer/qgt/qgt_onthefly_logic.py
@@ -52,7 +52,7 @@ def _mat_vec(jvp_fn, v, diag_shift, pdf=None):
     # Oᴴw = (wᴴO)ᴴ = (w* O)* since 1D arrays are not transposed
     # vjp_fn packages output into a length-1 tuple
     (res,) = tree_conj(vjp_fn(w.conjugate()))
-    res = mpi.mpi_tree_map(mpi.mpi_sum_jax, res)[0]
+    res = mpi.mpi_tree_sum(res)
 
     return tree_axpy(diag_shift, v, res)  # res + diag_shift * v
 
@@ -125,7 +125,7 @@ def _Odagger_DeltaO_v(forward_fn, params, samples, v, pdf=None):
         w_ = pdf_ * (w_ - mpi.mpi_sum_jax(pdf_ @ w_)[0])
         w = chunk_fn(w_)
     res = _OH_w(forward_fn, params, samples, w)
-    return mpi.mpi_tree_map(mpi.mpi_sum_jax, res)[0]  # MPI
+    return mpi.mpi_tree_sum(res)  # MPI
 
 
 # @partial(jax.jit, static_argnums=1)

--- a/netket/utils/mpi/__init__.py
+++ b/netket/utils/mpi/__init__.py
@@ -42,3 +42,4 @@ from .primitives import (
 )
 
 from .tree_util import mpi_tree_map
+from .tree_sum import mpi_tree_sum

--- a/netket/utils/mpi/tree_sum.py
+++ b/netket/utils/mpi/tree_sum.py
@@ -1,0 +1,52 @@
+import jax
+from functools import partial
+from . import mpi_sum_jax
+
+
+def _mpi_args_sum(*args):
+    token = jax.lax.create_token()
+    res = []
+    for x in args:
+        y, token = mpi_sum_jax(x, token=token)
+        res.append(y)
+    return tuple(res)
+
+
+def _mpi_args_sum_impl(*args, transpose):
+    if transpose:
+        return args
+    else:
+        return _mpi_args_sum(*args)
+
+
+def _mpi_args_sum_transpose_rule(tan_args, *x_args, transpose):
+    return _mpi_args_sum_impl(*tan_args, transpose=not transpose)
+
+
+def _mpi_args_sum_abstract_eval(*args, transpose):
+    return map(lambda x: jax.abstract_arrays.ShapedArray(x.shape, x.dtype), args)
+
+
+def _batch_rule(prim, batched_args, batch_dims, **params):
+    return prim.bind(*batched_args, **params), batch_dims
+
+
+mpi_args_sum_p = jax.core.Primitive("mpi_args_sum")
+mpi_args_sum_p.multiple_results = True
+mpi_args_sum_p.def_impl(_mpi_args_sum_impl)
+mpi_args_sum_p.def_abstract_eval(_mpi_args_sum_abstract_eval)
+jax.interpreters.ad.primitive_transposes[mpi_args_sum_p] = _mpi_args_sum_transpose_rule
+jax.interpreters.xla.register_initial_style_primitive(mpi_args_sum_p)
+jax.interpreters.mlir.register_lowering(
+    mpi_args_sum_p,
+    jax.interpreters.mlir.lower_fun(_mpi_args_sum_impl, multiple_results=True),
+)
+jax.interpreters.batching.primitive_batchers[mpi_args_sum_p] = partial(
+    _batch_rule, mpi_args_sum_p
+)
+
+
+def mpi_tree_sum(x):
+    leaves, treedef = jax.tree_util.tree_flatten(x)
+    out = mpi_args_sum_p.bind(*leaves, transpose=False)
+    return treedef.unflatten(out)

--- a/netket/utils/mpi/tree_util.py
+++ b/netket/utils/mpi/tree_util.py
@@ -12,33 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .mpi import (
-    mpi4jax_available as available,
-    MPI,
-    MPI_py_comm,
-    MPI_jax_comm,
-    n_nodes,
-    node_number,
-    rank,
-)
+import jax
 
-from .primitives import (
-    mpi_all,
-    mpi_allgather,
-    mpi_any,
-    mpi_bcast,
-    mpi_max,
-    mpi_mean,
-    mpi_sum,
-)
-from .primitives import (
-    mpi_all_jax,
-    mpi_allgather_jax,
-    mpi_any_jax,
-    mpi_bcast_jax,
-    mpi_max_jax,
-    mpi_mean_jax,
-    mpi_sum_jax,
-)
 
-from .tree_util import mpi_tree_map
+def mpi_tree_map(f, tree, *rest, is_leaf=None, token=None, **kwargs):
+
+    leaves, treedef = jax.tree_util.tree_flatten(tree, is_leaf)
+    all_leaves = [leaves] + [treedef.flatten_up_to(r) for r in rest]
+    out_leaves = []
+    for xs in zip(*all_leaves):
+        y, token = f(*xs, token=token, **kwargs)
+        out_leaves.append(y)
+    return treedef.unflatten(out_leaves), token

--- a/netket/vqs/mc/mc_state/expect_forces.py
+++ b/netket/vqs/mc/mc_state/expect_forces.py
@@ -106,4 +106,4 @@ def forces_expect_hermitian(
 
     new_model_state = new_model_state[0] if is_mutable else None
 
-    return Ō, jax.tree_map(lambda x: mpi.mpi_sum_jax(x)[0], Ō_grad), new_model_state
+    return Ō, mpi.mpi_tree_map(mpi.mpi_sum_jax, Ō_grad)[0], new_model_state

--- a/netket/vqs/mc/mc_state/expect_forces_chunked.py
+++ b/netket/vqs/mc/mc_state/expect_forces_chunked.py
@@ -18,7 +18,6 @@ import warnings
 
 import jax
 from jax import numpy as jnp
-from jax import tree_map
 from flax.core.scope import CollectionFilter, DenyList  # noqa: F401
 
 from netket import jax as nkjax
@@ -146,4 +145,4 @@ def forces_expect_hermitian_chunked(
         (jnp.conjugate(O_loc) / n_samples),
     )[0]
 
-    return Ō, tree_map(lambda x: mpi.mpi_sum_jax(x)[0], Ō_grad), new_model_state
+    return Ō, mpi.mpi_tree_map(mpi.mpi_sum_jax, Ō_grad)[0], new_model_state

--- a/netket/vqs/mc/mc_state/expect_grad.py
+++ b/netket/vqs/mc/mc_state/expect_grad.py
@@ -180,6 +180,6 @@ def grad_expect_operator_kernel(
 
     return (
         Ō_stats,
-        jax.tree_map(lambda x: mpi.mpi_mean_jax(x)[0], Ō_pars_grad),
+        mpi.mpi_tree_map(mpi.mpi_mean_jax, Ō_pars_grad)[0],
         new_model_state,
     )


### PR DESCRIPTION

Recently, while running VMC, I have been seeing MPI errors (on cpu) which look like

``` 
0%|          | 0/1000 [00:00<?, ?it/s]r0 | MPI_Allreduce returned error code 15: b'MPI_ERR_TRUNCATE: message truncated' - aborting
--------------------------------------------------------------------------
MPI_ABORT was invoked on rank 0 in communicator MPI COMMUNICATOR 4 CREATE FROM 0
with errorcode 15.

NOTE: invoking MPI_ABORT causes Open MPI to kill all MPI processes.
You may or may not see output from other processes, depending on
exactly when Open MPI kills them.
```
 
I believe they could be caused by reordered mpi allreduce commands over the different leaves in 
https://github.com/netket/netket/blob/fae7c32914ddc041b7fe4c5fb74febe1ac8264b1/netket/optimizer/qgt/qgt_onthefly_logic.py#L55

This is an attempt to fix this by enforcing consistent ordering using tokens.

Tests will fail because of the solver trying to transpose the tokens with AD.
@PhilipVinc any ideas?