### PR TITLE
jacobian: do not rescale output by sqrt samples

### DIFF
--- a/netket/jax/_jacobian/logic.py
+++ b/netket/jax/_jacobian/logic.py
@@ -32,7 +32,15 @@ from . import jacobian_pytree
 
 
 @partial(
-    jax.jit, static_argnames=("apply_fun", "mode", "chunk_size", "center", "dense")
+    jax.jit,
+    static_argnames=(
+        "apply_fun",
+        "mode",
+        "chunk_size",
+        "center",
+        "dense",
+        "_sqrt_rescale",
+    ),
 )
 def jacobian(
     apply_fun: Callable,

--- a/netket/optimizer/qgt/qgt_jacobian_dense.py
+++ b/netket/optimizer/qgt/qgt_jacobian_dense.py
@@ -137,6 +137,7 @@ def QGTJacobianDense(
         chunk_size=chunk_size,
         dense=True,
         center=True,
+        _sqrt_rescale=True,
     )
 
     if offset is not None:

--- a/netket/optimizer/qgt/qgt_jacobian_pytree.py
+++ b/netket/optimizer/qgt/qgt_jacobian_pytree.py
@@ -139,6 +139,7 @@ def QGTJacobianPyTree(
         chunk_size=chunk_size,
         dense=False,
         center=True,
+        _sqrt_rescale=True,
     )
 
     if offset is not None:

--- a/test/optimizer/test_qgt_logic.py
+++ b/test/optimizer/test_qgt_logic.py
@@ -408,6 +408,7 @@ def test_matvec_treemv_modes(e, jit, holomorphic, pardtype, outdtype):
         mode=mode,
         dense=False,
         center=True,
+        _sqrt_rescale=True,
     )
     # TODO Apply offset if offset is not None
 


### PR DESCRIPTION
Fixes #1613 .

Ensures that jacobian does not return a rescaled output unless an internal flag is specified. 
Eventually this flag will be removed, but keeping it for now because it makes our life easier and would complicate @inailuig 's life and PR.

I should add some tests testing jacobian specifically...