### PR TITLE
Switch the order of axes output by the samplers

### DIFF
--- a/netket/experimental/sampler/metropolis_pmap.py
+++ b/netket/experimental/sampler/metropolis_pmap.py
@@ -199,7 +199,7 @@ class MetropolisSamplerPmap(MetropolisSampler):
             n_steps_proc=state.n_steps_proc,
             n_accepted_proc=state.n_accepted_proc,
         )
-        return samples.reshape(samples.shape[0], -1, samples.shape[-1]), state
+        return samples.reshape((-1,) + samples.shape[-2:]), state
 
     def _repr_pretty_(sampler, p, cycle):
         super()._repr_pretty_(p, cycle)
@@ -232,7 +232,7 @@ def _sample_next_pmap(sampler, machine, parameters, state):
 @partial(
     jax.pmap,
     in_axes=(None, None, None, 0, None),
-    out_axes=(1, 0),
+    out_axes=(0, 0),
     static_broadcasted_argnums=(1, 4),
 )
 def _sample_chain_pmap(sampler, machine, parameters, state, chain_length):

--- a/netket/jax/_expect.py
+++ b/netket/jax/_expect.py
@@ -53,7 +53,7 @@ def _expect(n_chains, log_pdf, expected_fun, pars, σ, *expected_fun_args):
     if n_chains is not None:
         L_σ = L_σ.reshape((n_chains, -1))
 
-    L̄_σ = mpi_statistics(L_σ.T)
+    L̄_σ = mpi_statistics(L_σ)
     # L̄_σ = L_σ.mean(axis=0)
 
     return L̄_σ.mean, L̄_σ
@@ -66,7 +66,7 @@ def _expect_fwd(n_chains, log_pdf, expected_fun, pars, σ, *expected_fun_args):
     else:
         L_σ_r = L_σ
 
-    L̄_stat = mpi_statistics(L_σ_r.T)
+    L̄_stat = mpi_statistics(L_σ_r)
 
     L̄_σ = L̄_stat.mean
     # L̄_σ = L_σ.mean(axis=0)

--- a/netket/sampler/autoreg.py
+++ b/netket/sampler/autoreg.py
@@ -157,7 +157,7 @@ class ARDirectSampler(Sampler):
         # We just need a buffer for `σ` before generating each sample
         # The result does not depend on the initial contents in it
         σ = jnp.zeros(
-            (chain_length * sampler.n_chains_per_rank, sampler.hilbert.size),
+            (sampler.n_chains_per_rank * chain_length, sampler.hilbert.size),
             dtype=sampler.dtype,
         )
 
@@ -167,7 +167,7 @@ class ARDirectSampler(Sampler):
 
         indices = jnp.arange(sampler.hilbert.size)
         (σ, _, _), _ = jax.lax.scan(scan_fun, (σ, cache, key_scan), indices)
-        σ = σ.reshape((chain_length, sampler.n_chains_per_rank, sampler.hilbert.size))
+        σ = σ.reshape((sampler.n_chains_per_rank, chain_length, sampler.hilbert.size))
 
         new_state = state.replace(key=new_key)
         return σ, new_state

--- a/netket/sampler/base.py
+++ b/netket/sampler/base.py
@@ -300,7 +300,7 @@ class Sampler(abc.ABC):
 
         for i in range(chain_length):
             samples, state = sampler._sample_chain(machine, parameters, state, 1)
-            yield samples[0, :, :]
+            yield samples[:, 0, :]
 
     @abc.abstractmethod
     def _sample_chain(

--- a/netket/sampler/exact.py
+++ b/netket/sampler/exact.py
@@ -115,13 +115,13 @@ class ExactSampler(Sampler):
         samples = jax.pure_callback(
             lambda numbers: sampler.hilbert.numbers_to_states(numbers),
             jax.ShapeDtypeStruct(
-                (chain_length * sampler.n_chains_per_rank, sampler.hilbert.size),
+                (sampler.n_chains_per_rank * chain_length, sampler.hilbert.size),
                 jnp.float64,
             ),
             numbers,
         )
         samples = jnp.asarray(samples, dtype=sampler.dtype).reshape(
-            chain_length, sampler.n_chains_per_rank, sampler.hilbert.size
+            sampler.n_chains_per_rank, chain_length, sampler.hilbert.size
         )
 
         return samples, state.replace(rng=new_rng)

--- a/netket/sampler/metropolis.py
+++ b/netket/sampler/metropolis.py
@@ -370,7 +370,8 @@ class MetropolisSampler(Sampler):
             xs=None,
             length=chain_length,
         )
