### PR TITLE
Finish PauliStringsJax

### DIFF
--- a/netket/operator/_pauli_strings/jax.py
+++ b/netket/operator/_pauli_strings/jax.py
@@ -318,7 +318,7 @@ class PauliStringsJax(PauliStringsBase, DiscreteJaxOperator):
         # currently there are two modes:
         # 1. index: indexes into the vector to flip qubits and compute the sign
         #           faster if the strings act only on a few qubits
-        # 2. mask: uses masks to flip qubits and compute the sign
+        # mask: uses masks to flip qubits and compute the sign
         #          faster if the strings act on many of the qubits
         #          (and possibly on gpu)
         # By adapting pack_internals_jax hybrid approaches are also possible.

--- a/netket/operator/_pauli_strings/jax.py
+++ b/netket/operator/_pauli_strings/jax.py
@@ -316,7 +316,7 @@ class PauliStringsJax(PauliStringsBase, DiscreteJaxOperator):
             )
         # private variable for setting the mode
         # currently there are two modes:
-        # 1. index: indexes into the vector to flip qubits and compute the sign
+        # index: indexes into the vector to flip qubits and compute the sign
         #           faster if the strings act only on a few qubits
         # mask: uses masks to flip qubits and compute the sign
         #          faster if the strings act on many of the qubits

--- a/netket/operator/_pauli_strings/jax.py
+++ b/netket/operator/_pauli_strings/jax.py
@@ -315,6 +315,13 @@ class PauliStringsJax(PauliStringsBase, DiscreteJaxOperator):
                 "nonzero cuttof is not yet implemented in PauliStringsJax"
             )
         # private variable for setting the mode
+        # currently there are two modes:
+        # 1. index: indexes into the vector to flip qubits and compute the sign
+        #           faster if the strings act only on a few qubits
+        # 2. mask: uses masks to flip qubits and compute the sign
+        #          faster if the strings act on many of the qubits
+        #          (and possibly on gpu)
+        # By adapting pack_internals_jax hybrid approaches are also possible.
         # depending on performance tests we might expose or remove it
         _check_mode(_mode)
         self._mode = _mode

--- a/netket/operator/_pauli_strings/jax.py
+++ b/netket/operator/_pauli_strings/jax.py
@@ -118,6 +118,16 @@ def sites_to_mask(sites, n_sites, dtype=bool):
     return mask
 
 
+_available_modes = ["index", "mask"]
+
+
+def _check_mode(mode):
+    if mode not in _available_modes:
+        raise ValueError(
+            f"unknown mode {mode}. Available modes are {_available_modes}."
+        )
+
+
 def pack_internals_jax(
     operators,
     weights,
@@ -141,8 +151,8 @@ def pack_internals_jax(
     """
 
     # index_dtype needs to be signed (we use -1 for padding)
-    # mode can be either index or mask
-    assert mode in ["index", "mask"]
+
+    _check_mode(mode)
 
     # group together operators with same final state (i.e. those which flip the same sites)
     # see code of pack_internals for more details
@@ -279,6 +289,7 @@ class PauliStringsJax(PauliStringsBase, DiscreteJaxOperator):
         *,
         cutoff: float = 0.0,
         dtype: DType = complex,
+        _mode: str = "index",
     ):
         super().__init__(hilbert, operators, weights, cutoff=cutoff, dtype=dtype)
 
@@ -305,7 +316,8 @@ class PauliStringsJax(PauliStringsBase, DiscreteJaxOperator):
             )
         # private variable for setting the mode
         # depending on performance tests we might expose or remove it
-        self._mode = "mask"
+        _check_mode(_mode)
+        self._mode = _mode
         self._hi_local_states = tuple(self.hilbert.local_states)
         self._initialized = False
 

--- a/test/operator/test_operator.py
+++ b/test/operator/test_operator.py
@@ -94,10 +94,13 @@ operators["Pauli Hamiltonian (XX)"] = nk.operator.PauliStrings(["XX"], [0.1])
 operators["Pauli Hamiltonian (XX+YZ+IZ)"] = nk.operator.PauliStrings(
     ["XX", "YZ", "IZ"], [0.1, 0.2, -1.4]
 )
-operators["Pauli Hamiltonian Jax"] = nk.operator.PauliStringsJax(
-    ["XX", "YZ", "IZ"], [0.1, 0.2, -1.4]
+operators["Pauli Hamiltonian Jax (_mode=index)"] = nk.operator.PauliStringsJax(
+    ["XX", "YZ", "IZ"], [0.1, 0.2, -1.4], _mode="index"
 )
 
+operators["Pauli Hamiltonian Jax (_mode=mask)"] = nk.operator.PauliStringsJax(
+    ["XX", "YZ", "IZ"], [0.1, 0.2, -1.4], _mode="mask"
+)
 hi = nkx.hilbert.SpinOrbitalFermions(5)
 operators["FermionOperator2nd"] = nkx.operator.FermionOperator2nd(
     hi,


### PR DESCRIPTION
Stuff which didn't make it into https://github.com/netket/netket/pull/1510 before it was merged.
I had done two implementations of the operator (mask and index, and you could do sth hybrid), this 
- tests both
- switches the default to indexing, which seems faster for short strings (on gpu one needs to test)
In particular with indexing it almost matches the performance of isingjax (convert it with -> to_local_operator->to_pauli_strings->to_jax_operator)
- privately exposes choosing the implementation in the constructor of the operator

