### PR TITLE
Make Samplers and rules 'standard' classes, less magical

### DIFF
--- a/netket/experimental/sampler/metropolis_pmap.py
+++ b/netket/experimental/sampler/metropolis_pmap.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import warnings
+
 from typing import Callable, Union
 from functools import partial
 
@@ -29,7 +31,6 @@ from netket.sampler import SamplerState
 from netket.sampler import MetropolisSamplerState, MetropolisSampler
 
 
-@struct.dataclass
 class MetropolisSamplerPmapState(MetropolisSamplerState):
     """
     Sampler State for the `MetropolisSamplerPmap` sampler.
@@ -52,7 +53,6 @@ class MetropolisSamplerPmapState(MetropolisSamplerState):
         super()._repr_pretty_(p, cycle)
 
 
-@struct.dataclass
 class MetropolisSamplerPmap(MetropolisSampler):
     r"""
     Metropolis-Hastings sampler for an Hilbert space according to a specific transition rule where chains are split
@@ -77,7 +77,9 @@ class MetropolisSamplerPmap(MetropolisSampler):
     The dtype of the sampled states can be chosen.
     """
 
-    def __pre_init__(self, *args, n_chains_per_device=None, **kwargs):
+    _sampler_device: MetropolisSampler = struct.static_field()
+
+    def __init__(self, *args, n_chains_per_device=None, **kwargs):
         """
         Constructs a Metropolis Sampler.
 
@@ -116,8 +118,6 @@ class MetropolisSamplerPmap(MetropolisSampler):
         kwargs["n_chains_per_rank"] = n_chains_per_device * n_devices
 
         if kwargs["n_chains_per_rank"] != n_chains_per_device * n_devices:
-            import warnings
-
             warnings.warn(
                 f"Using {n_chains_per_device*n_devices} chains "
                 f"({n_chains_per_device} chains on each of {n_devices} devices).",
@@ -125,14 +125,11 @@ class MetropolisSamplerPmap(MetropolisSampler):
                 stacklevel=2,
             )
 
-        return args, kwargs
-
-    def __post_init__(self):
-        super().__post_init__()
+        super().__init__(*args, **kwargs)
 
         n_chains_per_device = self.n_chains_per_rank // len(jax.devices())
 
