### PR TITLE
Remove continuous-space tutorials for the time being

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -58,7 +58,6 @@ tutorials/gs-j1j2
 tutorials/gs-matrix-models
 tutorials/gs-gcnn-honeycomb
 tutorials/lattice-fermions
-tutorials/gs-continuous-space
 ```   
 
 ```{toctree}


### PR DESCRIPTION
Continuous space tutorials are not rendered correctly and all the math is garbled.
I'm removing them until @gpescia fixes them...

see https://netket.readthedocs.io/en/latest/tutorials/gs-continuous-space.html