### PR TITLE
Add a burn in method to vqs

### DIFF
--- a/netket/vqs/mc/mc_state/state.py
+++ b/netket/vqs/mc/mc_state/state.py
@@ -509,6 +509,16 @@ class MCState(VariationalState):
             self.sample()
         return self._samples
 
+    def burn_in(self, n: int = 1):
+        """
+        Run the sampler n times to obtain samples that are better distributed
+        according to the Born distribution of the model.
+        Typically useful when a model is loaded from a parameter file.
+        """
+        for _ in range(n):
+            self.reset()
+            self.sample()
+
     def log_value(self, σ: jnp.ndarray) -> jnp.ndarray:
         """
         Evaluate the variational state for a batch of states and returns

--- a/test/variational/test_variational.py
+++ b/test/variational/test_variational.py
@@ -555,3 +555,8 @@ def test_expect_chunking(vstate, operator, n_chunks):
     jax.tree_map(
         partial(np.testing.assert_allclose, atol=1e-13), grad_nochunk, grad_chunk
     )
+
+
+def test_burn_in(vstate):
+    # just verify that it does not throw errors
+    vstate.burn_in(n=2)


### PR DESCRIPTION
Very small PR, but having something like this allows us to lower n_discard a lot. Relevant for @inailuig @gpescia 