### PR TITLE
Actually use chunk size in vs.local_estimators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@
 
 ## NetKet 3.11 (⚙️ In development)
 
+## NetKet 3.10.2 (8 november 2023)
+
+### Bug Fixes
+
+* Fixed a bug where it was not possible to recompile functions using two identical but different instances of PauliStringJax [#1647](https://github.com/netket/netket/pull/1647).
+* Fixed a minor bug where chunking was never actually used inside of :meth:`~netket.vqs.MCState.local_estimators`. This will turn on chunking for some other drivers such as {class}`netket.experimental.driver.VMC_SRt` and {class}`netket.experimental.driver.TDVPSchmitt`) [#1650](https://github.com/netket/netket/pull/1650).
+
 
 ## NetKet 3.10.1 (8 november 2023)
 

--- a/netket/vqs/mc/mc_state/state.py
+++ b/netket/vqs/mc/mc_state/state.py
@@ -736,7 +736,9 @@ def local_estimators(
     if chunk_size is None:
         kernel = get_local_kernel(state, op)
     else:
-        kernel = get_local_kernel(state, op, chunk_size)
+        kernel = nkjax.HashablePartial(
+            get_local_kernel(state, op, chunk_size), chunk_size=chunk_size
+        )
 
     return _local_estimators_kernel(
         kernel, state._apply_fun, shape[:-1], state.variables, s, extra_args


### PR DESCRIPTION
reported on Slack. 

Should probably look into why we do not already return a partial from the get kernel. I suspect there was a reason...