### PR TITLE
Fix toml

### DIFF
--- a/netket/operator/_kinetic.py
+++ b/netket/operator/_kinetic.py
@@ -83,7 +83,7 @@ class KineticEnergy(ContinuousOperator):
         return self._is_hermitian
 
     def _expect_kernel_single(
-        self, logpsi: Callable, params: PyTree, x: Array, inverse_mass: Optional[PyTree]
+        self, logpsi: Callable, params: PyTree, x: Array, mass: Optional[PyTree]
     ):
         def logpsi_x(x):
             return logpsi(params, x)
@@ -93,7 +93,7 @@ class KineticEnergy(ContinuousOperator):
         dp_dx2 = jnp.diag(jacfwd(dlogpsi_x)(x)[0].reshape(x.shape[0], x.shape[0]))
         dp_dx = dlogpsi_x(x)[0][0] ** 2
 
-        return -0.5 * jnp.sum(inverse_mass * (dp_dx2 + dp_dx), axis=-1)
+        return -0.5 * jnp.sum(mass * (dp_dx2 + dp_dx), axis=-1)
 
     @partial(jax.vmap, in_axes=(None, None, None, 0, None))
     def _expect_kernel(

--- a/netket/operator/_kinetic.py
+++ b/netket/operator/_kinetic.py
@@ -83,7 +83,7 @@ class KineticEnergy(ContinuousOperator):
         return self._is_hermitian
 
     def _expect_kernel_single(
-        self, logpsi: Callable, params: PyTree, x: Array, mass: Optional[PyTree]
+        self, logpsi: Callable, params: PyTree, x: Array, inverse_mass: Optional[PyTree]
     ):
         def logpsi_x(x):
             return logpsi(params, x)
@@ -93,7 +93,7 @@ class KineticEnergy(ContinuousOperator):
         dp_dx2 = jnp.diag(jacfwd(dlogpsi_x)(x)[0].reshape(x.shape[0], x.shape[0]))
         dp_dx = dlogpsi_x(x)[0][0] ** 2
 
-        return -0.5 * jnp.sum(mass * (dp_dx2 + dp_dx), axis=-1)
+        return -0.5 * jnp.sum(inverse_mass * (dp_dx2 + dp_dx), axis=-1)
 
     @partial(jax.vmap, in_axes=(None, None, None, 0, None))
     def _expect_kernel(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,7 @@ command_line = "-m pytest --verbose test"
 source = ["netket"]
 
 [tool.pytest.ini_options]
-addopts = "--color=yes --verbose --durations=100 -n auto --tb=short"
+addopts = "--color=yes --verbose --durations=100 --tb=short"
 doctest_optionflags = "NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL NUMBER"
 filterwarnings = [
     "ignore::UserWarning",
@@ -138,7 +138,7 @@ filterwarnings = [
 ]
 testpaths = [
     "test",
-]
+]gt
 
 [tool.ruff]
 target-version = "py38"


### PR DESCRIPTION
For me performing netket tests as indicated in the documentation (`pytest -n auto test/hilbert`) causes the following error:
ERROR: usage: pytest [options] [file_or_dir] [file_or_dir] [...]
pytest: error: unrecognized arguments: -n -n auto test/operator

When leaving away the options -n auto I get:
ERROR: usage: pytest [options] [file_or_dir] [file_or_dir] [...]
pytest: error: unrecognized arguments: -n test/operator

Removing the options -n auto from the .toml file allows me to do the test using:
`pytest test`
