### PR TITLE
Remove unnecessary vmap in local_value_kernel_jax_chunked

### DIFF
--- a/netket/vqs/mc/kernels.py
+++ b/netket/vqs/mc/kernels.py
@@ -185,7 +185,7 @@ def local_value_kernel_jax_chunked(
     """
     local_value_kernel = lambda s: local_value_kernel_jax(logpsi, pars, s, O)
 
-    local_value_chunked = nkjax.vmap_chunked(
+    local_value_chunked = nkjax.apply_chunked(
         local_value_kernel, in_axes=0, chunk_size=chunk_size
     )
 


### PR DESCRIPTION
When defining a `DiscreteJaxOperator`, the user is expected to define a `get_conn_padded` method which takes batches as an input. However, when `chunk_size` is set to a finite value, the following piece of code assumes `get_conn_padded` is also able to process single samples:

https://github.com/netket/netket/blob/228abe6b502fa6e3de959f0d81a3724a93fedf90/netket/vqs/mc/kernels.py#L188-L190

To avoid this, we (@inailuig ) propose to remove the unnecessary `vmap` therein, by using `apply_chunked`.