### PR TITLE
create fermionic operator from pyscf molecule

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -69,20 +69,12 @@ jobs:
           python -m pip install wheel
           echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
 
-      - name: Pip install oldest dependencies
-        if: matrix.oldest_deps
-        run: |
-          pip install --upgrade toml
-          python conf/compute_oldest_dependencies.py
-          pip install --upgrade -r oldest_requirements.txt
-          pip install -e ".[dev,extra]"
-
       - name: Pip install packages
         if: ${{ ! matrix.oldest_deps }}
         run: |
           pip install jaxlib
           if [ -z "${{ matrix.mpi }}" ]; then
-            pip install -e ".[dev,extra]"
+            pip install -e ".[dev,extra,pyscf]"
           else
             pip install -e ".[dev,mpi]"
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
 * Added new {class}`netket.models.Slater2nd` model implementing a Slater ansatz [#1622](https://github.com/netket/netket/pull/1622).
 * Added new {func}`netket.jax.logdet_cmplx` function to compute the complex log-determinant of a batch of matrices [#1622](https://github.com/netket/netket/pull/1622).
 * Added new {class}`netket.experimental.driver.VMC_SRt` driver, which leads in identical parameter updates as the standard Stochastic Reconfiguration with diagonal shift regularization. Therefore, it is essentially equivalent to using the standard {class}`nk.driver.VMC` with the {class}`nk.optimizer.SR` preconditioner. The advantage of this method is that it requires the inversion of a matrix with side number of samples instead of number of parameters, making this formulation particularly useful in typical deep learning scenarios [#1623](https://github.com/netket/netket/pull/1623).
+* Added a new function :func:`netket.experimental.operator.from_pyscf_molecule` to construct the electronic hamiltonian of a given molecule specified through pyscf. This is accompanied by :func:`netket.experimental.operator.pyscf.TV_from_pyscf_molecule` to compute the T and V tensors of a pyscf molecule [#1602](https://github.com/netket/netket/pull/1602).
+
 
 ### Breaking Changes
 * The {class}`netket.nn.blocks.SymmExpSum` layer is now normalised by the number of elements in the symmetry group in order to maintain a reasonable normalisation [#1624](https://github.com/netket/netket/pull/1624).

--- a/docs/api/api-experimental.md
+++ b/docs/api/api-experimental.md
@@ -197,6 +197,8 @@ It is experimental until it has been thoroughly tested by the community, meaning
    operator.fermion.create
    operator.fermion.destroy
    operator.fermion.number
+   operator.from_pyscf_molecule
+   operator.pyscf.TV_from_pyscf_molecule
 ```
 
 ## Observables

--- a/docs/api/api-experimental.md
+++ b/docs/api/api-experimental.md
@@ -111,17 +111,6 @@ This module contains experimental loggers that can be used with the optimization
 
 ## Time Evolution Driver
 
-````{admonition} Apple ARM (M1) processors 
-:class: warning
-
-Those drivers are automatically jitted with `jax.jit`. To disable jitting set 
-```python
-netket.config.netket_disable_ode_jit = True
-```
-or set the equivalent environment variable.
-
-````
-
 
 ```{eval-rst}
 .. currentmodule:: netket.experimental
@@ -139,17 +128,6 @@ or set the equivalent environment variable.
 ## ODE Integrators
 
 This is a collection of ODE integrators that can be used with the TDVP driver above.
-
-````{admonition} Apple ARM (M1) processors 
-:class: warning
-
-Those drivers are automatically jitted with `jax.jit`. To disable jitting set 
-```python
-netket.config.netket_disable_ode_jit = True
-```
-or set the equivalent environment variable.
-
-````
 
 ```{eval-rst}
 .. currentmodule:: netket.experimental

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -118,6 +118,7 @@ intersphinx_mapping = {
     "flax": ("https://flax.readthedocs.io/en/latest/", None),
     "igraph": ("https://igraph.org/python/api/latest", None),
     "qutip": ("https://qutip.org/docs/latest/", None),
+    "pyscf": ("https://pyscf.org/", None),
 }
 
 # (Optional) Logo. Should be small enough to fit the navbar (ideally 24x24).

--- a/netket/experimental/operator/__init__.py
+++ b/netket/experimental/operator/__init__.py
@@ -17,7 +17,8 @@ __all__ = ["FermionOperator2nd"]
 
 from ._fermion_operator_2nd import FermionOperator2nd
 from . import fermion
+from .pyscf import from_pyscf_molecule
 
 from netket.utils import _auto_export
 
-_auto_export(__name__)
+_auto_export(__name__, ignore="pyscf")

--- a/netket/experimental/operator/__init__.py
+++ b/netket/experimental/operator/__init__.py
@@ -21,4 +21,4 @@ from .pyscf import from_pyscf_molecule
 
 from netket.utils import _auto_export
 
-_auto_export(__name__, ignore="pyscf")
+_auto_export(__name__)

--- a/netket/experimental/operator/pyscf.py
+++ b/netket/experimental/operator/pyscf.py
@@ -1,6 +1,19 @@
+# Copyright 2023 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import Optional
 
-import sparse
 import numpy as np
 
 import jax
@@ -25,6 +38,8 @@ def compute_pyscf_integrals(mol, mo_coeff):
 
 
 def spinorb_from_spatial_sparse_coo2(tij_sparse, interleave=False, spin_values=[0, 1]):
+    sparse = import_optional_dependency("sparse", descr="TV_from_pyscf_molecule")
+
     # Σ_ijσ t_ij c†_iσ c_jσ
     # for σ ∈ spin_values
     # interleave=True -> 2i+spin
@@ -66,6 +81,8 @@ def spinorb_from_spatial_sparse_coo2(tij_sparse, interleave=False, spin_values=[
 def spinorb_from_spatial_sparse_coo4(
     vijkl_sparse, interleave=False, _order_preserving=False
 ):
+    sparse = import_optional_dependency("sparse", descr="TV_from_pyscf_molecule")
+
     # Σ_ijklμσ v_ijkl c†_iμ c†_jσ c_kμ c_lσ
     # interleave=True -> 2i+spin
     # interleave=False -> n*spin+i
@@ -103,6 +120,8 @@ def spinorb_from_spatial_sparse_coo4(
 
 
 def to_desc_order_sparse(vijkl_sparse, cutoff, set_zero_same=True):
+    sparse = import_optional_dependency("sparse", descr="TV_from_pyscf_molecule")
+
     # !! use this only after adding spin, spinorb_from_spatial_sparse will be wrong
     # because the (implicitly assumed) symmetries of the tensor are not conserved
 
@@ -235,6 +254,8 @@ def TV_from_pyscf_molecule(
         ...
 
     """
+    sparse = import_optional_dependency("sparse", descr="TV_from_pyscf_molecule")
+
     # Compute the T and V matrices
     E_nuc, tij, vijkl = compute_pyscf_integrals(molecule, mo_coeff)
     tij_sparse = sparse.COO.from_numpy(tij * (np.abs(tij) >= cutoff))

--- a/netket/experimental/operator/pyscf.py
+++ b/netket/experimental/operator/pyscf.py
@@ -135,9 +135,9 @@ def spinorb_from_spatial_sparse(tij_sparse, vijkl_sparse, interleave=False):
 
 def pyscf_molecule_to_arrays(mol, mo_coeff=None):
     if mo_coeff is None:
-        from pyscf import scf
+        pyscf = import_optional_dependency("pyscf", descr="pyscf_molecule_to_arrays")
 
-        mf = scf.HF(mol).run()
+        mf = pyscf.scf.HF(mol).run()
         mo_coeff = mf.mo_coeff
     return compute_pyscf_integrals(mol, mo_coeff)
 

--- a/netket/experimental/operator/pyscf.py
+++ b/netket/experimental/operator/pyscf.py
@@ -4,6 +4,7 @@ import numpy as np
 import jax
 import jax.numpy as jnp
 
+from netket.utils.optional_deps import import_optional_dependency
 from netket.experimental.hilbert import SpinOrbitalFermions
 from ._fermion_operator_2nd import FermionOperator2nd
 

--- a/netket/experimental/operator/pyscf.py
+++ b/netket/experimental/operator/pyscf.py
@@ -1,0 +1,226 @@
+import sparse
+import numpy as np
+
+import jax
+import jax.numpy as jnp
+
+from netket.experimental.hilbert import SpinOrbitalFermions
+from ._fermion_operator_2nd import FermionOperator2nd
+
+
+def compute_pyscf_integrals(mol, mo_coeff):
+    t_ij_ao = jnp.asarray(mol.intor("int1e_kin") + mol.intor("int1e_nuc"))
+    v_ijkl_ao = jnp.asarray(mol.intor("int2e").transpose(0, 2, 3, 1))
+    c = jnp.asarray(mo_coeff.T)
+    t_ij_mo = jax.jit(jnp.einsum, static_argnums=0)("ij,ai,bj->ab", t_ij_ao, c, c)
+    v_ijkl_mo = jax.jit(jnp.einsum, static_argnums=0)(
+        "ijkl,ai,bj,ck,dl->abcd", v_ijkl_ao, c, c, c, c
+    )
+    const = jnp.asarray(float(mol.energy_nuc()))
+    return const, t_ij_mo, v_ijkl_mo
+
+
+def spinorb_from_spatial_sparse_coo2(tij_sparse, interleave=False, spin_values=[0, 1]):
+    # Σ_ijσ t_ij c†_iσ c_jσ
+    # for σ ∈ spin_values
+    # interleave=True -> 2i+spin
+    # interleave=False -> n*spin+i
+
+    if isinstance(spin_values, int):
+        spin_values = list(spin_values)
+    # assert spin_values in [[0], [1], [0,1]]
+
+    assert isinstance(tij_sparse, sparse.COO)
+    n = tij_sparse.shape[0]
+
+    if interleave:
+        t = lambda x: 2 * x
+        tp1 = lambda x: 2 * x + 1
+    else:
+        t = lambda x: x
+        tp1 = lambda x: x + n
+
+    i, j = tij_sparse.coords
+    a = tij_sparse.data
+    a2 = []
+    i2 = []
+    j2 = []
+    if 0 in spin_values:
+        a2.append(a)
+        i2.append(t(i))
+        j2.append(t(j))
+    if 1 in spin_values:
+        a2.append(a)
+        i2.append(tp1(i))
+        j2.append(tp1(j))
+    i2 = np.concatenate(i2)
+    j2 = np.concatenate(j2)
+    a2 = np.concatenate(a2)
+    return sparse.COO(np.array([i2, j2]), a2, shape=(2 * n, 2 * n))
+
+
+def spinorb_from_spatial_sparse_coo4(
+    vijkl_sparse, interleave=False, _order_preserving=False
+):
+    # Σ_ijklμσ v_ijkl c†_iμ c†_jσ c_kμ c_lσ
+    # interleave=True -> 2i+spin
+    # interleave=False -> n*spin+i
+    assert isinstance(vijkl_sparse, sparse.COO)
+    n = vijkl_sparse.shape[0]
+
+    if interleave:
+        t = lambda x: 2 * x
+        tp1 = lambda x: 2 * x + 1
+    else:
+        t = lambda x: x
+        tp1 = lambda x: x + n
+
+    p, q, r, s = vijkl_sparse.coords
+    b = vijkl_sparse.data
+
+    if _order_preserving:
+        # swap i/j and k/l
+        a2 = np.concatenate([-b, -b, b, b])
+        p2 = np.concatenate([tp1(q), tp1(p), t(p), tp1(p)])
+        q2 = np.concatenate([t(p), t(q), t(q), tp1(q)])
+        r2 = np.concatenate([tp1(r), tp1(s), t(r), tp1(r)])
+        s2 = np.concatenate([t(s), t(r), t(s), tp1(s)])
+    else:
+        # same as openfermion
+        a2 = np.concatenate([b, b, b, b])
+        p2 = np.concatenate([t(p), tp1(p), t(p), tp1(p)])
+        q2 = np.concatenate([tp1(q), t(q), t(q), tp1(q)])
+        r2 = np.concatenate([tp1(r), t(r), t(r), tp1(r)])
+        s2 = np.concatenate([t(s), tp1(s), t(s), tp1(s)])
+
+    return sparse.COO(
+        np.array([p2, q2, r2, s2]), a2, shape=(2 * n, 2 * n, 2 * n, 2 * n)
+    )
+
+
+def to_desc_order_sparse(vijkl_sparse, cutoff, set_zero_same=True):
+    # !! use this only after adding spin, spinorb_from_spatial_sparse will be wrong
+    # because the (implicitly assumed) symmetries of the tensor are not conserved
+
+    # assume (1,1,0,0) are already index order (daggers are left/ij)
+    # swap i/j k/l so that i>j and k>l
+
+    # now swap the larger one to the left, will cause lots of them to cancel
+    i, j, k, l = vijkl_sparse.coords
+    a = vijkl_sparse.data.copy()
+    a[np.where(i < j)] *= -1
+    a[np.where(k < l)] *= -1
+    if set_zero_same:
+        # set to zero all those where we try to create / destroy two on the same orbital
+        a[np.where(i == j)] *= 0
+        a[np.where(k == l)] *= 0
+    new_coords = np.array(
+        [np.maximum(i, j), np.minimum(i, j), np.maximum(k, l), np.minimum(k, l)]
+    )
+    # use coo to merge same indices
+    vijkl_sparse2 = sparse.COO(new_coords, a, shape=vijkl_sparse.shape)
+    # we might have some new almost zeros from the cancellations, make sure they are 0
+    new_coords2 = vijkl_sparse2.coords
+    a2 = vijkl_sparse2.data
+    mask = np.abs(a2) > cutoff
+    return sparse.COO(new_coords2[:, mask], a2[mask], shape=vijkl_sparse.shape)
+
+
+def spinorb_from_spatial_sparse(tij_sparse, vijkl_sparse, interleave=False):
+    return spinorb_from_spatial_sparse_coo2(
+        tij_sparse, interleave
+    ), spinorb_from_spatial_sparse_coo4(vijkl_sparse, interleave)
+
+
+def pyscf_molecule_to_arrays(mol, mo_coeff=None):
+    if mo_coeff is None:
+        from pyscf import scf
+
+        mf = scf.HF(mol).run()
+        mo_coeff = mf.mo_coeff
+    return compute_pyscf_integrals(mol, mo_coeff)
+
+
+def arrays_to_terms(
+    const, tij_sparse, vijkl_sparse, term_conj2=(1, 0), term_conj4=(1, 0, 1, 0)
+):
+    ij = np.array(
+        [
+            tij_sparse.coords[0],
+            np.ones_like(tij_sparse.coords[0], dtype=int) * term_conj2[0],
+            tij_sparse.coords[1],
+            np.ones_like(tij_sparse.coords[1], dtype=int) * term_conj2[1],
+        ]
+    ).T.reshape(-1, 2, 2)
+
+    ijkl = np.array(
+        [
+            vijkl_sparse.coords[0],
+            np.ones_like(vijkl_sparse.coords[0], dtype=int) * term_conj4[0],
+            vijkl_sparse.coords[1],
+            np.ones_like(vijkl_sparse.coords[1], dtype=int) * term_conj4[1],
+            vijkl_sparse.coords[2],
+            np.ones_like(vijkl_sparse.coords[2], dtype=int) * term_conj4[2],
+            vijkl_sparse.coords[3],
+            np.ones_like(vijkl_sparse.coords[3], dtype=int) * term_conj4[3],
+        ]
+    ).T.reshape(-1, 4, 2)
+    terms = ij.tolist() + ijkl.tolist()
+    weights = tij_sparse.data.tolist() + vijkl_sparse.data.tolist()
+    return terms, weights, const
+
+
+def operator_from_arrays(
+    const,
+    tij_sparse,
+    vijkl_sparse,
+    n_electrons,
+    hi=None,
+    cls=FermionOperator2nd,
+    term_conj2=(1, 0),
+    term_conj4=(1, 0, 1, 0),
+):
+    """
+    H = const + Σ tᵢⱼ cᵢ†cⱼ + Σ vᵢⱼₖₗ cᵢ†cⱼcₖ†cₗ
+    use term_conj4=(1,1,0,0) if you want cᵢ†cⱼ†cₖcₗ instead.
+    use a zero matrix/tensor of the correct shape for tij and/or vijkl if you only want to use one of them
+    """
+    if hi is None:
+        if isinstance(n_electrons, tuple):
+            assert len(n_electrons) == 2
+            hi = SpinOrbitalFermions(
+                n_orbitals=tij_sparse.shape[0] // 2, s=1 / 2, n_fermions=n_electrons
+            )
+        else:
+            hi = SpinOrbitalFermions(
+                n_orbitals=tij_sparse.shape[0], n_fermions=n_electrons
+            )
+    terms, weights, constant = arrays_to_terms(
+        const, tij_sparse, vijkl_sparse, term_conj2=term_conj2, term_conj4=term_conj4
+    )
+    return cls(hi, terms, weights, constant)
+
+
+def FermiOperator2nd_from_pyscf_molecule(
+    mol, mo_coeff=None, cutoff=1e-11, cls=FermionOperator2nd
+):
+    """defaults to molecular orbitals
+    !! factor 0.5 is added here
+    """
+    E_nuc, tij, vijkl = pyscf_molecule_to_arrays(mol, mo_coeff)
+    tij_sparse = sparse.COO.from_numpy(tij * (np.abs(tij) >= cutoff))
+    vijkl_sparse = sparse.COO.from_numpy(vijkl * (np.abs(vijkl) >= cutoff))
+    tij_sparse_spin, vijkl_sparse_spin = spinorb_from_spatial_sparse(
+        tij_sparse, vijkl_sparse
+    )
+    vijkl_sparse_spin = to_desc_order_sparse(vijkl_sparse_spin, cutoff)
+    ha = operator_from_arrays(
+        E_nuc,
+        tij_sparse_spin,
+        0.5 * vijkl_sparse_spin,
+        mol.nelec,
+        term_conj4=(1, 1, 0, 0),
+        cls=cls,
+    )
+    # TODO run setup and set _max_conn_size here estimating it analytially
+    return ha

--- a/netket/experimental/operator/pyscf.py
+++ b/netket/experimental/operator/pyscf.py
@@ -316,14 +316,12 @@ def from_pyscf_molecule(
         >>> E_hf = sum(mf.scf_summary.values())
         >>>
         >>> E_fci = fci.FCI(mf).kernel()[0]
-        >>> print('fci', E_fci)
-            fci -7.882527528833891
         >>>
         >>> ha = nkx.operator.from_pyscf_molecule(mol)
             converged SCF energy = -7.86338212728528
         >>> E0 = float(nk.exact.lanczos_ed(ha))
-        >>> print(f"{E0 = }, {E_fci = }")
-        E0 = -7.882527528833887, E_fci = -7.882527528833891
+        >>> print(f"{E0 = :.5f}, {E_fci = :.5f}")
+        E0 = -7.88253, E_fci = -7.88253
 
     Example:
         Constructs the hamiltonian for a Li-H molecule, using the `sto-3g` basis

--- a/netket/experimental/operator/pyscf.py
+++ b/netket/experimental/operator/pyscf.py
@@ -269,7 +269,7 @@ def TV_from_pyscf_molecule(
 
 
 def from_pyscf_molecule(
-    molecule: "pyscf.gto.mole.Mole",  # noqa: F821
+    molecule: "pyscf.gto.mole.Mole",  # type: pyscf.gto.mole.Mole  # noqa: F821
     mo_coeff: Optional[np.ndarray] = None,
     *,
     cutoff: float = 1e-11,
@@ -308,7 +308,7 @@ def from_pyscf_molecule(
 
     Example:
         Constructs the hamiltonian for a Li-H molecule, using the `sto-3g` basis
-        and the Boys orbitals
+        and the Boys orbitals using :class:`~pyscf.lo.Boys`.
 
         >>> from pyscf import gto, scf, lo
         >>> import netket as nk; import netket.experimental as nkx
@@ -325,11 +325,12 @@ def from_pyscf_molecule(
         >>> ha = nkx.operator.from_pyscf_molecule(mol, mo_coeff=mo_coeff)
 
     Args:
-        molecule: The pyscf `Mole` object describing the Hamiltonian
+        molecule: The pyscf :class:`~pyscf.gto.mole.Mole` object describing the
+            Hamiltonian
         mo_coeff: The molecular orbital coefficients determining the
             linear combination of atomic orbitals to produce the
             molecular orbitals. If unspecified this defaults to
-            the hartree fock orbitals.
+            the hartree fock orbitals computed using :class:`~pyscf.scf.HF`.
         cutoff: Ignores all matrix elements in the `V` and `T` matrix that have
             magnitude less than this value. Defaults to :math:`10^{-11}`
         implementation: The particular implementation to use for the operator.

--- a/netket/nn/blocks/symmetry_sum.py
+++ b/netket/nn/blocks/symmetry_sum.py
@@ -33,7 +33,7 @@ class SymmExpSum(nn.Module):
 
     .. math::
 
-        \log\psi_\theta(\sigma) = \frac{1}{\abs{G}}\log\sum_{g\in G}
+        \log\psi_\theta(\sigma) = \frac{1}{|G|}\log\sum_{g\in G}
             \chi_g\exp[\log\psi_\theta(T_{g}\sigma)]
 
     For the ground-state, it is usually found that :math:`\chi_g=1 \forall g\in G`.

--- a/netket/optimizer/solver/solvers.py
+++ b/netket/optimizer/solver/solvers.py
@@ -85,8 +85,8 @@ def pinv(A, b, rcond=1e-12, x0=None):
     Solve the linear system using jax's implementation of the
     pseudo-inverse.
 
-    Internally it calls :ref:`~jax.numpy.linalg.pinv` which
-    uses a :ref:`~jax.numpy.linalg.svd` decomposition with
+    Internally it calls :func:`~jax.numpy.linalg.pinv` which
+    uses a :func:`~jax.numpy.linalg.svd` decomposition with
     the same value of **rcond**.
 
     .. note::
@@ -95,7 +95,7 @@ def pinv(A, b, rcond=1e-12, x0=None):
         the pseudo-inverse
         :func:`netket.optimizer.solver.pinv_smooth` (which
         internally uses hermitian diagonaliation) outperform
-        jax's :ref:`~jax.numpy.linalg.pinv`.
+        jax's :func:`~jax.numpy.linalg.pinv`.
 
         For that reason, we suggest to use
         :func:`~netket.optimizer.solver.pinv_smooth` instead of
@@ -128,7 +128,7 @@ def svd(A, b, rcond=None, x0=None):
     Solve the linear system using Singular Value Decomposition.
     The diagonal shift on the matrix should be 0.
 
-    Internally uses {ref}`jax.numpy.linalg.lstsq`.
+    Internally uses :func:`jax.numpy.linalg.lstsq`.
 
     Args:
         A: the matrix A in Ax=b
@@ -150,7 +150,7 @@ def cholesky(A, b, lower=False, x0=None):
     Solve the linear system using a Cholesky Factorisation.
     The diagonal shift on the matrix should be 0.
 
-    Internally uses {ref}`jax.numpy.linalg.cho_solve`.
+    Internally uses :func:`jax.numpy.linalg.cho_solve`.
 
     Args:
         A: the matrix A in Ax=b
@@ -174,7 +174,7 @@ def LU(A, b, trans=0, x0=None):
     Solve the linear system using a LU Factorisation.
     The diagonal shift on the matrix should be 0.
 
-    Internally uses {ref}`jax.numpy.linalg.lu_solve`.
+    Internally uses :func:`jax.numpy.linalg.lu_solve`.
 
     Args:
         A: the matrix A in Ax=b
@@ -200,7 +200,7 @@ def solve(A, b, assume_a="pos", x0=None):
     Solve the linear system.
     The diagonal shift on the matrix should be 0.
 
-    Internally uses {ref}`jax.numpy.solve`.
+    Internally uses :func:`jax.numpy.solve`.
 
     Args:
         A: the matrix A in Ax=b

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,10 @@ mpi = [
     "mpi4py>=3.0.1, <4",
     "mpi4jax>=0.3.9, <0.5"
     ]
+pyscf = [
+    "sparse>=0.12.0",
+    "pyscf>=2.0"
+]
 extra = [
     "tensorboardx>=2.0.0",
     "openfermion>=1.0.0",

--- a/test/operator/test_pyscf.py
+++ b/test/operator/test_pyscf.py
@@ -1,0 +1,45 @@
+# Copyright 2023 The Netket Authors. - All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+import numpy as np
+
+import netket as nk
+import netket.experimental as nkx
+
+
+def test_pyscf():
+    pytest.importorskip("pyscf")
+
+    from pyscf import gto, scf, fci
+
+    bond_length = 1.5109
+    geometry = [
+        ("Li", (0.0, 0.0, -bond_length / 2)),
+        ("H", (0.0, 0.0, bond_length / 2)),
+    ]
+    mol = gto.M(atom=geometry, basis="STO-3G")
+
+    mf = scf.RHF(mol).run()
+    E_fci = fci.FCI(mf).kernel()[0]
+
+    ha = nkx.operator.from_pyscf_molecule(mol, mo_coeff=mf.mo_coeff)
+
+    assert ha.hilbert.n_orbitals == 6
+    assert ha.hilbert.n_fermions == 4
+    assert ha.hilbert.n_fermions_per_spin == (2, 2)
+
+    # check that ED gives same value as FCI in pyscf
+    np.testing.assert_allclose(E_fci, nk.exact.lanczos_ed(ha))


### PR DESCRIPTION
requires the [sparse](https://github.com/pydata/sparse) package

example:
```python
from pyscf import gto, scf, fci
from netket.experimental.operator.pyscf import FermiOperator2nd_from_pyscf_molecule
import netket as nk
import numpy as np

bond_length = 1.5109
basis='STO-3G'
geometry = [('Li', (0., 0., -bond_length/2)), ('H', (0., 0., bond_length/2))]
mol = gto.M(atom=geometry, basis=basis)

mf = scf.RHF(mol).run()
E_hf = sum(mf.scf_summary.values())

E_fci = fci.FCI(mf).kernel()[0]
print('fci', E_fci)

ha = FermiOperator2nd_from_pyscf_molecule(mol)
E0 = float(nk.exact.lanczos_ed(ha))
assert np.allclose(E0, E_fci)
print(E0)
```