### PR TITLE
Change transpose convention, add ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 * {class}`netket.experimental.SpinOrbitalFermions` attributes have been changed: {attr}`~netket.experimental.SpinOrbitalFermions.n_fermions` now always returns an integer with the total number of fermions in the system (if specified). A new attribute {attr}`~netket.experimental.SpinOrbitalFermions.n_fermions_per_spin` has been introduced that returns the same tuple of fermion number per spin subsector as before. A few fields are now marked as read-only as modifications where ignored [#1622](https://github.com/netket/netket/pull/1622).
 * The {class}`netket.nn.blocks.SymmExpSum` layer is now normalised by the number of elements in the symmetry group in order to maintain a reasonable normalisation [#1624](https://github.com/netket/netket/pull/1624).
+* The connected elements and expectation values of all non-simmetric fermionic operators is now changed in order to be correct [#1640](https://github.com/netket/netket/pull/1640).
 
 ### Improvements
 
@@ -35,6 +36,7 @@
 * Do not rescale the output of `netket.jax.jacobian` by the square root of number of samples. Previously, when specifying `center=True` we were incorrectly rescaling the output [#1614](https://github.com/netket/netket/pull/1614).
 * Fix bug in {class}`netket.operator.PauliStrings` that caused the dtype to get out of sync with the dtype of the internal arrays, causing errors when manipulating them symbolically [#1619](https://github.com/netket/netket/pull/1619).
 * Fix bug that prevented the use of {class}`netket.operator.DiscreteJaxOperator` as observables with all drivers [#1625](https://github.com/netket/netket/pull/1625).
+* Fermionic operator `get_conn` method was returning values as if the operator was transposed, and has now been fixed. This will break the expectation value of non-simmetric fermionic operators, but hopefully nobody was looking into them [#1640](https://github.com/netket/netket/pull/1640).
 
 ## NetKet 3.9.2
 

--- a/netket/experimental/operator/_fermion_operator_2nd.py
+++ b/netket/experimental/operator/_fermion_operator_2nd.py
@@ -527,8 +527,11 @@ class FermionOperator2nd(DiscreteOperator):
         new_operators = {}
         for t, w in self._operators.items():
             for to, wo in other._operators.items():
-                new_t = t + to
-                new_operators[new_t] = new_operators.get(new_t, 0) + w * wo
+                # if the last operator of t and the first of to are
+                # equal, we have a ...ĉᵢĉᵢ... which is null.
+                if t[-1] != to[0]:
+                    new_t = t + to
+                    new_operators[new_t] = new_operators.get(new_t, 0) + w * wo
 
         if not np.isclose(other._constant, 0.0):
             for t, w in self._operators.items():

--- a/netket/experimental/operator/_fermion_operator_2nd.py
+++ b/netket/experimental/operator/_fermion_operator_2nd.py
@@ -247,22 +247,15 @@ class FermionOperator2nd(DiscreteOperator):
         """Prunes the operator by removing all terms with zero weights, grouping, and normal ordering (inplace)."""
         operators = self._operators
         terms, weights = list(operators.keys()), list(operators.values())
+
         if order:
             terms, weights = _normal_ordering(terms, weights)
+
         terms, weights, constant = _collect_constants(terms, weights)
         operators = dict(zip(terms, weights))
-        operators = _reduce_operators(operators, self.dtype)
-        constant = self._constant + constant
-        if inplace:
-            self._operators = operators
-            self._constant = constant
-        else:
-            new = FermionOperator2nd(
-                self.hilbert, constant=self._constant + constant, dtype=self.dtype
-            )
-            new._operators = operators
-            new._constant = constant
-            return new
+
+        self._operators = _reduce_operators(operators, self.dtype)
+        self._constant = self._constant + constant
 
     @property
     def dtype(self) -> DType:

--- a/netket/experimental/operator/_fermion_operator_2nd_utils.py
+++ b/netket/experimental/operator/_fermion_operator_2nd_utils.py
@@ -320,7 +320,10 @@ def _canonicalize_input(
     # add the weights of terms that occur multiple times
     operators = zero_defaultdict(dtype)
     for t, w in zip(terms, weights):
-        operators[t] += w
+        if len(t) == 0:  # take the constant out
+            constant += w
+        else:
+            operators[t] += w
     operators = _remove_dict_zeros(dict(operators))
 
     return operators, constant, dtype

--- a/netket/experimental/operator/_fermion_operator_2nd_utils.py
+++ b/netket/experimental/operator/_fermion_operator_2nd_utils.py
@@ -1,7 +1,7 @@
 import re
 from collections import defaultdict
 import numpy as np
-from typing import Union
+from numbers import Number
 import copy
 
 from netket.utils.types import DType, PyTree
@@ -17,19 +17,24 @@ r""" A term of the form :math:`\hat{a}_1^\dagger \hat{a}_2` would take the form
 `((1,1), (2,0))`, where (1,1) represents :math:`\hat{a}_1^\dagger` and (2,0)
 represents :math:`\hat{a}_2`."""
 
-OperatorList = list[OperatorTerm]
+OperatorTermsList = list[OperatorTerm]
 """ A list of operators that would e.g. describe a Hamiltonian """
 
-OperatorDict = dict[OperatorTerm, Union[float, complex]]
+OperatorWeightsList = list[Number]
+""" A list of weights of corresponding terms """
+
+OperatorDict = dict[OperatorTerm, Number]
 """ A dict containing OperatorTerm as key and weights as the values """
 
 
-def _order_fun(term: OperatorTerm, weight: Union[float, complex] = 1.0):
+def _normal_order_term(
+    term: OperatorTerm, weight: Number = 1.0
+) -> tuple[OperatorTermsList, OperatorWeightsList]:
     """
     Return a normal ordered single term of the fermion operator.
-    Normal ordering corresponds to placing the operator acting on the
-    highest index on the left and lowest index on the right. In addition,
-    the creation operators are placed on the left and annihilation on the right.
+    Normal ordering corresponds to placing creating operators on the left
+    and annihilation on the right.
+    Then, it places the highest index on the left and lowest index on the right
     In this ordering, we make sure to account for the anti-commutation of operators.
     """
 
@@ -57,7 +62,7 @@ def _order_fun(term: OperatorTerm, weight: Union[float, complex] = 1.0):
                     new_term = term[: (j - 1)] + term[(j + 1) :]
 
                     # ad the processed term
-                    o, w = _order_fun(tuple(new_term), parity * weight)
+                    o, w = _normal_order_term(tuple(new_term), parity * weight)
                     ordered_terms += o
                     ordered_weights += w
 
@@ -79,18 +84,94 @@ def _order_fun(term: OperatorTerm, weight: Union[float, complex] = 1.0):
     return ordered_terms, ordered_weights
 
 
-def _normal_ordering(terms: OperatorList, weights: list[Union[float, complex]] = 1.0):
+def _normal_ordering(
+    terms: OperatorTermsList, weights: OperatorWeightsList = 1.0
+) -> tuple[OperatorTermsList, OperatorWeightsList]:
     """
     Returns the normal ordered terms and weights of the fermion operator.
-    We use the following normal ordering convention: we order the terms with
-    the highest index of the operator on the left and the lowest index on the right. In addition,
-    creation operators are placed on the left and annihilation operators on the right.
     """
     ordered_terms = []
     ordered_weights = []
     # loop over all the terms and weights and order each single term with corresponding weight
     for term, weight in zip(terms, weights):
-        ordered = _order_fun(term, weight)
+        ordered = _normal_order_term(term, weight)
+        ordered_terms += ordered[0]
+        ordered_weights += ordered[1]
+    ordered_terms = _make_tuple_tree(ordered_terms)
+    return ordered_terms, ordered_weights
+
+
+def _pair_order_term(
+    term: OperatorTerm, weight: Number = 1.0
+) -> tuple[OperatorTermsList, OperatorWeightsList]:
+    """
+    Return a pair ordered single term of the fermion operator.
+    Pair ordering corresponds to placing first the highest indices on the right,
+    and then making sure the creation operators are on the left and annihilation on the right.
+    In this ordering, we make sure to account for the anti-commutation of operators.
+    """
+
+    parity = -1
+    term = copy.deepcopy(list(term))
+    weight = copy.copy(weight)
+    ordered_terms = []
+    ordered_weights = []
+    # the arguments given to this function will be transformed in a normal ordered way
+    # loop through all the operators in the single term from left to right and order them
+    # by swapping the term operators (and transform the weights by multiplying with the parity factors)
+    for i in range(1, len(term)):
+        for j in range(i, 0, -1):
+            right_term = term[j]
+            left_term = term[j - 1]
+            # print("consider term:", left_term, right_term)
+
+            ## exchange operators if biggest is on the right (need commutataion relations)
+            # exchange operators if biggest is on the left (need commutataion relations)
+            if right_term[0] < left_term[0]:  # not the same, always switch
+                # fulfil anti commutation relations
+                term[j - 1] = right_term
+                term[j] = left_term
+                weight *= parity
+
+            # exchange operators if creation operator is on the right and annihilation on the left
+            elif right_term[0] == left_term[0]:
+                if right_term[1] and not left_term[1]:
+                    term[j - 1] = right_term
+                    term[j] = left_term
+                    weight *= parity
+
+                    # if same indices switch order (creation on the left), remember a a^ = 1 + a^ a
+                    # if right_term[0] == left_term[0]:
+                    new_term = term[: (j - 1)] + term[(j + 1) :]
+
+                    # ad the processed term
+                    o, w = _pair_order_term(tuple(new_term), parity * weight)
+                    ordered_terms += o
+                    ordered_weights += w
+
+                # if we have two creation or two annihilation operators
+                elif right_term[1] == left_term[1]:
+                    # If same two Fermionic operators are repeated,
+                    # evaluate to zero.
+                    # if parity == -1 and right_term[0] == left_term[0]:
+                    return ordered_terms, ordered_weights
+
+    ordered_terms.append(term)
+    ordered_weights.append(weight)
+    return ordered_terms, ordered_weights
+
+
+def _pair_ordering(
+    terms: OperatorTermsList, weights: OperatorWeightsList = 1.0
+) -> tuple[OperatorTermsList, OperatorWeightsList]:
+    """
+    Returns the pair ordered terms and weights of the fermion operator.
+    """
+    ordered_terms = []
+    ordered_weights = []
+    # loop over all the terms and weights and order each single term with corresponding weight
+    for term, weight in zip(terms, weights):
+        ordered = _pair_order_term(term, weight)
         ordered_terms += ordered[0]
         ordered_weights += ordered[1]
     ordered_terms = _make_tuple_tree(ordered_terms)
@@ -98,7 +179,7 @@ def _normal_ordering(terms: OperatorList, weights: list[Union[float, complex]] =
 
 
 def _check_hermitian(
-    terms: OperatorList, weights: list[Union[float, complex]] = 1.0
+    terms: OperatorTermsList, weights: OperatorWeightsList = 1.0
 ) -> bool:
     """
     Check whether a set of terms and weights for a hermitian operator
@@ -132,7 +213,9 @@ def _check_hermitian(
     return is_hermitian
 
 
-def _herm_conj(terms: OperatorList, weights: list[Union[float, complex]] = 1):
+def _herm_conj(
+    terms: OperatorTermsList, weights: OperatorWeightsList = 1
+) -> tuple[OperatorTermsList, OperatorWeightsList]:
     """Returns the hermitian conjugate of the terms and weights."""
     conj_term = []
     conj_weight = []
@@ -144,8 +227,8 @@ def _herm_conj(terms: OperatorList, weights: list[Union[float, complex]] = 1):
 
 
 def _convert_terms_to_spin_blocks(
-    terms: OperatorList, n_orbitals: int, n_spin_components: int
-):
+    terms: OperatorTermsList, n_orbitals: int, n_spin_components: int
+) -> OperatorTermsList:
     """
     See explanation in from_openfermion in conversion between conventions of netket
     and openfermion.
@@ -173,7 +256,9 @@ def _convert_terms_to_spin_blocks(
     return tuple(list(map(_convert_term, terms)))
 
 
-def _collect_constants(terms: OperatorList, weights: list[Union[float, complex]]):
+def _collect_constants(
+    terms: OperatorTermsList, weights: OperatorWeightsList
+) -> tuple[OperatorTermsList, OperatorWeightsList, Number]:
     """
     Openfermion has the convention to store constants as empty terms
     Returns new terms and weights list, and the collected constants
@@ -190,7 +275,12 @@ def _collect_constants(terms: OperatorList, weights: list[Union[float, complex]]
     return new_terms, new_weights, constant
 
 
-def _canonicalize_input(terms, weights, constant, dtype):
+def _canonicalize_input(
+    terms: OperatorTermsList,
+    weights: OperatorWeightsList,
+    constant: Number,
+    dtype: DType,
+) -> tuple[OperatorDict, Number, DType]:
     r"""
     The canonical form is a tree tuple with a tuple pair of integers at the
     lowest level
@@ -236,7 +326,7 @@ def _canonicalize_input(terms, weights, constant, dtype):
     return operators, constant, dtype
 
 
-def _verify_input(hilbert, operators, raise_error=True):
+def _verify_input(hilbert, operators, raise_error=True) -> bool:
     """Check whether all input is valid"""
     terms = list(operators.keys())
 
@@ -263,12 +353,12 @@ def _verify_input(hilbert, operators, raise_error=True):
     return all(_check_term(term) for term in terms)
 
 
-def _remove_dict_zeros(d: dict):
+def _remove_dict_zeros(d: dict) -> dict:
     """Remove redundant zero values from a dictionary"""
     return {k: v for k, v in d.items() if not np.isclose(v, 0.0)}
 
 
-def _parse_term_tree(terms) -> OperatorList:
+def _parse_term_tree(terms: OperatorTermsList) -> OperatorTermsList:
     """Convert the terms tree into a canonical form of tuple tree of depth 3"""
 
     def _parse_branch(t):
@@ -332,7 +422,7 @@ def _make_tuple_tree(terms: PyTree) -> PyTree:
     return _make_tuple(terms)
 
 
-def _check_tree_structure(terms) -> OperatorList:
+def _check_tree_structure(terms: OperatorTermsList) -> OperatorTermsList:
     """
     Check whether the terms structure is depth 3 everywhere
     and contains pairs of (idx, dagger) everywhere
@@ -387,7 +477,7 @@ def _reduce_operators(operators: OperatorDict, dtype: DType) -> OperatorDict:
     return red_ops
 
 
-def zero_defaultdict(dtype):
+def zero_defaultdict(dtype: DType) -> defaultdict:
     """
     Temporary function to make sure we get a good initializer for each dtype
     """

--- a/test/operator/test_fermions.py
+++ b/test/operator/test_fermions.py
@@ -862,14 +862,15 @@ def test_fermion_reduce():
 
     hi = nkx.hilbert.SpinOrbitalFermions(2)
 
-    # order, not in place
+    # order
     op1 = nkx.operator.FermionOperator2nd(
         hi,
         terms=("0^ 1", "0^ 1", "0^ 1^", "0 1^", "1 1^"),
         weights=(1, 1, 3, 4j, 7j),
         constant=1,
     )
-    op1_ordered = op1.reduce(inplace=False, order=True)
+    op1_ordered = op1.copy()
+    op1_ordered.reduce(order=True)
     op2 = nkx.operator.FermionOperator2nd(
         hi,
         terms=("0^ 1", "1^ 0^", "1^ 0", "1^ 1"),
@@ -879,19 +880,8 @@ def test_fermion_reduce():
     np.testing.assert_allclose(op1_ordered.to_dense(), op1.to_dense())
     np.testing.assert_allclose(op1_ordered.to_dense(), op2.to_dense())
     _dict_compare(op1_ordered.operators, op2.operators)
-    # inplace, order
-    op1 = nkx.operator.FermionOperator2nd(
-        hi,
-        terms=("0^ 1", "0^ 1", "0^ 1^", "0 1^", "1 1^"),
-        weights=(1, 1, 3, 4j, 7j),
-        constant=1,
-    )
-    op1.reduce(inplace=True, order=True)
-    np.testing.assert_allclose(op1_ordered.to_dense(), op1.to_dense())
-    np.testing.assert_allclose(op1_ordered.to_dense(), op2.to_dense())
-    _dict_compare(op1_ordered.operators, op2.operators)
-    _dict_compare(op1_ordered.operators, op1.operators)
-    # no ordering, not in place
+
+    # no ordering
     op1 = nkx.operator.FermionOperator2nd(
         hi,
         terms=("0^ 1", "0^ 1", "0^ 1^", "0 1^", "1 1^"),
@@ -899,7 +889,8 @@ def test_fermion_reduce():
         constant=1,
     )
     op1_operators = op1.operators.copy()
-    op1_ordered = op1.reduce(inplace=False, order=False)
+    op1_ordered = op1.copy()
+    op1_ordered.reduce(order=False)
     op2 = nkx.operator.FermionOperator2nd(
         hi, terms=("0^ 1", "0 1^", "1 1^"), weights=(2, 4j, 7j), constant=1
     )


### PR DESCRIPTION
Made this into a new pull request, since this undoes most of the changes in #1638
It uses the new PR in #1639 instead.
It adds the following:
- the convention to the correct <x|O|x'> mels, where it was <x'|O|x> before (i.e. solves https://github.com/netket/netket/issues/1385)
- it adds a 'pair'ordering
- the ordering can be called directly from the object
- terms of size 0 are converted to constants, rather than throwing an error

The tests were changed to have the correct convention for the mels.