### PR TITLE
Support single precision and real dtypes in Pauli Strings

### DIFF
--- a/netket/operator/_pauli_strings/base.py
+++ b/netket/operator/_pauli_strings/base.py
@@ -23,6 +23,7 @@ from numba import jit
 from itertools import product
 from numbers import Number
 
+from netket import jax as nkjax
 from netket.hilbert import Qubit, AbstractHilbert
 from netket.utils.numbers import dtype as _dtype, is_scalar
 
@@ -101,6 +102,12 @@ def canonicalize_input(hilbert: AbstractHilbert, operators, weights, *, dtype=No
         dtype = jnp.promote_types(np.float32, _dtype(weights))
     # Fallback to float32 when float64 is disabled in JAX
     dtype = jnp.empty((), dtype=dtype).dtype
+
+    # If real dtype but there is a 'Y' in the string, upconvert
+    # the dtype to complex
+    if not nkjax.is_complex_dtype(dtype):
+        if np.any(np.char.find(operators, "Y") != -1):
+            dtype = nkjax.dtype_complex(dtype)
 
     weights = cast_operator_matrix_dtype(weights, dtype=dtype)
 

--- a/netket/operator/_pauli_strings/base.py
+++ b/netket/operator/_pauli_strings/base.py
@@ -339,7 +339,7 @@ class PauliStringsBase(DiscreteOperator):
                 "\n\n"
             )
         elif is_scalar(other):
-            op = self.copy(dtype=np.promote_types(self.dtype, _dtype(other)))
+            op = self.copy(dtype=jnp.promote_types(self.dtype, _dtype(other)))
             return op.__imul__(other)
 
         return NotImplemented
@@ -360,7 +360,9 @@ class PauliStringsBase(DiscreteOperator):
                     f"Cannot multiply inplace operator of type {type(self)} and "
                     f"dtype {self.dtype} to scalar with dtype {_dtype(other)}"
                 )
-            other = np.asarray(other, dtype=np.promote_types(self.dtype, _dtype(other)))
+            other = np.asarray(
+                other, dtype=jnp.promote_types(self.dtype, _dtype(other))
+            )
 
             self._weights = self.weights * other
             self._reset_caches()
@@ -384,7 +386,7 @@ class PauliStringsBase(DiscreteOperator):
         return self.__iadd__(-other)
 
     def __add__(self, other: Union["PauliStringsBase", Number]):
-        op = self.copy(dtype=np.promote_types(self.dtype, _dtype(other)))
+        op = self.copy(dtype=jnp.promote_types(self.dtype, _dtype(other)))
         op = op.__iadd__(other)
         return op
 

