### PR TITLE
jit a few internal functions to make them work with global device arrays

### DIFF
--- a/netket/optimizer/qgt/qgt_jacobian_dense.py
+++ b/netket/optimizer/qgt/qgt_jacobian_dense.py
@@ -108,6 +108,9 @@ def QGTJacobianDense(
         pdf = split_array_mpi(vstate.probability_distribution())
     else:
         samples = vstate.samples
+        if samples.ndim >= 3:
+            # use jit so that we can do it on global shared array
+            samples = jax.jit(jax.lax.collapse, static_argnums=(1, 2))(samples, 0, 2)
         pdf = None
 
     if mode is None:
@@ -127,7 +130,7 @@ def QGTJacobianDense(
     jacobians = nkjax.jacobian(
         vstate._apply_fun,
         vstate.parameters,
-        samples.reshape(-1, samples.shape[-1]),
+        samples,
         vstate.model_state,
         mode=mode,
         pdf=pdf,

--- a/netket/optimizer/qgt/qgt_jacobian_pytree.py
+++ b/netket/optimizer/qgt/qgt_jacobian_pytree.py
@@ -109,6 +109,9 @@ def QGTJacobianPyTree(
         pdf = split_array_mpi(vstate.probability_distribution())
     else:
         samples = vstate.samples
+        if samples.ndim >= 3:
+            # use jit so that we can do it on global shared array
+            samples = jax.jit(jax.lax.collapse, static_argnums=(1, 2))(samples, 0, 2)
         pdf = None
 
     # Choose sensible default mode
@@ -129,7 +132,7 @@ def QGTJacobianPyTree(
     jacobians = nkjax.jacobian(
         vstate._apply_fun,
         vstate.parameters,
-        samples.reshape(-1, samples.shape[-1]),
+        samples,
         vstate.model_state,
         mode=mode,
         pdf=pdf,

--- a/netket/optimizer/qgt/qgt_onthefly.py
+++ b/netket/optimizer/qgt/qgt_onthefly.py
@@ -65,10 +65,10 @@ def QGTOnTheFly(vstate=None, *, chunk_size=None, **kwargs) -> "QGTOnTheFlyT":
         samples = split_array_mpi(vstate._all_states)
         pdf = split_array_mpi(vstate.probability_distribution())
     else:
-        if jnp.ndim(vstate.samples) == 2:
-            samples = vstate.samples
-        else:
-            samples = vstate.samples.reshape((-1, vstate.samples.shape[-1]))
+        samples = vstate.samples
+        if samples.ndim >= 3:
+            # use jit so that we can do it on global shared array
+            samples = jax.jit(jax.lax.collapse, static_argnums=(1, 2))(samples, 0, 2)
         pdf = None
 
     if chunk_size is None and hasattr(vstate, "chunk_size"):

--- a/netket/sampler/metropolis.py
+++ b/netket/sampler/metropolis.py
@@ -266,7 +266,9 @@ class MetropolisSampler(Sampler):
         return state
 
     def _reset(sampler, machine, parameters, state):
-        new_rng, rng = jax.random.split(state.rng)
+        new_rng, rng = jax.jit(jax.random.split)(
+            state.rng
+        )  # use jit so that we can do it on global shared array
 
         if sampler.reset_chains:
             σ = sampler.rule.random_state(sampler, machine, parameters, state, rng)

--- a/netket/sampler/metropolis.py
+++ b/netket/sampler/metropolis.py
@@ -83,7 +83,8 @@ class MetropolisSamplerState(SamplerState):
     @property
     def n_accepted(self) -> int:
         """Total number of moves accepted across all processes since the last reset."""
-        res, _ = mpi.mpi_sum_jax(jnp.sum(self.n_accepted_proc))
+        # jit sum for gda
+        res, _ = mpi.mpi_sum_jax(jax.jit(jnp.sum)(self.n_accepted_proc))
         return res
 
     def __repr__(self):


### PR DESCRIPTION
i.e. arrays which are `isinstance(x, jax.Array) and not x.is_fully_addressable`.
See https://jax.readthedocs.io/en/latest/jax_array_migration.html#jax-array-migration