### PR TITLE
Change convention of fermion operators to the correct conjugated one, and improvements on internal structure.

### DIFF
--- a/netket/experimental/operator/_fermion_operator_2nd.py
+++ b/netket/experimental/operator/_fermion_operator_2nd.py
@@ -39,9 +39,9 @@ from ._fermion_operator_2nd_utils import (
     _make_tuple_tree,
     _remove_zero_weights,
     _verify_input,
-    OperatorDict,
     OperatorWeightsList,
     OperatorTermsList,
+    OperatorTerm,
     _normal_ordering,
     _pair_ordering,
 )
@@ -254,7 +254,7 @@ class FermionOperator2nd(DiscreteOperator):
         return self._constant
 
     @property
-    def operator_dict(self) -> OperatorDict:
+    def operator_dict(self) -> dict[OperatorTerm, Union[float, complex]]:
         """
         Return a dict with terms as keys and weights as values.
         This does not include the constant term.
@@ -567,7 +567,7 @@ class FermionOperator2nd(DiscreteOperator):
                 f"Cannot add inplace operator with dtype {type(other)} "
                 f"to operator with dtype {self.dtype}"
             )
-        operators = self.operator_dict
+        operators = dict(zip(self.terms, self.weights))
         for t, w in zip(other.terms, other.weights):
             if t in operators.keys():
                 operators[t] += w

--- a/netket/experimental/operator/_fermion_operator_2nd.py
+++ b/netket/experimental/operator/_fermion_operator_2nd.py
@@ -651,7 +651,6 @@ class FermionOperator2nd(DiscreteOperator):
         Reoder the operators to normal order
         `Normal ordering documentation <https://en.wikipedia.org/wiki/Normal_order#Fermions>`_
         """
-        self.reduce()
         terms, weights = _normal_ordering(self.terms, self.weights)
         new = FermionOperator2nd(
             self.hilbert,
@@ -662,11 +661,11 @@ class FermionOperator2nd(DiscreteOperator):
         )
         new._terms = terms
         new._weights = weights
+        new.reduce()
         return new
 
     def to_pair_order(self):
         """Reoder the operators to pair order"""
-        self.reduce()
         terms, weights = _pair_ordering(self.terms, self.weights)
         new = FermionOperator2nd(
             self.hilbert,
@@ -677,6 +676,7 @@ class FermionOperator2nd(DiscreteOperator):
         )
         new._terms = terms
         new._weights = weights
+        new.reduce()
         return new
 
 

--- a/netket/experimental/operator/_fermion_operator_2nd.py
+++ b/netket/experimental/operator/_fermion_operator_2nd.py
@@ -120,6 +120,7 @@ class FermionOperator2nd(DiscreteOperator):
         self._terms = _terms
         self._weights = _weights
         self._constant = _constant
+        self.reduce()
 
         self._initialized = False
         self._is_hermitian = None  # set when requested
@@ -137,9 +138,7 @@ class FermionOperator2nd(DiscreteOperator):
         """Analyze the operator strings and precompute arrays for get_conn inference"""
         if force or not self._initialized:
             # only reduce once
-            self._terms, self._weights = _remove_zero_weights(
-                self._terms, self._weights
-            )
+            self.reduce()
             # following lists will be used to compute matrix elements
             # they are filled in _add_term
             out = _pack_internals(self._terms, self._weights, self._dtype)

--- a/netket/experimental/operator/_fermion_operator_2nd.py
+++ b/netket/experimental/operator/_fermion_operator_2nd.py
@@ -253,7 +253,7 @@ class FermionOperator2nd(DiscreteOperator):
         return self._weights
 
     @property
-    def constant(self) -> Union[float, complex]:
+    def constant(self) -> Number:
         return self._constant
 
     @property

--- a/netket/experimental/operator/_fermion_operator_2nd.py
+++ b/netket/experimental/operator/_fermion_operator_2nd.py
@@ -263,7 +263,11 @@ class FermionOperator2nd(DiscreteOperator):
 
     @classmethod
     def identity(cls, hilbert: AbstractHilbert, **kwargs):
-        return cls(hilbert, "I" * hilbert.size, **kwargs)
+        return cls(hilbert, [], [], constant=1.0, **kwargs)
+
+    @classmethod
+    def zero(cls, hilbert: AbstractHilbert, **kwargs):
+        return cls(hilbert, [], [], constant=0.0, **kwargs)
 
     @property
     def dtype(self) -> DType:

--- a/netket/experimental/operator/_fermion_operator_2nd_utils.py
+++ b/netket/experimental/operator/_fermion_operator_2nd_utils.py
@@ -4,7 +4,7 @@ import numpy as np
 import copy
 from typing import Union
 
