### PR TITLE
Add grad chunk size

### DIFF
--- a/netket/vqs/mc/mc_state/expect_forces_chunked.py
+++ b/netket/vqs/mc/mc_state/expect_forces_chunked.py
@@ -83,6 +83,8 @@ def expect_and_forces_impl(  # noqa: F811
     *,
     mutable: CollectionFilter = False,
 ) -> tuple[Stats, PyTree]:
+    print(chunk_size)
+    print(1, mutable)
     chunk_size, grad_chunk_size = chunk_size
 
     σ, args = get_local_kernel_arguments(vstate, Ô)
@@ -91,6 +93,7 @@ def expect_and_forces_impl(  # noqa: F811
 
     Ō, Ō_grad, new_model_state = forces_expect_hermitian_chunked(
         chunk_size,
+        grad_chunk_size,
         local_estimator_fun,
         vstate._apply_fun,
         mutable,
@@ -106,7 +109,7 @@ def expect_and_forces_impl(  # noqa: F811
     return Ō, Ō_grad
 
 
-@partial(jax.jit, static_argnums=(0, 1, 2, 3))
+@partial(jax.jit, static_argnums=(0, 1, 2, 3, 4))
 def forces_expect_hermitian_chunked(
     chunk_size: int,
     grad_chunk_size: int,

--- a/netket/vqs/mc/mc_state/expect_grad_chunked.py
+++ b/netket/vqs/mc/mc_state/expect_grad_chunked.py
@@ -53,10 +53,19 @@ def expect_and_grad_fallback(  # noqa: F811
     *args,
     **kwargs,
 ):
-    warnings.warn(
-        ignore_chunk_warning(vstate, operator, chunk_size, name="expect_and_grad")
-    )
-    return expect_and_grad(vstate, operator, None, *args, **kwargs)
+    # chunk size
+    if isinstance(chunk_size, int):
+        chunk_size = None
+        warnings.warn(
+            ignore_chunk_warning(vstate, operator, chunk_size, name="expect_and_grad")
+        )
+
+    # if chunk size is a tuple (for forward and backward)
+    # convert to single chunk size
+    if isinstance(chunk_size, tuple):
+        chunk_size = chunk_size[0]
+
+    return expect_and_grad(vstate, operator, chunk_size, *args, **kwargs)
 
 
 @expect_and_grad_nonhermitian.dispatch(precedence=-10)
@@ -66,9 +75,17 @@ def expect_and_grad_nonhermitian_chunk_fallback(
     chunk_size: Any,
     **kwargs,
 ):
-    warnings.warn(
-        ignore_chunk_warning(
-            vstate, Ô, chunk_size, name="expect_and_grad_nonhermitian"
+    if isinstance(chunk_size, int):
+        chunk_size = None
+        warnings.warn(
+            ignore_chunk_warning(
+                vstate, Ô, chunk_size, name="expect_and_grad_nonhermitian"
+            )
         )
-    )
-    return expect_and_grad_nonhermitian(vstate, Ô, None, **kwargs)
+
+    # if chunk size is a tuple (for forward and backward)
+    # convert to single chunk size
+    if isinstance(chunk_size, tuple):
+        chunk_size = chunk_size[0]
+
+    return expect_and_grad_nonhermitian(vstate, Ô, chunk_size, **kwargs)

--- a/netket/vqs/mc/mc_state/state.py
+++ b/netket/vqs/mc/mc_state/state.py
@@ -645,7 +645,7 @@ class MCState(VariationalState):
 
         return expect_and_grad(
             self,
-            Ô,
+            O,
             (self.chunk_size, self.grad_chunk_size),
             mutable=mutable,
             **kwargs,
@@ -692,7 +692,7 @@ class MCState(VariationalState):
             mutable = self.mutable
 
         return expect_and_forces(
-            self, Ô, (self.chunk_size, self.grad_chunk_size), mutable=mutable
+            self, O, (self.chunk_size, self.grad_chunk_size), mutable=mutable
         )
 
     def quantum_geometric_tensor(


### PR DESCRIPTION
This PR adds an argument grad_chunk_size so that different chunk sizes can be used for the forward and backwards passes. 

Generally speaking for a multi-layer perceptron with H hidden nodes and L layers the forward pass takes H memory and the backward pass takes H^2 + LH memory. So there's many situations where it's efficient to use a larger chunk size for the forward pass. 

