### PR TITLE
Fix bug in PauliString algebra

### DIFF
--- a/netket/operator/_pauli_strings/base.py
+++ b/netket/operator/_pauli_strings/base.py
@@ -329,6 +329,7 @@ class PauliStringsBase(DiscreteOperator):
             self.weights,
             other.operators,
             other.weights,
+            dtype=self.dtype,
         )
 
         self._operators = operators
@@ -559,7 +560,7 @@ def _reduce_pauli_string(op_arr, w_arr):
     return operators, weights
 
 
-def _matmul(op_arr1, w_arr1, op_arr2, w_arr2):
+def _matmul(op_arr1, w_arr1, op_arr2, w_arr2, *, dtype):
     """(Symbolic) Tensor product of two PauliStrings
     Args:
         op_arr1, op_arr2 (np.array): Arrays operators (strings) in a PauliStrings sum
@@ -573,9 +574,11 @@ def _matmul(op_arr1, w_arr1, op_arr2, w_arr2):
     operators = []
     weights = []
     for (op1, w1), (op2, w2) in product(zip(op_arr1, w_arr1), zip(op_arr2, w_arr2)):
+        # warning: numba always returns complex values, even if we are expecting float.
         op, w = _make_new_pauli_string(op1, w1, op2, w2)
         operators.append(op)
         weights.append(w)
-    operators, weights = np.array(operators), np.array(weights)
+    # so here we recast to the desired dtype
+    operators, weights = np.array(operators), np.array(weights).astype(dtype)
     operators, weights = _reduce_pauli_string(operators, weights)
     return operators, weights

--- a/test/operator/test_pauli.py
+++ b/test/operator/test_pauli.py
@@ -304,6 +304,17 @@ def test_pauli_jax_sparse_works():
     np.testing.assert_allclose(ham_jax_d, ham_d)
 
 
+def test_pauli_problem():
+    x1 = nk.operator.PauliStringsJax("XII")
+    x2 = nk.operator.PauliStringsJax("IXI")
+    x3 = x1 @ x2
+    assert x1.weights.dtype == jnp.float32
+    assert x2.weights.dtype == jnp.float32
+    assert x3.weights.dtype == jnp.float32
+
+    assert (x1 + x1 @ x2).weights.dtype == jnp.float32
+
+
 def test_pauliY_promotion_to_complex():
     ham = nk.operator.PauliStrings("XXX", dtype=np.float32)
     assert ham.dtype == np.float32


### PR DESCRIPTION
```python
In [19]: x_1.dtype
Out[19]: dtype('float64')

In [20]: x_2.dtype
Out[20]: dtype('float64')

In [21]: (x_1@x_2).dtype
Out[21]: dtype('float64')

In [22]: x_1@x_2
Out[22]:
PauliStringsJax(hilbert=Spin(s=1/2, N=6), n_strings=1, dtype=float64, dict(operators:weights)=
    IXIIII : (1+0j)
)
```