--- a/netket/operator/_pauli_strings/base.py
+++ b/netket/operator/_pauli_strings/base.py
@@ -103,6 +103,8 @@ def canonicalize_input(hilbert: AbstractHilbert, operators, weights, *, dtype=No
     # Fallback to float32 when float64 is disabled in JAX
     dtype = jnp.empty((), dtype=dtype).dtype
 
+    operators = np.asarray(operators, dtype=str)
+
     # If real dtype but there is a 'Y' in the string, upconvert
     # the dtype to complex
     if not nkjax.is_complex_dtype(dtype):
@@ -110,8 +112,6 @@ def canonicalize_input(hilbert: AbstractHilbert, operators, weights, *, dtype=No
             dtype = nkjax.dtype_complex(dtype)
 
     weights = cast_operator_matrix_dtype(weights, dtype=dtype)
-
-    operators = np.asarray(operators, dtype=str)
 
     return hilbert, operators, weights, weights.dtype
 

--- a/netket/operator/_pauli_strings/base.py
+++ b/netket/operator/_pauli_strings/base.py
@@ -155,11 +155,9 @@ class PauliStringsBase(DiscreteOperator):
         if not isinstance(hilbert, AbstractHilbert):
             hilbert, operators, weights = None, hilbert, operators
 
-        print(hilbert, operators, weights, dtype)
         hilbert, operators, weights, dtype = canonicalize_input(
             hilbert, operators, weights, dtype=dtype
         )
-        print(dtype)
 
         if not np.isscalar(cutoff) or cutoff < 0:
             raise ValueError("invalid cutoff in PauliStrings.")

--- a/netket/operator/_pauli_strings/base.py
+++ b/netket/operator/_pauli_strings/base.py
@@ -257,10 +257,11 @@ class PauliStringsBase(DiscreteOperator):
         print_list = []
         for op, w in zip(self.operators, self.weights):
             print_list.append(f"    {op} : {str(w)}")
-        s = "{}(hilbert={}, n_strings={}, dict(operators:weights)=\n{}\n)".format(
+        s = "{}(hilbert={}, n_strings={}, dtype={}, dict(operators:weights)=\n{}\n)".format(
             type(self).__name__,
             self.hilbert,
             len(self.operators),
+            self.dtype,
             ",\n".join(print_list),
         )
         return s

--- a/netket/operator/_pauli_strings/jax.py
+++ b/netket/operator/_pauli_strings/jax.py
@@ -285,7 +285,7 @@ class PauliStringsJax(PauliStringsBase, DiscreteJaxOperator):
         weights: Union[float, complex, list[Union[float, complex]]] = None,
         *,
         cutoff: float = 0.0,
-        dtype: DType = complex,
+        dtype: DType = None,
         _mode: str = "index",
     ):
         super().__init__(hilbert, operators, weights, cutoff=cutoff, dtype=dtype)

--- a/netket/operator/_pauli_strings/jax.py
+++ b/netket/operator/_pauli_strings/jax.py
@@ -347,6 +347,10 @@ class PauliStringsJax(PauliStringsBase, DiscreteJaxOperator):
             self._z_data = z_data
             self._initialized = True
 
+    def _reset_caches(self):
+        super()._reset_caches()
+        self._initialized = False
+
     def n_conn(self, x):
         # TODO implement it once we have cutoff
         return jnp.full(x.shape[:-1], self.max_conn_size, dtype=np.int32)

--- a/netket/operator/_pauli_strings/jax.py
+++ b/netket/operator/_pauli_strings/jax.py
@@ -148,6 +148,13 @@ def pack_internals_jax(
     Returns a dictionary with all the data fields
     """
 
+    # Check if there are Y operators in the strings, and in that
+    # case uppromote float to complex
+    if not jnp.issubdtype(weight_dtype, jnp.complexfloating):
+        # this checks if there is an Y in one of the strings
+        if np.any(np.char.find(operators, "Y") != -1):
+            weight_dtype = jnp.promote_types(jnp.complex64, weight_dtype)
+
     # index_dtype needs to be signed (we use -1 for padding)
 
     _check_mode(mode)

--- a/netket/operator/_pauli_strings/jax.py
+++ b/netket/operator/_pauli_strings/jax.py
@@ -150,10 +150,16 @@ def pack_internals_jax(
 
     # Check if there are Y operators in the strings, and in that
     # case uppromote float to complex
+    # Should never happen because we check in init...
     if not jnp.issubdtype(weight_dtype, jnp.complexfloating):
         # this checks if there is an Y in one of the strings
         if np.any(np.char.find(operators, "Y") != -1):
-            weight_dtype = jnp.promote_types(jnp.complex64, weight_dtype)
+            # weight_dtype = jnp.promote_types(jnp.complex64, weight_dtype)
+            raise TypeError(
+                "Found PauliStringsJax with real dtype but with Y paulis.\n"
+                "This should not be happening.\n"
+                "Please open an issue on the netket repository.\n"
+            )
 
     # index_dtype needs to be signed (we use -1 for padding)
 

--- a/netket/operator/_pauli_strings/numba.py
+++ b/netket/operator/_pauli_strings/numba.py
@@ -159,6 +159,10 @@ class PauliStrings(PauliStringsBase):
             self._local_states = np.array(self.hilbert.states_at_index(0))
             self._initialized = True
 
+    def _reset_caches(self):
+        super()._reset_caches()
+        self._initialized = False
+
     @staticmethod
     @jit(nopython=True)
     def _flattened_kernel(

--- a/netket/operator/_pauli_strings/numba.py
+++ b/netket/operator/_pauli_strings/numba.py
@@ -96,7 +96,7 @@ class PauliStrings(PauliStringsBase):
         weights: Union[float, complex, list[Union[float, complex]]] = None,
         *,
         cutoff: float = 1.0e-10,
-        dtype: DType = complex,
+        dtype: DType = None,
     ):
         super().__init__(hilbert, operators, weights, cutoff=cutoff, dtype=dtype)
 

--- a/test/operator/test_pauli.py
+++ b/test/operator/test_pauli.py
@@ -304,3 +304,14 @@ def test_pauli_jax_sparse_works():
 
     ham_d = ham.to_dense()
     np.testing.assert_allclose(ham_jax_d, ham_d)
+
+
+def test_pauliY_promotion_to_complex():
+    ham = nk.operator.PauliStrings("XXX", dtype=np.float32)
+    assert ham.dtype == np.float32
+    ham = nk.operator.PauliStrings("XXY", dtype=np.float32)
+    assert ham.dtype == np.complex64
+    ham = nk.operator.PauliStrings(["XXX", "XXY"], dtype=np.float32)
+    assert ham.dtype == np.complex64
+    ham = nk.operator.PauliStrings(["XXX", "XXY"], dtype=np.complex64)
+    assert ham.dtype == np.complex64

--- a/test/operator/test_pauli.py
+++ b/test/operator/test_pauli.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
 import pytest
+
+import numpy as np
+import jax.numpy as jnp
 
 import netket as nk
 
@@ -209,6 +211,21 @@ def test_pauli_add_and_multiply():
     op_add_cte = nk.operator.PauliStrings(["X", "Y", "Z"], [-1, 1, 1]) + 2
     op_true_add_cte = nk.operator.PauliStrings(["X", "Y", "Z", "I"], [-1, 1, 1, 2])
     assert np.allclose(op_add_cte.to_dense(), op_true_add_cte.to_dense())
+
+    # test multiplication and addition with numpy/jax scalar
+    op1 = np.array(0.5) * nk.operator.PauliStrings(["X"], [1])
+    op1_true = nk.operator.PauliStrings(["X"], [0.5])
+    assert np.allclose(op1.to_dense(), op1_true.to_dense())
+
+    op1 = jnp.array(0.5) * nk.operator.PauliStrings(["X"], [1])
+    assert np.allclose(op1.to_dense(), op1_true.to_dense())
+
+    op1 = np.array(0.5) + nk.operator.PauliStrings(["X"], [1])
+    op1_true = nk.operator.PauliStrings(["I", "X"], [0.5, 1])
+    assert np.allclose(op1.to_dense(), op1_true.to_dense())
+
+    op1 = jnp.array(0.5) + nk.operator.PauliStrings(["X"], [1])
+    assert np.allclose(op1.to_dense(), op1_true.to_dense())
 
 
 @pytest.mark.parametrize(

--- a/test/operator/test_pauli.py
+++ b/test/operator/test_pauli.py
@@ -315,3 +315,8 @@ def test_pauliY_promotion_to_complex():
     assert ham.dtype == np.complex64
     ham = nk.operator.PauliStrings(["XXX", "XXY"], dtype=np.complex64)
     assert ham.dtype == np.complex64
+
+
+def test_pauli_empty_constructor_error():
+    with pytest.raises(ValueError, match=r".*the hilbert space must be specified.*"):
+        nk.operator.PauliStrings([])


### PR DESCRIPTION
The implementation of PauliStrings and binary operations (sum subtract, multiply...) did not support real-valued coefficients and upcasted everything to complex double precision all the time.

This PR fixes that, and now it is possible to have real-weights and single precision paulisrings.

This PR also allows for the construction of an empty (null) Pauli string, which was erroring before, as it is a mathematically valid object.