-from netket.utils.types import DType, PyTree
+from netket.utils.types import PyTree
 
 OperatorTuple = tuple[int, int]
 r""" Creation and annihilation operators at mode i are encoded as
@@ -22,9 +22,6 @@ OperatorTermsList = list[OperatorTerm]
 
 OperatorWeightsList = list[Union[float, complex]]
 """ A list of weights corresponding to the operators in OperatorList """
-
-OperatorDict = dict[OperatorTerm, Union[float, complex]]
-""" A dict containing OperatorTerm as key and weights as the values """
 
 
 def _check_hermitian(
@@ -309,20 +306,6 @@ def _is_diag_term(term: OperatorTerm) -> bool:
     for orb_idx, dagger in term:
         ops[orb_idx][int(dagger)] += 1
     return all((x[0] == x[1]) for x in ops.values())
-
-
-def _reduce_operators(operators: OperatorDict, dtype: DType) -> OperatorDict:
-    """
-    Reduce the operators by adding equivalent terms together
-    """
-
-    red_ops = zero_defaultdict(dtype)
-    terms = list(operators.keys())
-    weights = list(operators.values())
-    for term, weight in zip(*_normal_ordering(terms, weights)):
-        red_ops[term] += weight
-    red_ops = _remove_dict_zeros(dict(red_ops))
-    return red_ops
 
 
 def zero_defaultdict(dtype):

--- a/netket/experimental/operator/fermion.py
+++ b/netket/experimental/operator/fermion.py
@@ -123,7 +123,7 @@ def identity(hilbert: _AbstractHilbert, dtype: _DType = None):
     Returns:
         An instance of {class}`nk.operator.LocalOperator`.
     """
-    return _FermionOperator2nd(hilbert, [], [], constant=1.0, dtype=dtype)
+    return _FermionOperator2nd.identity(hilbert, dtype=dtype)
 
 
 def zero(hilbert: _AbstractHilbert, dtype: _DType = None):
