### PR TITLE
throw error in Ising when using non Spin Hilbert space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,13 @@
 
 ## NetKet 3.11 (⚙️ In development)
 
-## NetKet 3.10.2 (8 november 2023)
+## NetKet 3.10.2 (14 november 2023)
 
 ### Bug Fixes
 
 * Fixed a bug where it was not possible to recompile functions using two identical but different instances of PauliStringJax [#1647](https://github.com/netket/netket/pull/1647).
-* Fixed a minor bug where chunking was never actually used inside of :meth:`~netket.vqs.MCState.local_estimators`. This will turn on chunking for some other drivers such as {class}`netket.experimental.driver.VMC_SRt` and {class}`netket.experimental.driver.TDVPSchmitt`) [#1650](https://github.com/netket/netket/pull/1650).
+* Fixed a minor bug where chunking was never actually used inside of {meth}`~netket.vqs.MCState.local_estimators`. This will turn on chunking for some other drivers such as {class}`netket.experimental.driver.VMC_SRt` and {class}`netket.experimental.driver.TDVPSchmitt`) [#1650](https://github.com/netket/netket/pull/1650).
+* {class}`netket.operator.Ising` now throws an error when it is constructed using a non-{class}`netket.hilbert.Spin` hilbert space [#1648](https://github.com/netket/netket/pull/1648).
 
 
 ## NetKet 3.10.1 (8 november 2023)

--- a/netket/operator/_ising/numba.py
+++ b/netket/operator/_ising/numba.py
@@ -69,7 +69,7 @@ class Ising(IsingBase):
         """
         if not isinstance(hilbert, Spin):
             raise TypeError(
-                """The Hilbert space used by Ising must be a `Spin` space.
+                """The Hilbert space used by Ising must be a `Spin-1/2` space.
 
                 This limitation could be lifted by 'fixing' the method
                 `_flattened_kernel` to work with arbitrary hilbert spaces, which
@@ -80,6 +80,8 @@ class Ising(IsingBase):
                 workaround.
                 """
             )
+        if len(hilbert.local_states) != 2:
+            raise ValueError("Ising only supports Spin-1/2 hilbert spaces.")
 
         h = np.array(h, dtype=dtype)
         J = np.array(J, dtype=dtype)

--- a/netket/operator/_ising/numba.py
+++ b/netket/operator/_ising/numba.py
@@ -21,7 +21,7 @@ import numpy as np
 from numba import jit
 
 from netket.graph import AbstractGraph
-from netket.hilbert import AbstractHilbert
+from netket.hilbert import Spin
 from netket.utils.types import DType
 from netket.errors import concrete_or_error, NumbaOperatorGetConnDuringTracingError
 
@@ -41,7 +41,7 @@ class Ising(IsingBase):
     @wraps(IsingBase.__init__)
     def __init__(
         self,
-        hilbert: AbstractHilbert,
+        hilbert: Spin,
         graph: AbstractGraph,
         h: float,
         J: float = 1.0,
@@ -67,6 +67,20 @@ class Ising(IsingBase):
             >>> print(op)
             Ising(J=0.5, h=1.321; dim=20)
         """
+        if not isinstance(hilbert, Spin):
+            raise TypeError(
+                """The Hilbert space used by Ising must be a `Spin` space.
+
+                This limitation could be lifted by 'fixing' the method
+                `_flattened_kernel` to work with arbitrary hilbert spaces, which
+                should be relatively straightforward to do, but we have not done so
+                yet.
+
+                In the meantime, you can just use `nk.operator.IsingJax` as a
+                workaround.
+                """
+            )
+
         h = np.array(h, dtype=dtype)
         J = np.array(J, dtype=dtype)
         if isinstance(graph, jax.Array):

--- a/test/operator/test_hamiltonian.py
+++ b/test/operator/test_hamiltonian.py
@@ -24,6 +24,21 @@ def test_ising_int_dtype():
     (H @ H).collect()
 
 
+def test_ising_error():
+    g = nk.graph.Hypercube(8, 1)
+    with pytest.raises(TypeError):
+        hi = nk.hilbert.Qubit(8)
+        _ = nk.operator.Ising(hi, graph=g, h=1.0)
+
+    with pytest.raises(ValueError):
+        hi = nk.hilbert.Spin(1.0, 8)
+        _ = nk.operator.Ising(hi, graph=g, h=1.0)
+
+    with pytest.raises(ValueError):
+        hi = nk.hilbert.Spin(1.0, 8)
+        _ = nk.operator.IsingJax(hi, graph=g, h=1.0)
+
+
 def test_Heisenberg():
     g = nk.graph.Hypercube(8, 1)
     hi = nk.hilbert.Spin(0.5) ** 8

--- a/test/operator/test_hamiltonian.py
+++ b/test/operator/test_hamiltonian.py
@@ -126,11 +126,12 @@ def _colored_graph(graph):
 )
 def test_jax_conn(graph, partial_hilbert, partial_H_pair, dtype):
     hilbert = partial_hilbert(graph)
-    H1 = partial_H_pair[0](hilbert, graph)
     H2 = partial_H_pair[1](hilbert, graph)
 
-    if isinstance(hilbert, nk.hilbert.Qubit) and isinstance(H1, nk.operator.Ising):
+    if isinstance(hilbert, nk.hilbert.Qubit) and isinstance(H2, nk.operator.IsingJax):
         pytest.skip("The original Ising only supports Spin")
+
+    H1 = partial_H_pair[0](hilbert, graph)
 
     σ = hilbert.random_state(nk.jax.PRNGKey(0), size=(10,), dtype=dtype)
     σp1, mels1 = H1.get_conn_padded(σ)

--- a/test/variational/test_autoreg.py
+++ b/test/variational/test_autoreg.py
@@ -173,8 +173,12 @@ def test_vmc_same(partial_model_pair, hilbert, dtype, machine_pow, skip):
     assert vstate1.n_discard_per_chain == 0
     samples1 = vstate1.sample()
 
-    graph = nk.graph.Hypercube(length=hilbert.size, n_dim=1)
-    H = nk.operator.IsingJax(hilbert=hilbert, graph=graph, h=1)
+    H = nk.operator.LocalOperator(hilbert)
+    for i in range(hilbert.size):
+        j = i % hilbert.size
+        H += -nk.operator.spin.sigmax(hilbert, i)
+        H += nk.operator.spin.sigmaz(hilbert, i) @ nk.operator.spin.sigmaz(hilbert, j)
+
     optimizer = optax.adam(learning_rate=1e-3)
     vmc1 = nk.VMC(H, optimizer, variational_state=vstate1)
     vmc1.run(n_iter=3)

--- a/test/variational/test_autoreg.py
+++ b/test/variational/test_autoreg.py
@@ -174,7 +174,7 @@ def test_vmc_same(partial_model_pair, hilbert, dtype, machine_pow, skip):
     samples1 = vstate1.sample()
 
     graph = nk.graph.Hypercube(length=hilbert.size, n_dim=1)
-    H = nk.operator.Ising(hilbert=hilbert, graph=graph, h=1)
+    H = nk.operator.IsingJax(hilbert=hilbert, graph=graph, h=1)
     optimizer = optax.adam(learning_rate=1e-3)
     vmc1 = nk.VMC(H, optimizer, variational_state=vstate1)
     vmc1.run(n_iter=3)


### PR DESCRIPTION
Ising only works with Spin space. Throw an error with other Hilbert space and suggest to use `IsingJax` instead.

Noticed again by @adrien-kahn

