### PR TITLE
[experimental] Add initial support for jax multi-device and multi-process environments (part 2)

### DIFF
--- a/.github/workflows/CI_sharding.yml
+++ b/.github/workflows/CI_sharding.yml
@@ -37,7 +37,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install wheel
           pip install jaxlib
-          pip install -e ".[dev]"
+          pip install -e ".[dev,extra]"
 
       - name: run tests on 2 cpus
         run: |

--- a/.github/workflows/CI_sharding.yml
+++ b/.github/workflows/CI_sharding.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  pull_request:
+
+  push:
+    branches:
+      - master
+
+jobs:
+  test_sharding:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            python-version: "3.10"
+            runscript: "run_test_sharding.sh"
+
+          - os: ubuntu-latest
+            python-version: "3.10"
+            runscript: "run_standard_tests_with_sharding.sh"
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Pip install packages
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install wheel
+          pip install jaxlib
+          pip install -e ".[dev]"
+
+      - name: run tests on 2 cpus
+        run: |
+          ./test_sharding/"${{ matrix.runscript }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 ## NetKet 3.11 (⚙️ In development)
 
 ### New features
-* Added experimental support running netket on multiple jax devices (as an alternative to MPI). It is enabled by setting the environment variable/configuration flag `NETKET_EXPERIMENTAL_SHARDING=1`. Parallelization is achieved by distributing the Markov chains / samples equally across all available devices utilizing [`jax.Array` sharding](https://jax.readthedocs.io/en/latest/notebooks/Distributed_arrays_and_automatic_parallelization.html). On GPU multi-node setups are supported via [jax.distribued](https://jax.readthedocs.io/en/latest/multi_process.html), whereas on CPU it is limited to a single process but several threads can be used by setting `XLA_FLAGS='--xla_force_host_platform_device_count=XX'` [#1511](https://github.com/netket/netket/pull/1511).
+* Added experimental support for running NetKet on multiple jax devices (as an alternative to MPI). It is enabled by setting the environment variable/configuration flag `NETKET_EXPERIMENTAL_SHARDING=1`. Parallelization is achieved by distributing the Markov chains / samples equally across all available devices utilizing [`jax.Array` sharding](https://jax.readthedocs.io/en/latest/notebooks/Distributed_arrays_and_automatic_parallelization.html). On GPU multi-node setups are supported via [jax.distribued](https://jax.readthedocs.io/en/latest/multi_process.html), whereas on CPU it is limited to a single process but several threads can be used by setting `XLA_FLAGS='--xla_force_host_platform_device_count=XX'` [#1511](https://github.com/netket/netket/pull/1511).
 
 
 ## NetKet 3.10.1 (8 november 2023)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 
 ## NetKet 3.11 (⚙️ In development)
 
+### New features
+* Added experimental support running netket on multiple jax devices (as an alternative to MPI). It is enabled by setting the environment variable/configuration flag `NETKET_EXPERIMENTAL_SHARDING=1`. Parallelization is achieved by distributing the Markov chains / samples equally across all available devices utilizing [`jax.Array` sharding](https://jax.readthedocs.io/en/latest/notebooks/Distributed_arrays_and_automatic_parallelization.html). On GPU multi-node setups are supported via [jax.distribued](https://jax.readthedocs.io/en/latest/multi_process.html), whereas on CPU it is limited to a single process but several threads can be used by setting `XLA_FLAGS='--xla_force_host_platform_device_count=XX'` [#1511](https://github.com/netket/netket/pull/1511).
+
 
 ## NetKet 3.10.1 (8 november 2023)
 

--- a/docs/docs/configurations.md
+++ b/docs/docs/configurations.md
@@ -36,7 +36,7 @@ True
 
 Please note that not all configurations can be set at runtime, and some will raise an error.
 
-Options are used to activate experimental or debug functionalities or to disable some parts of netket. 
+Options are used to activate experimental or debug functionalities or to disable some parts of netket.
 Please keep in mind that all options related to experimental or internal functionalities might be removed in a future release.
 
 # List of configuration options
@@ -104,5 +104,14 @@ Please keep in mind that all options related to experimental or internal functio
   - True/**[False]**
   - no
   - Set to True when building documentation with Sphinx. Disables some decorators. This is for internal use only.
-  
+
+* - `NETKET_EXPERIMENTAL_SHARDING`
+  - True/**[False]**
+  - no
+  - Flag to turn on experimental support for multiple jax devices. When True, NetKet will distribute the markov chains/samples uniformly across all available jax devices and utilize them for computations.
+
+* - `NETKET_EXPERIMENTAL_SHARDING_CPU`
+  - integer
+  - no
+  - Convenience helper to set the flag `XLA_FLAGS='--xla_force_host_platform_device_count=XX', forcing jax to use multiple threads as separate cpu devices.
 `````

--- a/docs/docs/configurations.md
+++ b/docs/docs/configurations.md
@@ -114,4 +114,10 @@ Please keep in mind that all options related to experimental or internal functio
   - integer
   - no
   - Convenience helper to set the flag `XLA_FLAGS='--xla_force_host_platform_device_count=XX', forcing jax to use multiple threads as separate cpu devices.
+
+* - `NETKET_EXPERIMENTAL_SHARDING_NUMBA_WRAPPER_WARNING`
+  - **[True]**/False
+  - yes
+  - Raise a warning when the highly experimental wrapper for numba operators applied to sharded arrays is used.
+
 `````

--- a/docs/docs/sharp-bits.md
+++ b/docs/docs/sharp-bits.md
@@ -96,7 +96,7 @@ import netket as nk
 Then it can be conveniently launched with `srun` (on slurm clusters) or `mpirun`.
 For more details and manual setups we refer to the [jax documentation](https://jax.readthedocs.io/en/latest/multi_process.html).
 
-Note that jax internally uses the [grpc library](https://grpc.io) (essentially a rest api on a http server) to infer the cluster topology and the [nvidia nccl library](https://developer.nvidia.com/nccl) for communication between gpus. Thus it is required that `libnccl2` and `libnccl2-dev` are installed in addition to cuda.
+Note that jax internally uses the [grpc library](https://grpc.io) (launching a http server) for setup and book-keeping of the cluster and the [nvidia nccl library](https://developer.nvidia.com/nccl) for communication between gpus. Thus it is required that `libnccl2` and `libnccl2-dev` are installed in addition to cuda.
 Even if launched with mpirun, mpi is not actually used for communication, but the environment variables set by it are instead picked up by `jax.distributed.initialize`.
 
 If you run into communication errors you might want to set the environment variable `NCCL_DEBUG=INFO` for detailed error messages.

--- a/docs/docs/sharp-bits.md
+++ b/docs/docs/sharp-bits.md
@@ -73,8 +73,63 @@ Eventually we would like the selection to be automatic, but this has not yet bee
 
 Please open tickets if you find issues!
 
-(nan)=
+(jax_multi_process)=
+## Running on multi-gpu clusters with jax.distributed
+Historically the main way to run NetKet in parallel has been to use MPI. However, with jax adding shared arrays and collective operations on multiple devices/nodes (see [here](https://jax.readthedocs.io/en/latest/jax_array_migration.html#jax-array-migration) and [here](https://jax.readthedocs.io/en/latest/multi_process.html)) we adapted NetKet to support it.
+This feature is still experimental and can be enabled by setting the flag `NETKET_EXPERIMENTAL_SHARDING=1`.
 
+(jax_multi_process_setup)=
+### Setup
+To launch netket on a multi-node gpu cluster usually all that is required is to add a call to `jax.distributed.initialize()` at the top of the main script, e.g. as follows:
+
+```python
+import jax
+jax.distributed.initialize()
+
+import os
+os.environ['NETKET_EXPERIMENTAL_SHARDING'] = 1
+
+import netket as nk
+# ...
+```
+
+Then it can be conveniently launched with `srun` (on slurm clusters) or `mpirun`.
+For more details and manual setups we refer to the [jax documentation](https://jax.readthedocs.io/en/latest/multi_process.html).
+
+Note that jax internally uses the [grpc library](https://grpc.io) (essentially a rest api on a http server) to infer the cluster topology and the [nvidia nccl library](https://developer.nvidia.com/nccl) for communication between gpus. Thus it is required that `libnccl2` and `libnccl2-dev` are installed in addition to cuda.
+Even if launched with mpirun, mpi is not actually used for communication, but the environment variables set by it are instead picked up by `jax.distributed.initialize`.
+
+If you run into communication errors you might want to set the environment variable `NCCL_DEBUG=INFO` for detailed error messages.
+
+(grpc_proxy)=
+### GRPC incompatibility with http proxy wildcards
+We noticed that communication errors can arise when a http proxy is used on the cluster. Grpc will try to communicate with the other nodes via the proxy, whenever they are only excluded in the `no_proxy` variable via wildcards (e.g. `no_proxy=10.0.0.*`) which we found grpc cannot parse. To avoid this one needs to include all addresses explicitly.
+
+Alternatively, a simple way to work around it is to disable the proxy completely for jax by unsetting the respective environment variables (see [grpc docs](https://grpc.github.io/grpc/cpp/md_doc_environment_variables.html)) e.g. as follows:
+```python
+import os
+del os.environ['http_proxy']
+del os.environ['https_proxy']
+del os.environ['no_proxy']
+
+import jax
+jax.distributed.initialize()
+```
+
+(multi_device)=
+### Multiple devices per process
+In our testing it is best to use 1 process per gpu on the cluster.
+
+Nevertheless, if you want to use multiple gpus per process you can force jax to do so by setting `local_device_ids`, e.g. extracting it from `CUDA_VISIBLE_DEVICES` as follows:
+
+```python
+import os
+import jax
+ldi = list(map(int, os.environ.get('CUDA_VISIBLE_DEVICES').split(',')))
+jax.distributed.initialize(local_device_ids=ldi)
+```
+
+(nan)=
 ## NaNs in training and loss of precision
 
 If you find NaNs while training, especially if you are using your own model, there might be a few reasons:

--- a/docs/docs/sharp-bits.md
+++ b/docs/docs/sharp-bits.md
@@ -74,12 +74,18 @@ Eventually we would like the selection to be automatic, but this has not yet bee
 Please open tickets if you find issues!
 
 (jax_multi_process)=
-## Running on multi-gpu clusters with jax.distributed
+## Running on multi-gpu clusters
 Historically the main way to run NetKet in parallel has been to use MPI. However, with jax adding shared arrays and collective operations on multiple devices/nodes (see [here](https://jax.readthedocs.io/en/latest/jax_array_migration.html#jax-array-migration) and [here](https://jax.readthedocs.io/en/latest/multi_process.html)) we adapted NetKet to support it.
-This feature is still experimental and can be enabled by setting the flag `NETKET_EXPERIMENTAL_SHARDING=1`.
+To run on a single node with multiple gpus all that is necessary is to set the flag `NETKET_EXPERIMENTAL_SHARDING=1`.
+
+:::{warning}
+This feature is still experimental and not everything may work perfectly right out of the box.
+Any feedback, be it positive or negative, would be greatly appreciated.
+:::
+
 
 (jax_multi_process_setup)=
-### Setup
+### Multi-node setup with jax.distributed
 To launch netket on a multi-node gpu cluster usually all that is required is to add a call to `jax.distributed.initialize()` at the top of the main script, e.g. as follows:
 
 ```python

--- a/netket/driver/abstract_variational_driver.py
+++ b/netket/driver/abstract_variational_driver.py
@@ -59,7 +59,7 @@ class AbstractVariationalDriver(abc.ABC):
 
     def __init__(self, variational_state, optimizer, minimized_quantity_name=""):
         self._mynode = mpi.node_number
-        self._is_root = self._mynode == 0
+        self._is_root = self._mynode == 0 and jax.process_index() == 0
         self._mpi_nodes = mpi.n_nodes
         self._loss_stats = None
         self._loss_name = minimized_quantity_name

--- a/netket/experimental/dynamics/_rk_solver_structures.py
+++ b/netket/experimental/dynamics/_rk_solver_structures.py
@@ -42,7 +42,9 @@ def maybe_jax_jit(fun, *jit_args, **jit_kwargs):
     @wraps(fun)
     def _maybe_jitted_fun(*args, **kwargs):
         if config.netket_experimental_disable_ode_jit:
-            return fun(*args, **kwargs)
+            with jax.spmd_mode("allow_all"):
+                res = fun(*args, **kwargs)
+            return res
         else:
             return jitted_fun(*args, **kwargs)
 

--- a/netket/experimental/logging/hdf5_log.py
+++ b/netket/experimental/logging/hdf5_log.py
@@ -17,6 +17,8 @@ import numpy as np
 from flax.serialization import to_bytes
 from flax.core import pop as fpop, FrozenDict
 
+from netket import config
+
 _mode_shorthands = {"write": "w", "append": "a", "fail": "x"}
 
 

--- a/netket/experimental/logging/hdf5_log.py
+++ b/netket/experimental/logging/hdf5_log.py
@@ -17,8 +17,6 @@ import numpy as np
 from flax.serialization import to_bytes
 from flax.core import pop as fpop, FrozenDict
 
-from netket import config
-
 _mode_shorthands = {"write": "w", "append": "a", "fail": "x"}
 
 

--- a/netket/jax/__init__.py
+++ b/netket/jax/__init__.py
@@ -58,6 +58,9 @@ from ._math import logsumexp_cplx, logdet_cmplx
 
 from ._jacobian import jacobian, jacobian_default_mode
 
+# internal sharding utilities
+from . import sharding
+
 from netket.utils import _hide_submodules
 
 _hide_submodules(__name__)

--- a/netket/jax/_vjp_chunked.py
+++ b/netket/jax/_vjp_chunked.py
@@ -162,6 +162,9 @@ def vjp_chunked(
 ):
     """calculate the vjp in small chunks for a function where the leading dimension of the output only depends on the leading dimension of some of the arguments
 
+    .. note::
+        If experimental sharing is activated, the chunk_argnums are assumed to be sharded (not replicated) among devices.
+
     Args:
         fun: Function to be differentiated. It must accept chunks of size chunk_size of the primals in chunk_argnums.
         primals:  A sequence of primal values at which the Jacobian of ``fun`` should be evaluated.
@@ -180,6 +183,7 @@ def vjp_chunked(
         a function corresponding to the vjp_fun returned by an equivalent ``jax.vjp(fun, *primals)[1]``` call
         which computes the vjp in chunks (recomputing the forward pass every time on subsequent calls).
         If return_forward=True the vjp_fun returned returns a tuple containing the output of the forward pass and the vjp.
+
 
     Example:
         >>> import jax

--- a/netket/jax/_vjp_chunked.py
+++ b/netket/jax/_vjp_chunked.py
@@ -10,6 +10,8 @@ from netket.jax import (
     vjp as nkvjp,
 )
 from netket.utils import HashablePartial
+from netket.utils import config
+from netket.jax.sharding import sharding_decorator
 
 from ._scanmap import _multimap
 from ._chunk_utils import _chunk as _tree_chunk, _unchunk as _tree_unchunk
@@ -227,6 +229,57 @@ def vjp_chunked(
 
     if chunk_argnums == ():
         chunk_size = None
+
+    ############################################################################
+    # sharding
+
+    if config.netket_experimental_sharding and chunk_size is not None:
+        if return_forward:
+            raise NotImplementedError
+
+        # assume the chunk_argnums are also sharded
+        # later we might introduce an extra arg for it
+        sharded_argnums = chunk_argnums
+        sharded_args = tuple(i in sharded_argnums for i in range(len(primals)))
+
+        # for the output we need to consult nondiff_argnums, which are removed
+        non_sharded_argnums = tuple(
+            set(range(len(primals))).difference(sharded_argnums)
+        )
+        out_args = _gen_append_cond_vjp(primals, nondiff_argnums, non_sharded_argnums)
+        red_ops = tuple(jax.lax.psum if c else False for c in out_args)
+
+        # check the chunk_size is not larger than the shard per device
+        chunk_size = sharding_decorator(
+            partial(check_chunk_size, chunk_argnums, chunk_size),
+            sharded_args_tree=sharded_args,
+            reduction_op_tree=True,
+        )(*primals)
+
+        if chunk_size is not None:
+            _vjpc = _vjp_chunked(
+                fun,
+                has_aux=has_aux,
+                chunk_argnums=chunk_argnums,
+                chunk_size=chunk_size,
+                nondiff_argnums=nondiff_argnums,
+                return_forward=return_forward,
+                conjugate=conjugate,
+            )
+            vjp_fun_sh = Partial(
+                sharding_decorator(
+                    _vjpc,
+                    sharded_args_tree=(sharded_args, True),
+                    reduction_op_tree=red_ops,
+                ),
+                primals,
+            )
+            return vjp_fun_sh
+        else:
+            pass  # no chunking, continue below
+
+    ############################################################################
+    # no sharding (or sharded, but not chunking)
 
     # check the chunk_size is not larger than the arrays
     chunk_size = check_chunk_size(chunk_argnums, chunk_size, *primals)

--- a/netket/jax/_vmap_chunked.py
+++ b/netket/jax/_vmap_chunked.py
@@ -11,7 +11,7 @@ from netket.utils import config
 from netket.jax.sharding import sharding_decorator
 
 
-def _fun(vmapped_fun, chunk_size, argnums, *args, **kwargs):
+def _eval_fun_in_chunks(vmapped_fun, chunk_size, argnums, *args, **kwargs):
     n_elements = jax.tree_util.tree_leaves(args[argnums[0]])[0].shape[0]
     n_chunks, n_rest = divmod(n_elements, chunk_size)
 
@@ -45,9 +45,11 @@ def _fun(vmapped_fun, chunk_size, argnums, *args, **kwargs):
     return y
 
 
-def _fun_sharding(vmapped_fun, chunk_size, argnums, *args, **kwargs):
+def _eval_fun_in_chunks_sharding(vmapped_fun, chunk_size, argnums, *args, **kwargs):
+    # Equivalent to `_eval_fun_in_chunks` above but preserves sharding,
+    # by computing the vmapped_fun in chunks on every shard (which sits on a separate device)
     sharded_args_tree = tuple(i in argnums for i, a in enumerate(args))
-    f = HashablePartial(_fun, vmapped_fun, chunk_size, argnums, **kwargs)
+    f = HashablePartial(_eval_fun_in_chunks, vmapped_fun, chunk_size, argnums, **kwargs)
     return sharding_decorator(f, sharded_args_tree)(*args)
 
 
@@ -65,9 +67,11 @@ def _chunk_vmapped_function(
     if isinstance(argnums, int):
         argnums = (argnums,)
     if axis_0_is_sharded:
-        return HashablePartial(_fun_sharding, vmapped_fun, chunk_size, argnums)
+        return HashablePartial(
+            _eval_fun_in_chunks_sharding, vmapped_fun, chunk_size, argnums
+        )
     else:
-        return HashablePartial(_fun, vmapped_fun, chunk_size, argnums)
+        return HashablePartial(_eval_fun_in_chunks, vmapped_fun, chunk_size, argnums)
 
 
 def _parse_in_axes(in_axes):
@@ -109,6 +113,10 @@ def apply_chunked(
 
         f = jax.vmap(f_orig)
 
+    .. note::
+        If netket_experimental_sharding is enabled, this function assumes that chunked in_axes are sharded by default.
+        This can be overridden by specifying axis_0_is_sharded=False.
+
     Args:
         f: A function that satisfies the condition above
         in_axes: The axes that should be scanned along. Only supports `0` or `None`
@@ -140,6 +148,10 @@ def vmap_chunked(
         nk.jax.apply_chunked(jax.vmap(f, in_axes), in_axes, chunk_size)
 
     Some limitations to `in_axes` apply.
+
+    .. note::
+        If netket_experimental_sharding is enabled, this function assumes that chunked in_axes are sharded by default.
+        This can be overridden by specifying axis_0_is_sharded=False.
 
     Args:
         f: The function to be vectorised.

--- a/netket/jax/sharding.py
+++ b/netket/jax/sharding.py
@@ -29,7 +29,6 @@ from jax.tree_util import Partial
 from jax.sharding import Mesh, PartitionSpec as P, PositionalSharding
 from jax.experimental.shard_map import shard_map
 
-from netket.jax import HashablePartial
 from netket.utils import config
 from netket.errors import concrete_or_error, NumbaOperatorGetConnDuringTracingError
 

--- a/netket/jax/sharding.py
+++ b/netket/jax/sharding.py
@@ -1,0 +1,195 @@
+import math
+from functools import partial, wraps
+
+import jax
+import jax.numpy as jnp
+from jax.tree_util import Partial
+from jax.sharding import Mesh, PartitionSpec as P
+from jax.experimental.shard_map import shard_map
+
+from netket.utils import config
+
+
+def replicate_sharding(f):
+    """
+    Wrapper for python get_conn_padded to make it work with shared/global device arrays.
+    Not yet implemented, raises NotImplementedError
+
+    Args:
+        f: a python get_conn_padded (which takes self, x and maps it to (xp,mels))
+    """
+    if config.netket_experimental_sharding:
+        def _f(*args, **kwargs):
+            raise NotImplementedError(
+            "Numba operators are not yet supported with netket_experimental_sharding. Please rewrite your operator in jax."
+            )
+        return _f
+    else:
+        return f
+
+_identity = lambda x: x
+
+
+def _prepare_mask(n, n_pad):
+    return jnp.ones(n + n_pad, dtype=bool).at[-n_pad:].set(0)
+
+
+def put_global(inp_data, axis=0, pad=False, pad_value=None):
+    """
+    distribute a local array equally along an axis to all (local and global) devices
+    The size of the axis needs to be divisible by the number of devices.
+    each process needs to have the whole array (parts not belonging to it can be filled with garbage)
+
+    Args:
+        inp_data: the full array (on every process)
+        axis: (optional) axis alogn which to distribute
+
+    Returns:
+        a distributed jax.Array
+    """
+    if pad:
+        n = inp_data.shape[0]
+        # pad to the next multiple of device_count
+        device_count = jax.device_count()
+        n_pad = math.ceil(inp_data.shape[0] / device_count) * device_count - n
+        inp_data = jnp.pad(inp_data, ((0, n_pad), (0, 0)))
+        if pad_value is not None and n_pad > 0:
+            inp_data = inp_data.at[-n_pad:].set(pad_value)
+
+    shape = [
+        1,
+    ] * inp_data.ndim
+    shape[axis] = -1
+    sharding = jax.sharding.PositionalSharding(jax.devices()).reshape(shape)
+    out_data = jax.jit(_identity, out_shardings=sharding)(inp_data)
+    if pad:
+        if n_pad > 0:
+            mask = jax.jit(
+                _prepare_mask, out_shardings=sharding.reshape(-1), static_argnums=(0, 1)
+            )(n, n_pad)
+        else:
+            mask = None
+        return out_data, mask
+    else:
+        return out_data
+
+
+def extract_replicated(t):
+    """
+    Extract the value of a fully replicated global device array.
+
+    Args:
+        t: a jax Array (or a pytree of jax Arrays)
+
+    Returns:
+        A locally adressable representation of t
+    """
+
+    def _extract_replicated(x):
+        if isinstance(x, jax.Array) and not x.is_fully_addressable:
+            assert x.is_fully_replicated
+            return x.addressable_data(0)
+        else:
+            return x
+
+    return jax.tree_map(_extract_replicated, t)
+
+
+def gather(x):
+    """
+    make a sharded array fully replicated by gathering all parts on every device
+    """
+    return jax.jit(_identity, out_shardings=x.sharding.replicate())(x)
+
+
+def broadcast(x):
+    """
+    broadcast an array to all devices. Input on different processes is assumed to be the same
+    """
+    return jax.jit(
+        _identity,
+        out_shardings=jax.sharding.PositionalSharding(jax.devices())
+        .replicate()
+        .reshape((1,) * x.ndim),
+    )(x)
+
+
+def sharding_decorator(f, sharded_args_tree, reduction_op_tree=False):
+    """
+    A decorator which wraps a function so that it is evaluated on every shard of the distributed arguments,
+    and the output is either returned sharded, or reduced with a collective operation.
+
+    Does nothing unless config.netket_experimental_sharding=True.
+    Intended for netket internal use only, interface might change in the future depending on requirements.
+
+    Args:
+        f: a function
+        sharded_args_tree: a tuple/pyrtree of True/False indicating that the input is:
+            True: sharded on axis 0 (True)
+            False: assumed to be replicated
+            the args of f are flattened according to sharded_args_tree, so if an arg is a pytree it is assumed the whole tree
+        reduction_op_tree: a tuple/pyrtree of reduction_op, where for each output:
+            reduction_op is e.g. jax.lax.psum if it is to be reduced, then f_wrapped returns a replicated array
+            reduction op is False if it is not to be reduced, then f_wrapped returns a sharded array
+            reduction op is True if it is not an array/pytree, then it is returned as python object
+
+    Returns :
+        f_wrapped: wrapped version of f
+    """
+
+    if config.netket_experimental_sharding:
+        sharded_args, args_treedef = jax.tree_util.tree_flatten(sharded_args_tree)
+        reduction_op, out_treedef = jax.tree_util.tree_flatten(reduction_op_tree)
+
+        @wraps(f)
+        def _fun(*args):
+            args = args_treedef.flatten_up_to(args)
+
+            _sele = lambda cond, xs: tuple(x for c, x in zip(cond, xs) if c)
+            _not = lambda t: tuple(not x for x in t)
+            _sele2 = lambda cond, x, y: tuple(x if c else y for c in cond)
+
+            # workaround for shard_map not supporting non-array args part 1/2
+            nonarray_args = tuple(not hasattr(a, "dtype") for a in args)
+            args = tuple(
+                Partial(partial(lambda x: x, a)) if c else a
+                for a, c in zip(args, nonarray_args)
+            )
+
+            mesh = Mesh(jax.devices(), axis_names=("i"))
+            in_specs = _sele2(sharded_args, P("i"), P())
+            out_specs = out_treedef.unflatten(_sele2(reduction_op, P(), P("i")))
+
+            @partial(shard_map, mesh=mesh, in_specs=in_specs, out_specs=out_specs)
+            def _f(*args):
+                # workaround for shard_map not supporting non-array args part 2/2
+                args = tuple(a() if c else a for a, c in zip(args, nonarray_args))
+
+                res = f(*args_treedef.unflatten(args))
+
+                # apply reductions
+                # _id = lambda x: x
+                # _wrap = lambda x: Partial(lambda : x)
+                def _sele_op(o):
+                    if o is False:
+                        return lambda x: x
+                    if o is True:
+                        return lambda x: Partial(partial(lambda x: x, x))
+                    else:
+                        return partial(jax.tree_map, partial(o, axis_name="i"))
+
+                reductions = [_sele_op(o) for o in reduction_op]
+                res = out_treedef.flatten_up_to(res)
+                res = [f(r) for f, r in zip(reductions, res)]
+                res = out_treedef.unflatten(res)
+                return res
+
+            res = _f(*args)
+            res = out_treedef.flatten_up_to(res)
+            res = [a() if c is True else a for a, c in zip(res, reduction_op)]
+            res = out_treedef.unflatten(res)
+            return res
+
+        return _fun
+
+    return f

--- a/netket/logging/json_log.py
+++ b/netket/logging/json_log.py
@@ -19,6 +19,8 @@ from os import path as _path
 
 from flax import serialization
 
+from netket.jax.sharding import extract_replicated
+
 from .runtime_log import RuntimeLog
 
 
@@ -173,7 +175,9 @@ class JsonLog(RuntimeLog):
 
         _time = time.time()
 
-        binary_data = serialization.to_bytes(variational_state.variables)
+        binary_data = serialization.to_bytes(
+            extract_replicated(variational_state.variables)
+        )
         with open(self._prefix + ".mpack", "wb") as outfile:
             outfile.write(binary_data)
 

--- a/netket/logging/state_log.py
+++ b/netket/logging/state_log.py
@@ -22,6 +22,8 @@ from os import path as _path
 
 from flax import serialization
 
+from netket.jax.sharding import extract_replicated
+
 
 def save_binary_to_tar(tar_file, byte_data, name):
     abuf = BytesIO(byte_data)
@@ -165,7 +167,9 @@ class StateLog:
             self._init_output()
 
         _time = time.time()
-        binary_data = serialization.to_bytes(variational_state.variables)
+        binary_data = serialization.to_bytes(
+            extract_replicated(variational_state.variables)
+        )
         if self._tar:
             save_binary_to_tar(
                 self._tar_file, binary_data, str(self._file_step) + ".mpack"

--- a/netket/nn/utils.py
+++ b/netket/nn/utils.py
@@ -25,6 +25,9 @@ from netket.utils import get_afun_if_module, mpi
 from netket.utils.types import Array, PyTree
 from netket.hilbert import DiscreteHilbert
 
+from netket.utils import config
+from netket.jax.sharding import extract_replicated, gather, put_global
+
 from flax.traverse_util import flatten_dict, unflatten_dict
 from flax.core import unfreeze
 
@@ -36,6 +39,8 @@ def split_array_mpi(array: Array) -> Array:
     identical on all ranks.
     !!! Warn
          The output is a numpy array.
+    !!! Warn
+         This should not be used with sharding (netket.netket_experimental_sharding=True)
     Args:
          array: A nd-array
 
@@ -74,13 +79,23 @@ def to_array(
         chunk_size: Optional integer to specify the largest chunks of samples that
             the model will be evaluated upon. By default it is `None`, and when specified
             samples are split into chunks of at most `chunk_size`.
+
+    When running with netket_experimental_sharding=True:
+      If allgather=True, the final wave function is fully replicated array
+      If allgather=False, the final wave function is a sharded array,
+                          padded with zeros to the next multiple of the number of devices
     """
     if not hilbert.is_indexable:
         raise RuntimeError("The hilbert space is not indexable")
 
     apply_fun = get_afun_if_module(apply_fun)
 
-    if mpi.n_nodes == 1:
+    if config.netket_experimental_sharding:
+        # for now assume no mpi (no hybrid)
+        x = hilbert.all_states()
+        xs, mask = put_global(x, pad=True, pad_value=x[0])
+        n_states = xs.shape[0]
+    elif mpi.n_nodes == 1:
         xs = hilbert.all_states()
         mask = None
         n_states = xs.shape[0]
@@ -109,6 +124,14 @@ def to_array(
         chunk_size,
         mask,
     )
+    if allgather and config.netket_experimental_sharding:
+        # for simplicity we gather here outside of jit
+        # alternatively we could use a sharding constraint in _to_array_rank
+        psi = gather(psi)
+        # make it a local numpy array, so that we can operate with e.g.
+        # a sparse scipy array on it and jax thinks its replicated next time we pass it to jit
+        psi = np.asarray(extract_replicated(psi))
+        psi = psi[: hilbert.n_states]
     return psi
 
 

--- a/netket/operator/_discrete_operator.py
+++ b/netket/operator/_discrete_operator.py
@@ -21,6 +21,7 @@ from scipy.sparse import csr_matrix as _csr_matrix
 from netket.hilbert import DiscreteHilbert
 from netket.operator import AbstractOperator
 from netket.utils.optional_deps import import_optional_dependency
+from netket.jax.sharding import replicate_sharding
 
 
 class DiscreteOperator(AbstractOperator):
@@ -43,6 +44,7 @@ class DiscreteOperator(AbstractOperator):
         """The maximum number of non zero ⟨x|O|x'⟩ for every x."""
         raise NotImplementedError
 
+    @replicate_sharding
     def get_conn_padded(self, x: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
         r"""Finds the connected elements of the Operator.
 

--- a/netket/operator/_discrete_operator.py
+++ b/netket/operator/_discrete_operator.py
@@ -21,7 +21,7 @@ from scipy.sparse import csr_matrix as _csr_matrix
 from netket.hilbert import DiscreteHilbert
 from netket.operator import AbstractOperator
 from netket.utils.optional_deps import import_optional_dependency
-from netket.jax.sharding import replicate_sharding
+from netket.jax.sharding import replicate_sharding_decorator_for_get_conn_padded
 
 
 class DiscreteOperator(AbstractOperator):
@@ -44,7 +44,7 @@ class DiscreteOperator(AbstractOperator):
         """The maximum number of non zero ⟨x|O|x'⟩ for every x."""
         raise NotImplementedError
 
-    @replicate_sharding
+    @replicate_sharding_decorator_for_get_conn_padded
     def get_conn_padded(self, x: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
         r"""Finds the connected elements of the Operator.
 

--- a/netket/sampler/autoreg.py
+++ b/netket/sampler/autoreg.py
@@ -23,6 +23,7 @@ from netket.sampler import Sampler, SamplerState
 from netket.utils import struct
 from netket.utils.deprecation import warn_deprecation
 from netket.utils.types import PRNGKeyT
+from netket.utils import mpi
 from netket import config
 
 
@@ -65,7 +66,9 @@ class ARDirectSampler(Sampler):
             warn_deprecation(
                 "Specifying `n_chains` or `n_chains_per_rank` when constructing exact samplers is deprecated."
             )
-        kwargs["n_chains_per_rank"] = 1
+            kwargs.pop("n_chains_per_rank")
+            kwargs.pop("n_chains")
+        kwargs["n_chains"] = mpi.n_nodes
         return super().__pre_init__(*args, **kwargs)
 
     def __post_init__(self):

--- a/netket/sampler/autoreg.py
+++ b/netket/sampler/autoreg.py
@@ -22,6 +22,7 @@ from netket.sampler import Sampler, SamplerState
 from netket.utils import struct
 from netket.utils.deprecation import warn_deprecation
 from netket.utils.types import PRNGKeyT
+from netket import config
 
 
 @struct.dataclass
@@ -140,6 +141,11 @@ class ARDirectSampler(Sampler):
             (sampler.n_chains_per_rank * chain_length, sampler.hilbert.size),
             dtype=sampler.dtype,
         )
+
+        if config.netket_experimental_sharding:
+            σ = jax.lax.with_sharding_constraint(
+                σ, jax.sharding.PositionalSharding(jax.devices()).reshape(-1, 1)
+            )
 
         # Initialize `cache` before generating each sample,
         # even if `variables` is not changed and `reset` is not called

--- a/netket/sampler/autoreg.py
+++ b/netket/sampler/autoreg.py
@@ -64,7 +64,7 @@ class ARDirectSampler(Sampler):
             warn_deprecation(
                 "Specifying `n_chains` or `n_chains_per_rank` when constructing exact samplers is deprecated."
             )
-
+        kwargs["n_chains_per_rank"] = 1
         return super().__pre_init__(*args, **kwargs)
 
     def __post_init__(self):

--- a/netket/sampler/base.py
+++ b/netket/sampler/base.py
@@ -115,7 +115,7 @@ class Sampler(abc.ABC):
 
         # this does nothing if n_chains_per_rank is not None and n_chains is None
         kwargs["n_chains_per_rank"] = _compute_n_chains_per(
-            kwargs.pop("n_chains", None),
+            n_chains,
             kwargs.pop("n_chains_per_rank", None),
             mpi.n_nodes,
             "rank",

--- a/netket/sampler/base.py
+++ b/netket/sampler/base.py
@@ -98,7 +98,7 @@ class Sampler(abc.ABC):
         return (hilbert,), kwargs
 
     def __post_init__(self):
-        # Raise error if n_chains is a multiple of the number of mpi ranks
+        # Raise error if n_chains is not a multiple of the number of mpi ranks
         self.n_chains_per_rank
 
         # Raise errors if hilbert is not an Hilbert

--- a/netket/sampler/exact.py
+++ b/netket/sampler/exact.py
@@ -23,6 +23,7 @@ from netket.nn import to_array
 from netket.utils import struct
 from netket.utils.deprecation import warn_deprecation
 from netket.utils.types import PyTree, SeedT
+from netket.utils import mpi
 from netket import config
 
 from .base import Sampler, SamplerState
@@ -62,7 +63,9 @@ class ExactSampler(Sampler):
             warn_deprecation(
                 "Specifying `n_chains` or `n_chains_per_rank` when constructing exact samplers is deprecated."
             )
-        kwargs["n_chains_per_rank"] = 1
+            kwargs.pop("n_chains_per_rank")
+            kwargs.pop("n_chains")
+        kwargs["n_chains"] = mpi.n_nodes
         return super().__pre_init__(*args, **kwargs)
 
     @property

--- a/netket/sampler/exact.py
+++ b/netket/sampler/exact.py
@@ -62,7 +62,7 @@ class ExactSampler(Sampler):
             warn_deprecation(
                 "Specifying `n_chains` or `n_chains_per_rank` when constructing exact samplers is deprecated."
             )
-
+        kwargs["n_chains_per_rank"] = 1
         return super().__pre_init__(*args, **kwargs)
 
     @property
@@ -130,7 +130,8 @@ class ExactSampler(Sampler):
         # TODO run the part above in parallel
         if config.netket_experimental_sharding:
             samples = jax.lax.with_sharding_constraint(
-                samples, jax.sharding.PositionalSharding(jax.devices()).reshape(1, -1, 1)
+                samples,
+                jax.sharding.PositionalSharding(jax.devices()).reshape(1, -1, 1),
             )
 
         return samples, state.replace(rng=new_rng)

--- a/netket/sampler/metropolis.py
+++ b/netket/sampler/metropolis.py
@@ -16,6 +16,8 @@ from functools import partial
 from typing import Any, Callable, Optional, Union
 from textwrap import dedent
 
+import numpy as np
+
 import jax
 from flax import linen as nn
 from jax import numpy as jnp
@@ -138,6 +140,36 @@ def _assert_good_log_prob_shape(log_prob, n_chains_per_rank, machine):
         )
 
 
+def _compute_n_chains_per(
+    n_chains, n_chains_per_whatever, n_whatever, whatever_str, default
+):
+    # small helper function to round the number of chains to the next multiple of [whatever]
+    # here [whatever] can be e.g. mpi ranks or jax devices
+    if n_chains is None and n_chains_per_whatever is None:
+        n_chains_per_whatever = default
+    elif n_chains is not None and n_chains_per_whatever is not None:
+        raise ValueError(
+            f"Cannot specify both `n_chains` and `n_chains_per_{whatever_str}`"
+        )
+    elif n_chains is not None:
+        n_chains_per_whatever = max(int(np.ceil(n_chains / n_whatever)), 1)
+        if n_chains_per_whatever * n_whatever != n_chains:
+            if mpi.rank == 0:
+                import warnings
+
+                warnings.warn(
+                    f"Using {n_chains_per_whatever} chains per {whatever_str} among {n_whatever} {whatever_str}s "
+                    f"(total={n_chains_per_whatever * n_whatever} instead of n_chains={n_chains}). "
+                    f"To directly control the number of chains on every {whatever_str}, specify "
+                    f"`n_chains_per_{whatever_str}` when constructing the sampler. "
+                    f"To silence this warning, either use `n_chains_per_{whatever_str}` or use `n_chains` "
+                    f"that is a multiple of the number of {whatever_str}s",
+                    category=UserWarning,
+                    stacklevel=2,
+                )
+    return n_chains_per_whatever
+
+
 @struct.dataclass
 class MetropolisSampler(Sampler):
     r"""
@@ -156,7 +188,8 @@ class MetropolisSampler(Sampler):
 
     The dtype of the sampled states can be chosen.
     """
-
+    n_chains_per_rank: int = struct.field(pytree_node=False, default=None, repr=False)
+    """Number of independent chains on every MPI rank."""
     rule: MetropolisRule = None
     """The Metropolis transition rule."""
     n_sweeps: int = struct.field(pytree_node=False, default=None)
@@ -179,6 +212,7 @@ class MetropolisSampler(Sampler):
                 `n_chains/mpi.n_nodes` chains. In general, we recommend specifying `n_chains_per_rank`
                 as it is more portable.
             n_chains_per_rank: Number of independent chains on every MPI rank (default = 16).
+            n_chains_per_device: Number of independent chains on every jax device (default = 16).
             n_sweeps: Number of sweeps for each step along the chain.
                 This is equivalent to subsampling the Markov chain. (Defaults to the number of sites
                 in the Hilbert space.)
@@ -188,6 +222,7 @@ class MetropolisSampler(Sampler):
                 the pdf (default = 2).
             dtype: The dtype of the states sampled (default = np.float64).
         """
+
         # Validate the inputs
         if not isinstance(rule, MetropolisRule):
             raise TypeError(
@@ -195,14 +230,32 @@ class MetropolisSampler(Sampler):
                 f"`type(rule)={type(rule)}`."
             )
 
-        if "n_chains" not in kwargs and "n_chains_per_rank" not in kwargs:
-            kwargs["n_chains_per_rank"] = 16
+        n_chains = kwargs.pop("n_chains", None)
+        n_chains_per_rank = kwargs.pop("n_chains_per_rank", None)
+        n_chains_per_device = kwargs.pop("n_chains_per_device", None)
+
+        if config.netket_experimental_sharding:
+            # here we ignore n_chains_per_rank; TODO raise warning if it is passed?
+            n_devices = jax.device_count()
+            # TODO use more default chains if on gpu?
+            n_chains_per_device = _compute_n_chains_per(
+                n_chains, n_chains_per_device, n_devices, "device", 16
+            )
+            # per definition there is only one MPI rank when we are sharded (and use no mpi),
+            # so this is just the total number of chains
+            kwargs["n_chains_per_rank"] = n_chains_per_device * n_devices
+        else:  # MPI
+            # here we ignore n_chains_per_device; TODO raise warning if it is passed?
+            n_nodes = mpi.n_nodes
+            # TODO use more default chains if on gpu?
+            n_chains_per_rank = _compute_n_chains_per(
+                n_chains, n_chains_per_rank, n_nodes, "rank", 16
+            )
+            kwargs["n_chains_per_rank"] = n_chains_per_rank
 
         # process arguments in the base
         args, kwargs = super().__pre_init__(hilbert=hilbert, **kwargs)
-
         kwargs["rule"] = rule
-
         return args, kwargs
 
     def __post_init__(self):

--- a/netket/sampler/metropolis.py
+++ b/netket/sampler/metropolis.py
@@ -291,7 +291,7 @@ class MetropolisSampler(Sampler):
             n_chains,
             n_chains_per_rank_or_device,
             n_ranks_or_devices,
-            "device_or_rank",
+            "rank_or_device",
             default_n_chains_per_rank_or_device,
         )
 

--- a/netket/stats/mc_stats.py
+++ b/netket/stats/mc_stats.py
@@ -20,6 +20,7 @@ import numpy as np
 from jax import numpy as jnp
 
 from netket.utils import config, mpi, struct
+from netket.jax.sharding import extract_replicated
 
 from . import mean as _mean
 from . import var as _var
@@ -110,6 +111,8 @@ class Stats:
         return "Mean", self.to_dict()
 
     def __repr__(self):
+        # extract adressable data from fully replicated arrays
+        self = extract_replicated(self)
         mean, err, var = _format_decimal(self.mean, self.error_of_mean, self.variance)
         if not math.isnan(self.R_hat):
             ext = f", R̂={self.R_hat:.4f}"

--- a/netket/utils/_dependencies_check.py
+++ b/netket/utils/_dependencies_check.py
@@ -20,6 +20,8 @@ silently or unexpectedly.
 
 from textwrap import dedent
 
+from .config_flags import config
+
 from .version_check import module_version, version_string
 
 
@@ -53,6 +55,16 @@ def create_msg(pkg_name, cur_version, desired_version, extra_msg="", pip_pkg_nam
 if not module_version("jax") >= (0, 4, 3):  # pragma: no cover
     cur_version = version_string("jax")
     raise ImportError(create_msg("jax", cur_version, "0.4.3"))
+
+if config.netket_experimental_sharding:
+    if not module_version("jax") >= (0, 4, 16):  # pragma: no cover
+        cur_version = version_string("jax")
+        extra = """Reason: The experimental sharding mode requires a very
+                   recent jax version. Please update to at least 0.4.16
+                   """
+
+        raise ImportError(create_msg("jax", cur_version, "0.4.16", extra))
+
 
 if not module_version("optax") >= (0, 1, 3):  # pragma: no cover
     cur_version = version_string("optax")

--- a/netket/utils/config_flags.py
+++ b/netket/utils/config_flags.py
@@ -342,3 +342,17 @@ config.define(
     runtime=False,
     callback=_setup_experimental_sharding_cpu,
 )
+
+
+config.define(
+    "NETKET_EXPERIMENTAL_SHARDING_NUMBA_WRAPPER_WARNING",
+    bool,
+    default=True,
+    help=dedent(
+        """
+        Raise a warning when the highly experimental wrapper for numba operators
+        acting on sharded arrays is used.
+        """
+    ),
+    runtime=True,
+)

--- a/netket/utils/mpi/mpi.py
+++ b/netket/utils/mpi/mpi.py
@@ -24,7 +24,7 @@ _mpi4jax_loaded = False
 mpi4jax_available = False
 
 try:
-    if not config.netket_mpi:  # pragma: no cover
+    if not config.netket_mpi or config.netket_experimental_sharding:  # pragma: no cover
         # if mpi is disabled trigger import error
         # and follow the no-mpi code path
         raise ImportError

--- a/netket/vqs/mc/mc_mixed_state/state.py
+++ b/netket/vqs/mc/mc_mixed_state/state.py
@@ -26,6 +26,8 @@ from netket.stats import Stats
 from netket.utils.types import PyTree
 from netket.operator import AbstractOperator
 
+from netket.jax.sharding import extract_replicated
+
 from netket.vqs import VariationalMixedState
 
 from netket.vqs.mc import MCState
@@ -245,7 +247,7 @@ class MCMixedState(VariationalMixedState, MCState):
 
 def serialize_MCMixedState(vstate):
     state_dict = {
-        "variables": serialization.to_state_dict(vstate.variables),
+        "variables": serialization.to_state_dict(extract_replicated(vstate.variables)),
         "sampler_state": serialization.to_state_dict(vstate._sampler_state_previous),
         "diagonal": serialization.to_state_dict(vstate.diagonal),
         "n_samples": vstate.n_samples,
@@ -272,6 +274,7 @@ def deserialize_MCMixedState(vstate, state_dict):
     new_vstate.sampler_state = serialization.from_state_dict(
         vstate.sampler_state, state_dict["sampler_state"]
     )
+
     new_vstate.n_samples = state_dict["n_samples"]
     new_vstate.n_discard_per_chain = state_dict["n_discard_per_chain"]
     new_vstate.chunk_size = state_dict["chunk_size"]

--- a/netket/vqs/mc/mc_state/state.py
+++ b/netket/vqs/mc/mc_state/state.py
@@ -40,6 +40,8 @@ from netket.utils.types import PyTree, SeedT, NNInitFunc
 from netket.optimizer import LinearOperator
 from netket.optimizer.qgt import QGTAuto
 
+from netket.jax.sharding import extract_replicated
+
 from netket.vqs.base import VariationalState, expect, expect_and_grad, expect_and_forces
 from netket.vqs.mc import get_local_kernel, get_local_kernel_arguments
 
@@ -746,7 +748,7 @@ def local_estimators(
 # serialization
 def serialize_MCState(vstate):
     state_dict = {
-        "variables": serialization.to_state_dict(vstate.variables),
+        "variables": serialization.to_state_dict(extract_replicated(vstate.variables)),
         "sampler_state": serialization.to_state_dict(vstate._sampler_state_previous),
         "n_samples": vstate.n_samples,
         "n_discard_per_chain": vstate.n_discard_per_chain,

--- a/netket/vqs/mc/mc_state/state.py
+++ b/netket/vqs/mc/mc_state/state.py
@@ -730,7 +730,8 @@ def local_estimators(
 
     shape = s.shape
     if jnp.ndim(s) != 2:
-        s = s.reshape((-1, shape[-1]))
+        # jit for gda
+        s = jax.jit(jax.lax.collapse, static_argnums=(1, 2))(s, 0, s.ndim - 1)
 
     if chunk_size is None:
         chunk_size = state.chunk_size  # state.chunk_size can still be None

--- a/test/jax/test_math.py
+++ b/test/jax/test_math.py
@@ -36,7 +36,7 @@ def test_logdet():
     assert ld.dtype == jnp.complex64
     ldc = logdet_cmplx(A.astype(jnp.complex64))
     assert ldc.dtype == jnp.complex64
-    np.testing.assert_allclose(ld, ldc, rtol=1e-6)
+    np.testing.assert_allclose(ld, ldc, rtol=1.5e-6)
 
     A = jax.random.normal(k, (3, 4, 5, 5), dtype=jnp.float64)
     ld = logdet_cmplx(A)

--- a/test/jax/test_vjp_chunked.py
+++ b/test/jax/test_vjp_chunked.py
@@ -5,14 +5,19 @@ import netket as nk
 import numpy as np
 from functools import partial
 
+from netket.jax.sharding import put_global
+from netket import config
+
 from .. import common
 
 pytestmark = common.skipif_mpi
 
 
 @pytest.mark.parametrize("jit", [False, True])
-@pytest.mark.parametrize("chunk_size", [None, 16, 10000, 1000000])
-@pytest.mark.parametrize("return_forward", [False, True])
+@pytest.mark.parametrize("chunk_size", [None, 16, 8192, 1000000])
+@pytest.mark.parametrize(
+    "return_forward", [False] if config.netket_experimental_sharding else [False, True]
+)
 @pytest.mark.parametrize("chunk_argnums", [1, (1,)])
 @pytest.mark.parametrize("nondiff_argnums", [1, (1,)])
 def test_vjp_chunked(chunk_size, jit, return_forward, chunk_argnums, nondiff_argnums):
@@ -22,8 +27,8 @@ def test_vjp_chunked(chunk_size, jit, return_forward, chunk_argnums, nondiff_arg
 
     k = jax.random.split(jax.random.PRNGKey(123), 4)
     p = jax.random.uniform(k[0], shape=(8,))
-    X = jax.random.uniform(k[2], shape=(10000, 8))
-    w = jax.random.uniform(k[3], shape=(10000,))
+    X = put_global(jax.random.uniform(k[2], shape=(8192, 8)))
+    w = put_global(jax.random.uniform(k[3], shape=(8192,)))
 
     vjp_fun_chunked = nk.jax.vjp_chunked(
         f,

--- a/test/jax/test_vjp_chunked.py
+++ b/test/jax/test_vjp_chunked.py
@@ -5,7 +5,7 @@ import netket as nk
 import numpy as np
 from functools import partial
 
-from netket.jax.sharding import put_global
+from netket.jax.sharding import distribute_to_devices_along_axis
 from netket import config
 
 from .. import common
@@ -27,8 +27,8 @@ def test_vjp_chunked(chunk_size, jit, return_forward, chunk_argnums, nondiff_arg
 
     k = jax.random.split(jax.random.PRNGKey(123), 4)
     p = jax.random.uniform(k[0], shape=(8,))
-    X = put_global(jax.random.uniform(k[2], shape=(8192, 8)))
-    w = put_global(jax.random.uniform(k[3], shape=(8192,)))
+    X = distribute_to_devices_along_axis(jax.random.uniform(k[2], shape=(8192, 8)))
+    w = distribute_to_devices_along_axis(jax.random.uniform(k[3], shape=(8192,)))
 
     vjp_fun_chunked = nk.jax.vjp_chunked(
         f,

--- a/test/logging/test_hdf5_log.py
+++ b/test/logging/test_hdf5_log.py
@@ -31,6 +31,9 @@ def vstate(request):
     )
 
 
+@pytest.mark.skipif(
+    nk.config.netket_experimental_sharding, reason="Only run without sharding"
+)
 def test_hdf5log(vstate, tmp_path):
     # skip test if hdf5py not installed
     h5py = pytest.importorskip("h5py")
@@ -59,6 +62,9 @@ def test_hdf5log(vstate, tmp_path):
     assert iters.shape[0] == 30
 
 
+@pytest.mark.skipif(
+    nk.config.netket_experimental_sharding, reason="Only run without sharding"
+)
 def test_lazy_init(tmp_path):
     # skip test if hdf5py not installed
     pytest.importorskip("h5py")

--- a/test/observable/renyi2/test_renyi2.py
+++ b/test/observable/renyi2/test_renyi2.py
@@ -110,6 +110,9 @@ def test_invalid_partition():
         nkx.observable.Renyi2EntanglementEntropy(hi, subsys)
 
 
+@pytest.mark.skipif(
+    nk.config.netket_experimental_sharding, reason="Only run without sharding"
+)
 def test_oddchains():
     pytest.importorskip("qutip")
 

--- a/test/operator/test_hamiltonian.py
+++ b/test/operator/test_hamiltonian.py
@@ -138,9 +138,10 @@ def test_jax_conn(graph, partial_hilbert, partial_H_pair, dtype):
     n_conn1 = H1.n_conn(σ)
     n_conn2 = H2.n_conn(σ)
 
-    assert isinstance(σp1, np.ndarray)
-    assert isinstance(mels1, np.ndarray)
-    assert isinstance(n_conn1, np.ndarray)
+    if not nk.config.netket_experimental_sharding:
+        assert isinstance(σp1, np.ndarray)
+        assert isinstance(mels1, np.ndarray)
+        assert isinstance(n_conn1, np.ndarray)
     σp2 = np.asarray(σp2)
     mels2 = np.asarray(mels2)
     n_conn2 = np.asarray(n_conn2)

--- a/test/optimizer/test_qgt_logic.py
+++ b/test/optimizer/test_qgt_logic.py
@@ -28,6 +28,7 @@ from jax.tree_util import Partial
 
 import itertools
 
+import netket as nk
 from netket import jax as nkjax
 from netket import stats as nkstats
 from netket.utils import mpi
@@ -36,7 +37,7 @@ from netket.optimizer.qgt import (
     qgt_jacobian_pytree_logic,
     qgt_jacobian_common,
 )
-from netket.jax.sharding import distribute_to_devices_along_axis
+from netket.jax.sharding import distribute_to_devices_along_axis, device_count_per_rank
 
 from .. import common
 
@@ -263,7 +264,9 @@ def test_reassemble_complex(e):
 
 
 @common.named_parametrize("holomorphic", [True, False])
-@common.named_parametrize("n_samp", [24 * jax.device_count(), 1024])
+@common.named_parametrize(
+    "n_samp", [24 * device_count_per_rank(), 1024]
+)
 @common.named_parametrize("jit", [True, False])
 @pytest.mark.parametrize("outdtype, pardtype", all_test_types)
 @common.named_parametrize("chunk_size", [8, None])
@@ -294,7 +297,9 @@ def test_matvec(e, jit, chunk_size):
 
 
 @common.named_parametrize("holomorphic", [True, False])
-@common.named_parametrize("n_samp", [24 * jax.device_count(), 1024])
+@common.named_parametrize(
+    "n_samp", [24 * device_count_per_rank(), 1024]
+)
 @common.named_parametrize("jit", [True, False])
 @pytest.mark.parametrize("outdtype, pardtype", all_test_types)
 @common.named_parametrize("chunk_size", [8, None])
@@ -340,7 +345,9 @@ def test_matvec_linear_transpose(e, jit, chunk_size):
 
 # TODO separate test for prepare_centered_oks
 @common.named_parametrize("holomorphic", [True])
-@common.named_parametrize("n_samp", [25 * jax.device_count(), 1024])
+@common.named_parametrize(
+    "n_samp", [25 * device_count_per_rank(), 1024]
+)
 @common.named_parametrize("jit", [True, False])
 @common.named_parametrize("chunk_size", [7, None])
 @pytest.mark.parametrize(
@@ -377,7 +384,9 @@ def test_matvec_treemv(e, jit, holomorphic, pardtype, outdtype, chunk_size):
 # TODO separate test for prepare_centered_oks
 # TODO test C->R ?
 @common.named_parametrize("holomorphic", [True, False])
-@common.named_parametrize("n_samp", [25 * jax.device_count(), 1024])
+@common.named_parametrize(
+    "n_samp", [25 * device_count_per_rank(), 1024]
+)
 @common.named_parametrize("jit", [True, False])
 @pytest.mark.parametrize("outdtype, pardtype", test_types)
 def test_matvec_treemv_modes(e, jit, holomorphic, pardtype, outdtype):
@@ -434,7 +443,7 @@ def e_offset(n_samp, outdtype, pardtype, holomorphic, offset, seed=123):
 
 
 @pytest.mark.parametrize("holomorphic", [True])
-@pytest.mark.parametrize("n_samp", [25 * jax.device_count(), 1024])
+@pytest.mark.parametrize("n_samp", [25 * device_count_per_rank(), 1024])
 @pytest.mark.parametrize(
     "outdtype, pardtype",
     r_c_test_types,  # r_r_test_types + c_c_test_types + r_c_test_types

--- a/test/optimizer/test_qgt_logic.py
+++ b/test/optimizer/test_qgt_logic.py
@@ -36,6 +36,7 @@ from netket.optimizer.qgt import (
     qgt_jacobian_pytree_logic,
     qgt_jacobian_common,
 )
+from netket.jax.sharding import put_global
 
 from .. import common
 
@@ -178,9 +179,9 @@ class Example:
         k = jax.random.PRNGKey(seed)
         k1, k2, k3, k4, k5 = jax.random.split(k, 5)
 
-        self.samples = jax.random.normal(k1, (n_samp, 2))
-        self.w = jax.random.normal(k2, (n_samp,), self.dtype).astype(
-            self.dtype
+        self.samples = put_global(jax.random.normal(k1, (n_samp, 2)))
+        self.w = put_global(
+            jax.random.normal(k2, (n_samp,), self.dtype).astype(self.dtype)
         )  # TODO remove astype once its fixed in jax
         self.params = tree_random_normal_like(k3, self.target)
         self.v = tree_random_normal_like(k4, self.target)
@@ -260,7 +261,7 @@ def test_reassemble_complex(e):
 
 
 @common.named_parametrize("holomorphic", [True, False])
-@common.named_parametrize("n_samp", [24, 1024])
+@common.named_parametrize("n_samp", [24 * jax.device_count(), 1024])
 @common.named_parametrize("jit", [True, False])
 @pytest.mark.parametrize("outdtype, pardtype", all_test_types)
 @common.named_parametrize("chunk_size", [8, None])
@@ -291,7 +292,7 @@ def test_matvec(e, jit, chunk_size):
 
 
 @common.named_parametrize("holomorphic", [True, False])
-@common.named_parametrize("n_samp", [24, 1024])
+@common.named_parametrize("n_samp", [24 * jax.device_count(), 1024])
 @common.named_parametrize("jit", [True, False])
 @pytest.mark.parametrize("outdtype, pardtype", all_test_types)
 @common.named_parametrize("chunk_size", [8, None])
@@ -337,7 +338,7 @@ def test_matvec_linear_transpose(e, jit, chunk_size):
 
 # TODO separate test for prepare_centered_oks
 @common.named_parametrize("holomorphic", [True])
-@common.named_parametrize("n_samp", [25, 1024])
+@common.named_parametrize("n_samp", [25 * jax.device_count(), 1024])
 @common.named_parametrize("jit", [True, False])
 @common.named_parametrize("chunk_size", [7, None])
 @pytest.mark.parametrize(
@@ -361,7 +362,7 @@ def test_matvec_treemv(e, jit, holomorphic, pardtype, outdtype, chunk_size):
 
     if jit:
         mv = jax.jit(mv)
-        centered_jacobian_fun = jax.jit(centered_jacobian_fun, static_argnums=0)
+        centered_jacobian_fun = jax.jit(centered_jacobian_fun)
 
     centered_oks = centered_jacobian_fun(e.f, e.params, e.samples)
     centered_oks = divide_by_sqrt_n_samp(centered_oks, e.samples)
@@ -374,7 +375,7 @@ def test_matvec_treemv(e, jit, holomorphic, pardtype, outdtype, chunk_size):
 # TODO separate test for prepare_centered_oks
 # TODO test C->R ?
 @common.named_parametrize("holomorphic", [True, False])
-@common.named_parametrize("n_samp", [25, 1024])
+@common.named_parametrize("n_samp", [25 * jax.device_count(), 1024])
 @common.named_parametrize("jit", [True, False])
 @pytest.mark.parametrize("outdtype, pardtype", test_types)
 def test_matvec_treemv_modes(e, jit, holomorphic, pardtype, outdtype):
@@ -431,7 +432,7 @@ def e_offset(n_samp, outdtype, pardtype, holomorphic, offset, seed=123):
 
 
 @pytest.mark.parametrize("holomorphic", [True])
-@pytest.mark.parametrize("n_samp", [25, 1024])
+@pytest.mark.parametrize("n_samp", [25 * jax.device_count(), 1024])
 @pytest.mark.parametrize(
     "outdtype, pardtype",
     r_c_test_types,  # r_r_test_types + c_c_test_types + r_c_test_types

--- a/test/optimizer/test_qgt_logic.py
+++ b/test/optimizer/test_qgt_logic.py
@@ -36,7 +36,7 @@ from netket.optimizer.qgt import (
     qgt_jacobian_pytree_logic,
     qgt_jacobian_common,
 )
-from netket.jax.sharding import put_global
+from netket.jax.sharding import distribute_to_devices_along_axis
 
 from .. import common
 
@@ -179,8 +179,10 @@ class Example:
         k = jax.random.PRNGKey(seed)
         k1, k2, k3, k4, k5 = jax.random.split(k, 5)
 
-        self.samples = put_global(jax.random.normal(k1, (n_samp, 2)))
-        self.w = put_global(
+        self.samples = distribute_to_devices_along_axis(
+            jax.random.normal(k1, (n_samp, 2))
+        )
+        self.w = distribute_to_devices_along_axis(
             jax.random.normal(k2, (n_samp,), self.dtype).astype(self.dtype)
         )  # TODO remove astype once its fixed in jax
         self.params = tree_random_normal_like(k3, self.target)

--- a/test/optimizer/test_qgt_logic.py
+++ b/test/optimizer/test_qgt_logic.py
@@ -28,7 +28,6 @@ from jax.tree_util import Partial
 
 import itertools
 
-import netket as nk
 from netket import jax as nkjax
 from netket import stats as nkstats
 from netket.utils import mpi

--- a/test/optimizer/test_qgt_logic.py
+++ b/test/optimizer/test_qgt_logic.py
@@ -264,9 +264,7 @@ def test_reassemble_complex(e):
 
 
 @common.named_parametrize("holomorphic", [True, False])
-@common.named_parametrize(
-    "n_samp", [24 * device_count_per_rank(), 1024]
-)
+@common.named_parametrize("n_samp", [24 * device_count_per_rank(), 1024])
 @common.named_parametrize("jit", [True, False])
 @pytest.mark.parametrize("outdtype, pardtype", all_test_types)
 @common.named_parametrize("chunk_size", [8, None])
@@ -297,9 +295,7 @@ def test_matvec(e, jit, chunk_size):
 
 
 @common.named_parametrize("holomorphic", [True, False])
-@common.named_parametrize(
-    "n_samp", [24 * device_count_per_rank(), 1024]
-)
+@common.named_parametrize("n_samp", [24 * device_count_per_rank(), 1024])
 @common.named_parametrize("jit", [True, False])
 @pytest.mark.parametrize("outdtype, pardtype", all_test_types)
 @common.named_parametrize("chunk_size", [8, None])
@@ -345,9 +341,7 @@ def test_matvec_linear_transpose(e, jit, chunk_size):
 
 # TODO separate test for prepare_centered_oks
 @common.named_parametrize("holomorphic", [True])
-@common.named_parametrize(
-    "n_samp", [25 * device_count_per_rank(), 1024]
-)
+@common.named_parametrize("n_samp", [25 * device_count_per_rank(), 1024])
 @common.named_parametrize("jit", [True, False])
 @common.named_parametrize("chunk_size", [7, None])
 @pytest.mark.parametrize(
@@ -384,9 +378,7 @@ def test_matvec_treemv(e, jit, holomorphic, pardtype, outdtype, chunk_size):
 # TODO separate test for prepare_centered_oks
 # TODO test C->R ?
 @common.named_parametrize("holomorphic", [True, False])
-@common.named_parametrize(
-    "n_samp", [25 * device_count_per_rank(), 1024]
-)
+@common.named_parametrize("n_samp", [25 * device_count_per_rank(), 1024])
 @common.named_parametrize("jit", [True, False])
 @pytest.mark.parametrize("outdtype, pardtype", test_types)
 def test_matvec_treemv_modes(e, jit, holomorphic, pardtype, outdtype):

--- a/test/sampler/test_sampler.py
+++ b/test/sampler/test_sampler.py
@@ -19,6 +19,8 @@ from .. import common
 
 import netket as nk
 from netket.hilbert import DiscreteHilbert, Particle
+from netket.utils import mpi
+from netket.jax.sharding import device_count_per_rank
 
 from netket import experimental as nkx
 
@@ -520,4 +522,7 @@ def test_exact_sampler(sampler):
         assert sampler.n_chains_per_rank == 1
     else:
         assert sampler.is_exact is False
-        assert sampler.n_chains_per_rank == 16 * jax.device_count()
+        assert (
+            sampler.n_chains
+            == 16 * mpi.n_nodes * device_count_per_rank()
+        )

--- a/test/sampler/test_sampler.py
+++ b/test/sampler/test_sampler.py
@@ -240,21 +240,21 @@ def set_pdf_power(request):
 
 def test_states_in_hilbert(sampler, model_and_weights):
     hi = sampler.hilbert
+    chain_length = 50
     if isinstance(hi, DiscreteHilbert):
         all_states = hi.all_states()
 
         ma, w = model_and_weights(hi, sampler)
 
-        for sample in sampler.samples(ma, w, chain_length=50):
-            assert sample.shape == (sampler.n_chains, hi.size)
-            for v in sample:
-                assert v in all_states
+        samples, _ = sampler.sample(ma, w, chain_length=chain_length)
+        assert samples.shape == (sampler.n_chains, chain_length, hi.size)
+        for sample in np.asarray(samples).reshape(-1, hi.size):
+            assert sample in all_states
 
     elif isinstance(hi, Particle):
         ma, w = model_and_weights(hi, sampler)
-
-        for sample in sampler.samples(ma, w, chain_length=50):
-            assert sample.shape == (sampler.n_chains, hi.size)
+        samples, _ = sampler.sample(ma, w, chain_length=chain_length)
+        assert samples.shape == (sampler.n_chains, chain_length, hi.size)
 
     # if hasattr(sa, "acceptance"):
     #    assert np.min(sampler.acceptance) >= 0 and np.max(sampler.acceptance) <= 1.0
@@ -520,4 +520,4 @@ def test_exact_sampler(sampler):
         assert sampler.n_chains_per_rank == 1
     else:
         assert sampler.is_exact is False
-        assert sampler.n_chains_per_rank == 16
+        assert sampler.n_chains_per_rank == 16 * jax.device_count()

--- a/test/sampler/test_sampler.py
+++ b/test/sampler/test_sampler.py
@@ -522,7 +522,4 @@ def test_exact_sampler(sampler):
         assert sampler.n_chains_per_rank == 1
     else:
         assert sampler.is_exact is False
-        assert (
-            sampler.n_chains
-            == 16 * mpi.n_nodes * device_count_per_rank()
-        )
+        assert sampler.n_chains == 16 * mpi.n_nodes * device_count_per_rank()

--- a/test/stats/test_stats.py
+++ b/test/stats/test_stats.py
@@ -22,6 +22,7 @@ from functools import partial
 
 import netket as nk
 from netket.stats import statistics
+from netket.jax.sharding import device_count_per_rank
 from scipy.optimize import curve_fit
 
 from .. import common
@@ -88,10 +89,10 @@ def _test_stats_mean_std(hi, ham, ma, n_chains):
 @pytest.mark.parametrize(
     "n_chains",
     [
-        1 * jax.device_count(),
-        2 * jax.device_count(),
-        16 * jax.device_count(),
-        32 * jax.device_count(),
+        1 * device_count_per_rank(),
+        2 * device_count_per_rank(),
+        16 * device_count_per_rank(),
+        32 * device_count_per_rank(),
     ],
 )
 def test_stats_mean_std(n_chains):

--- a/test/stats/test_stats.py
+++ b/test/stats/test_stats.py
@@ -88,10 +88,10 @@ def _test_stats_mean_std(hi, ham, ma, n_chains):
 @pytest.mark.parametrize(
     "n_chains",
     [
-        1,
-        2,
-        16,
-        32,
+        1 * jax.device_count(),
+        2 * jax.device_count(),
+        16 * jax.device_count(),
+        32 * jax.device_count(),
     ],
 )
 def test_stats_mean_std(n_chains):

--- a/test/variational/test_continuous_expect.py
+++ b/test/variational/test_continuous_expect.py
@@ -40,9 +40,19 @@ sab = nk.sampler.MetropolisGaussian(hilb, sigma=1.0, n_chains=16, n_sweeps=1)
 
 model = test()
 model2 = test2()
-vs_continuous = nk.vqs.MCState(sab, model, n_samples=10**6, n_discard_per_chain=2000)
+vs_continuous = nk.vqs.MCState(
+    sab,
+    model,
+    n_samples=256 * 1024,
+    n_discard_per_chain=2048,
+    sampler_seed=123,
+)
 vs_continuous2 = nk.vqs.MCState(
-    sab, model2, n_samples=10**7, n_discard_per_chain=2000
+    sab,
+    model2,
+    n_samples=1024 * 1024,
+    n_discard_per_chain=2048,
+    sampler_seed=123,
 )
 
 
@@ -59,18 +69,18 @@ def test_expect():
     :math:`<V> = \int_0^5 dx V(x) |\psi(x)|^2 / \int_0^5 |\psi(x)|^2 = 0.1975164 (\psi = 1)`
     :math:`<\nabla V> = \nabla_p \int_0^5 dx V(x) |\psi(x)|^2 / \int_0^5 |\psi(x)|^2 = -0.140256 (\psi = \exp(p^2 x))`
     """
-    np.testing.assert_allclose(0.1975164, sol_nc.mean, atol=10 ** (-3))
-    np.testing.assert_allclose(-0.140256, O_grad_nc, atol=10 ** (-3))
+    np.testing.assert_allclose(0.1975164, sol_nc.mean, atol=1e-3)
+    np.testing.assert_allclose(-0.140256, O_grad_nc, atol=1e-3)
 
-    vs_continuous.chunk_size = 100
-    vs_continuous2.chunk_size = 100
+    vs_continuous.chunk_size = 128
+    vs_continuous2.chunk_size = 128
 
-    assert vs_continuous.chunk_size == 100
-    assert vs_continuous2.chunk_size == 100
+    assert vs_continuous.chunk_size == 128
+    assert vs_continuous2.chunk_size == 128
 
     sol = vs_continuous.expect(pot)
     O_stat, O_grad = vs_continuous2.expect_and_grad(e)
     O_grad, _ = nk.jax.tree_ravel(O_grad)
 
-    np.testing.assert_allclose(sol_nc.mean, sol.mean, atol=10 ** (-8))
-    np.testing.assert_allclose(O_grad_nc, O_grad, atol=10 ** (-8))
+    np.testing.assert_allclose(sol_nc.mean, sol.mean, atol=1e-8)
+    np.testing.assert_allclose(O_grad_nc, O_grad, atol=1e-8)

--- a/test/variational/test_variational.py
+++ b/test/variational/test_variational.py
@@ -355,8 +355,8 @@ def test_qutip_conversion(vstate):
 )
 def test_expect(vstate, operator):
     # Use lots of samples
-    vstate.n_samples = 5 * 1e5
-    vstate.n_discard_per_chain = 1e3
+    vstate.n_samples = 256 * 1024
+    vstate.n_discard_per_chain = 1024
 
     # sample the expectation value and gradient with tons of samples
     O_stat1 = vstate.expect(operator)

--- a/test_sharding/readme.md
+++ b/test_sharding/readme.md
@@ -1,0 +1,14 @@
+### NetKet Sharding Tests
+
+This folder contains tests for running NetKet on multiple jax devices.
+
+They are kept separate from the normal tests as they need to be run with different flags (some of those set in pyproject.toml are incompatible and I haven't found a reliable way to override them)
+
+In particular it contains scripts to run:
+
+- run the normal tests on 2 cpu devices (run_standard_tests_with_sharding.sh)
+- run specific tests for sharding on 2 cpu devices (run_test_sharding.sh)
+- run specific tests for sharding on 2 separate processes with 1 gpu each (run_test_sharding_distributed.sh)
+  This is for now tailored specifically to the configuration of our custom runner with 2 gpu vm's
+
+They need to be run from the root folder of the netket repository, e.g. with `./test_sharding/run_test_sharding.sh`

--- a/test_sharding/run_standard_tests_with_sharding.sh
+++ b/test_sharding/run_standard_tests_with_sharding.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+export NETKET_EXPERIMENTAL_SHARDING=1
+export NETKET_EXPERIMENTAL_SHARDING_CPU=2
+export JAX_PLATFORM_NAME=cpu
+python3 -m pytest -n 0 $@ test

--- a/test_sharding/run_test_sharding.sh
+++ b/test_sharding/run_test_sharding.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+export NETKET_EXPERIMENTAL_SHARDING=1
+export NETKET_EXPERIMENTAL_SHARDING_CPU=2
+export JAX_PLATFORM_NAME=cpu
+python3 -m pytest -p no:warnings --color=yes --verbose -n 0 --tb=short $@ test_sharding/test_sharding.py

--- a/test_sharding/run_test_sharding_distributed.sh
+++ b/test_sharding/run_test_sharding_distributed.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# to run on our self-hosted runner with 2 gpu vm's
+mpirun --hostfile /etc/hostfile -x NETKET_EXPERIMENTAL_SHARDING=1 -x NETKET_MPI_WARNING=0 python3 -m pytest -p no:warnings --color=yes --verbose -n 0 --tb=short $@ test_sharding/test_sharding_distributed.py

--- a/test_sharding/test_sharding.py
+++ b/test_sharding/test_sharding.py
@@ -1,0 +1,387 @@
+import pytest
+
+import jax
+import numpy as np
+import netket as nk
+import netket.experimental as nkx
+
+from flax import serialization
+from jax.sharding import PositionalSharding
+
+
+def _setup(L, alpha=1):
+    g = nk.graph.Hypercube(length=L, n_dim=1, pbc=True)
+    hi = nk.hilbert.Spin(s=1 / 2, N=g.n_nodes)
+    ma = nk.models.RBM(alpha=alpha, param_dtype=np.complex128)
+    sa = nk.sampler.MetropolisLocal(hi, n_chains=16 * jax.device_count(), dtype=np.int8)
+    vs = nk.vqs.MCState(sa, ma, n_samples=1024, n_discard_per_chain=8)
+    ha = nk.operator.IsingJax(hilbert=vs.hilbert, graph=g, h=1.0)
+    return vs, g, ha
+
+
+@pytest.mark.skipif(
+    not nk.config.netket_experimental_sharding, reason="Only run with sharding"
+)
+def test_setup():
+    # make sure that the tests are running with >1 devices
+    assert jax.device_count() > 1
+
+
+@pytest.mark.skipif(
+    not nk.config.netket_experimental_sharding, reason="Only run with sharding"
+)
+def test_sampling():
+    vs, *_ = _setup(16)
+    n_chains = 16 * jax.device_count()
+    n_samples = 1024
+
+    # check sampler state has correct sharding
+    x = vs.sampler_state.σ
+    assert x.shape == (n_chains, vs.hilbert.size)
+    assert isinstance(x.sharding, PositionalSharding)
+    assert x.sharding.shape == (jax.device_count(), 1)
+    assert x.sharding.device_set == set(jax.devices())
+
+    # check samples have correct sharding
+    samples = vs.sample()
+    assert samples.shape == (n_chains, n_samples // n_chains, vs.hilbert.size)
+    assert isinstance(samples.sharding, PositionalSharding)
+    assert samples.sharding.shape == (jax.device_count(), 1, 1)
+    assert samples.sharding.device_set == set(jax.devices())
+
+    # check sampler state still has correct sharding after having sampled
+    x = vs.sampler_state.σ
+    assert x.shape == (n_chains, vs.hilbert.size)
+    assert isinstance(x.sharding, PositionalSharding)
+    assert x.sharding.shape == (jax.device_count(), 1)
+    assert x.sharding.device_set == set(jax.devices())
+
+
+@pytest.mark.skipif(
+    not nk.config.netket_experimental_sharding, reason="Only run with sharding"
+)
+def test_expect():
+    vs, _, ha = _setup(16)
+    E = vs.expect(ha)
+    # check printing works
+    str(E)
+    for l in jax.tree_util.tree_leaves(E):
+        assert l.is_fully_replicated
+        assert isinstance(l.sharding, PositionalSharding)
+        assert l.sharding.device_set == set(jax.devices())
+
+
+@pytest.mark.skipif(
+    not nk.config.netket_experimental_sharding, reason="Only run with sharding"
+)
+def test_grad():
+    vs, g, ha = _setup(16)
+    E, G = vs.expect_and_grad(ha)
+    # check printing works
+    str(E)
+    for l in jax.tree_util.tree_leaves(E):
+        assert l.is_fully_replicated
+        assert isinstance(l.sharding, PositionalSharding)
+        assert l.sharding.device_set == set(jax.devices())
+
+    for l in jax.tree_util.tree_leaves(G):
+        assert l.is_fully_replicated
+        assert isinstance(l.sharding, PositionalSharding)
+        assert l.sharding.device_set == set(jax.devices())
+
+
+@pytest.mark.parametrize(
+    "Op",
+    [
+        pytest.param(nk.operator.Ising, id="numba"),
+        pytest.param(nk.operator.IsingJax, id="jax"),
+    ],
+)
+@pytest.mark.parametrize(
+    "qgt",
+    [
+        pytest.param(nk.optimizer.qgt.QGTJacobianPyTree, id="pytree"),
+        pytest.param(nk.optimizer.qgt.QGTJacobianDense, id="dense"),
+        pytest.param(nk.optimizer.qgt.QGTOnTheFly, id="onthefly"),
+    ],
+)
+@pytest.mark.parametrize(
+    "chunk_size",
+    [None, 64],
+)
+@pytest.mark.skipif(
+    not nk.config.netket_experimental_sharding, reason="Only run with sharding"
+)
+def test_vmc(Op, qgt, chunk_size):
+    vs, g, _ = _setup(16)
+    vs.chunk_size = chunk_size
+    # initially the params are only on the first device of each process
+    # but they will be broadcast on the first invocation, so here we only check its fully addressable
+    for l in jax.tree_util.tree_leaves(vs.variables):
+        assert l.is_fully_replicated
+
+    ha = Op(hilbert=vs.hilbert, graph=g, h=1.0)
+    opt = nk.optimizer.Sgd(learning_rate=0.05)
+    sr = nk.optimizer.SR(qgt(holomorphic=True), diag_shift=0.01)
+    gs = nk.VMC(ha, opt, variational_state=vs, preconditioner=sr)
+    gs.run(5)
+
+    for l in jax.tree_util.tree_leaves(vs.variables):
+        assert l.is_fully_replicated
+        assert isinstance(l.sharding, PositionalSharding)
+        assert l.sharding.device_set == set(jax.devices())
+
+
+@pytest.mark.parametrize(
+    "qgt",
+    [
+        pytest.param(nk.optimizer.qgt.QGTJacobianPyTree, id="pytree"),
+        pytest.param(nk.optimizer.qgt.QGTJacobianDense, id="dense"),
+    ],
+)
+@pytest.mark.skipif(
+    not nk.config.netket_experimental_sharding, reason="Only run with sharding"
+)
+def test_qgt_jacobian(qgt):
+    n_samples = 1024
+    vs, *_ = _setup(16)
+    S = vs.quantum_geometric_tensor(qgt(holomorphic=True))
+    for l in jax.tree_util.tree_leaves(S.O):
+        assert l.shape[0] == n_samples
+        assert isinstance(l.sharding, PositionalSharding)
+        assert l.sharding.shape[0] == jax.device_count()
+        assert l.sharding.device_set == set(jax.devices())
+    v = vs.parameters
+    res = S @ v
+
+    for l in jax.tree_util.tree_leaves(res):
+        assert l.is_fully_replicated
+        assert isinstance(l.sharding, PositionalSharding)
+        assert l.sharding.device_set == set(jax.devices())
+
+
+@pytest.mark.skipif(
+    not nk.config.netket_experimental_sharding, reason="Only run with sharding"
+)
+def test_qgt_onthefly():
+    vs, *_ = _setup(16)
+    S = vs.quantum_geometric_tensor(nk.optimizer.qgt.QGTOnTheFly(holomorphic=True))
+    # TODO maybe check S._mat_vec tree leaves
+    v = vs.parameters
+    res = S @ v
+
+    for l in jax.tree_util.tree_leaves(res):
+        assert l.is_fully_replicated
+        assert isinstance(l.sharding, PositionalSharding)
+        assert l.sharding.device_set == set(jax.devices())
+
+
+@pytest.mark.parametrize(
+    "Op",
+    [
+        pytest.param(nk.operator.Ising, id="numba"),
+        pytest.param(nk.operator.IsingJax, id="jax"),
+    ],
+)
+@pytest.mark.skipif(
+    not nk.config.netket_experimental_sharding, reason="Only run with sharding"
+)
+def test_operators(Op):
+    vs, g, *_ = _setup(16)
+    ha = Op(hilbert=vs.hilbert, graph=g, h=1.0)
+    x = jax.jit(jax.lax.collapse, static_argnums=(1, 2))(vs.samples, 0, 2)
+
+    assert x.sharding.shape == (jax.device_count(), 1)
+    xp, mels = ha.get_conn_padded(x)
+
+    n_conn = xp.shape[1]
+    assert xp.shape == (x.shape[0], n_conn, x.shape[-1])
+    assert mels.shape == (x.shape[0], n_conn)
+
+    assert isinstance(xp.sharding, PositionalSharding)
+    assert isinstance(mels.sharding, PositionalSharding)
+
+    assert xp.sharding.shape == (jax.device_count(), 1, 1)
+    assert mels.sharding.shape == (jax.device_count(), 1)
+
+    assert xp.sharding.device_set == set(jax.devices())
+    assert mels.sharding.device_set == set(jax.devices())
+
+
+@pytest.mark.skipif(
+    not nk.config.netket_experimental_sharding, reason="Only run with sharding"
+)
+@pytest.mark.parametrize(
+    "chunk_size",
+    [None, 64],
+)
+def test_fullsumstate(chunk_size):
+    L = 12
+    g = nk.graph.Hypercube(length=L, n_dim=1, pbc=True)
+    hi = nk.hilbert.Spin(s=1 / 2, N=g.n_nodes)
+    ma = nk.models.RBM(alpha=1, param_dtype=np.complex128)
+    vs = nk.vqs.FullSumState(hi, ma, chunk_size=chunk_size)
+    ha = nk.operator.IsingJax(hilbert=vs.hilbert, graph=g, h=1.0)
+    opt = nk.optimizer.Sgd(learning_rate=0.05)
+    sr = nk.optimizer.SR(
+        nk.optimizer.qgt.QGTOnTheFly(holomorphic=True), diag_shift=0.01
+    )
+    gs = nk.VMC(ha, opt, variational_state=vs, preconditioner=sr)
+    gs.run(5)
+
+
+@pytest.mark.skipif(
+    not nk.config.netket_experimental_sharding, reason="Only run with sharding"
+)
+@pytest.mark.parametrize(
+    "chunk_size",
+    [None, 64],
+)
+def test_exactsampler(chunk_size):
+    L = 12
+    g = nk.graph.Hypercube(length=L, n_dim=1, pbc=True)
+    hi = nk.hilbert.Spin(s=1 / 2, N=g.n_nodes)
+    ma = nk.models.RBM(alpha=1, param_dtype=np.complex128)
+    sa = nk.sampler.ExactSampler(hi, dtype=np.int8)
+    vs = nk.vqs.MCState(sa, ma, n_samples=1024, chunk_size=chunk_size)
+
+    pos_sharding = jax.sharding.PositionalSharding(jax.devices())
+    assert vs.samples.sharding.is_equivalent_to(pos_sharding.reshape(1, -1, 1), 3)
+
+    ha = nk.operator.IsingJax(hilbert=vs.hilbert, graph=g, h=1.0)
+    opt = nk.optimizer.Sgd(learning_rate=0.05)
+    sr = nk.optimizer.SR(
+        nk.optimizer.qgt.QGTOnTheFly(holomorphic=True), diag_shift=0.01
+    )
+    gs = nk.VMC(ha, opt, variational_state=vs, preconditioner=sr)
+    gs.run(5)
+
+
+@pytest.mark.skipif(
+    not nk.config.netket_experimental_sharding, reason="Only run with sharding"
+)
+def test_autoreg():
+    L = 32
+    g = nk.graph.Hypercube(length=L, n_dim=1, pbc=True)
+    hi = nk.hilbert.Spin(s=1 / 2, N=g.n_nodes)
+    ha = nk.operator.IsingJax(hilbert=hi, graph=g, h=1)
+    ma = nk.models.FastARNNConv1D(hilbert=hi, layers=3, features=16, kernel_size=3)
+    sa = nk.sampler.ARDirectSampler(hi)
+    opt = nk.optimizer.Sgd(learning_rate=0.1)
+    sr = nk.optimizer.SR(diag_shift=0.01)
+    vs = nk.vqs.MCState(sa, ma, n_samples=256)
+    pos_sharding = jax.sharding.PositionalSharding(jax.devices())
+    assert vs.samples.sharding.is_equivalent_to(pos_sharding.reshape(1, -1, 1), 3)
+    gs = nk.VMC(ha, opt, variational_state=vs, preconditioner=sr)
+    gs.run(n_iter=5)
+
+
+@pytest.mark.skipif(
+    not nk.config.netket_experimental_sharding, reason="Only run with sharding"
+)
+@pytest.mark.parametrize(
+    "logger",
+    [
+        pytest.param(
+            (
+                nk.logging.RuntimeLog(),
+                lambda logger: logger.serialize("_test_runtimelog.json"),
+            ),
+            id="RuntimeLog",
+        ),
+        pytest.param(
+            (
+                nk.logging.JsonLog("_test_jsonlog", save_params_every=1, write_every=1),
+                lambda logger: None,
+            ),
+            id="JsonLog",
+        ),
+        pytest.param(
+            (nk.logging.StateLog("_test_statelog", save_every=1), lambda logger: None),
+            id="StateLog",
+        ),
+        pytest.param(
+            (
+                nkx.logging.HDF5Log(
+                    "_test_hdf5log", save_params=True, save_params_every=1
+                ),
+                lambda logger: None,
+            ),
+            id="HDF5Log",
+        ),
+    ],
+)
+def test_loggers(logger):
+    vs, _, ha = _setup(12)
+    logger, out_fun = logger
+    opt = nk.optimizer.Sgd(learning_rate=0.05)
+    gs = nk.VMC(ha, opt, variational_state=vs)
+    gs.run(10, out=logger)
+    out_fun(logger)
+
+
+@pytest.mark.skipif(
+    not nk.config.netket_experimental_sharding, reason="Only run with sharding"
+)
+def test_serialization():
+    vs, _, ha = _setup(12)
+
+    b = serialization.to_bytes(vs)
+    vs = serialization.from_bytes(vs, b)
+
+    opt = nk.optimizer.Sgd(learning_rate=0.05)
+    gs = nk.VMC(ha, opt, variational_state=vs)
+    gs.run(1)
+
+    b = serialization.to_bytes(gs.state)
+    vs2 = serialization.from_bytes(gs.state, b)
+    gs2 = nk.VMC(ha, opt, variational_state=vs2)
+    gs2.run(1)
+
+
+@pytest.mark.skipif(
+    not nk.config.netket_experimental_sharding, reason="Only run with sharding"
+)
+@pytest.mark.parametrize("ode_jit", [False, True])
+def test_timeevolution(ode_jit):
+    nk.config.update("netket_experimental_disable_ode_jit", not ode_jit)
+    L = 8
+    vs, _, ha = _setup(L)
+    Sx = sum([nk.operator.spin.sigmax(ha.hilbert, i) for i in range(L)])
+    Sx = Sx.to_pauli_strings().to_jax_operator()
+    integrator = nkx.dynamics.Euler(dt=0.001)
+    te = nkx.TDVP(
+        ha,
+        variational_state=vs,
+        integrator=integrator,
+        t0=0.0,
+        qgt=nk.optimizer.qgt.QGTOnTheFly(holomorphic=True, diag_shift=1e-4),
+        error_norm="qgt",
+    )
+    te.run(T=0.005, obs={"Sx": Sx}, show_progress=True)
+    te2 = nkx.driver.TDVPSchmitt(
+        ha,
+        variational_state=vs,
+        integrator=integrator,
+        t0=0.0,
+        error_norm="qgt",
+        holomorphic=True,
+    )
+    te2.run(T=0.005, obs={"Sx": Sx}, show_progress=True)
+
+
+@pytest.mark.skipif(
+    not nk.config.netket_experimental_sharding, reason="Only run with sharding"
+)
+def test_srt():
+    vs, _, ha = _setup(12, alpha=2)
+    vs.n_samples = 64
+    opt = nk.optimizer.Sgd(learning_rate=0.05)
+    gs = nkx.driver.VMC_SRt(
+        ha,
+        opt,
+        variational_state=vs,
+        diag_shift=0.1,
+        jacobian_mode="complex",
+    )
+    gs.run(2)

--- a/test_sharding/test_sharding_distributed.py
+++ b/test_sharding/test_sharding_distributed.py
@@ -1,0 +1,5 @@
+import jax
+
+jax.distributed.initialize()
+
+from test_sharding import *  # noqa


### PR DESCRIPTION
Fully relies on the trivial automatic parallelization over the chains using shared global jax.Array's.

Does the following:
- turn the sampler state (just the \sigma) into a global device array using jit with out_shardings. 
- wrap the call to the numba operator so that the xp and mels  are shared arrays just like the samples inputted to it were, or use operators written in jax
- extract the results from the shared arrays before printing/saving
- use jax_threefry_partitionable=True (their new rng impl)

Supports both multiple local devices as well as [jax.distributed](https://jax.readthedocs.io/en/latest/multi_process.html) (the latter is only available on gpu and tpu)
On gpu it Internally uses the [nvidia NCCL](https://developer.nvidia.com/nccl) library for communication, so it should be quite efficient.
On cpu one can  use multiple devices with threads via `--xla_force_host_platform_device_count=XX`, multi-node is not available yet.

My initial benchmarks on gpu showed it's competitive with mpi.