-
+        # make it (n_chains, n_samples_per_chain) as expected by netket.stats.statistics
+        samples = jnp.swapaxes(samples, 0, 1)
         return samples, state
 
     def __repr__(sampler):

--- a/netket/sampler/metropolis_numpy.py
+++ b/netket/sampler/metropolis_numpy.py
@@ -214,6 +214,9 @@ class MetropolisSamplerNumpy(MetropolisSampler):
             state, σ = sampler.sample_next(machine, parameters, state)
             samples[i] = σ
 
+        # make it (n_chains, n_samples_per_chain) as expected by netket.stats.statistics
+        samples = np.swapaxes(samples, 0, 1)
+
         return samples, state
 
     def __repr__(sampler):

--- a/netket/vqs/mc/mc_state/expect_forces.py
+++ b/netket/vqs/mc/mc_state/expect_forces.py
@@ -75,9 +75,9 @@ def forces_expect_hermitian(
     local_value_args: PyTree,
 ) -> Tuple[PyTree, PyTree]:
 
-    σ_shape = σ.shape
-    if jnp.ndim(σ) != 2:
-        σ = σ.reshape((-1, σ_shape[-1]))
+    n_chains = σ.shape[0]
+    if σ.ndim >= 3:
+        σ = jax.lax.collapse(σ, 0, 2)
 
     n_samples = σ.shape[0] * mpi.n_nodes
 
@@ -88,7 +88,7 @@ def forces_expect_hermitian(
         local_value_args,
     )
 
-    Ō = statistics(O_loc.reshape(σ_shape[:-1]).T)
+    Ō = statistics(O_loc.reshape((n_chains, -1)))
 
     O_loc -= Ō.mean
 

--- a/netket/vqs/mc/mc_state/expect_grad.py
+++ b/netket/vqs/mc/mc_state/expect_grad.py
@@ -136,9 +136,9 @@ def grad_expect_operator_kernel(
     local_value_args: PyTree,
 ) -> Tuple[PyTree, PyTree, Stats]:
 
