### PR TITLE
Add new particle construor

### DIFF
--- a/netket/hilbert/particle.py
+++ b/netket/hilbert/particle.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Union
+from typing import Optional, Union
 import numpy as np
 from .continuous_hilbert import ContinuousHilbert
 
@@ -23,8 +23,10 @@ class Particle(ContinuousHilbert):
     def __init__(
         self,
         N: Union[int, tuple[int, ...]],
-        L: tuple[float, ...],
-        pbc: Union[bool, tuple[bool, ...]],
+        L: Optional[tuple[float, ...]] = None,
+        pbc: Optional[Union[bool, tuple[bool, ...]]] = None,
+        *,
+        D: Optional[int] = None,
     ):
         """
         Constructs new ``Particles`` given specifications
@@ -35,14 +37,27 @@ class Particle(ContinuousHilbert):
                 there are with a certain spin-projection.
             L: Tuple indicating the maximum of the continuous quantum number(s) in the configurations. Each entry
                 in the tuple corresponds to a different physical dimension.
-                If np.inf is used an infinite box is considered and `pbc=False` is mandatory (because what are PBC
+                If `np.inf` is used an infinite box is considered and `pbc=False` is mandatory (because what are PBC
                 if there are no boundaries?). If a finite value is given, a minimum value of zero is assumed for the
                 quantum number(s).
                 A particle in a 3D box of size L would take `(L,L,L)`. A rotor model would take e.g. `(2pi,)`.
             pbc: Tuple or bool indicating whether to use periodic boundary conditions in a given physical dimension.
                 If tuple it must have the same length as domain. If bool the same value is used for all the dimensions
                 defined in domain.
+            D: (Optional) Number of dimensions. Can be specified instead of `L` and `pbc` in order to construct a
+                `Particle` in a $D-$ dimensional infinite box. Equivalent to
+                `Particle(N, L=(np.inf,) * D, pbc=False)`.
         """
+        if D is None and L is None:
+            raise ValueError("Must specify at least `L` or `D`.")
+        elif D is not None:
+            if L is not None:
+                raise TypeError(
+                    "Cannot specify at the same time `D` and `L`. If you want to use "
+                    "an infinite box, just specify D, otherwise specify L."
+                )
+            L = (np.inf,) * D
+
         # Assume 1D if L is a scalar
         if not hasattr(L, "__len__"):
             L = (L,)
@@ -50,13 +65,18 @@ class Particle(ContinuousHilbert):
         if not hasattr(N, "__len__"):
             N = (N,)
 
+        if pbc is None:
+            if np.all(np.isinf(L)):
+                pbc = False
+            else:
+                raise ValueError("`pbc` must be specified if `L` is finite.")
+
         if isinstance(pbc, bool):
             pbc = [pbc] * len(L)
 
         if np.any(np.logical_and(np.isinf(L), pbc)):
             raise ValueError(
-                "If you do have periodic boundary conditions the size of the box (L) "
-                "must be finite."
+                "Cannot combine periodic boundary conditions and infinite size along the same dimension."
             )
 
         self._N = sum(N)

--- a/test/hilbert/test_hilbert.py
+++ b/test/hilbert/test_hilbert.py
@@ -660,3 +660,21 @@ def test_hilbert_numba_throws(hi):
         numbers_to_states(hi, 1)
     with pytest.raises(HilbertIndexingDuringTracingError):
         states_to_numbers(hi, jnp.zeros((hi.size,)))()
+
+
+def test_particle_alternative_constructors():
+    hi1 = nk.hilbert.Particle(N=5, L=(np.inf, np.inf), pbc=False)
+    hi2 = nk.hilbert.Particle(N=5, L=(np.inf, np.inf))
+    assert hi1 == hi2
+
+    hi2 = nk.hilbert.Particle(N=5, D=2)
+    assert hi1 == hi2
+
+    with pytest.raises(ValueError, match=r"Must specify at least.*"):
+        nk.hilbert.Particle(N=5)
+
+    with pytest.raises(TypeError, match=r"Cannot specify at the same time.*"):
+        nk.hilbert.Particle(N=5, L=np.inf, D=1)
+
+    with pytest.raises(ValueError, match=r".*must be specified.*"):
+        nk.hilbert.Particle(N=5, L=3)


### PR DESCRIPTION
As discussed in the first point of #1575 .

adds the following constructor 
```python
    hi1 = nk.hilbert.Particle(N=5, L=(np.inf, np.inf), pbc=False)
    hi2 = nk.hilbert.Particle(N=5, D=2)
    assert hi1 == hi2
```

as well as a default value for `pbc` when a dimension is infinite.
```python
    hi1 = nk.hilbert.Particle(N=5, L=(np.inf, np.inf))
    hi2 = nk.hilbert.Particle(N=5, D=2)
    assert hi1 == hi2
```