### PR TITLE
Throw informative errors if one uses operators/hilbert inside of jax

### DIFF
--- a/docs/api/api.md
+++ b/docs/api/api.md
@@ -16,22 +16,22 @@ This page lists the documentation of all sub-packages of NetKet.
 ```{toctree}
 :maxdepth: 1
 
+callbacks
+drivers
+errors
+exact
 graph
 hilbert
-operator
-exact
-sampler
-stats
+jax
+logging
 models
 nn
-jax
-vqs
-drivers
+operator
 optimizer
-logging
-callbacks
+sampler
+stats
 utils
-
+vqs
 ```
 
 ## Default drivers

--- a/docs/api/errors.md
+++ b/docs/api/errors.md
@@ -1,0 +1,21 @@
+(netket_errors_api)=
+# netket.errors
+
+```{eval-rst}
+.. currentmodule:: netket.errors
+
+```
+
+Netket has the following classes of errors.
+
+
+## Error classes
+
+```{eval-rst}
+.. autosummary::
+  :toctree: _generated/errors
+  :nosignatures:
+
+  NumbaOperatorGetConnDuringTracingError
+  HilbertIndexingDuringTracingError
+```

--- a/netket/__init__.py
+++ b/netket/__init__.py
@@ -24,6 +24,8 @@ from ._version import version as __version__  # noqa: F401
 from . import utils
 from .utils import config
 