-    σ_shape = σ.shape
-    if jnp.ndim(σ) != 2:
-        σ = σ.reshape((-1, σ_shape[-1]))
+    n_chains = σ.shape[0]
+    if σ.ndim >= 3:
+        σ = jax.lax.collapse(σ, 0, 2)
 
     is_mutable = mutable is not False
     logpsi = lambda w, σ: model_apply_fun(
@@ -155,7 +155,7 @@ def grad_expect_operator_kernel(
             pars,
             σ,
             local_value_args,
-            n_chains=σ_shape[0],
+            n_chains=n_chains,
         )
 
     Ō, Ō_pb, Ō_stats = nkjax.vjp(

--- a/netket/vqs/mc/mc_state/state.py
+++ b/netket/vqs/mc/mc_state/state.py
@@ -684,9 +684,7 @@ class MCState(VariationalState):
 def _local_estimators_kernel(kernel, apply_fun, shape, variables, samples, extra_args):
     O_loc = kernel(apply_fun, variables, samples, extra_args)
 
-    # transpose O_loc so it matches the (n_chains, n_samples_per_chain) shape
-    # expected by netket.stats.statistics.
-    return O_loc.reshape(shape).T
+    return O_loc.reshape(shape)
 
 
 def local_estimators(

--- a/test/sampler/test_sampler.py
+++ b/test/sampler/test_sampler.py
@@ -324,15 +324,15 @@ def test_correct_sampling(sampler_c, model_and_weights, set_pdf_power):
             )
 
             assert samples.shape == (
-                n_samples // 100,
                 sampler.n_chains,
+                n_samples // 100,
                 hi.size,
             )
             samples, sampler_state = sampler.sample(
                 ma, w, state=sampler_state, chain_length=n_samples
             )
 
-            assert samples.shape == (n_samples, sampler.n_chains, hi.size)
+            assert samples.shape == (sampler.n_chains, n_samples, hi.size)
 
             sttn = hi.states_to_numbers(np.asarray(samples.reshape(-1, hi.size)))
             n_s = sttn.size
@@ -368,8 +368,8 @@ def test_correct_sampling(sampler_c, model_and_weights, set_pdf_power):
             )
 
             assert samples.shape == (
-                n_discard,
                 sampler.n_chains,
+                n_discard,
                 hi.size,
             )
             samples, sampler_state = sampler.sample(
@@ -379,7 +379,7 @@ def test_correct_sampling(sampler_c, model_and_weights, set_pdf_power):
                 chain_length=n_samples,
             )
 
-            assert samples.shape == (n_samples, sampler.n_chains, hi.size)
+            assert samples.shape == (sampler.n_chains, n_samples, hi.size)
 
             samples = samples.reshape(-1, samples.shape[-1])
 

--- a/test/stats/test_stats.py
+++ b/test/stats/test_stats.py
@@ -72,10 +72,10 @@ def _test_stats_mean_std(hi, ham, ma, n_chains):
     samples, state = sampler.sample(
         ma, w, chain_length=num_samples_per_chain, state=state
     )
-    assert samples.shape == (num_samples_per_chain, n_chains, hi.size)
+    assert samples.shape == (n_chains, num_samples_per_chain, hi.size)
 
     eloc = local_values(ma.apply, w, ham, samples)
-    assert eloc.shape == (num_samples_per_chain, n_chains)
+    assert eloc.shape == (n_chains, num_samples_per_chain)
 
     stats = statistics(eloc.T)
 

--- a/test/variational/test_variational.py
+++ b/test/variational/test_variational.py
@@ -141,17 +141,17 @@ def test_n_samples_api(vstate, _mpi_size):
     vstate.n_samples = 3
     check_consistent(vstate, _mpi_size)
     assert vstate.samples.shape[0:2] == (
-        int(np.ceil(3 / _mpi_size)),
         vstate.sampler.n_chains_per_rank,
+        int(np.ceil(3 / _mpi_size)),
     )
 
     vstate.n_samples_per_rank = 4
     check_consistent(vstate, _mpi_size)
-    assert vstate.samples.shape[0:2] == (4, vstate.sampler.n_chains_per_rank)
+    assert vstate.samples.shape[0:2] == (vstate.sampler.n_chains_per_rank, 4)
 
     vstate.chain_length = 2
     check_consistent(vstate, _mpi_size)
-    assert vstate.samples.shape[0:2] == (2, vstate.sampler.n_chains_per_rank)
+    assert vstate.samples.shape[0:2] == (vstate.sampler.n_chains_per_rank, 2)
 
     vstate.n_samples = 1000
     vstate.n_discard_per_chain = None
@@ -170,16 +170,16 @@ def test_n_samples_api(vstate, _mpi_size):
     vstate.n_samples = 3
     check_consistent(vstate, _mpi_size)
     # `n_samples` is rounded up
-    assert vstate.samples.shape[0:2] == (1, vstate.sampler.n_chains_per_rank)
+    assert vstate.samples.shape[0:2] == (vstate.sampler.n_chains_per_rank, 1)
 
     vstate.n_samples_per_rank = 16 // _mpi_size + 1
     check_consistent(vstate, _mpi_size)
     # `n_samples` is rounded up
-    assert vstate.samples.shape[0:2] == (2, vstate.sampler.n_chains_per_rank)
+    assert vstate.samples.shape[0:2] == (vstate.sampler.n_chains_per_rank, 2)
 
     vstate.chain_length = 2
     check_consistent(vstate, _mpi_size)
-    assert vstate.samples.shape[0:2] == (2, vstate.sampler.n_chains_per_rank)
+    assert vstate.samples.shape[0:2] == (vstate.sampler.n_chains_per_rank, 2)
 
 
 @common.skipif_mpi

--- a/test/variational/test_variational_mixed.py
+++ b/test/variational/test_variational_mixed.py
@@ -106,17 +106,17 @@ def test_n_samples_api(vstate, _mpi_size):
     vstate.n_samples = 3
     check_consistent(vstate, _mpi_size)
     assert vstate.samples.shape[0:2] == (
-        int(np.ceil(3 / _mpi_size)),
         vstate.sampler.n_chains_per_rank,
+        int(np.ceil(3 / _mpi_size)),
     )
 
     vstate.n_samples_per_rank = 4
     check_consistent(vstate, _mpi_size)
-    assert vstate.samples.shape[0:2] == (4, vstate.sampler.n_chains_per_rank)
+    assert vstate.samples.shape[0:2] == (vstate.sampler.n_chains_per_rank, 4)
 
     vstate.chain_length = 2
     check_consistent(vstate, _mpi_size)
-    assert vstate.samples.shape[0:2] == (2, vstate.sampler.n_chains_per_rank)
+    assert vstate.samples.shape[0:2] == (vstate.sampler.n_chains_per_rank, 2)
 
     vstate.n_samples = 1000
     vstate.n_discard_per_chain = None
@@ -137,16 +137,16 @@ def test_n_samples_api(vstate, _mpi_size):
     vstate.n_samples = 3
     check_consistent(vstate, _mpi_size)
     # `n_samples` is rounded up
-    assert vstate.samples.shape[0:2] == (1, vstate.sampler.n_chains_per_rank)
+    assert vstate.samples.shape[0:2] == (vstate.sampler.n_chains_per_rank, 1)
 
     vstate.n_samples_per_rank = 16 // _mpi_size + 1
     check_consistent(vstate, _mpi_size)
     # `n_samples` is rounded up
-    assert vstate.samples.shape[0:2] == (2, vstate.sampler.n_chains_per_rank)
+    assert vstate.samples.shape[0:2] == (vstate.sampler.n_chains_per_rank, 2)
 
     vstate.chain_length = 2
     check_consistent(vstate, _mpi_size)
-    assert vstate.samples.shape[0:2] == (2, vstate.sampler.n_chains_per_rank)
+    assert vstate.samples.shape[0:2] == (vstate.sampler.n_chains_per_rank, 2)
 
 
 def test_n_samples_diag_api(vstate, _mpi_size):
@@ -170,16 +170,16 @@ def test_n_samples_diag_api(vstate, _mpi_size):
     check_consistent_diag(vstate)
     assert (
         vstate.diagonal.samples.shape[0:2]
-        == (int(np.ceil(3 / _mpi_size)), vstate.sampler_diag.n_chains_per_rank)
-        == (int(np.ceil(3 / _mpi_size)), vstate.diagonal.sampler.n_chains_per_rank)
+        == (vstate.sampler_diag.n_chains_per_rank, int(np.ceil(3 / _mpi_size)))
+        == (vstate.diagonal.sampler.n_chains_per_rank, int(np.ceil(3 / _mpi_size)))
     )
 
     vstate.chain_length_diag = 2
     check_consistent_diag(vstate)
     assert (
         vstate.diagonal.samples.shape[0:2]
-        == (2, vstate.sampler_diag.n_chains_per_rank)
-        == (2, vstate.diagonal.sampler.n_chains_per_rank)
+        == (vstate.sampler_diag.n_chains_per_rank, 2)
+        == (vstate.diagonal.sampler.n_chains_per_rank, 2)
     )
 
     vstate.n_samples_diag = 1000
@@ -205,8 +205,8 @@ def test_n_samples_diag_api(vstate, _mpi_size):
     # `n_samples_diag` is rounded up
     assert (
         vstate.diagonal.samples.shape[0:2]
-        == (1, vstate.sampler_diag.n_chains_per_rank)
-        == (1, vstate.diagonal.sampler.n_chains_per_rank)
+        == (vstate.sampler_diag.n_chains_per_rank, 1)
+        == (vstate.diagonal.sampler.n_chains_per_rank, 1)
     )
 
     vstate.chain_length_diag = 2
@@ -218,8 +218,8 @@ def test_n_samples_diag_api(vstate, _mpi_size):
     )
     assert (
         vstate.diagonal.samples.shape[0:2]
-        == (2, vstate.sampler_diag.n_chains_per_rank)
-        == (2, vstate.diagonal.sampler.n_chains_per_rank)
+        == (vstate.sampler_diag.n_chains_per_rank, 2)
+        == (vstate.diagonal.sampler.n_chains_per_rank, 2)
     )
 
 


### PR DESCRIPTION
Previously the samplers were outputting arrays of shape `(n_samples_per_chain, n_chains, ...)`, an artefact of the jax scan being used to do the sampling,  which was inconsistent with e.g. `nk.stats.statistics` which expects `(n_chains, n_samples_per_chain, ...)`.
This PR swaps the order of the axes in the output of the samplers to `(n_chains, n_samples_per_chain, ...)`, so that we have a consistent order everywhere.