-        _sampler = MetropolisSampler(
+        self._sampler_device = MetropolisSampler(
             self.hilbert,
             n_chains_per_rank=n_chains_per_device,
             rule=self.rule,
@@ -140,8 +137,6 @@ class MetropolisSamplerPmap(MetropolisSampler):
             reset_chains=self.reset_chains,
             machine_pow=self.machine_pow,
         )
-
-        object.__setattr__(self, "_sampler_device", _sampler)
 
     @property
     def n_chains_per_device(self):

--- a/netket/experimental/sampler/metropolis_pt.py
+++ b/netket/experimental/sampler/metropolis_pt.py
@@ -26,7 +26,6 @@ from netket.sampler import MetropolisSamplerState, MetropolisSampler
 from netket.sampler.rules import LocalRule, ExchangeRule, HamiltonianRule
 
 
-@struct.dataclass
 class MetropolisPtSamplerState(MetropolisSamplerState):
     beta: jnp.ndarray = None
 
@@ -35,6 +34,25 @@ class MetropolisPtSamplerState(MetropolisSamplerState):
     beta_position: jnp.ndarray = None
     beta_diffusion: jnp.ndarray = None
     exchange_steps: int = 0
+
+    def __init__(
+        self,
+        *,
+        beta,
+        n_accepted_per_beta,
+        beta_0_index,
+        beta_position,
+        beta_diffusion,
+        exchange_steps,
+        **kwargs,
+    ):
+        self.beta = beta
+        self.n_accepted_per_beta = n_accepted_per_beta
+        self.beta_0_index = beta_0_index
+        self.beta_position = beta_position
+        self.beta_diffusion = beta_diffusion
+        self.exchange_steps = exchange_steps
+        super().__init__(**kwargs)
 
     def __repr__(self):
         if self.n_steps > 0:
@@ -50,36 +68,6 @@ class MetropolisPtSamplerState(MetropolisSamplerState):
         return text
 
 
-_init_doc = r"""
-``MetropolisSampler`` is a generic Metropolis-Hastings sampler using
-a transition rule to perform moves in the Markov Chain.
-The transition kernel is used to generate
-a proposed state :math:`s^\prime`, starting from the current state :math:`s`.
-The move is accepted with probability
-
-.. math::
-    A(s\rightarrow s^\prime) = \mathrm{min}\left (1,\frac{P(s^\prime)}{P(s)} e^{L(s,s^\prime)} \right),
-
-where the probability being sampled from is :math:`P(s)=|M(s)|^p`. Here :math:`M(s)` is a
-user-provided function (the machine), :math:`p` is also user-provided with default value :math:`p=2`,
-and :math:`L(s,s^\prime)` is a suitable correcting factor computed by the transition kernel.
-
-
-Args:
-    hilbert: The hilbert space to sample
-    rule: A `MetropolisRule` to generate random transitions from a given state as
-            well as uniform random states.
-    n_chains: The number of Markov Chain to be run in parallel on a single process.
-    n_sweeps: The number of exchanges that compose a single sweep.
-            If None, sweep_size is equal to the number of degrees of freedom being sampled
-            (the size of the input vector s to the machine).
-    n_chains: The number of batches of the states to sample (default = 8)
-    machine_pow: The power to which the machine should be exponentiated to generate the pdf (default = 2).
-    dtype: The dtype of the states sampled (default = np.float32).
-"""
-
-
-@struct.dataclass(init_doc=_init_doc)
 class MetropolisPtSampler(MetropolisSampler):
     """
     Metropolis-Hastings with Parallel Tempering sampler.
@@ -92,14 +80,43 @@ class MetropolisPtSampler(MetropolisSampler):
     n_replicas: int = struct.field(pytree_node=False, default=32)
     """The number of replicas"""
 
-    def __post_init__(self):
-        super().__post_init__()
+    def __init__(self, *args, n_replicas: int = 32, **kwargs):
+        r"""
+        ``MetropolisSampler`` is a generic Metropolis-Hastings sampler using
+        a transition rule to perform moves in the Markov Chain.
+        The transition kernel is used to generate
+        a proposed state :math:`s^\prime`, starting from the current state :math:`s`.
+        The move is accepted with probability
+
+        .. math::
+            A(s\rightarrow s^\prime) = \mathrm{min}\left (1,\frac{P(s^\prime)}{P(s)} e^{L(s,s^\prime)} \right),
+
+        where the probability being sampled from is :math:`P(s)=|M(s)|^p`. Here :math:`M(s)` is a
+        user-provided function (the machine), :math:`p` is also user-provided with default value :math:`p=2`,
+        and :math:`L(s,s^\prime)` is a suitable correcting factor computed by the transition kernel.
+
+
+        Args:
+            hilbert: The hilbert space to sample
+            rule: A `MetropolisRule` to generate random transitions from a given state as
+                    well as uniform random states.
+            n_chains: The number of Markov Chain to be run in parallel on a single process.
+            n_sweeps: The number of exchanges that compose a single sweep.
+                    If None, sweep_size is equal to the number of degrees of freedom being sampled
+                    (the size of the input vector s to the machine).
+            n_chains: The number of batches of the states to sample (default = 8)
+            machine_pow: The power to which the machine should be exponentiated to generate the pdf (default = 2).
+            dtype: The dtype of the states sampled (default = np.float32).
+        """
         if (
-            not isinstance(self.n_replicas, int)
-            and self.n_replicas > 0
+            not isinstance(n_replicas, int)
+            and n_replicas > 0
             and np.mod(self.n_replicas, 2) == 0
         ):
             raise ValueError("n_replicas must be an even integer > 0.")
+        self.n_replicas = n_replicas
+
+        super().__init__(*args, **kwargs)
 
     @property
     def n_batches(self):
@@ -122,8 +139,6 @@ class MetropolisPtSampler(MetropolisSampler):
             σ=σ,
             rng=key_state,
             rule_state=rule_state,
-            n_steps_proc=0,
-            n_accepted_proc=0,
             beta=beta,
             beta_0_index=jnp.zeros((sampler.n_chains,), dtype=jnp.int64),
             n_accepted_per_beta=jnp.zeros(
@@ -148,7 +163,6 @@ class MetropolisPtSampler(MetropolisSampler):
             σ=σ,
             rng=new_rng,
             rule_state=rule_state,
-            n_steps_proc=0,
             n_accepted_proc=0,
             n_accepted_per_beta=jnp.zeros(
                 (sampler.n_chains, sampler.n_replicas), dtype=jnp.int64

--- a/netket/operator/_local_liouvillian.py
+++ b/netket/operator/_local_liouvillian.py
@@ -66,7 +66,6 @@ class LocalLiouvillian(AbstractSuperOperator):
 
     """
 
-
     def __init__(
         self,
         ham: DiscreteOperator,

--- a/netket/operator/_local_operator/base.py
+++ b/netket/operator/_local_operator/base.py
@@ -63,7 +63,6 @@ class LocalOperator(DiscreteOperator):
     in the quantum information sense).
     """
 
-
     def __init__(
         self,
         hilbert: AbstractHilbert,

--- a/netket/sampler/autoreg.py
+++ b/netket/sampler/autoreg.py
@@ -19,6 +19,7 @@ import jax
 from jax import numpy as jnp
 
 from netket import jax as nkjax
+from netket import config
 from netket.hilbert import DiscreteHilbert
 from netket.sampler import Sampler, SamplerState
 from netket.utils.deprecation import warn_deprecation

--- a/netket/sampler/autoreg.py
+++ b/netket/sampler/autoreg.py
@@ -81,7 +81,7 @@ class ARDirectSampler(Sampler):
                 "ARDirectSampler.machine_pow should not be used. Modify the model `machine_pow` directly."
             )
 
-        if self.hilbert.constrained:
+        if hilbert.constrained:
             raise ValueError(
                 "Only unconstrained Hilbert spaces can be sampled autoregressively with "
                 "this sampler. To sample constrained spaces, you must write your own (do get in "

--- a/netket/sampler/autoreg.py
+++ b/netket/sampler/autoreg.py
@@ -19,21 +19,21 @@ import jax
 from jax import numpy as jnp
 
 from netket import jax as nkjax
+from netket.hilbert import DiscreteHilbert
 from netket.sampler import Sampler, SamplerState
-from netket.utils import struct
 from netket.utils.deprecation import warn_deprecation
-from netket.utils.types import PRNGKeyT
-from netket.utils import mpi
-from netket import config
+from netket.utils.types import PRNGKeyT, DType
 
 
-@struct.dataclass
 class ARDirectSamplerState(SamplerState):
     key: PRNGKeyT
     """state of the random number generator."""
 
+    def __init__(self, key):
+        self.key = key
+        super().__init__()
 
-@struct.dataclass
+
 class ARDirectSampler(Sampler):
     r"""
     Direct sampler for autoregressive neural networks.
@@ -51,7 +51,15 @@ class ARDirectSampler(Sampler):
     sampler.
     """
 
-    def __pre_init__(self, *args, **kwargs):
+    def __init__(
+        self,
+        hilbert: DiscreteHilbert,
+        machine_pow: None = None,
+        dtype: DType = float,
+        *,
+        n_chains=None,
+        n_chains_per_rank=None,
+    ):
         """
         Construct an autoregressive direct sampler.
 
@@ -62,20 +70,12 @@ class ARDirectSampler(Sampler):
         Note:
             `ARDirectSampler.machine_pow` has no effect. Please set the model's `machine_pow` instead.
         """
-        if "n_chains" in kwargs or "n_chains_per_rank" in kwargs:
+        if n_chains is not None or n_chains_per_rank is not None:
             warn_deprecation(
                 "Specifying `n_chains` or `n_chains_per_rank` when constructing exact samplers is deprecated."
             )
-            kwargs.pop("n_chains_per_rank")
-            kwargs.pop("n_chains")
-        kwargs["n_chains"] = mpi.n_nodes
-        return super().__pre_init__(*args, **kwargs)
 
-    def __post_init__(self):
-        super().__post_init__()
-
-        # self.machine_pow may be traced in jit
-        if isinstance(self.machine_pow, int) and self.machine_pow != 2:
+        if machine_pow is not None:
             raise ValueError(
                 "ARDirectSampler.machine_pow should not be used. Modify the model `machine_pow` directly."
             )
@@ -86,6 +86,8 @@ class ARDirectSampler(Sampler):
                 "this sampler. To sample constrained spaces, you must write your own (do get in "
                 "touch with us. We are interested!)"
             )
+
+        return super().__init__(hilbert, machine_pow=2, dtype=dtype)
 
     @property
     def is_exact(sampler):

--- a/netket/sampler/base.py
+++ b/netket/sampler/base.py
@@ -24,7 +24,7 @@ from jax import numpy as jnp
 from netket import jax as nkjax
 from netket.hilbert import AbstractHilbert
 from netket.utils import get_afun_if_module, mpi, numbers, struct, wrap_afun
-from netket.utils.deprecation import deprecated, warn_deprecation
+from netket.utils.deprecation import deprecated
 from netket.utils.types import PyTree, DType, SeedT
 from netket.jax import HashablePartial
 

--- a/netket/sampler/base.py
+++ b/netket/sampler/base.py
@@ -15,6 +15,7 @@
 import abc
 from typing import Optional, Union, Callable
 from collections.abc import Iterator
+import warnings
 
 import numpy as np
 from flax import linen as nn
@@ -27,18 +28,52 @@ from netket.utils.deprecation import deprecated, warn_deprecation
 from netket.utils.types import PyTree, DType, SeedT
 from netket.jax import HashablePartial
 
-fancy = []
+
+def compute_n_chains(
+    n_chains_per_rank: Optional[int] = None, n_chains: Optional[int] = None, default=1
+) -> int:
+    """
+    Compute the number of chains per rank given either n_chains_per_rank
+    and n_chains
+    """
+    if n_chains_per_rank is not None and n_chains is not None:
+        raise ValueError("Cannot specify both `n_chains` and `n_chains_per_rank`")
+    elif n_chains is not None:
+        n_chains_per_rank = max(int(np.ceil(n_chains / mpi.n_nodes)), 1)
+        if mpi.n_nodes > 1 and mpi.rank == 0:
+            if n_chains_per_rank * mpi.n_nodes != n_chains:
+                warnings.warn(
+                    f"Using {n_chains_per_rank} chains per rank among {mpi.n_nodes} ranks "
+                    f"(total={n_chains_per_rank * mpi.n_nodes} instead of n_chains={n_chains}). "
+                    f"To directly control the number of chains on every rank, specify "
+                    f"`n_chains_per_rank` when constructing the sampler. "
+                    f"To silence this warning, either use `n_chains_per_rank` or use `n_chains` "
+                    f"that is a multiple of the number of MPI ranks.",
+                    category=UserWarning,
+                    stacklevel=2,
+                )
+    elif n_chains_per_rank is not None:
+        pass
+    else:
+        # Default value
+        n_chains_per_rank = default
+
+    if not n_chains_per_rank > 0:
+        raise TypeError(
+            "n_chains_per_rank must be a positive integer, but "
+            f"you specified {n_chains_per_rank}"
+        )
+
+    return n_chains_per_rank * mpi.n_nodes
 
 
-@struct.dataclass
-class SamplerState(abc.ABC):
+class SamplerState(struct.Pytree):
     """
     Base class holding the state of a sampler.
     """
 
 
-@struct.dataclass
-class Sampler(abc.ABC):
+class Sampler(struct.Pytree):
     """
     Abstract base class for all samplers.
 
@@ -59,54 +94,33 @@ class Sampler(abc.ABC):
     hilbert: AbstractHilbert = struct.field(pytree_node=False)
     """The Hilbert space to sample."""
 
-    n_chains: int = struct.field(pytree_node=False, default=None, repr=False)
-    """Total Number of independent chains"""
-
     machine_pow: int = struct.field(default=2)
     """The power to which the machine should be exponentiated to generate the pdf."""
 
     dtype: DType = struct.field(pytree_node=False, default=float)
     """The dtype of the states sampled."""
 
-    def __pre_init__(
-        self, hilbert: AbstractHilbert, n_chains: Optional[int] = None, **kwargs
+    def __init__(
+        self,
+        hilbert: AbstractHilbert,
+        *,
+        machine_pow: int = 2,
+        dtype: DType = float,
     ):
         """
         Construct a Monte Carlo sampler.
 
         Args:
             hilbert: The Hilbert space to sample.
-            n_chains: The total number of independent chains across all MPI ranks (default = mpi.n_nodes)
             machine_pow: The power to which the machine should be exponentiated to generate the pdf (default = 2).
             dtype: The dtype of the states sampled (default = np.float64).
         """
-
-        if "n_chains_per_rank" in kwargs:
-            warn_deprecation(
-                "Specifying `n_chains_per_rank` when constructing the Sampler is deprecated."
-            )
-            if n_chains is None:
-                n_chains = mpi.n_nodes * kwargs.pop("n_chains_per_rank")
-            else:
-                raise ValueError(
-                    "Cannot specify both `n_chains` and `n_chains_per_rank`"
-                )
-        if n_chains is None:
-            n_chains = mpi.n_nodes
-        kwargs["n_chains"] = n_chains
-
-        return (hilbert,), kwargs
-
-    def __post_init__(self):
-        # Raise error if n_chains is not a multiple of the number of mpi ranks
-        self.n_chains_per_rank
-
         # Raise errors if hilbert is not an Hilbert
-        if not isinstance(self.hilbert, AbstractHilbert):
+        if not isinstance(hilbert, AbstractHilbert):
             raise TypeError(
                 "\n\nThe argument `hilbert` of a Sampler must be a subtype "
                 "of netket.hilbert.AbstractHilbert, but you passed in an object "
-                f"of type {type(self.hilbert)}, which is not an AbstractHilbert.\n\n"
+                f"of type {type(hilbert)}, which is not an AbstractHilbert.\n\n"
                 "TO FIX THIS ERROR,\ndouble check the arguments passed to the "
                 "sampler when constructing it, and verify that they have the "
                 "correct types.\n\n"
@@ -115,13 +129,14 @@ class Sampler(abc.ABC):
                 "\n"
             )
 
-        # workaround Jax bug under pmap
-        # might be removed in the future
-        if type(self.machine_pow) != object:
-            if not np.issubdtype(numbers.dtype(self.machine_pow), np.integer):
-                raise ValueError(
-                    f"machine_pow ({self.machine_pow}) must be a positive integer"
-                )
+        if not np.issubdtype(numbers.dtype(machine_pow), np.integer):
+            raise ValueError(
+                f"machine_pow ({self.machine_pow}) must be a positive integer"
+            )
+
+        self.hilbert = hilbert
+        self.machine_pow = machine_pow
+        self.dtype = dtype
 
     @property
     def n_chains_per_rank(self) -> int:
@@ -136,6 +151,15 @@ class Sampler(abc.ABC):
                 "The number of chains is not a multiple of the number of mpi ranks"
             )
         return res
+
+    @property
+    def n_chains(self) -> int:
+        """
+        The total number of independent chains per MPI rank.
+
+        If you are not using MPI, this is equal to :attr:`~Sampler.n_chains`.
+        """
+        return mpi.n_nodes
 
     @property
     def n_batches(self) -> int:

--- a/netket/sampler/exact.py
+++ b/netket/sampler/exact.py
@@ -19,26 +19,27 @@ import jax
 from flax import linen as nn
 from jax import numpy as jnp
 
+from netket.hilbert import DiscreteHilbert
 from netket.nn import to_array
-from netket.utils import struct
 from netket.utils.deprecation import warn_deprecation
-from netket.utils.types import PyTree, SeedT
-from netket.utils import mpi
-from netket import config
+from netket.utils.types import PyTree, SeedT, DType
 
 from .base import Sampler, SamplerState
 
 
-@struct.dataclass
 class ExactSamplerState(SamplerState):
     pdf: Any
     rng: Any
+
+    def __init__(self, pdf: Any, rng: Any):
+        self.pdf = pdf
+        self.rng = rng
+        super().__init__()
 
     def __repr__(self):
         return f"ExactSamplerState(rng state={self.rng})"
 
 
-@struct.dataclass
 class ExactSampler(Sampler):
     """
     This sampler generates i.i.d. samples from :math:`|\\Psi(\\sigma)|^2`.
@@ -50,7 +51,15 @@ class ExactSampler(Sampler):
     option.
     """
 
-    def __pre_init__(self, *args, **kwargs):
+    def __init__(
+        self,
+        hilbert: DiscreteHilbert,
+        machine_pow: int = 2,
+        dtype: DType = float,
+        *,
+        n_chains=None,
+        n_chains_per_rank=None,
+    ):
         """
         Construct an exact sampler.
 
@@ -59,14 +68,12 @@ class ExactSampler(Sampler):
             machine_pow: The power to which the machine should be exponentiated to generate the pdf (default = 2).
             dtype: The dtype of the states sampled (default = np.float64).
         """
-        if "n_chains" in kwargs or "n_chains_per_rank" in kwargs:
+        if n_chains is not None or n_chains_per_rank is not None:
             warn_deprecation(
                 "Specifying `n_chains` or `n_chains_per_rank` when constructing exact samplers is deprecated."
             )
-            kwargs.pop("n_chains_per_rank")
-            kwargs.pop("n_chains")
-        kwargs["n_chains"] = mpi.n_nodes
-        return super().__pre_init__(*args, **kwargs)
+
+        super().__init__(hilbert, machine_pow=machine_pow, dtype=dtype)
 
     @property
     def is_exact(sampler):

--- a/netket/sampler/exact.py
+++ b/netket/sampler/exact.py
@@ -19,6 +19,7 @@ import jax
 from flax import linen as nn
 from jax import numpy as jnp
 
+from netket import config
 from netket.hilbert import DiscreteHilbert
 from netket.nn import to_array
 from netket.utils.deprecation import warn_deprecation

--- a/netket/sampler/metropolis.py
+++ b/netket/sampler/metropolis.py
@@ -109,7 +109,10 @@ class MetropolisSamplerState(SamplerState):
 
 # serialization when sharded
 def serialize_MetropolisSamplerState_sharding(sampler_state):
-    state_dict = sampler_state.__dict__
+    state_dict = MetropolisSamplerState._to_flax_state_dict(
+        MetropolisSamplerState._pytree__static_fields, sampler_state
+    )
+
     for prop in ["σ", "n_accepted_proc"]:
         x = state_dict.get(prop, None)
         if x is not None and isinstance(x, jax.Array) and len(x.devices()) > 1:
@@ -123,7 +126,10 @@ def deserialize_MetropolisSamplerState_sharding(sampler_state, state_dict):
         x = state_dict[prop]
         if x is not None:
             state_dict[prop] = distribute_to_devices_along_axis(x)
-    return sampler_state.replace(**state_dict)
+
+    return MetropolisSamplerState._from_flax_state_dict(
+        MetropolisSamplerState._pytree__static_fields, sampler_state, state_dict
+    )
 
 
 if config.netket_experimental_sharding:

--- a/netket/sampler/rules/__init__.py
+++ b/netket/sampler/rules/__init__.py
@@ -20,8 +20,8 @@ from .exchange import ExchangeRule
 from .hamiltonian import HamiltonianRule
 from .continuous_gaussian import GaussianRule
 from .langevin import LangevinRule
-from .tensor import tensorRule as TensorRule
-from .multiple import multipleRules as MultipleRules
+from .tensor import TensorRule
+from .multiple import MultipleRules
 
 # numpy backend
 from .local_numpy import LocalRuleNumpy

--- a/netket/sampler/rules/base.py
+++ b/netket/sampler/rules/base.py
@@ -28,8 +28,7 @@ if config.netket_sphinx_build:
     from netket import sampler
 
 
-@struct.dataclass
-class MetropolisRule(abc.ABC):
+class MetropolisRule(struct.Pytree):
     """
     Base class for transition rules of Metropolis, such as Local, Exchange, Hamiltonian
     and several others.

--- a/netket/sampler/rules/continuous_gaussian.py
+++ b/netket/sampler/rules/continuous_gaussian.py
@@ -15,12 +15,10 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
-from flax import struct
 
 from .base import MetropolisRule
 
 
-@struct.dataclass
 class GaussianRule(MetropolisRule):
     r"""
     A transition rule acting on all particle positions at once.
@@ -29,11 +27,21 @@ class GaussianRule(MetropolisRule):
     Gaussian distribution of width sigma.
     """
 
-    sigma: float = 1.0
+    sigma: float
     """
     The variance of the gaussian distribution centered around the current
     configuration, used to propose new configurations.
     """
+
+    def __init__(self, sigma: float = 1.0):
+        """
+        Constructs the Gaussian hastings proposal rule.
+
+        Args:
+            sigma: The variance of the gaussian distribution centered around the current
+                configuration, used to propose new configurations. (default=1.0)
+        """
+        self.sigma = sigma
 
     def transition(rule, sampler, machine, parameters, state, key, r):
         if jnp.issubdtype(r.dtype, jnp.complexfloating):

--- a/netket/sampler/rules/exchange.py
+++ b/netket/sampler/rules/exchange.py
@@ -50,12 +50,21 @@ class ExchangeRule(MetropolisRule):
     region where :math:`\sum_i s_i = \mathrm{constant}` is needed,
     otherwise the sampling would be strongly not ergodic.
     """
+
     clusters: jax.Array
+    r"""2-Dimensional tensor :math:`T_{i,j}` of shape
+    :math:`N_\text{clusters}\times 2` where the first dimension
+    runs over the list of 2-site clusters and the second dimension
+    runs over the 2 sites of those clusters.
+
+    The Exchange rule will swap the two sites of a random row of this
+    matrix at every Metropolis step.
+    """
 
     def __init__(
         self,
         *,
-        clusters: Optional[list[list[int]]] = None,
+        clusters: Optional[list[tuple[int, int]]] = None,
         graph: Optional[AbstractGraph] = None,
         d_max: int = 1,
     ):
@@ -66,7 +75,9 @@ class ExchangeRule(MetropolisRule):
         determine the clusters to exchange.
 
         Args:
-            clusters: The list of clusters that can be exchanged.
+            clusters: The list of clusters that can be exchanged. This should be
+                a list of 2-tuples containing two integers. Every tuple is an edge,
+                or cluster of sites to be exchanged.
             graph: A graph, from which the edges determine the clusters
                 that can be exchanged.
             d_max: Only valid if a graph is passed in. The maximum distance
@@ -107,7 +118,12 @@ class ExchangeRule(MetropolisRule):
         return f"ExchangeRule(# of clusters: {len(self.clusters)})"
 
 
-def compute_clusters(graph, d_max):
+def compute_clusters(graph: AbstractGraph, d_max: int):
+    """
+    Given a netket graph and a maximum distance, computes all clusters.
+    If `d_max = 1` this is equivalent to taking the edges of the graph.
+    Then adds next-nearest neighbors and so on.
+    """
     clusters = []
     distances = np.asarray(graph.distances())
     size = distances.shape[0]

--- a/netket/sampler/rules/fixed.py
+++ b/netket/sampler/rules/fixed.py
@@ -12,12 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from flax import struct
 
 from .base import MetropolisRule
 
 
-@struct.dataclass
 class FixedRule(MetropolisRule):
     r"""
     A transition rule relaxing and doing nothing.

--- a/netket/sampler/rules/hamiltonian.py
+++ b/netket/sampler/rules/hamiltonian.py
@@ -19,16 +19,15 @@ import jax.numpy as jnp
 
 import numpy as np
 
-from flax import struct
 from numba import jit
 from numba4jax import njit4jax
 
 from netket.operator import AbstractOperator, DiscreteJaxOperator
+from netket.utils import struct
 
 from .base import MetropolisRule
 
 
-@struct.dataclass
 class HamiltonianRuleBase(MetropolisRule):
     """
     Rule proposing moves according to the terms in an operator.
@@ -36,6 +35,9 @@ class HamiltonianRuleBase(MetropolisRule):
 
     operator: AbstractOperator = struct.field(pytree_node=False)
     """The (hermitian) operator giving the transition amplitudes."""
+
+    def __init__(self, operator: AbstractOperator):
+        self.operator = operator
 
     def init_state(rule, sampler, machine, params, key):
         if sampler.hilbert != rule.operator.hilbert:

--- a/netket/sampler/rules/hamiltonian_numpy.py
+++ b/netket/sampler/rules/hamiltonian_numpy.py
@@ -17,9 +17,9 @@ import math
 from numba import jit
 
 import numpy as np
-from flax import struct
 
-from netket.operator import AbstractOperator
+from netket.operator import DiscreteOperator
+from netket.utils import struct
 
 from .base import MetropolisRule
 
@@ -30,7 +30,6 @@ class HamiltonianRuleState:
     """Preallocated array for sections"""
 
 
-@struct.dataclass
 class HamiltonianRuleNumpy(MetropolisRule):
     """
     Rule for Numpy sampler backend proposing moves according to the terms in an operator.
@@ -43,16 +42,27 @@ class HamiltonianRuleNumpy(MetropolisRule):
 
     """
 
-    operator: AbstractOperator = struct.field(pytree_node=False)
+    operator: DiscreteOperator = struct.field(pytree_node=False)
     """The (hermitian) operator giving the transition amplitudes."""
 
-    def __post_init__(self):
-        # Raise errors if hilbert is not an Hilbert
-        if not isinstance(self.operator, AbstractOperator):
+    def __init__(self, operator: DiscreteOperator):
+        """
+        Constructs the Hamiltonian sampling rule for the
+        :class:`netket.sampler.MetropolisNumpy`sampler.
+
+        If you are using the standard jax sampler, look for
+        :class:`netket.sampler.rules.HamiltonianRule`.
+
+        Args:
+            operator: The hermitian operator to be used to generate
+                configurations.
+        """
+        if not isinstance(operator, DiscreteOperator):
             raise TypeError(
                 "Argument to HamiltonianRule must be a valid operator, "
-                f"but operator is a {type(self.operator)}."
+                f"but operator is a {type(operator)}."
             )
+        self.operator = operator
 
     def init_state(rule, sampler, machine, params, key):
         if sampler.hilbert != rule.operator.hilbert:

--- a/netket/sampler/rules/langevin.py
+++ b/netket/sampler/rules/langevin.py
@@ -1,3 +1,19 @@
+# Copyright 2023 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional
+
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -9,7 +25,6 @@ from .base import MetropolisRule
 import netket.jax as nkjax
 
 
-@struct.dataclass
 class LangevinRule(MetropolisRule):
     r"""
     A transition rule that uses Langevin dynamics [1] to update samples.
@@ -23,14 +38,21 @@ class LangevinRule(MetropolisRule):
     [1]: https://en.wikipedia.org/wiki/Metropolis-adjusted_Langevin_algorithm
     """
 
-    dt: float = 0.001
-    """
-    Time step in the Langevin dynamics
-    """
-    chunk_size: int = struct.field(pytree_node=False, default=None)
-    """
-    Chunk size for computing gradients of the ansatz
-    """
+    dt: float
+    """Time step in the Langevin dynamics."""
+    chunk_size: Optional[int] = struct.field(pytree_node=False)
+    """Chunk size for computing gradients of the ansatz."""
+
+    def __init__(self, dt: float = 0.001, chunk_size: Optional[int] = None):
+        """
+        Constructs the Langevin Hastings proposal rule.
+
+        Args:
+            dt: the timestep for the langevin dynamics (default=0.001)
+            chunk_size: optional chunk size to reduce memory usage
+        """
+        self.dt = dt
+        self.chunk_size = chunk_size
 
     def transition(rule, sampler, machine, parameters, state, key, r):
         if jnp.issubdtype(r.dtype, jnp.complexfloating):

--- a/netket/sampler/rules/local.py
+++ b/netket/sampler/rules/local.py
@@ -14,14 +14,12 @@
 
 import jax
 
-from flax import struct
 
 from netket.hilbert.random import flip_state
 
 from .base import MetropolisRule
 
 
-@struct.dataclass
 class LocalRule(MetropolisRule):
     r"""
     A transition rule acting on the local degree of freedom.

--- a/netket/sampler/rules/local_numpy.py
+++ b/netket/sampler/rules/local_numpy.py
@@ -15,7 +15,8 @@
 from numba import jit
 
 import numpy as np
-from flax import struct
+
+from netket.utils import struct
 
 from .base import MetropolisRule
 

--- a/netket/utils/struct/pytree.py
+++ b/netket/utils/struct/pytree.py
@@ -9,6 +9,7 @@ from types import MappingProxyType
 import jax
 
 from .fields import CachedProperty, _cache_name, _raw_cache_name, Uninitialized
+from netket.utils import config
 
 P = tp.TypeVar("P", bound="Pytree")
 
@@ -162,6 +163,18 @@ class Pytree(metaclass=PytreeMeta):
 
         if mutable and len(cached_prop_fields) != 0:
             raise ValueError("cannot use cached properties with " "mutable pytrees.")
+
+        if config.netket_sphinx_build:
+            for k in static_fields:
+                try:
+                    delattr(cls, k)
+                except AttributeError:
+                    pass
+            for k in data_fields:
+                try:
+                    delattr(cls, k)
+                except AttributeError:
+                    pass
 
         # new
         init_fields = tuple(sorted(data_fields.union(static_fields)))

--- a/netket/vqs/full_summ/state.py
+++ b/netket/vqs/full_summ/state.py
@@ -72,7 +72,6 @@ class FullSumState(VariationalState):
 
     _chunk_size: Optional[int] = None
 
-
     def __init__(
         self,
         hilbert: AbstractHilbert,

--- a/netket/vqs/mc/mc_mixed_state/state.py
+++ b/netket/vqs/mc/mc_mixed_state/state.py
@@ -45,7 +45,6 @@ class MCMixedState(VariationalMixedState, MCState):
     according to another sampler.
     """
 
-
     def __init__(
         self,
         sampler,

--- a/netket/vqs/mc/mc_state/state.py
+++ b/netket/vqs/mc/mc_state/state.py
@@ -134,7 +134,6 @@ class MCState(VariationalState):
 
     _chunk_size: Optional[int] = None
 
-
     def __init__(
         self,
         sampler: Sampler,


### PR DESCRIPTION
This PR makes samplers and rules less magical (so gets rid of those pesky `__pre_init__` and `__post_init__`, which are torturing @inailuig ) by making them 'standard' PyTree classes with a standard `__init__` method.

This makes inheritance easier, by the way, and also the documentation a bit prettier because things like `ExchangeRule` and others don't necessitate a constructor function.

@inailuig this PR also removes the `n_chains_per_rank` in the constructor from the base Sampler class, and leaves it to the subclasses that want to define it.