@@ -138,4 +138,4 @@ def zero(hilbert: _AbstractHilbert, dtype: _DType = None):
 
     Returns:
         An instance of {class}`nk.operator.LocalOperator`."""
-    return _FermionOperator2nd(hilbert, [], [], constant=0.0, dtype=dtype)
+    return _FermionOperator2nd.zero(hilbert, dtype=dtype)

--- a/test/operator/test_fermions.py
+++ b/test/operator/test_fermions.py
@@ -78,6 +78,7 @@ op_ferm["float_round"] = (
     [pytest.param(op, is_herm, id=name) for name, (op, is_herm) in op_ferm.items()],
 )
 def test_is_hermitian_fermion2nd(op_ferm, is_hermitian):
+    print(op_ferm, op_ferm.terms, op_ferm.weights)
     assert op_ferm.is_hermitian == is_hermitian
 
 
@@ -175,6 +176,16 @@ def compare_openfermion_fermions():
     # compare from_openfermion vs FermionOperator 2nd
     assert np.array_equal(fo_dense, fermop_dense)
 
+    # add a test from a non-hermitian operator
+    of_fermion_operator = FermionOperator("") + FermionOperator(  # todo
+        "0^ 2", 0.5 + 0.3j
+    )
+    fo2 = nkx.operator.FermionOperator2nd.from_openfermion(of_fermion_operator)
+    fo_nk = nkx.operator.FermionOperator2nd(
+        terms=["0^ 2"], weights=[0.5 + 0.3j], constant=1
+    )
+    assert np.array_equal(fo2.to_dense(), fo_nk.to_dense())
+
 
 def test_add_fermions():
     hi = nkx.hilbert.SpinOrbitalFermions(5)
@@ -213,6 +224,22 @@ def test_add_fermions():
 
 
 def test_create_annihil_number():
+    hi = nkx.hilbert.SpinOrbitalFermions(2)
+    op1 = nkx.operator.FermionOperator2nd(hi, terms=("0^ 0", "1^ 0"), weights=(0.3, 2))
+
+    # without spin
+    def c(site):
+        return destroy(hi, site)
+
+    def cdag(site):
+        return create(hi, site)
+
+    def cn(site):
+        return number(hi, site)
+
+    op2 = 0.3 * cn(0) + 2 * cdag(1) * c(0)
+    np.testing.assert_allclose(op1.to_dense(), op2.to_dense())
+
     hi = nkx.hilbert.SpinOrbitalFermions(5)
     op1 = nkx.operator.FermionOperator2nd(hi, terms=("0^ 0", "1^ 2"), weights=(0.3, 2))
 
@@ -261,12 +288,8 @@ def test_operations_fermions():
     )
     op2copy = op2.copy()
     assert op2copy.hilbert == op2.hilbert
-    np.testing.assert_allclose(
-        list(op2._operators.keys()), list(op2copy._operators.keys())
-    )
-    np.testing.assert_allclose(
-        list(op2._operators.values()), list(op2copy._operators.values())
-    )
+    np.testing.assert_allclose(list(op2.terms), list(op2copy.terms))
+    np.testing.assert_allclose(list(op2.weights), list(op2copy.weights))
     assert op2.is_hermitian == op2copy.is_hermitian
     np.testing.assert_allclose(op2.to_dense(), op2copy.to_dense())
 
@@ -695,8 +718,9 @@ def test_fermion_matrices():
     mat = np.array([[0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 2]])
     np.testing.assert_allclose(mat, op.to_dense())
 
+    # test non hermitian (!!! convention is <x|O|x'> !!!)
     op = nkx.operator.FermionOperator2nd(hi, terms=("0^ 1", "1^ 0"), weights=(2, 1))
-    mat = np.array([[0, 0, 0, 0], [0, 0, 2, 0], [0, 1, 0, 0], [0, 0, 0, 0]])
+    mat = np.array([[0, 0, 0, 0], [0, 0, 1, 0], [0, 2, 0, 0], [0, 0, 0, 0]])
     np.testing.assert_allclose(mat, op.to_dense())
 
     op = nkx.operator.FermionOperator2nd(hi, terms=("0^ 0", "1^ 1"), weights=(2, 1))
@@ -704,7 +728,21 @@ def test_fermion_matrices():
     np.testing.assert_allclose(mat, op.to_dense())
 
     op = nkx.operator.FermionOperator2nd(hi, terms=("0^",), weights=(2,))
-    mat = np.array([[0, 0, 2, 0], [0, 0, 0, 2], [0, 0, 0, 0], [0, 0, 0, 0]])
+    mat = np.array([[0, 0, 0, 0], [0, 0, 0, 0], [2, 0, 0, 0], [0, 2, 0, 0]])
+    np.testing.assert_allclose(mat, op.to_dense())
+
+    # check the jordan-wigner sign !
+    op = nkx.operator.FermionOperator2nd(hi, terms=("1^",), weights=(2,))
+    mat = np.array([[0, 0, 0, 0], [2, 0, 0, 0], [0, 0, 0, 0], [0, 0, -2, 0]])
+    np.testing.assert_allclose(mat, op.to_dense())
+
+    # check the jordan-wigner sign !
+    op = nkx.operator.FermionOperator2nd(hi, terms=("1^ 0^",), weights=(2 + 1j,))
+    mat = np.array([[0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [-(2 + 1j), 0, 0, 0]])
+    np.testing.assert_allclose(mat, op.to_dense())
+
+    op = nkx.operator.FermionOperator2nd(hi, terms=("0^ 1^",), weights=(2 + 1j,))
+    mat = np.array([[0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [+(2 + 1j), 0, 0, 0]])
     np.testing.assert_allclose(mat, op.to_dense())
 
     # with fermion constraints
@@ -712,8 +750,8 @@ def test_fermion_matrices():
     op1 = nkx.operator.FermionOperator2nd(hi, terms=("0^ 1", "1^ 0"), weights=(2, 1))
     mat1 = np.array(
         [
-            [0, 2],
-            [1, 0],
+            [0, 1],
+            [2, 0],
         ]
     )
     np.testing.assert_allclose(mat1, op1.to_dense())
@@ -785,3 +823,36 @@ def test_fermi_hubbard():
         ham += U * nc(u, up) * nc(u, down)
 
     print("Hamiltonian =", ham.operator_string())
+
+
+def test_fermion_ordering():
+    from netket.experimental.operator._fermion_operator_2nd_utils import _dict_compare
+
+    hi = nkx.hilbert.SpinOrbitalFermions(2)
+    op1 = nkx.operator.FermionOperator2nd(
+        hi, terms=("0^ 1", "0^ 1^", "0 1^", "1 1^"), weights=(2, 3, 4j, 7j), constant=1
+    )
+    op1_ordered = op1.to_normal_order()
+    op2 = nkx.operator.FermionOperator2nd(
+        hi,
+        terms=("0^ 1", "1^ 0^", "1^ 0", "1^ 1"),
+        weights=(2, -3, -4j, -7j),
+        constant=1 + 7j,
+    )
+    np.testing.assert_allclose(op1_ordered.to_dense(), op1.to_dense())
+    np.testing.assert_allclose(op1_ordered.to_dense(), op2.to_dense())
+    _dict_compare(op1_ordered.operator_dict, op2.operator_dict)
+
+    op1 = nkx.operator.FermionOperator2nd(
+        hi, terms=("0^ 1", "0^ 1^", "0 1^", "1 1^"), weights=(2, 3, 4j, 7j), constant=1
+    )
+    op1_ordered = op1.to_pair_order()
+    op2 = nkx.operator.FermionOperator2nd(
+        hi,
+        terms=("1 0^", "1^ 0^", "1^ 0", "1^ 1"),
+        weights=(-2, -3, -4j, -7j),
+        constant=1 + 7j,
+    )
+    np.testing.assert_allclose(op1_ordered.to_dense(), op1.to_dense())
+    np.testing.assert_allclose(op1_ordered.to_dense(), op2.to_dense())
+    _dict_compare(op1_ordered.operator_dict, op2.operator_dict)


### PR DESCRIPTION
This one changes:
-  the convention to the correct <x|O|x'> mels, where it was <x'|O|x> before (i.e. solves #1385)
- it changes the internal structure to use separate terms and weights, not dictionaries (i.e. as requested in #1576)
- it adds a 'pair'ordering
- the ordering can be called directly from the object
- terms of size 0 are converted to constants, rather than throwing an error