+from . import errors
+
 __all__ = [
     "exact",
     "graph",
@@ -37,6 +39,7 @@ __all__ = [
     "vqs",
     "nn",
 ]
+
 
 from . import jax
 from . import stats

--- a/netket/errors.py
+++ b/netket/errors.py
@@ -1,0 +1,280 @@
+# Copyright 2023 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Use an empty top-level docstring so Sphinx won't output the one below.
+""""""
+
+
+"""NetKet error classes.
+(Inspired by Flax error classes)
+
+=== When to create a Flax error class?
+
+If an error message requires more explanation than a one-liner, it is useful to
+add it as a separate error class. This may lead to some duplication with
+existing documentation or docstrings, but it will provide users with more help
+when they are debugging a problem. We can also point to existing documentation
+from the error docstring directly.
+
+=== How to name the error class?
+
+* If the error occurs when doing something, name the error
+  <Verb><Object><TypeOfError>Error
+
+  For instance, if you want to raise an error when applying a module with an
+  invalid method, the error can be: ApplyModuleInvalidMethodError.
+
+ <TypeOfError> is optional, for instance if there is only one error when
+  modifying a variable, the error can simply be: ModifyVariableError.
+
+* If there is no concrete action involved the only a description of the error is
+  sufficient. For instance: InvalidFilterError, NameInUseError, etc.
+
+
+=== Copy/pastable template for new error messages:
+
+class Template(FlaxError):
+  "" "
+
+  "" "
+  def __init__(self):
+    super().__init__(f'')
+"""
+
+
+class NetketError(Exception):
+    def __init__(self, message):
+        error_index = "https://netket.readthedocs.io/en/latest/api/errors.html"
+        error_dir = "https://netket.readthedocs.io/en/latest/api/_generated/errors"
+        module_name = self.__class__.__module__
+        class_name = self.__class__.__name__
+        error_msg = (
+            f"{message}"
+            f"\n"
+            f"\n-------------------------------------------------------"
+            f"\n"
+            f"For more detailed informations, visit the following link:"
+            f"\n\t {error_dir}/{module_name}.{class_name}.html"
+            f"\n"
+            f"or the list of all common errors at"
+            f"\n\t {error_index}"
+            f"\n-------------------------------------------------------"
+            f"\n"
+        )
+        super().__init__(error_msg)
+
+
+#################################################
+# Hilbert errors                                #
+#################################################
+
+
+class HilbertIndexingDuringTracingError(NetketError):
+    """Illegal attempt to use state indexing function from
+    inside of a Jax function transformation.
+
+    This happens when you call functions such as
+    :meth:`~netket.hilbert.DiscreteHilbert.states_to_numbers` or
+    its opposite :meth:`~netket.hilbert.DiscreteHilbert.numbers_to_states` from
+    within a :func:`jax.jit`, :func:`jax.grad`, :func:`jax.vjp` or similar jax
+    function transformations.
+
+    There is currently no workaround rather than returning the arrays from
+    the jax function and performing the conversion outside of it.
+
+    """
+
+    def __init__(self):
+        super().__init__(
+            "\n"
+            "Attempted to use state-indexing functions of an hilbert object "
+            "inside a Jax function transformation (jax.jit, jax.grad & others)."
+            "\n\n"
+            "Functions that convert states to indices and vice-versa such as "
+            "`hilbert.states_to_numbers()` or `hilbert.numbers_to_states()` "
+            "are implemented in Numba and cannot be executed from within a"
+            "jax function transformation."
+        )
+
+
+#################################################
+# Operators errors                              #
+#################################################
+
+
+class NumbaOperatorGetConnDuringTracingError(NetketError):
+    """Illegal attempt to use Numba-operators inside of a Jax
+    function transformation.
+
+    This happens when calling :meth:`~netket.operator.DiscreteOperator.get_conn_padded` or
+    :meth:`~netket.operator.DiscreteOperator.get_conn_flattened` inside of a function
+    that is being transformed by jax with transformations such as :func:`jax.jit`
+    or :func:`jax.grad`, and the operator is not compatible with Jax.
+
+    To avoid this error you can (i) convert your operator to a Jax compatible format if possible,
+    or (ii) compute the connected elements outside of the jax function transformation and pass the
+    results to a jax-transformed function.
+
+    (i) Converting an Operator to a Jax compatible format
+    -----------------------------------------------------
+
+    Some operators can be converted to a jax-compatible format by calling the method
+    `operator.to_jax_operator()`. If this method is not available or raises an error, it means
+    that the operator cannot be converted.
+
+    If the operator can be converted to a jax-compatible format, it will be possible to pass
+    it as a standard argument to a jax-transformed function and it should not be declared as
+    a static argument.
+
+    Jax compatible operators can be used like standard operators, for example by passing
+    it to :meth:`~netket.vqs.MCState.expect` function. However, the performance will differ from
+    standard operators. In general, you might find that compile time will be much worse, while
+    runtime might be faster or slower, depending on several factors.
+
+    The biggest advantage to Jax operators, however, is when experimenting with jax code, as you
+    can succesfully use them in your own custom functions as in the example below:
+
+    .. code-block:: python
+
+        import netket as nk
+        import jax
+        import jax.numpy as jnp
+
+        graph = nk.graph.Chain(10)
+        hilbert = nk.hilbert.Spin(1/2, graph.n_nodes)
+        ham = nk.operator.Ising(hilbert, graph, h=1.0)
+        ham_jax = ham.to_jax_operator()
+
+        ma = nk.models.RBM()
+        pars = ma.init(jax.random.PRNGKey(1), jnp.ones((2,graph.n_nodes)))
+
+        samples = hilbert.all_states()
+
+        @jax.jit
+        def compute_local_energies(pars, ham_jax, s):
+            # this would raise the error
+            sp, mels = ham.get_conn_padded(s)
+            # this will work
+            sp, mels = ham_jax.get_conn_padded(s)
+
+            logpsi_sp = ma.apply(pars, sp)
+            logpsi_s = jnp.expand_dims(ma.apply(pars, s), -1)
+
+            return jnp.sum(mels * jnp.exp(logpsi_sp-logpsi_s), axis=-1)
+
+        elocs = compute_local_energies(pars, ham_jax, samples)
+        elocs_grad = jax.jacrev(compute_local_energies)(pars, ham_jax, samples)
+
+    .. note::
+
+        Note that this transformation might be a relatively expensive operation, so you should avoid
+        executing this inside of an hot loop.
+
+
+    (ii) Precomputing connected elements outside of Jax transformations
+    -------------------------------------------------------------------
+
+    In most cases you won't be able to convert the operator to a Jax-compatible format.
+    In those cases, the workaround we usually employ is to precompute the connected elements
+    before entering the Jax context, splitting our function into a non-jitted function and
+    into a jitted kernel.
+
+    .. code-block:: python
+
+      import netket as nk
+      import jax
+      import jax.numpy as jnp
+
+      graph = nk.graph.Chain(10)
+      hilbert = nk.hilbert.Spin(1/2, graph.n_nodes)
+      ham = nk.operator.Ising(hilbert, graph, h=1.0)
+
+      ma = nk.models.RBM()
+      pars = ma.init(jax.random.PRNGKey(1), jnp.ones((2,graph.n_nodes)))
+
+      samples = hilbert.all_states()
+
+      def compute_local_energies(pars, ham, s):
+          sp, mels = ham.get_conn_padded(s)
+          return _compute_local_energies_kernel(pars, s, sp, mels)
+
+      @jax.jit
+      def _compute_local_energies_kernel(pars, s, sp, mels):
+          logpsi_sp = ma.apply(pars, sp)
+          logpsi_s = jnp.expand_dims(ma.apply(pars, s), -1)
+          return jnp.sum(mels * jnp.exp(logpsi_sp-logpsi_s), axis=-1)
+
+      elocs = compute_local_energies(pars, ham_jax, samples)
+      elocs_grad = jax.jacrev(compute_local_energies)(pars, ham_jax, samples)
+
+
+    Most :class:`~netket.operator.DiscreteOperator`s are implemented in Numba and therefore are not jax-compatible.
+    To know if it's valid to use an operator inside of a jax function transformation you can
+    check that it inherits from :class:`~netket.operator.DiscreteJaxOperator` by executing
+
+    .. code-block:: python
+
+        isinstance(operator, nk.operator.DiscreteJaxOperator)
+
+    """
+
+    def __init__(self, operator):
+        operator_type = type(operator)
+        super().__init__(
+            f"\n"
+            f"Attempted to use a Numba-based operator ({operator_type}) "
+            f"inside a Jax function transformation (jax.jit, jax.grad & others)."
+            f"\n\n"
+            f"Numba-based operators are not compatible with Jax function "
+            f"transformations, and can only be used outside of jax-function "
+            f"boundaries."
+            f"\n\n"
+            f"Some operators can be converted to a Jax-compatible version by"
+            f"calling `operator.to_jax_operator()`, but not all support it."
+            f"If your operator does not support it, read the documentation to "
+            f"find how to work-around this issue."
+        )
+
+
+#################################################
+# Functions to throw errors                     #
+#################################################
+
+
+def concrete_or_error(force, value, error_class, *args, **kwargs):
+    """
+    Wraps `jax.core.concrete_or_error` but allows us to throw our
+    own errors.
+
+    Args:
+      force: function to be executed on the value (for example np.asarray)
+        that would fail if value is not concrete
+      value: the argument to `force`
+      error: the constructor of the custom error to throw.
+      *args: any additional argument and keyword argument to pass to the custom
+        error type constructor.
+    """
+    import jax
+
+    from jax.core import ConcretizationTypeError
+
+    try:
+        return jax.core.concrete_or_error(
+            force,
+            value,
+            """
+          """,
+        )
+    except ConcretizationTypeError as err:
+        raise error_class(*args, **kwargs) from err

--- a/netket/experimental/operator/_fermion_operator_2nd.py
+++ b/netket/experimental/operator/_fermion_operator_2nd.py
@@ -24,6 +24,7 @@ from netket.operator._discrete_operator import DiscreteOperator
 from netket.operator._pauli_strings import _count_of_locations
 from netket.hilbert.abstract_hilbert import AbstractHilbert
 from netket.utils.numbers import is_scalar, dtype as _dtype
+from netket.errors import concrete_or_error, NumbaOperatorGetConnDuringTracingError
 
 from netket.experimental.hilbert import SpinOrbitalFermions
 
@@ -341,7 +342,14 @@ class FermionOperator2nd(DiscreteOperator):
             array: An array containing the matrix elements :math:`O(x,x')` associated to each x'.
         """
         self._setup()
-        x = np.array(x)
+
+        x = concrete_or_error(
+            np.asarray,
+            x,
+            NumbaOperatorGetConnDuringTracingError,
+            self,
+        )
+
         assert (
             x.shape[-1] == self.hilbert.size
         ), "size of hilbert space does not match size of x"

--- a/netket/hilbert/discrete_hilbert.py
+++ b/netket/hilbert/discrete_hilbert.py
@@ -20,6 +20,7 @@ import numpy as np
 
 from netket.utils.types import Array
 from netket.utils.numbers import is_scalar
+from netket.errors import HilbertIndexingDuringTracingError, concrete_or_error
 
 from .abstract_hilbert import AbstractHilbert
 
@@ -121,6 +122,11 @@ class DiscreteHilbert(AbstractHilbert):
                 quantum numbers.
             out: Optional Array of quantum numbers corresponding to numbers.
         """
+
+        numbers = concrete_or_error(
+            np.asarray, numbers, HilbertIndexingDuringTracingError
+        )
+
         if out is None:
             out = np.empty((np.atleast_1d(numbers).shape[0], self.size))
 
@@ -152,6 +158,10 @@ class DiscreteHilbert(AbstractHilbert):
                 f"Size of this state ({states.shape[-1]}) not"
                 f"corresponding to this hilbert space {self.size}"
             )
