### PR TITLE
Add log-probability correction to the exchange rule.

### DIFF
--- a/netket/sampler/rules/exchange.py
+++ b/netket/sampler/rules/exchange.py
@@ -68,13 +68,13 @@ class ExchangeRule_(MetropolisRule):
             si = rule.clusters[cluster, 0]
             sj = rule.clusters[cluster, 1]
 
-            σp = σ.at[si].set(σ[sj])
-            return σp.at[sj].set(σ[si])
+            # log-probability correction
+            log_corr = jnp.log(σ[si] != σ[sj])
 
-        return (
-            jax.vmap(scalar_update_fun, in_axes=(0, 0), out_axes=0)(σ, cluster_id),
-            None,
-        )
+            σp = σ.at[si].set(σ[sj])
+            return σp.at[sj].set(σ[si]), log_corr
+
+        return jax.vmap(scalar_update_fun, in_axes=(0, 0), out_axes=0)(σ, cluster_id)
 
     def __repr__(self):
         return f"ExchangeRule(# of clusters: {len(self.clusters)})"


### PR DESCRIPTION
This minimal PR prevents the sampler from overestimating the acceptance when using the exchange rule. This is especially relevant when samples are close to uniform. There, the rule acts trivially most of the time, yielding a high "displayed" acceptance although the chain's state did not update.