### PR TITLE
port local operator to jax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 * Recurrent neural networks and layers have been added to `nkx.models` and `nkx.nn` [#1305](https://github.com/netket/netket/pull/1305).
 * Added experimental support for running NetKet on multiple jax devices (as an alternative to MPI). It is enabled by setting the environment variable/configuration flag `NETKET_EXPERIMENTAL_SHARDING=1`. Parallelization is achieved by distributing the Markov chains / samples equally across all available devices utilizing [`jax.Array` sharding](https://jax.readthedocs.io/en/latest/notebooks/Distributed_arrays_and_automatic_parallelization.html). On GPU multi-node setups are supported via [jax.distribued](https://jax.readthedocs.io/en/latest/multi_process.html), whereas on CPU it is limited to a single process but several threads can be used by setting `XLA_FLAGS='--xla_force_host_platform_device_count=XX'` [#1511](https://github.com/netket/netket/pull/1511).
+* {class}`netket.operator.LocalOperatorJax` is a new Jax-compatible implementation of local operators. It can also be constructed starting from a standard operator by calling `operator.to_jax_operator()` [#1654](https://github.com/netket/netket/pull/1654).
 
 ### Breaking Changes
 

--- a/docs/api/errors.md
+++ b/docs/api/errors.md
@@ -19,6 +19,7 @@ Netket has the following classes of errors.
   HilbertIndexingDuringTracingError
   HolomorphicUndeclaredWarning
   JaxOperatorSetupDuringTracingError
+  JaxOperatorNotConvertibleToNumba
   NonHolomorphicQGTOnTheFlyDenseRepresentationError
   NumbaOperatorGetConnDuringTracingError
   RealQGTComplexDomainError

--- a/netket/errors.py
+++ b/netket/errors.py
@@ -360,7 +360,7 @@ class JaxOperatorNotConvertibleToNumba(NetketError):
     below:
 
     .. code-block:: python
-        
+
         import netket as nk
 
         hi = nk.hilbert.Spin(0.5, 2)
@@ -382,16 +382,16 @@ class JaxOperatorNotConvertibleToNumba(NetketError):
     open an issue.
 
     """
+
     def __init__(self, operator):
-        operator_type = type(operator)
         super().__init__(
-            f"\n"
+            "\n"
             "Illegal attempt to convert to the Numba format a Jax operator that had been flattened "
             "and unflattened."
-            f"\n\n"
-            f"Jax-based operators cannot be flattened or passed to a jax function and then be "
+            "\n\n"
+            "Jax-based operators cannot be flattened or passed to a jax function and then be "
             "converted to their numba format."
-            )
+        )
 
 
 #################################################

--- a/netket/errors.py
+++ b/netket/errors.py
@@ -351,6 +351,49 @@ class JaxOperatorSetupDuringTracingError(NetketError):
         )
 
 
+class JaxOperatorNotConvertibleToNumba(NetketError):
+    """Illegal attempt to convert to the Numba format a Jax operator that had been flattened
+    and unflattened.
+
+    This probably happened because you passed a Jax operator to a jax function transformation
+    or jitted function and then tried to re-convert it to the numba format like in the example
+    below:
+
+    .. code-block:: python
+        
+        import netket as nk
+
+        hi = nk.hilbert.Spin(0.5, 2)
+
+        op = nk.operator.spin.sigmax(hi, 0)
+        op = op.to_jax_operator()
+
+        @jax.jit
+        def test(op):
+            op.to_numba_operator()
+
+        test(op)
+
+    Unfortunately, once an operator is flattened with {ref}`jax.tree_util.tree_flatten`, which
+    happens at all jax-function transformation boundaries, it usually cannot be converted back to
+    the original numba form.
+
+    This happens for performance reasons, and we might reconsider. If it is a problem for you, do
+    open an issue.
+
+    """
+    def __init__(self, operator):
+        operator_type = type(operator)
+        super().__init__(
+            f"\n"
+            "Illegal attempt to convert to the Numba format a Jax operator that had been flattened "
+            "and unflattened."
+            f"\n\n"
+            f"Jax-based operators cannot be flattened or passed to a jax function and then be "
+            "converted to their numba format."
+            )
+
+
 #################################################
 # Jacobian and QGT errors                       #
 #################################################

--- a/netket/hilbert/index/constrained.py
+++ b/netket/hilbert/index/constrained.py
@@ -92,7 +92,7 @@ class ConstrainedHilbertIndex:
 
         out[:] = np.searchsorted(self._bare_numbers, out)
 
-        if np.max(out) >= self.n_states:
+        if np.max(out, initial=0) >= self.n_states:
             raise RuntimeError(
                 "The required state does not satisfy " "the given constraints."
             )

--- a/netket/operator/__init__.py
+++ b/netket/operator/__init__.py
@@ -18,7 +18,7 @@ from ._discrete_operator import DiscreteOperator
 from ._discrete_operator_jax import DiscreteJaxOperator
 
 from ._pauli_strings import PauliStrings, PauliStringsJax
-from ._local_operator import LocalOperator
+from ._local_operator import LocalOperator, LocalOperatorJax
 from ._graph_operator import GraphOperator
 from ._lazy import Adjoint, Transpose, Squared
 from ._heisenberg import Heisenberg

--- a/netket/operator/_graph_operator.py
+++ b/netket/operator/_graph_operator.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Union
+from typing import Optional, Union
 
 from netket.utils.types import DType
 
@@ -162,6 +162,15 @@ class GraphOperator(LocalOperator):
         the constructor.
         """
         return self._acting_on_subspace
+
+    def copy(self, *, dtype: Optional[DType] = None):
+        """Returns a copy of the operator, while optionally changing the dtype
+        of the operator.
+
+        Args:
+            dtype: optional dtype
+        """
+        return super().copy(dtype=dtype, _cls=LocalOperator)
 
     def __repr__(self):
         ao = self.acting_on

--- a/netket/operator/_local_operator/__init__.py
+++ b/netket/operator/_local_operator/__init__.py
@@ -12,4 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .base import LocalOperator
+from .base import LocalOperatorBase
+from .numba import LocalOperator
+from .jax import LocalOperatorJax

--- a/netket/operator/_local_operator/base.py
+++ b/netket/operator/_local_operator/base.py
@@ -200,12 +200,15 @@ class LocalOperatorBase(DiscreteOperator):
             self.hilbert, self.operators, self.acting_on, self.constant, self.dtype
         )
 
-    def copy(self, *, dtype: Optional[DType] = None):
+    def copy(self, *, dtype: Optional[DType] = None, _cls=None):
         """Returns a copy of the operator, while optionally changing the dtype
         of the operator.
 
         Args:
             dtype: optional dtype
+
+        Internal args:
+            _cls: used to specify the target class
         """
 
         if dtype is None:
@@ -214,7 +217,10 @@ class LocalOperatorBase(DiscreteOperator):
         if not np.can_cast(self.dtype, dtype, casting="same_kind"):
             raise ValueError(f"Cannot cast {self.dtype} to {dtype}")
 
-        new = type(self)(self.hilbert, constant=self.constant, dtype=dtype)
+        if _cls is None:
+            _cls = type(self)
+
+        new = _cls(self.hilbert, constant=self.constant, dtype=dtype)
         new.mel_cutoff = self.mel_cutoff
 
         if dtype == self.dtype:

--- a/netket/operator/_local_operator/base.py
+++ b/netket/operator/_local_operator/base.py
@@ -20,13 +20,11 @@ from textwrap import dedent
 
 import numpy as np
 import jax.numpy as jnp
-import numba
 from scipy.sparse import issparse
 
 from netket.hilbert import AbstractHilbert
 from netket.utils.types import DType, Array
 from netket.utils.numbers import dtype as _dtype, is_scalar
-from netket.errors import concrete_or_error, NumbaOperatorGetConnDuringTracingError
 
 from .._discrete_operator import DiscreteOperator
 from .._lazy import Transpose
@@ -36,7 +34,6 @@ from .helpers import (
     _multiply_operators,
     cast_operator_matrix_dtype,
 )
-from .compile_helpers import pack_internals
 from .convert import local_operators_to_pauli_strings
 
 if TYPE_CHECKING:
@@ -57,7 +54,7 @@ def _is_sorted(a):
     return True
 
 
-class LocalOperator(DiscreteOperator):
+class LocalOperatorBase(DiscreteOperator):
     """A custom local operator. This is a sum of an arbitrary number of operators
     acting locally on a limited set of k quantum numbers (i.e. k-local,
     in the quantum information sense).
@@ -169,8 +166,6 @@ class LocalOperator(DiscreteOperator):
         return self._size
 
     @property
-    # A way to cache the property depending on modifications of self._operators is described here:
-    # https://stackoverflow.com/questions/48262273/python-bookkeeping-dependencies-in-cached-attributes-that-might-change
     def is_hermitian(self) -> bool:
         """Returns true if this operator is hermitian."""
         # TODO: (VolodyaCO) I guess that if we have an operator with diagonal elements equal to 1j*C+Y, some complex constant, and
@@ -219,7 +214,7 @@ class LocalOperator(DiscreteOperator):
         if not np.can_cast(self.dtype, dtype, casting="same_kind"):
             raise ValueError(f"Cannot cast {self.dtype} to {dtype}")
 
-        new = LocalOperator(self.hilbert, constant=self.constant, dtype=dtype)
+        new = type(self)(self.hilbert, constant=self.constant, dtype=dtype)
         new.mel_cutoff = self.mel_cutoff
 
         if dtype == self.dtype:
@@ -264,13 +259,13 @@ class LocalOperator(DiscreteOperator):
     def __neg__(self):
         return -1 * self
 
-    def __add__(self, other: Union["LocalOperator", numbers.Number]):
+    def __add__(self, other: Union["LocalOperatorBase", numbers.Number]):
         op = self.copy(dtype=jnp.promote_types(self.dtype, _dtype(other)))
         op = op.__iadd__(other)
         return op
 
     def __iadd__(self, other):
-        if isinstance(other, LocalOperator):
+        if isinstance(other, LocalOperatorBase):
             if self.hilbert != other.hilbert:
                 return NotImplemented
 
@@ -346,7 +341,7 @@ class LocalOperator(DiscreteOperator):
         return NotImplemented
 
     def __imatmul__(self, other):
-        if not isinstance(other, LocalOperator):
+        if not isinstance(other, LocalOperatorBase):
             return NotImplemented
 
         if not np.can_cast(other.dtype, self.dtype, casting="same_kind"):
@@ -356,14 +351,14 @@ class LocalOperator(DiscreteOperator):
 
         return self._op_imatmul_(other)
 
-    def _op__matmul__(self, other: "LocalOperator") -> "LocalOperator":
-        if not isinstance(other, LocalOperator):
+    def _op__matmul__(self, other: "LocalOperatorBase") -> "LocalOperatorBase":
+        if not isinstance(other, LocalOperatorBase):
             return NotImplemented
         op = self.copy(dtype=jnp.promote_types(self.dtype, _dtype(other)))
         return op._op_imatmul_(other)
 
-    def _op_imatmul_(self, other: "LocalOperator") -> "LocalOperator":
-        if not isinstance(other, LocalOperator):
+    def _op_imatmul_(self, other: "LocalOperatorBase") -> "LocalOperatorBase":
+        if not isinstance(other, LocalOperatorBase):
             return NotImplemented
 
         # (α + ∑ᵢAᵢ)(β + ∑ᵢBᵢ) =
@@ -410,354 +405,11 @@ class LocalOperator(DiscreteOperator):
         self._initialized = False
         self._is_hermitian = None
 
-    def _setup(self, force: bool = False):
-        """Analyze the operator strings and precompute arrays for get_conn inference"""
-        if force or not self._initialized:
-            data = pack_internals(
-                self.hilbert,
-                self._operators_dict,
-                self.constant,
-                self.dtype,
-                self.mel_cutoff,
-            )
-
-            self._acting_on = data["acting_on"]
-            self._acting_size = data["acting_size"]
-            self._diag_mels = data["diag_mels"]
-            self._mels = data["mels"]
-            self._x_prime = data["x_prime"]
-            self._n_conns = data["n_conns"]
-            self._local_states = data["local_states"]
-            self._basis = data["basis"]
-            self._nonzero_diagonal = data["nonzero_diagonal"]
-            self._max_conn_size = data["max_conn_size"]
-            self._initialized = True
-
     @property
     def max_conn_size(self) -> int:
         """The maximum number of non zero ⟨x|O|x'⟩ for every x."""
         self._setup()
         return self._max_conn_size
-
-    def get_conn_flattened(self, x, sections, pad=False):
-        r"""Finds the connected elements of the Operator. Starting
-        from a given quantum number x, it finds all other quantum numbers x' such
-        that the matrix element :math:`O(x,x')` is different from zero. In general there
-        will be several different connected states x' satisfying this
-        condition, and they are denoted here :math:`x'(k)`, for :math:`k=0,1...N_{\mathrm{connected}}`.
-
-        This is a batched version, where x is a matrix of shape (batch_size,hilbert.size).
-
-        Args:
-            x (matrix): A matrix of shape (batch_size,hilbert.size) containing
-                        the batch of quantum numbers x.
-            sections (array): An array of size (batch_size) useful to unflatten
-                        the output of this function.
-                        See numpy.split for the meaning of sections.
-            pad (bool): Whether to use zero-valued matrix elements in order to return all equal sections.
-
-        Returns:
-            matrix: The connected states x', flattened together in a single matrix.
-            array: An array containing the matrix elements :math:`O(x,x')` associated to each x'.
-
-        """
-        self._setup()
-
-        x = concrete_or_error(
-            np.asarray,
-            x,
-            NumbaOperatorGetConnDuringTracingError,
-            self,
-        )
-
-        return self._get_conn_flattened_kernel(
-            x,
-            sections,
-            self._local_states,
-            self._basis,
-            self._constant,
-            self._diag_mels,
-            self._n_conns,
-            self._mels,
-            self._x_prime,
-            self._acting_on,
-            self._acting_size,
-            self._nonzero_diagonal,
-            pad,
-        )
-
-    def _get_conn_flattened_closure(self):
-        self._setup()
-        _local_states = self._local_states
-        _basis = self._basis
-        _constant = self._constant
-        _diag_mels = self._diag_mels
-        _n_conns = self._n_conns
-        _mels = self._mels
-        _x_prime = self._x_prime
-        _acting_on = self._acting_on
-        _acting_size = self._acting_size
-        # workaround my painfully discovered Numba#6979 (cannot use numpy bools in closures)
-        _nonzero_diagonal = bool(self._nonzero_diagonal)
-
-        fun = self._get_conn_flattened_kernel
-
-        def gccf_fun(x, sections):
-            return fun(
-                x,
-                sections,
-                _local_states,
-                _basis,
-                _constant,
-                _diag_mels,
-                _n_conns,
-                _mels,
-                _x_prime,
-                _acting_on,
-                _acting_size,
-                _nonzero_diagonal,
-            )
-
-        return numba.jit(nopython=True)(gccf_fun)
-
-    @staticmethod
-    @numba.jit(nopython=True)
-    def _get_conn_flattened_kernel(
-        x,
-        sections,
-        local_states,
-        basis,
-        constant,
-        diag_mels,
-        n_conns,
-        all_mels,
-        all_x_prime,
-        acting_on,
-        acting_size,
-        nonzero_diagonal,
-        pad=False,
-    ):
-        batch_size = x.shape[0]
-        n_sites = x.shape[1]
-        dtype = all_mels.dtype
-
-        # TODO remove this line when numba 0.53 is dropped 0.54 is minimum version
-        # workaround a bug in Numba arising when NUMBA_BOUNDSCHECK=1
-        constant = constant.item()
-
-        assert sections.shape[0] == batch_size
-
-        n_operators = n_conns.shape[0]
-        xs_n = np.empty((batch_size, n_operators), dtype=np.intp)
-
-        tot_conn = 0
-        max_conn = 0
-
-        for b in range(batch_size):
-            # diagonal element
-            conn_b = 1 if nonzero_diagonal else 0
-
-            # counting the off-diagonal elements
-            for i in range(n_operators):
-                acting_size_i = acting_size[i]
-
-                xs_n[b, i] = 0
-                x_b = x[b]
-                x_i = x_b[acting_on[i, :acting_size_i]]
-                for k in range(acting_size_i):
-                    xs_n[b, i] += (
-                        np.searchsorted(
-                            local_states[i, acting_size_i - k - 1],
-                            x_i[acting_size_i - k - 1],
-                        )
-                        * basis[i, k]
-                    )
-
-                conn_b += n_conns[i, xs_n[b, i]]
-
-            tot_conn += conn_b
-            sections[b] = tot_conn
-
-            if pad:
-                max_conn = max(conn_b, max_conn)
-
-        if pad:
-            tot_conn = batch_size * max_conn
-
-        x_prime = np.empty((tot_conn, n_sites), dtype=x.dtype)
-        mels = np.empty(tot_conn, dtype=dtype)
-
-        c = 0
-        for b in range(batch_size):
-            c_diag = c
-            x_batch = x[b]
-
-            if nonzero_diagonal:
-                mels[c_diag] = constant
-                x_prime[c_diag] = np.copy(x_batch)
-                c += 1
-
-            for i in range(n_operators):
-                if nonzero_diagonal:
-                    mels[c_diag] += diag_mels[i, xs_n[b, i]]
-
-                n_conn_i = n_conns[i, xs_n[b, i]]
-
-                if n_conn_i > 0:
-                    sites = acting_on[i]
-                    acting_size_i = acting_size[i]
-
-                    for cc in range(n_conn_i):
-                        mels[c + cc] = all_mels[i, xs_n[b, i], cc]
-                        x_prime[c + cc] = np.copy(x_batch)
-
-                        for k in range(acting_size_i):
-                            x_prime[c + cc, sites[k]] = all_x_prime[
-                                i, xs_n[b, i], cc, k
-                            ]
-                    c += n_conn_i
-
-            if pad:
-                delta_conn = max_conn - (c - c_diag)
-                mels[c : c + delta_conn].fill(0)
-                x_prime[c : c + delta_conn, :] = np.copy(x_batch)
-                c += delta_conn
-                sections[b] = c
-
-        return x_prime, mels
-
-    def get_conn_filtered(self, x, sections, filters):
-        r"""Finds the connected elements of the Operator using only a subset of operators. Starting
-        from a given quantum number x, it finds all other quantum numbers x' such
-        that the matrix element :math:`O(x,x')` is different from zero. In general there
-        will be several different connected states x' satisfying this
-        condition, and they are denoted here :math:`x'(k)`, for :math:`k=0,1...N_{\mathrm{connected}}`.
-
-        This is a batched version, where x is a matrix of shape (batch_size,hilbert.size).
-
-        Args:
-            x (matrix): A matrix of shape (batch_size,hilbert.size) containing
-                        the batch of quantum numbers x.
-            sections (array): An array of size (batch_size) useful to unflatten
-                        the output of this function.
-                        See numpy.split for the meaning of sections.
-            filters (array): Only operators op(filters[i]) are used to find the connected elements of
-                        x[i].
-
-        Returns:
-            matrix: The connected states x', flattened together in a single matrix.
-            array: An array containing the matrix elements :math:`O(x,x')` associated to each x'.
-
-        """
-        self._setup()
-
-        x = concrete_or_error(
-            np.asarray,
-            x,
-            NumbaOperatorGetConnDuringTracingError,
-            self,
-        )
-
-        return self._get_conn_filtered_kernel(
-            x,
-            sections,
-            self._local_states,
-            self._basis,
-            self._constant,
-            self._diag_mels,
-            self._n_conns,
-            self._mels,
-            self._x_prime,
-            self._acting_on,
-            self._acting_size,
-            filters,
-        )
-
-    @staticmethod
-    @numba.jit(nopython=True)
-    def _get_conn_filtered_kernel(
-        x,
-        sections,
-        local_states,
-        basis,
-        constant,
-        diag_mels,
-        n_conns,
-        all_mels,
-        all_x_prime,
-        acting_on,
-        acting_size,
-        filters,
-    ):
-        batch_size = x.shape[0]
-        n_sites = x.shape[1]
-        dtype = all_mels.dtype
-
-        assert filters.shape[0] == batch_size and sections.shape[0] == batch_size
-
-        # TODO remove this line when numba 0.53 is dropped 0.54 is minimum version
-        # workaround a bug in Numba arising when NUMBA_BOUNDSCHECK=1
-        constant = constant.item()
-
-        n_operators = n_conns.shape[0]
-        xs_n = np.empty((batch_size, n_operators), dtype=np.intp)
-
-        tot_conn = 0
-
-        for b in range(batch_size):
-            # diagonal element
-            tot_conn += 1
-
-            # counting the off-diagonal elements
-            i = filters[b]
-
-            assert i < n_operators and i >= 0
-            acting_size_i = acting_size[i]
-
-            xs_n[b, i] = 0
-            x_b = x[b]
-            x_i = x_b[acting_on[i, :acting_size_i]]
-            for k in range(acting_size_i):
-                xs_n[b, i] += (
-                    np.searchsorted(
-                        local_states[i, acting_size_i - k - 1],
-                        x_i[acting_size_i - k - 1],
-                    )
-                    * basis[i, k]
-                )
-
-            tot_conn += n_conns[i, xs_n[b, i]]
-            sections[b] = tot_conn
-
-        x_prime = np.empty((tot_conn, n_sites))
-        mels = np.empty(tot_conn, dtype=dtype)
-
-        c = 0
-        for b in range(batch_size):
-            c_diag = c
-            mels[c_diag] = constant
-            x_batch = x[b]
-            x_prime[c_diag] = np.copy(x_batch)
-            c += 1
-
-            i = filters[b]
-            # Diagonal part
-            mels[c_diag] += diag_mels[i, xs_n[b, i]]
-            n_conn_i = n_conns[i, xs_n[b, i]]
-
-            if n_conn_i > 0:
-                sites = acting_on[i]
-                acting_size_i = acting_size[i]
-
-                for cc in range(n_conn_i):
-                    mels[c + cc] = all_mels[i, xs_n[b, i], cc]
-                    x_prime[c + cc] = np.copy(x_batch)
-
-                    for k in range(acting_size_i):
-                        x_prime[c + cc, sites[k]] = all_x_prime[i, xs_n[b, i], cc, k]
-                c += n_conn_i
-
-        return x_prime, mels
 
     def __repr__(self):
         ao = self.acting_on
@@ -766,12 +418,3 @@ class LocalOperator(DiscreteOperator):
         if len(acting_str) > 55:
             acting_str = f"#acting_on={len(ao)} locations"
         return f"{type(self).__name__}(dim={self.hilbert.size}, {acting_str}, constant={self.constant}, dtype={self.dtype})"
-
-    def to_jax_operator(self) -> "LocalOperatorJax":  # noqa: F821
-        """
-        Returns the jax-compatible version of this operator, which is an
-        instance of :class:`netket.operator.LocalOperatorJax`.
-        """
-        from .jax import LocalOperatorJax
-
-        return LocalOperatorJax.from_numba_operator(self)

--- a/netket/operator/_local_operator/base.py
+++ b/netket/operator/_local_operator/base.py
@@ -766,3 +766,12 @@ class LocalOperator(DiscreteOperator):
         if len(acting_str) > 55:
             acting_str = f"#acting_on={len(ao)} locations"
         return f"{type(self).__name__}(dim={self.hilbert.size}, {acting_str}, constant={self.constant}, dtype={self.dtype})"
+
+    def to_jax_operator(self) -> "PauliStringsJax":  # noqa: F821
+        """
+        Returns the jax-compatible version of this operator, which is an
+        instance of :class:`netket.operator.PauliStringsJax`.
+        """
+        from .jax import LocalOperatorJax
+
+        return LocalOperatorJax.from_numba_operator(self)

--- a/netket/operator/_local_operator/base.py
+++ b/netket/operator/_local_operator/base.py
@@ -767,10 +767,10 @@ class LocalOperator(DiscreteOperator):
             acting_str = f"#acting_on={len(ao)} locations"
         return f"{type(self).__name__}(dim={self.hilbert.size}, {acting_str}, constant={self.constant}, dtype={self.dtype})"
 
-    def to_jax_operator(self) -> "PauliStringsJax":  # noqa: F821
+    def to_jax_operator(self) -> "LocalOperatorJax":  # noqa: F821
         """
         Returns the jax-compatible version of this operator, which is an
-        instance of :class:`netket.operator.PauliStringsJax`.
+        instance of :class:`netket.operator.LocalOperatorJax`.
         """
         from .jax import LocalOperatorJax
 

--- a/netket/operator/_local_operator/compile_helpers.py
+++ b/netket/operator/_local_operator/compile_helpers.py
@@ -47,17 +47,25 @@ def pack_internals(
     n_operators = len(operators_dict)
 
     """Analyze the operator strings and precompute arrays for get_conn inference"""
+
+    # how many sites each operator is acting on
     acting_size = np.array([len(aon) for aon in op_acting_on], dtype=np.intp)
 
+    # compute the maximum number of off-diagonal nonzeros (over all rows) of each operator
     op_n_conns_offdiag = max_nonzero_per_row(operators, mel_cutoff)
 
     # Support empty LocalOperators such as the identity.
     if len(acting_size) > 0:
+        # maximum number of sites any operator is acting on
         max_acting_on_sz = np.max(acting_size)
+
+        # max local hilbert size of all sites acted on by any operator
         max_local_hilbert_size = max(
             [max(map(hilbert.size_at_index, aon)) for aon in op_acting_on]
         )
+        # maximum size of any operator (maximum size of the matrix / prod of local hilbert spaces)
         max_op_size = max(map(lambda x: x.shape[0], operators))
+        # maximum number of off-diagonal nonzeros of any operator
         max_op_size_offdiag = np.max(op_n_conns_offdiag)
     else:
         max_acting_on_sz = 0
@@ -65,13 +73,24 @@ def pack_internals(
         max_op_size = 0
         max_op_size_offdiag = 0
 
+    # matrix storing which sites each operator acts on, padded with -1
     acting_on = np.full((n_operators, max_acting_on_sz), -1, dtype=np.intp)
     for i, aon in enumerate(op_acting_on):
         acting_on[i][: len(aon)] = aon
 
+    ###
+    # allocate empty arrays which are filled below
+
+    # array which will be storing the local states
+    # of each site each operator is acting on
     local_states = np.full(
         (n_operators, max_acting_on_sz, max_local_hilbert_size), np.nan
     )
+
+    # array storing the basis for each site each operator is acting on
+    # The basis is an integer used to map (indices of) local states on sites
+    # to (indices of) states in the space spanned by all sites the op is acting on
+    # (it is simply the product of number of local states of the sites before)
     basis = np.full((n_operators, max_acting_on_sz), 0x7FFFFFFF, dtype=np.int64)
 
     diag_mels = np.full((n_operators, max_op_size), np.nan, dtype=dtype)
@@ -81,15 +100,23 @@ def pack_internals(
         np.nan,
         dtype=dtype,
     )
+    # x_prime contains the local state after the operator has been applied
+    # for the sites the operator is acting on, for each row
+    # (each row also corresponds to a list of local states)
     x_prime = np.full(
         (n_operators, max_op_size, max_op_size_offdiag, max_acting_on_sz),
         -1,
         dtype=np.float64,
     )
+    # store the number of off-diagonal nonzeros per row of each operator
     n_conns = np.full((n_operators, max_op_size), 0, dtype=np.intp)
 
+    ###
+    # iterate over all operators
     for i, (aon, op) in enumerate(operators_dict.items()):
+        # how many sites this operator is acting on
         aon_size = len(aon)
+
         n_local_states_per_site = np.asarray([hilbert.size_at_index(i) for i in aon])
 
         ## add an operator to local_states
@@ -98,6 +125,8 @@ def pack_internals(
                 hilbert.states_at_index(site)
             )
 
+        # compute the basis of each site of this operator
+        # i.e. the product of the number of local states of all sites before it
         ba = 1
         for s in range(aon_size):
             basis[i, s] = ba
@@ -143,6 +172,8 @@ def pack_internals(
     )
 
     max_conn_size = 1 if nonzero_diagonal else 0
+    # estimate max_conn_size with the sum of the
+    # maximum number of off-diagonal nonzeros of all operators
     max_conn_size = max_conn_size + np.sum(op_n_conns_offdiag)
 
     return {
@@ -176,20 +207,28 @@ def _append_matrix(
     """
     op_size = operator.shape[0]
     assert op_size == operator.shape[1]
+    # iterate over rows
     for i in range(op_size):
+        # set diag mels
         diag_mels[i] = operator[i, i]
-        n_conns[i] = 0
+        # count number of connected elements
+        n_conns[i] = 0  # k_conn = 0
+        # iterate over cols
         for j in range(op_size):
+            # off-diagonal, non-zero
             if i != j and np.abs(operator[i, j]) > epsilon:
                 k_conn = n_conns[i]
+                # set off-doagnoal mels
                 mels[i, k_conn] = operator[i, j]
+                # convert the col to the corresponding local states
+                # and store it in x_prime
                 _number_to_state(
                     j,
                     hilb_size_per_site,
                     local_states_per_site[:acting_size, :],
                     x_prime[i, k_conn, :acting_size],
                 )
-                n_conns[i] += 1
+                n_conns[i] += 1  # k_conn=k_conn+1
 
 
 @numba.jit(nopython=True)

--- a/netket/operator/_local_operator/jax.py
+++ b/netket/operator/_local_operator/jax.py
@@ -251,7 +251,9 @@ class LocalOperatorJax(LocalOperatorBase, DiscreteJaxOperator):
                 (indices,) = np.where(acting_size == s)
                 self._local_states_jax.append(local_states[indices, :s])
                 self._acting_on_jax.append(acting_on[indices, :s])
-                self._n_conns_jax.append(n_conns[indices, :])  # TODO !! can we remove some of them, as a function of s???
+                self._n_conns_jax.append(
+                    n_conns[indices, :]
+                )  # TODO !! can we remove some of them, as a function of s???
                 self._diag_mels_jax.append(diag_mels[indices])  # TODO how long
                 self._all_x_prime_jax.append(all_x_prime[indices, :, :, :s])
                 self._all_mels_jax.append(all_mels[indices])

--- a/netket/operator/_local_operator/jax.py
+++ b/netket/operator/_local_operator/jax.py
@@ -251,7 +251,7 @@ class LocalOperatorJax(LocalOperatorBase, DiscreteJaxOperator):
                 (indices,) = np.where(acting_size == s)
                 self._local_states_jax.append(local_states[indices, :s])
                 self._acting_on_jax.append(acting_on[indices, :s])
-                self._n_conns_jax.append(n_conns[indices, : 2 * s])  # TODO 2x is ok?
+                self._n_conns_jax.append(n_conns[indices, :])  # TODO !! can we remove some of them, as a function of s???
                 self._diag_mels_jax.append(diag_mels[indices])  # TODO how long
                 self._all_x_prime_jax.append(all_x_prime[indices, :, :, :s])
                 self._all_mels_jax.append(all_mels[indices])

--- a/netket/operator/_local_operator/jax.py
+++ b/netket/operator/_local_operator/jax.py
@@ -92,6 +92,7 @@ def _local_operator_kernel_jax(
         basis_jax,
         constant,
     ) = op_args
+
     xs_n2 = []
     conn_b2 = []
     for ls, ao, nc, bsi in zip(local_states_jax, acting_on_jax, n_conns_jax, basis_jax):
@@ -145,7 +146,7 @@ def _local_operator_kernel_jax(
         xs_n = xs_n2[kk]
         all_mels = all_mels_jax[kk]
         acting_on = acting_on_jax[kk]
-        all_x_prime = all_x_prime_jax[kk]
+        all_x_prime = all_x_prime_jax[kk].astype(x.dtype)
         n_conns = n_conns_jax[kk]
 
         amixsall = all_mels[np.arange(xs_n.shape[1]), xs_n, :ncmax]

--- a/netket/operator/_local_operator/jax.py
+++ b/netket/operator/_local_operator/jax.py
@@ -220,7 +220,7 @@ class LocalOperatorJax(LocalOperatorBase, DiscreteJaxOperator):
     Jax-compatible version of :class:`netket.operator.LocalOperator`.
     """
 
-    _convertible : bool = True
+    _convertible: bool = True
     """Internal flag. True if it can be converted to numba, false
     otherwise."""
 

--- a/netket/operator/_local_operator/jax.py
+++ b/netket/operator/_local_operator/jax.py
@@ -306,6 +306,7 @@ class LocalOperatorJax(DiscreteJaxOperator):
 
     @classmethod
     def from_numba_operator(cls, local_operator_numba):
+        local_operator_numba = local_operator_numba.copy()
         local_operator_numba._setup()
         gcp_fun = get_get_conn_padded_closure(local_operator_numba)
         return cls(gcp_fun, local_operator_numba)

--- a/netket/operator/_local_operator/jax.py
+++ b/netket/operator/_local_operator/jax.py
@@ -38,14 +38,6 @@ def _inner_inner(acting_size_i, x_i, local_states_i, basis_i, k):
     return tmp1 * basis_i[k]
 
 
-@partial(jax.jit, static_argnums=0)
-def _inner(acting_size_i, x_i, local_states_i, basis_i):
-    return _inner_inner(
-        acting_size_i, x_i, local_states_i, basis_i, jnp.arange(acting_size_i)
-    ).sum()
-
-
-# @partial(jax.jit, inline=True)
 @partial(jax.vmap, in_axes=(0, None, None))  # samples
 @partial(jax.vmap, in_axes=(0, 0, 0))  # operators
 def inner(x_i, local_states_i, basis_i):

--- a/netket/operator/_local_operator/jax.py
+++ b/netket/operator/_local_operator/jax.py
@@ -14,7 +14,6 @@
 
 
 # this file contains a more-or-less 1:1 port of the numba localoperator to jax, using padding where necessary
-# TODO consider a complete rewrite in the future
 
 from functools import partial
 

--- a/netket/operator/_local_operator/jax.py
+++ b/netket/operator/_local_operator/jax.py
@@ -216,37 +216,20 @@ def get_get_conn_padded_closure(self):
     # Args:
     #   self: the numba operator
     # TODO run setup before this
-    def f(x):
-        return jax.tree_map(lambda x: jnp.array(x.copy()), x)
 
-    (
-        local_states,
-        basis,
-        constant,
-        diag_mels,
-        n_conns,
-        all_mels,
-        all_x_prime,
-        acting_on,
-        acting_size,
-        nonzero_diagonal,
-    ) = f(
-        (
-            self._local_states,
-            self._basis,
-            self._constant,
-            self._diag_mels,
-            self._n_conns,
-            self._mels,
-            self._x_prime,
-            self._acting_on,
-            self._acting_size,
-            self._nonzero_diagonal,
-        )
-    )
+    local_states = jnp.asarray(self._local_states)
+    basis = jnp.asarray(self._basis)
+    constant = jnp.asarray(self._constant)
+    diag_mels = jnp.asarray(self._diag_mels)
+    n_conns = jnp.asarray(self._n_conns)
+    all_mels = jnp.asarray(self._mels)
+    all_x_prime = jnp.asarray(self._x_prime)
+    acting_on = jnp.asarray(self._acting_on)
 
     mel_cutoff = None  # not implemented
     max_conn_size = self._max_conn_size
+    acting_size = self._acting_size
+    nonzero_diagonal = bool(self._nonzero_diagonal)
 
     local_states_jax = []
     acting_on_jax = []
@@ -275,7 +258,7 @@ def get_get_conn_padded_closure(self):
         constant,
     )
     ncmax_jax = tuple(map(int, jax.tree_map(jnp.max, n_conns_jax)))
-    nonzero_diagonal = bool(nonzero_diagonal)
+
     return Partial(
         HashablePartial(
             _local_operator_kernel_jax2.__wrapped__,

--- a/netket/operator/_local_operator/jax.py
+++ b/netket/operator/_local_operator/jax.py
@@ -183,6 +183,7 @@ def _local_operator_kernel_jax(
         # pad_value = -1
         xpm1 = x[:, None][:, :1]
         x_prime_jax.append(xpm1)
+        melsop_jax.append(jnp.zeros(x.shape[:-1]))
         mask_jax.append(jnp.full((x.shape[0], 1), fill_value=False))
 
     mels_jc = jnp.hstack([x.reshape(x.shape[0], -1) for x in melsop_jax])

--- a/netket/operator/_local_operator/jax.py
+++ b/netket/operator/_local_operator/jax.py
@@ -1,0 +1,311 @@
+# this file contains a more-or-less 1:1 port of the numba localoperator to jax, using padding where necessary
+# TODO consider a complete rewrite in the future
+
+
+import numpy as np
+
+import jax
+import jax.numpy as jnp
+
+from functools import partial
+from jax.tree_util import Partial
+from netket.jax import HashablePartial
+
+from netket.operator import DiscreteJaxOperator, LocalOperator
+
+
+from flax import struct
+
+
+@partial(jax.vmap, in_axes=(None, None, None, None, 0))
+def _inner_inner(acting_size_i, x_i, local_states_i, basis_i, k):
+    tmp1 = jnp.searchsorted(
+        local_states_i[acting_size_i - k - 1], x_i[acting_size_i - k - 1]
+    )
+    return tmp1 * basis_i[k]
+
+
+@partial(jax.jit, static_argnums=0)
+def _inner(acting_size_i, x_i, local_states_i, basis_i):
+    return _inner_inner(
+        acting_size_i, x_i, local_states_i, basis_i, jnp.arange(acting_size_i)
+    ).sum()
+
+
+# @partial(jax.jit, inline=True)
+@partial(jax.vmap, in_axes=(0, None, None))  # samples
+@partial(jax.vmap, in_axes=(0, 0, 0))  # operators
+def inner(x_i, local_states_i, basis_i):
+    acting_size_i = local_states_i.shape[-2]
+    return _inner_inner(
+        acting_size_i, x_i, local_states_i, basis_i, jnp.arange(acting_size_i)
+    ).sum()
+
+
+@partial(jax.vmap, in_axes=(0, 0, None))  # Ns
+@partial(jax.vmap, in_axes=(None, 0, 0))  # terms
+@partial(jax.vmap, in_axes=(None, 0, None))  # ncmax
+def _s(x, new_x_ao, acting_on):
+    return x.at[acting_on].set(new_x_ao)
+
+
+@partial(jax.vmap, in_axes=(0, 0, None, None))
+def _extr(xp, mels, max_conn_size, mel_cutoff):
+    index_nonzero = jnp.where(
+        jnp.abs(mels) > mel_cutoff, size=max_conn_size, fill_value=-1
+    )
+    return xp[index_nonzero], mels[index_nonzero]
+
+
+@partial(jax.vmap, in_axes=(None, 0))  # Ns
+@partial(jax.vmap, in_axes=(0, 0))  # term
+def _sele(diag_mels, xs_n):
+    return diag_mels[xs_n]
+
+
+@partial(jax.jit, static_argnums=(0, 1, 2))
+def _local_operator_kernel_jax(
+    nonzero_diagonal, ncmax_jax, max_conn_size, mel_cutoff, op_args, x
+):
+    assert x.ndim == 2
+    # batch_size = x.shape[0]
+    (
+        local_states_jax,
+        acting_on_jax,
+        n_conns_jax,
+        diag_mels_jax,
+        all_x_prime_jax,
+        all_mels_jax,
+        basis_jax,
+        constant,
+    ) = op_args
+    xs_n2 = []
+    conn_b2 = []
+    for ls, ao, nc, bsi in zip(local_states_jax, acting_on_jax, n_conns_jax, basis_jax):
+        xx = x[:, ao]
+        xs_n2.append(inner(xx, ls, bsi))
+
+    conn_b2_jax = jax.tree_map(
+        lambda nc, xx: nc[np.arange(xx.shape[1]), xx].sum(axis=-1), n_conns_jax, xs_n2
+    )
+    conn_b2 = sum(conn_b2_jax)
+    if nonzero_diagonal:
+        conn_b2 = conn_b2 + 1
+
+    # max_conn2 = conn_b2.max()
+    # tot_conn2 = max_conn2 * batch_size
+
+    # below we pad for every operator length to ncmax
+    # TODO use this to deterministically find 0s
+    n_conn_i2_jax = jax.tree_map(_sele, n_conns_jax, xs_n2)
+    # start_jax = jax.tree_map(jax.vmap(lambda x: jnp.cumsum(jnp.pad(x, pad_width=(1,0)))[:-1]), n_conn_i2_jax)
+
+    if nonzero_diagonal:
+        mels0 = constant + sum(
+            jax.tree_map(
+                lambda nc, xx: _sele(nc, xx).sum(axis=-1), diag_mels_jax, xs_n2
+            )
+        )
+        xp0 = x
+    elif max_conn_size is None:
+        xp0 = x[:, None][:, :0]
+        mels0 = jnp.zeros(xp0.shape[:-1])
+    melsop_jax = [mels0]
+    x_prime_jax = [xp0]
+    for kk in range(len(ncmax_jax)):
+        ncmax = ncmax_jax[kk]
+
+        # n_operators = acting_on_jax[kk].shape[0]
+        xs_n = xs_n2[kk]
+        all_mels = all_mels_jax[kk]
+        acting_on = acting_on_jax[kk]
+        all_x_prime = all_x_prime_jax[kk]
+        n_conns = n_conns_jax[kk]
+
+        amixsall = all_mels[np.arange(xs_n.shape[1]), xs_n, :ncmax]
+        nconnsall = n_conns[np.arange(xs_n.shape[1]), xs_n]
+        axxsall = all_x_prime[np.arange(xs_n.shape[1]), xs_n, :ncmax]
+        conn_maskall = np.arange(ncmax)[None, None] < nconnsall[:, :, None]
+
+        melsop = amixsall * conn_maskall
+        new = axxsall  # (Ns, terms, ncmax, nsitesactiongon)
+        old = x[:, acting_on]  # (Ns, terms, nsitesactiongon)
+        old = jnp.broadcast_to(old[:, :, None, :], new.shape)
+        mask = jnp.broadcast_to(conn_maskall[:, :, :, None], new.shape)
+        new_x_ao = jax.lax.select(mask, new, old)
+        xpnew = _s(x, new_x_ao, acting_on)
+        melsop_jax.append(melsop)
+        x_prime_jax.append(xpnew)
+
+    if max_conn_size is not None:
+        mask_jax = [jnp.full(mels0.shape, fill_value=True)]
+        for kk in range(len(ncmax_jax)):
+            nc = n_conn_i2_jax[kk]
+            ncm = ncmax_jax[kk]
+            mask = jnp.arange(ncm)[None, None, :] < nc[:, :, None]
+            mask_jax.append(mask)
+
+        # pad with old state and mel 0
+        # pad_value = -1
+        xpm1 = x[:, None][:, :1]
+        melsm10 = jnp.zeros(xp0.shape[:-1])
+        x_prime_jax.append(xpm1)
+        melsop_jax.append(melsm10)
+        mask_jax.append(jnp.full((x.shape[0], 1), fill_value=False))
+
+    mels_jc = jnp.hstack([x.reshape(x.shape[0], -1) for x in melsop_jax])
+    xp_jc = jnp.hstack([x.reshape(x.shape[0], -1, x.shape[-1]) for x in x_prime_jax])
+
+    # TODO run unique on it, there might be repeated xps
+
+    if max_conn_size is None:
+        return xp_jc, mels_jc, conn_b2
+    else:
+        if mel_cutoff is not None:
+            raise NotImplementedError
+        # this is the lazy one with checking mels
+        # return *_extr(xp_jc, mels_jc, max_conn_size, mel_cutoff), conn_b2, mels0
+
+        # here we compute it from where we padded:
+        mask_jc = jnp.hstack([x.reshape(x.shape[0], -1) for x in mask_jax])
+        (ind,) = jax.vmap(partial(jnp.where, size=max_conn_size, fill_value=-1))(
+            mask_jc
+        )
+        return (
+            xp_jc[jnp.arange(len(ind))[:, None], ind],
+            mels_jc[jnp.arange(len(ind))[:, None], ind],
+            conn_b2,
+        )
+
+
+# same as _local_operator_kernel_jax but does flattening and unflattening of extra axes
+@partial(jax.jit, static_argnums=(0, 1, 2))
+def _local_operator_kernel_jax2(
+    nonzero_diagonal, ncmax_jax, max_conn_size, mel_cutoff, op_args, x
+):
+    shape = x.shape
+    x = x.reshape(-1, x.shape[-1])
+    xp, mels, n_conn = _local_operator_kernel_jax(
+        nonzero_diagonal, ncmax_jax, max_conn_size, mel_cutoff, op_args, x
+    )
+    xp = xp.reshape(shape[:-1] + xp.shape[-2:])
+    mels = mels.reshape(shape[:-1] + mels.shape[-1:])
+    n_conn = n_conn.reshape(shape[:-1])
+    return xp, mels, n_conn
+
+
+def get_get_conn_padded_closure(self):
+    # Args:
+    #   self: the numba operator
+    # TODO run setup before this
+    def f(x):
+        return jax.tree_map(lambda x: jnp.array(x.copy()), x)
+
+    (
+        local_states,
+        basis,
+        constant,
+        diag_mels,
+        n_conns,
+        all_mels,
+        all_x_prime,
+        acting_on,
+        acting_size,
+        nonzero_diagonal,
+    ) = f(
+        (
+            self._local_states,
+            self._basis,
+            self._constant,
+            self._diag_mels,
+            self._n_conns,
+            self._mels,
+            self._x_prime,
+            self._acting_on,
+            self._acting_size,
+            self._nonzero_diagonal,
+        )
+    )
+
+    mel_cutoff = None  # not implemented
+    max_conn_size = self._max_conn_size
+
+    local_states_jax = []
+    acting_on_jax = []
+    n_conns_jax = []
+    diag_mels_jax = []
+    all_x_prime_jax = []
+    all_mels_jax = []
+    basis_jax = []
+    for s in np.unique(acting_size):
+        (indices,) = np.where(acting_size == s)
+        local_states_jax.append(local_states[indices, :s])
+        acting_on_jax.append(acting_on[indices, :s])
+        n_conns_jax.append(n_conns[indices, : 2 * s])  # TODO 2x is ok?
+        diag_mels_jax.append(diag_mels[indices])  # TODO how long
+        all_x_prime_jax.append(all_x_prime[indices, :, :, :s])
+        all_mels_jax.append(all_mels[indices])
+        basis_jax.append(basis[indices])
+    op_args = (
+        local_states_jax,
+        acting_on_jax,
+        n_conns_jax,
+        diag_mels_jax,
+        all_x_prime_jax,
+        all_mels_jax,
+        basis_jax,
+        constant,
+    )
+    ncmax_jax = tuple(map(int, jax.tree_map(jnp.max, n_conns_jax)))
+    nonzero_diagonal = bool(nonzero_diagonal)
+    return Partial(
+        HashablePartial(
+            _local_operator_kernel_jax2.__wrapped__,
+            nonzero_diagonal,
+            ncmax_jax,
+            max_conn_size,
+        ),
+        mel_cutoff,
+        op_args,
+    )
+
+
+# For now the only way to construct it is to first create the numba operator and then convert
+
+
+@struct.dataclass
+class LocalOperatorJax(DiscreteJaxOperator):
+    get_conn_padded_fun: Partial
+    operator: LocalOperator = struct.field(pytree_node=False)
+
+    @jax.jit
+    def get_conn_padded(self, x):
+        xp, mels, _ = self.get_conn_padded_fun(x)
+        return xp, mels
+
+    @property
+    def dtype(self):
+        return self.operator.dtype
+
+    @property
+    def hilbert(self):
+        return self.operator.hilbert
+
+    @property
+    def is_hermitian(self):
+        return self.operator.is_hermitian
+
+    @property
+    def max_conn_size(self):
+        return self.operator.max_conn_size
+
+    @jax.jit
+    def n_conn(self, x):
+        _, _, n_conn = self.get_conn_padded_fun(x)
+        return n_conn
+
+    @classmethod
+    def from_numba_operator(cls, local_operator_numba):
+        local_operator_numba._setup()
+        gcp_fun = get_get_conn_padded_closure(local_operator_numba)
+        return cls(gcp_fun, local_operator_numba)

--- a/netket/operator/_local_operator/jax.py
+++ b/netket/operator/_local_operator/jax.py
@@ -176,9 +176,6 @@ def _local_operator_kernel_jax(
             mask = jnp.arange(ncm)[None, None, :] < nc[:, :, None]
             mask_jax.append(mask)
 
-        if xp0 is not None:
-            melsop_jax.append(jnp.zeros(xp0.shape[:-1]))
-
         # pad with old state and mel 0
         # pad_value = -1
         xpm1 = x[:, None][:, :1]

--- a/netket/operator/_local_operator/numba.py
+++ b/netket/operator/_local_operator/numba.py
@@ -1,0 +1,396 @@
+# Copyright 2021-2022 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Union, Optional
+
+import numbers
+
+
+import numpy as np
+import numba
+
+from netket.hilbert import AbstractHilbert
+from netket.utils.types import DType, Array
+from netket.errors import concrete_or_error, NumbaOperatorGetConnDuringTracingError
+
+
+from .compile_helpers import pack_internals
+from .base import LocalOperatorBase
+
+
+class LocalOperator(LocalOperatorBase):
+    """A custom local operator. This is a sum of an arbitrary number of operators
+    acting locally on a limited set of k quantum numbers (i.e. k-local,
+    in the quantum information sense).
+    """
+
+    __module__ = "netket.operator"
+
+    def _setup(self, force: bool = False):
+        """Analyze the operator strings and precompute arrays for get_conn inference"""
+        if force or not self._initialized:
+            data = pack_internals(
+                self.hilbert,
+                self._operators_dict,
+                self.constant,
+                self.dtype,
+                self.mel_cutoff,
+            )
+
+            self._acting_on = data["acting_on"]
+            self._acting_size = data["acting_size"]
+            self._diag_mels = data["diag_mels"]
+            self._mels = data["mels"]
+            self._x_prime = data["x_prime"]
+            self._n_conns = data["n_conns"]
+            self._local_states = data["local_states"]
+            self._basis = data["basis"]
+            self._nonzero_diagonal = data["nonzero_diagonal"]
+            self._max_conn_size = data["max_conn_size"]
+            self._initialized = True
+
+    def get_conn_flattened(self, x, sections, pad=False):
+        r"""Finds the connected elements of the Operator. Starting
+        from a given quantum number x, it finds all other quantum numbers x' such
+        that the matrix element :math:`O(x,x')` is different from zero. In general there
+        will be several different connected states x' satisfying this
+        condition, and they are denoted here :math:`x'(k)`, for :math:`k=0,1...N_{\mathrm{connected}}`.
+
+        This is a batched version, where x is a matrix of shape (batch_size,hilbert.size).
+
+        Args:
+            x (matrix): A matrix of shape (batch_size,hilbert.size) containing
+                        the batch of quantum numbers x.
+            sections (array): An array of size (batch_size) useful to unflatten
+                        the output of this function.
+                        See numpy.split for the meaning of sections.
+            pad (bool): Whether to use zero-valued matrix elements in order to return all equal sections.
+
+        Returns:
+            matrix: The connected states x', flattened together in a single matrix.
+            array: An array containing the matrix elements :math:`O(x,x')` associated to each x'.
+
+        """
+        self._setup()
+
+        x = concrete_or_error(
+            np.asarray,
+            x,
+            NumbaOperatorGetConnDuringTracingError,
+            self,
+        )
+
+        return self._get_conn_flattened_kernel(
+            x,
+            sections,
+            self._local_states,
+            self._basis,
+            self._constant,
+            self._diag_mels,
+            self._n_conns,
+            self._mels,
+            self._x_prime,
+            self._acting_on,
+            self._acting_size,
+            self._nonzero_diagonal,
+            pad,
+        )
+
+    def _get_conn_flattened_closure(self):
+        self._setup()
+        _local_states = self._local_states
+        _basis = self._basis
+        _constant = self._constant
+        _diag_mels = self._diag_mels
+        _n_conns = self._n_conns
+        _mels = self._mels
+        _x_prime = self._x_prime
+        _acting_on = self._acting_on
+        _acting_size = self._acting_size
+        # workaround my painfully discovered Numba#6979 (cannot use numpy bools in closures)
+        _nonzero_diagonal = bool(self._nonzero_diagonal)
+
+        fun = self._get_conn_flattened_kernel
+
+        def gccf_fun(x, sections):
+            return fun(
+                x,
+                sections,
+                _local_states,
+                _basis,
+                _constant,
+                _diag_mels,
+                _n_conns,
+                _mels,
+                _x_prime,
+                _acting_on,
+                _acting_size,
+                _nonzero_diagonal,
+            )
+
+        return numba.jit(nopython=True)(gccf_fun)
+
+    @staticmethod
+    @numba.jit(nopython=True)
+    def _get_conn_flattened_kernel(
+        x,
+        sections,
+        local_states,
+        basis,
+        constant,
+        diag_mels,
+        n_conns,
+        all_mels,
+        all_x_prime,
+        acting_on,
+        acting_size,
+        nonzero_diagonal,
+        pad=False,
+    ):
+        batch_size = x.shape[0]
+        n_sites = x.shape[1]
+        dtype = all_mels.dtype
+
+        # TODO remove this line when numba 0.53 is dropped 0.54 is minimum version
+        # workaround a bug in Numba arising when NUMBA_BOUNDSCHECK=1
+        constant = constant.item()
+
+        assert sections.shape[0] == batch_size
+
+        n_operators = n_conns.shape[0]
+        xs_n = np.empty((batch_size, n_operators), dtype=np.intp)
+
+        tot_conn = 0
+        max_conn = 0
+
+        for b in range(batch_size):
+            # diagonal element
+            conn_b = 1 if nonzero_diagonal else 0
+
+            # counting the off-diagonal elements
+            for i in range(n_operators):
+                acting_size_i = acting_size[i]
+
+                xs_n[b, i] = 0
+                x_b = x[b]
+                x_i = x_b[acting_on[i, :acting_size_i]]
+                for k in range(acting_size_i):
+                    xs_n[b, i] += (
+                        np.searchsorted(
+                            local_states[i, acting_size_i - k - 1],
+                            x_i[acting_size_i - k - 1],
+                        )
+                        * basis[i, k]
+                    )
+
+                conn_b += n_conns[i, xs_n[b, i]]
+
+            tot_conn += conn_b
+            sections[b] = tot_conn
+
+            if pad:
+                max_conn = max(conn_b, max_conn)
+
+        if pad:
+            tot_conn = batch_size * max_conn
+
+        x_prime = np.empty((tot_conn, n_sites), dtype=x.dtype)
+        mels = np.empty(tot_conn, dtype=dtype)
+
+        c = 0
+        for b in range(batch_size):
+            c_diag = c
+            x_batch = x[b]
+
+            if nonzero_diagonal:
+                mels[c_diag] = constant
+                x_prime[c_diag] = np.copy(x_batch)
+                c += 1
+
+            for i in range(n_operators):
+                if nonzero_diagonal:
+                    mels[c_diag] += diag_mels[i, xs_n[b, i]]
+
+                n_conn_i = n_conns[i, xs_n[b, i]]
+
+                if n_conn_i > 0:
+                    sites = acting_on[i]
+                    acting_size_i = acting_size[i]
+
+                    for cc in range(n_conn_i):
+                        mels[c + cc] = all_mels[i, xs_n[b, i], cc]
+                        x_prime[c + cc] = np.copy(x_batch)
+
+                        for k in range(acting_size_i):
+                            x_prime[c + cc, sites[k]] = all_x_prime[
+                                i, xs_n[b, i], cc, k
+                            ]
+                    c += n_conn_i
+
+            if pad:
+                delta_conn = max_conn - (c - c_diag)
+                mels[c : c + delta_conn].fill(0)
+                x_prime[c : c + delta_conn, :] = np.copy(x_batch)
+                c += delta_conn
+                sections[b] = c
+
+        return x_prime, mels
+
+    def get_conn_filtered(self, x, sections, filters):
+        r"""Finds the connected elements of the Operator using only a subset of operators. Starting
+        from a given quantum number x, it finds all other quantum numbers x' such
+        that the matrix element :math:`O(x,x')` is different from zero. In general there
+        will be several different connected states x' satisfying this
+        condition, and they are denoted here :math:`x'(k)`, for :math:`k=0,1...N_{\mathrm{connected}}`.
+
+        This is a batched version, where x is a matrix of shape (batch_size,hilbert.size).
+
+        Args:
+            x (matrix): A matrix of shape (batch_size,hilbert.size) containing
+                        the batch of quantum numbers x.
+            sections (array): An array of size (batch_size) useful to unflatten
+                        the output of this function.
+                        See numpy.split for the meaning of sections.
+            filters (array): Only operators op(filters[i]) are used to find the connected elements of
+                        x[i].
+
+        Returns:
+            matrix: The connected states x', flattened together in a single matrix.
+            array: An array containing the matrix elements :math:`O(x,x')` associated to each x'.
+
+        """
+        self._setup()
+
+        x = concrete_or_error(
+            np.asarray,
+            x,
+            NumbaOperatorGetConnDuringTracingError,
+            self,
+        )
+
+        return self._get_conn_filtered_kernel(
+            x,
+            sections,
+            self._local_states,
+            self._basis,
+            self._constant,
+            self._diag_mels,
+            self._n_conns,
+            self._mels,
+            self._x_prime,
+            self._acting_on,
+            self._acting_size,
+            filters,
+        )
+
+    @staticmethod
+    @numba.jit(nopython=True)
+    def _get_conn_filtered_kernel(
+        x,
+        sections,
+        local_states,
+        basis,
+        constant,
+        diag_mels,
+        n_conns,
+        all_mels,
+        all_x_prime,
+        acting_on,
+        acting_size,
+        filters,
+    ):
+        batch_size = x.shape[0]
+        n_sites = x.shape[1]
+        dtype = all_mels.dtype
+
+        assert filters.shape[0] == batch_size and sections.shape[0] == batch_size
+
+        # TODO remove this line when numba 0.53 is dropped 0.54 is minimum version
+        # workaround a bug in Numba arising when NUMBA_BOUNDSCHECK=1
+        constant = constant.item()
+
+        n_operators = n_conns.shape[0]
+        xs_n = np.empty((batch_size, n_operators), dtype=np.intp)
+
+        tot_conn = 0
+
+        for b in range(batch_size):
+            # diagonal element
+            tot_conn += 1
+
+            # counting the off-diagonal elements
+            i = filters[b]
+
+            assert i < n_operators and i >= 0
+            acting_size_i = acting_size[i]
+
+            xs_n[b, i] = 0
+            x_b = x[b]
+            x_i = x_b[acting_on[i, :acting_size_i]]
+            for k in range(acting_size_i):
+                xs_n[b, i] += (
+                    np.searchsorted(
+                        local_states[i, acting_size_i - k - 1],
+                        x_i[acting_size_i - k - 1],
+                    )
+                    * basis[i, k]
+                )
+
+            tot_conn += n_conns[i, xs_n[b, i]]
+            sections[b] = tot_conn
+
+        x_prime = np.empty((tot_conn, n_sites))
+        mels = np.empty(tot_conn, dtype=dtype)
+
+        c = 0
+        for b in range(batch_size):
+            c_diag = c
+            mels[c_diag] = constant
+            x_batch = x[b]
+            x_prime[c_diag] = np.copy(x_batch)
+            c += 1
+
+            i = filters[b]
+            # Diagonal part
+            mels[c_diag] += diag_mels[i, xs_n[b, i]]
+            n_conn_i = n_conns[i, xs_n[b, i]]
+
+            if n_conn_i > 0:
+                sites = acting_on[i]
+                acting_size_i = acting_size[i]
+
+                for cc in range(n_conn_i):
+                    mels[c + cc] = all_mels[i, xs_n[b, i], cc]
+                    x_prime[c + cc] = np.copy(x_batch)
+
+                    for k in range(acting_size_i):
+                        x_prime[c + cc, sites[k]] = all_x_prime[i, xs_n[b, i], cc, k]
+                c += n_conn_i
+
+        return x_prime, mels
+
+    def to_jax_operator(self) -> "LocalOperatorJax":  # noqa: F821
+        """
+        Returns the jax-compatible version of this operator, which is an
+        instance of :class:`netket.operator.LocalOperatorJax`.
+        """
+        from .jax import LocalOperatorJax
+
+        return LocalOperatorJax(
+            self.hilbert,
+            self.operators,
+            self.acting_on,
+            self.constant,
+            dtype=self.dtype,
+        )

--- a/netket/operator/_local_operator/numba.py
+++ b/netket/operator/_local_operator/numba.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 
-
-
 import numpy as np
 import numba
 

--- a/netket/operator/_local_operator/numba.py
+++ b/netket/operator/_local_operator/numba.py
@@ -12,16 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Union, Optional
 
-import numbers
 
 
 import numpy as np
 import numba
 
-from netket.hilbert import AbstractHilbert
-from netket.utils.types import DType, Array
 from netket.errors import concrete_or_error, NumbaOperatorGetConnDuringTracingError
 
 

--- a/test/operator/test_operator.py
+++ b/test/operator/test_operator.py
@@ -77,11 +77,13 @@ sz = [[1, 0], [0, -1]]
 g = nk.graph.Graph(edges=[[i, i + 1] for i in range(20)])
 hi = nk.hilbert.CustomHilbert(local_states=[-1, 1], N=g.n_nodes)
 
-for name, LocalOp_impl in [("numba", nk.operator.LocalOperator),
-                            ("jax", nk.operator.LocalOperatorJax)]:
+for name, LocalOp_impl in [
+    ("numba", nk.operator.LocalOperator),
+    ("jax", nk.operator.LocalOperatorJax),
+]:
+
     def _loc(*args):
         return LocalOp_impl(hi, *args)
-
 
     sx_hat = _loc([sx] * 3, [[0], [1], [5]])
     sy_hat = _loc([sy] * 4, [[2], [3], [4], [9]])

--- a/test/operator/test_operator.py
+++ b/test/operator/test_operator.py
@@ -406,6 +406,18 @@ def test_operator_jax_getconn(op):
         sp_j, mels_j = _get_conn_padded(op_jax, states)
         assert mels_j.shape[-1] <= op.max_conn_size
 
+        # here we deal with the special case when the jax operator is padded
+        # with zeros, but the numba one is not.
+        # For simplicitt we assume that the padding is at the end,
+        # which might not be true in general, so if this fails for your operator
+        # please consider generalizing this test
+        if mels_j.shape[-1] > mels.shape[-1]:
+            n_conn = mels.shape[-1]
+            # make sure padding is at end and zero
+            np.testing.assert_allclose(mels_j[..., n_conn:], 0)
+            sp_j = sp_j[..., :n_conn, :]
+            mels_j = mels_j[..., :n_conn]
+
         np.testing.assert_allclose(sp, sp_j)
         np.testing.assert_allclose(mels, mels_j)
 

--- a/test/operator/test_operator.py
+++ b/test/operator/test_operator.py
@@ -77,20 +77,21 @@ sz = [[1, 0], [0, -1]]
 g = nk.graph.Graph(edges=[[i, i + 1] for i in range(20)])
 hi = nk.hilbert.CustomHilbert(local_states=[-1, 1], N=g.n_nodes)
 
+for name, LocalOp_impl in [("numba", nk.operator.LocalOperator),
+                            ("jax", nk.operator.LocalOperatorJax)]:
+    def _loc(*args):
+        return LocalOp_impl(hi, *args)
 
-def _loc(*args):
-    return nk.operator.LocalOperator(hi, *args)
 
+    sx_hat = _loc([sx] * 3, [[0], [1], [5]])
+    sy_hat = _loc([sy] * 4, [[2], [3], [4], [9]])
+    szsz_hat = _loc(sz, [0]) @ _loc(sz, [1])
+    szsz_hat += _loc(sz, [4]) @ _loc(sz, [5])
+    szsz_hat += _loc(sz, [6]) @ _loc(sz, [8])
+    szsz_hat += _loc(sz, [7]) @ _loc(sz, [0])
 
-sx_hat = _loc([sx] * 3, [[0], [1], [5]])
-sy_hat = _loc([sy] * 4, [[2], [3], [4], [9]])
-szsz_hat = _loc(sz, [0]) @ _loc(sz, [1])
-szsz_hat += _loc(sz, [4]) @ _loc(sz, [5])
-szsz_hat += _loc(sz, [6]) @ _loc(sz, [8])
-szsz_hat += _loc(sz, [7]) @ _loc(sz, [0])
-
-operators["Custom Hamiltonian"] = sx_hat + sy_hat + szsz_hat
-operators["Custom Hamiltonian Prod"] = sx_hat * 1.5 + (2.0 * sy_hat)
+    operators[f"Custom Hamiltonian ({name})"] = sx_hat + sy_hat + szsz_hat
+    operators[f"Custom Hamiltonian Prod ({name})"] = sx_hat * 1.5 + (2.0 * sy_hat)
 
 operators["Pauli Hamiltonian (XX)"] = nk.operator.PauliStrings(["XX"], [0.1])
 operators["Pauli Hamiltonian (XX+YZ+IZ)"] = nk.operator.PauliStrings(


### PR DESCRIPTION
Port I had done a long time ago. Should be thoroughly tested for correctness before use.

~Usage: Construct the numba `LocalOperator` first and then call `.to_jax_operator` on it.~