+
+        states = concrete_or_error(
+            np.asarray, states, HilbertIndexingDuringTracingError
+        )
 
         states_r = np.asarray(np.reshape(states, (-1, states.shape[-1])))
 

--- a/netket/hilbert/homogeneous.py
+++ b/netket/hilbert/homogeneous.py
@@ -19,6 +19,8 @@ from numbers import Real
 
 import numpy as np
 
+from netket.errors import HilbertIndexingDuringTracingError, concrete_or_error
+
 from .discrete_hilbert import DiscreteHilbert
 from .hilbert_index import HilbertIndex
 
@@ -143,12 +145,22 @@ class HomogeneousHilbert(DiscreteHilbert):
         return self._constraint_fn is not None
 
     def _numbers_to_states(self, numbers: np.ndarray, out: np.ndarray) -> np.ndarray:
+
+        numbers = concrete_or_error(
+            np.asarray, numbers, HilbertIndexingDuringTracingError
+        )
+
         if self.constrained:
             numbers = self._bare_numbers[numbers]
 
-        return self._hilbert_index.numbers_to_states(np.asarray(numbers), out)
+        return self._hilbert_index.numbers_to_states(numbers, out)
 
     def _states_to_numbers(self, states: np.ndarray, out: np.ndarray):
+
+        states = concrete_or_error(
+            np.asarray, states, HilbertIndexingDuringTracingError
+        )
+
         self._hilbert_index.states_to_numbers(states, out)
 
         if self.constrained:

