### PR TITLE
Correctly return Notimplemented for operations between operators

### DIFF
--- a/netket/experimental/operator/_fermion_operator_2nd.py
+++ b/netket/experimental/operator/_fermion_operator_2nd.py
@@ -462,7 +462,7 @@ class FermionOperator2nd(DiscreteOperator):
 
     def _op__imatmul__(self, other):
         if not isinstance(other, FermionOperator2nd):
-            return NotImplementedError
+            return NotImplemented
         if not self.hilbert == other.hilbert:
             raise ValueError(
                 "Can only multiply identical hilbert spaces (got A@B, "
@@ -497,7 +497,7 @@ class FermionOperator2nd(DiscreteOperator):
 
     def _op__matmul__(self, other):
         if not isinstance(other, FermionOperator2nd):
-            return NotImplementedError
+            return NotImplemented
         dtype = np.promote_types(self.dtype, other.dtype)
         op = self.copy(dtype=dtype)
         return op._op__imatmul__(other)

--- a/netket/operator/_pauli_strings/base.py
+++ b/netket/operator/_pauli_strings/base.py
@@ -310,7 +310,7 @@ class PauliStringsBase(DiscreteOperator):
 
     def _op__matmul__(self, other):
         if not isinstance(other, PauliStringsBase):
-            return NotImplementedError
+            return NotImplemented
         op = self.copy(
             dtype=np.promote_types(self.dtype, _dtype(other)),
             cutoff=max(self._cutoff, other._cutoff),


### PR DESCRIPTION
This makes it such that in #1598 he would get the error

```
TypeError: unsupported operand type(s) for *: 'FermionOperator2nd' and 'LocalOperator'
```
instead of the unreadable
```
TypeError: unsupported operand type(s) for *: 'type' and 'type'
```
