### PR TITLE
Ensure correct normalisation of symmexpsum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 ### Improvements 
 
 * Considerably reduced the memory consumption of `LocalOperators`, especially in the case of large local hilbert spaces. Also leveraged sparsity in the terms to speed up compilation (`_setup`) in the same cases [#1558](https://github.com/netket/netket/pull/1558).
-* {class}`netket.nn.blocks.SymmSumExp` now works with inputs of arbitrary dimensions, while previously it errored for all inputs that were not 2D [#1616](https://github.com/netket/netket/pull/1616)
+* {class}`netket.nn.blocks.SymmExpSum` now works with inputs of arbitrary dimensions, while previously it errored for all inputs that were not 2D [#1616](https://github.com/netket/netket/pull/1616)
 * Stop using `FrozenDict` from `flax` and instead return standard dictionaries for the variational parameters from the variational state. This makes it much easier to edit parameters [#1547](https://github.com/netket/netket/pull/1547).
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@
 * Added new shortcuts to build the identity operator as {func}`netket.operator.spin.identity` and {func}`netket.operator.boson.identity` [#1601](https://github.com/netket/netket/pull/1601).
 * Added new {class}`netket.hilbert.Particle` constructor that only takes as input the number of dimensions of the system [#1577](https://github.com/netket/netket/pull/1577).
 
+### Breaking Changes
+* The {class}`netket.nn.blocks.SymmExpSum` layer is now normalised by the number of elements in the symmetry group in order to maintain a reasonable normalisation [#1624](https://github.com/netket/netket/pull/1624).
+
 ### Bug Fixes
 
 * Fixed minor bug where {class}`netket.operator.LocalOperator` could not be built with `np.matrix` object obtained by converting scipy sparse matrices to dense [#1597](https://github.com/netket/netket/pull/1597).

--- a/netket/nn/blocks/symmetry_sum.py
+++ b/netket/nn/blocks/symmetry_sum.py
@@ -26,26 +26,29 @@ from netket.utils.types import Array
 
 class SymmExpSum(nn.Module):
     r"""
-    A flax module symmetrizing the log-wavefunction :math:`\log\psi_\theta(\sigma)` encoded
-    into another flax module (:class:`flax.linen.Module`) by summing over all possible symmetries
-    :math:`g` in a certain discrete permutation group :math:`G`.
+    A flax module symmetrizing the log-wavefunction :math:`\log\psi_\theta(\sigma)`
+    encoded into another flax module (:class:`flax.linen.Module`) by summing over
+    all possible symmetries :math:`g` in a certain discrete permutation
+    group :math:`G`.
 
     .. math::
 
-        \log\psi_\theta(\sigma) = \log\sum_{g\in G}\chi_g\exp[\log\psi_\theta(T_{g}\sigma)]
+        \log\psi_\theta(\sigma) = \frac{1}{\abs{G}}\log\sum_{g\in G}
+            \chi_g\exp[\log\psi_\theta(T_{g}\sigma)]
 
     For the ground-state, it is usually found that :math:`\chi_g=1 \forall g\in G`.
 
-    To construct this network, one has to specify the module, the symmetry group and (optionally)
-    the id of the character to consider. The symmetry
+    To construct this network, one has to specify the module, the symmetry group
+    and (optionally)the id of the character to consider.
 
     The module's :code:`.__call__` will be called.
     The :code:`symm_group` attribute
 
     Examples:
 
-       Constructs a :ref:`netket.nn.blocks.SymmExpSum` for a bare :ref:`netket.models.RBM`,
-       summing over all translations of a 2D Square lattice
+       Constructs a :ref:`netket.nn.blocks.SymmExpSum` for a bare
+       :ref:`netket.models.RBM`, summing over all translations of a
+       2D Square lattice
 
        >>> import netket as nk
        >>> graph = nk.graph.Square(3)
@@ -75,9 +78,12 @@ class SymmExpSum(nn.Module):
     to symmetrize in the :code:`.__call__` function."""
 
     symm_group: PermutationGroup
-    """The symmetry group to use. It should be a valid :ref:`netket.utils.group.PermutationGroup`
-    object. Can be easily extracted from a :ref:`netket.graph.Graph` object by calling
-    :meth:`~netket.graph.Graph.point_group` or :meth:`~netket.graph.Graph.translation_group`
+    """The symmetry group to use. It should be a valid
+    :ref:`netket.utils.group.PermutationGroup` object.
+
+    Can be extracted from a :ref:`netket.graph.Graph` object by calling
+    :meth:`~netket.graph.Graph.point_group` or
+    :meth:`~netket.graph.Graph.translation_group`
 
     .. code::
 
@@ -87,8 +93,10 @@ class SymmExpSum(nn.Module):
     """
 
     character_id: Optional[int] = None
-    """The # identifying the target character in the character table of the symmetry
-    group. By default the characters are taken to be all `1`, giving the homogeneous state.
+    """The # identifying the target character in the character table of
+    the symmetry group. By default the characters are taken to be all
+    `1`, giving the homogeneous state.
+
     The characters are accessed as:
 
     .. code::
@@ -122,6 +130,6 @@ class SymmExpSum(nn.Module):
             jax.scipy.special.logsumexp if np.all(characters >= 0) else logsumexp_cplx
         )
 
-        # log (sum_i ( c_i* exp(psi[sigma_i])))
-        psi = logsumexp_fun(psi_symm, axis=0, b=characters)
+        # log (sum_i ( c_i/Nsymm* exp(psi[sigma_i])))
+        psi = logsumexp_fun(psi_symm, axis=0, b=characters / len(self.symm_group))
         return psi

--- a/test/nn/test_symmsum.py
+++ b/test/nn/test_symmsum.py
@@ -16,6 +16,7 @@ import pytest
 import numpy as np
 
 import jax
+import jax.numpy as jnp
 
 import netket as nk
 import netket.nn as nknn
@@ -51,6 +52,13 @@ def test_symmexpsum(bare_module, character_id):
     if character_id != 1:
         for Tg in g:
             np.testing.assert_allclose(log_psi, vs.log_value(Tg @ hi.all_states()))
+
+    if character_id == 0:
+        # check that for symmetric inputs it gives same output of original
+        s0 = jnp.full((hi.size,), 1.3)
+        out_sym = ma.apply(vs.variables, s0)
+        out_bare = bare_module.apply({"params": vs.parameters["module"]}, s0)
+        np.testing.assert_allclose(out_sym, out_bare)
 
     # check that it works with different shapes
     s0 = hi.random_state(jax.random.PRNGKey(0))


### PR DESCRIPTION
Previously we were summing the symmetries network. This divides by the number of symmetries in order to retain a reasonable normalisation in the large symmetry limit.