--- a/netket/hilbert/homogeneous.py
+++ b/netket/hilbert/homogeneous.py
@@ -145,9 +145,9 @@ class HomogeneousHilbert(DiscreteHilbert):
     def _numbers_to_states(self, numbers: np.ndarray, out: np.ndarray) -> np.ndarray:
 
         # this is guaranteed
-        #numbers = concrete_or_error(
+        # numbers = concrete_or_error(
         #    np.asarray, numbers, HilbertIndexingDuringTracingError
-        #)
+        # )
 
         if self.constrained:
             numbers = self._bare_numbers[numbers]
@@ -157,9 +157,9 @@ class HomogeneousHilbert(DiscreteHilbert):
     def _states_to_numbers(self, states: np.ndarray, out: np.ndarray):
 
         # guaranteed
-        #states = concrete_or_error(
+        # states = concrete_or_error(
         #    np.asarray, states, HilbertIndexingDuringTracingError
-        #)
+        # )
 
         self._hilbert_index.states_to_numbers(states, out)
 

--- a/netket/hilbert/homogeneous.py
+++ b/netket/hilbert/homogeneous.py
@@ -19,8 +19,6 @@ from numbers import Real
 
 import numpy as np
 
-from netket.errors import HilbertIndexingDuringTracingError, concrete_or_error
-
 from .discrete_hilbert import DiscreteHilbert
 from .hilbert_index import HilbertIndex
 
@@ -146,9 +144,10 @@ class HomogeneousHilbert(DiscreteHilbert):
 
     def _numbers_to_states(self, numbers: np.ndarray, out: np.ndarray) -> np.ndarray:
 
-        numbers = concrete_or_error(
-            np.asarray, numbers, HilbertIndexingDuringTracingError
-        )
+        # this is guaranteed
+        #numbers = concrete_or_error(
+        #    np.asarray, numbers, HilbertIndexingDuringTracingError
+        #)
 
         if self.constrained:
             numbers = self._bare_numbers[numbers]
@@ -157,9 +156,10 @@ class HomogeneousHilbert(DiscreteHilbert):
 
     def _states_to_numbers(self, states: np.ndarray, out: np.ndarray):
 
-        states = concrete_or_error(
-            np.asarray, states, HilbertIndexingDuringTracingError
-        )
+        # guaranteed
+        #states = concrete_or_error(
+        #    np.asarray, states, HilbertIndexingDuringTracingError
+        #)
 
         self._hilbert_index.states_to_numbers(states, out)
 

--- a/netket/operator/_bose_hubbard.py
+++ b/netket/operator/_bose_hubbard.py
@@ -23,6 +23,7 @@ from netket.graph import AbstractGraph, Graph
 from netket.hilbert import Fock
 from netket.utils.types import DType
 from netket.utils.numbers import dtype as _dtype
+from netket.errors import concrete_or_error, NumbaOperatorGetConnDuringTracingError
 
 from . import boson
 from ._local_operator import LocalOperator
@@ -310,8 +311,15 @@ class BoseHubbard(SpecialHamiltonian):
         elif x.dtype != self._max_xprime.dtype:
             self._max_xprime = self._max_xprime.astype(x.dtype)
 
+        x = concrete_or_error(
+            np.asarray,
+            x,
+            NumbaOperatorGetConnDuringTracingError,
+            self,
+        )
+
         return self._flattened_kernel(
-            np.asarray(x),
+            x,
             sections,
             self._edges,
             self._U,

--- a/netket/operator/_ising/numba.py
+++ b/netket/operator/_ising/numba.py
@@ -23,6 +23,7 @@ from numba import jit
 from netket.graph import AbstractGraph
 from netket.hilbert import AbstractHilbert
 from netket.utils.types import DType
+from netket.errors import concrete_or_error, NumbaOperatorGetConnDuringTracingError
 
 from .base import IsingBase
 
@@ -134,9 +135,14 @@ class Ising(IsingBase):
             array: An array containing the matrix elements :math:`O(x,x')` associated to each x'.
 
         """
-        return self._flattened_kernel(
-            np.asarray(x), sections, self.edges, self._h, self._J
+        x = concrete_or_error(
+            np.asarray,
+            x,
+            NumbaOperatorGetConnDuringTracingError,
+            self,
         )
+
+        return self._flattened_kernel(x, sections, self.edges, self._h, self._J)
 
     def _get_conn_flattened_closure(self):
         _edges = self._edges

--- a/netket/operator/_local_operator.py
+++ b/netket/operator/_local_operator.py
@@ -25,6 +25,7 @@ from scipy.sparse import issparse
 from netket.hilbert import AbstractHilbert
 from netket.utils.types import DType, Array
 from netket.utils.numbers import dtype as _dtype, is_scalar
+from netket.errors import concrete_or_error, NumbaOperatorGetConnDuringTracingError
 
 from ._discrete_operator import DiscreteOperator
 from ._lazy import Transpose
@@ -449,8 +450,15 @@ class LocalOperator(DiscreteOperator):
         """
         self._setup()
 
+        x = concrete_or_error(
+            np.asarray,
+            x,
+            NumbaOperatorGetConnDuringTracingError,
+            self,
+        )
+
         return self._get_conn_flattened_kernel(
-            np.asarray(x),
+            x,
             sections,
             self._local_states,
             self._basis,
@@ -629,6 +637,14 @@ class LocalOperator(DiscreteOperator):
 
         """
         self._setup()
+
+        x = concrete_or_error(
+            np.asarray,
+            x,
+            NumbaOperatorGetConnDuringTracingError,
+            self,
+        )
+
         return self._get_conn_filtered_kernel(
             x,
             sections,

--- a/netket/operator/_pauli_strings.py
+++ b/netket/operator/_pauli_strings.py
@@ -22,6 +22,7 @@ from itertools import product
 
 from netket.hilbert import Qubit, AbstractHilbert
 from netket.utils.numbers import is_scalar
+from netket.errors import concrete_or_error, NumbaOperatorGetConnDuringTracingError
 
 from ._abstract_operator import AbstractOperator
 from ._discrete_operator import DiscreteOperator
@@ -467,7 +468,14 @@ class PauliStrings(DiscreteOperator):
 
         """
         self._setup()
-        x = np.array(x)
+
+        x = concrete_or_error(
+            np.asarray,
+            x,
+            NumbaOperatorGetConnDuringTracingError,
+            self,
+        )
+
         assert (
             x.shape[-1] == self.hilbert.size
         ), "size of hilbert space does not match size of x"

--- a/netket/utils/static_number.py
+++ b/netket/utils/static_number.py
@@ -34,7 +34,7 @@ class StaticZero(Number):
     dtype: DType = struct.field(pytree_node=False, default=bool)
 
     shape = property(lambda _: ())
-    ndim = property(lambda _: 1)
+    ndim = property(lambda _: 0)
     weak_dtype = property(lambda _: True)
     aval = property(lambda self: jax.ShapeDtypeStruct(self.shape, self.dtype))
 

--- a/test/hilbert/test_hilbert.py
+++ b/test/hilbert/test_hilbert.py
@@ -643,3 +643,22 @@ def test_constrained_eq_hash():
     hi2 = nk.hilbert.Fock(3, 4, n_particles=3)
     assert hi1 != hi2
     assert hash(hi1) != hash(hi2)
+
+
+@pytest.mark.parametrize("hi", discrete_hilbert_params)
+def test_hilbert_numba_throws(hi):
+    """Check that get conn throws an error"""
+    from netket.errors import HilbertIndexingDuringTracingError
+
+    @partial(jax.jit, static_argnums=0)
+    def numbers_to_states(hi, s):
+        return hi.numbers_to_states(s)
+    @partial(jax.jit, static_argnums=0)
+    def states_to_numbers(hi, s):
+        return hi.states_to_numbers(s)
+
+    with pytest.raises(HilbertIndexingDuringTracingError):
+        numbers_to_states(hi, 1)
+    with pytest.raises(HilbertIndexingDuringTracingError):
+        states_to_numbers(hi, jnp.zeros((hi.size,)))()
+

--- a/test/hilbert/test_hilbert.py
+++ b/test/hilbert/test_hilbert.py
@@ -653,6 +653,7 @@ def test_hilbert_numba_throws(hi):
     @partial(jax.jit, static_argnums=0)
     def numbers_to_states(hi, s):
         return hi.numbers_to_states(s)
+
     @partial(jax.jit, static_argnums=0)
     def states_to_numbers(hi, s):
         return hi.states_to_numbers(s)
@@ -661,4 +662,3 @@ def test_hilbert_numba_throws(hi):
         numbers_to_states(hi, 1)
     with pytest.raises(HilbertIndexingDuringTracingError):
         states_to_numbers(hi, jnp.zeros((hi.size,)))()
-

--- a/test/models/test_fullspace.py
+++ b/test/models/test_fullspace.py
@@ -49,4 +49,4 @@ def test_groundstate():
     vs = nk.vqs.FullSumState(hi, mod)
     vs.parameters = {"logstate": np.log(v[:, 0])}
 
-    assert np.allclose(vs.expect(ham).mean, w[0])
+    np.testing.assert_allclose(vs.expect(ham).mean, w[0])

--- a/test/utils/test_staticzero.py
+++ b/test/utils/test_staticzero.py
@@ -1,0 +1,56 @@
+import netket as nk
+from netket.utils.numbers import StaticZero
+import numpy as np
+
+import jax
+import jax.numpy as jnp
+
+
+def test_falseness():
+    a = StaticZero()
+    b = StaticZero()
+
+    assert a == b
+    assert hash(a) == hash(b)
+    assert not a
+
+
+def test_jax_pytree():
+    a = StaticZero()
+
+    data, struct = jax.tree_util.tree_flatten(a)
+    b = jax.tree_util.tree_unflatten(struct, data)
+
+    assert a == b
+    assert len(data) == 0
+
+
+def test_array_interface():
+    a = StaticZero()
+
+    assert a.shape == ()
+    assert a.ndim == 0
+    assert a.weak_dtype
+    assert isinstance(a.astype(float), StaticZero)
+    assert a.astype(float).dtype == float
+
+    np.testing.assert_allclose(np.asarray(a), np.array(False))
+    np.testing.assert_allclose(jnp.asarray(a), np.array(False))
+
+
+def test_binary_ops():
+    a = StaticZero()
+    a2 = StaticZero()
+    b = 2.0
+
+    assert -a == a
+    assert a + a2 == a
+    assert a - a2 == a
+    assert a * a2 == a
+
+    assert a + 2.0 == 2.0
+    assert 2.0 + a == 2.0
+    assert a - 2.0 == -2.0
+    assert 2.0 - a == 2.0
+    assert a * 2.0 == a
+    assert 2.0 * a == a


### PR DESCRIPTION
This is a common error I've seen several people make, especially when trying to use operators from netket.
So let's try to throw more informative errors now that we actually do support some jax operators:

to be merged after the previous PR

```python
In [1]: import netket as nk; g=nk.graph.Square(4); hi=nk.hilbert.Spin(0.5, g.n_nodes); import jax; import jax.numpy as jnp; import numpy as np

In [2]: ha=nk.operator.Ising(hi, graph=g, h=0.5)

In [3]: jax.jit(lambda x:ha.get_conn_padded(x))(ha.hilbert.all_states())
...
File ~/Dropbox/Ricerca/Codes/Python/netket/netket/errors.py:264, in concrete_or_error(force, value, error_class, *args, **kwargs)
    257     return jax.core.concrete_or_error(
    258         force,
    259         value,
    260         """
    261       """,
    262     )
    263 except ConcretizationTypeError as err:
--> 264     raise error_class(*args, **kwargs) from err

NumbaOperatorGetConnDuringTracingError:
Attempted to use a Numba-based operator (<class 'netket.operator._ising.numba.Ising'>) inside a Jax function transformation (jax.jit, jax.grad & others).

Numba-based operators are not compatible with Jax functiontransformations, and can only be used outside of jax-functionboundaries.

Some operators can be converted to a Jax-compatible version bycalling `operator.to_jax_operator()`, but not all support it.

-------------------------------------------------------
For more detailed informations, visit the following link:
	 https://netket.readthedocs.io/en/latest/api/_generated/errors/netket.errors.NumbaOperatorGetConnDuringTracingError.html
or the list of all common errors at
	 https://netket.readthedocs.io/en/latest/api/errors.html
-------------------------------------------------------
```