### PR TITLE
Initialize independent and dependent caches separately in ARNN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### New Features
 
 * Recurrent neural networks and layers have been added to `nkx.models` and `nkx.nn` [#1305](https://github.com/netket/netket/pull/1305).
+* Caches in ARNN that depend on model parameters can be initialized in {meth}`~netket.models.AbstractARNN._init_dependent_cache` [#1656](https://github.com/netket/netket/pull/1656).
 
 ## NetKet 3.10.2 (14 november 2023)
 

--- a/netket/models/autoreg.py
+++ b/netket/models/autoreg.py
@@ -161,6 +161,21 @@ class AbstractARNN(nn.Module):
         pass
 
     def init_cache(self, variables: PyTree, inputs: Array, key: PRNGKeyT) -> PyTree:
+        """
+        Initializes the cache before sampling.
+
+        Subclasses may override :meth:`~netket.models.AbstractARNN._init_independent_cache`
+        for caches that are independent of model parameters or any cache,
+        and :meth:`~netket.models.AbstractARNN._init_dependent_cache` for caches
+        that depend on model parameters or those independent caches.
+
+        When calling this method, `variables` should contain model parameters
+        but not any cache.
+
+        `_init_independent_cache` is called without providing the variables.
+        When `_init_dependent_cache` is called, the variables contain model
+        parameters and independent caches, but not dependent caches.
+        """
         variables_tmp = self.init(key, inputs, method=self._init_independent_cache)
         cache = variables_tmp.get("cache")
         if cache:

--- a/netket/sampler/autoreg.py
+++ b/netket/sampler/autoreg.py
@@ -93,11 +93,6 @@ class ARDirectSampler(Sampler):
         """
         return True
 
-    def _init_cache(sampler, model, σ, key):
-        variables = model.init(key, σ, 0, method=model.conditional)
-        cache = variables.get("cache")
-        return cache
-
     def _init_state(sampler, model, variables, key):
         return ARDirectSamplerState(key=key)
 
@@ -146,7 +141,7 @@ class ARDirectSampler(Sampler):
 
         # Initialize `cache` before generating a batch of samples,
         # even if `variables` is not changed and `reset` is not called
-        cache = sampler._init_cache(model, σ, key_init)
+        cache = model.init_cache(variables_no_cache, σ, key_init)
         if cache:
             variables = {**variables_no_cache, "cache": cache}
         else:

--- a/test/models/test_autoreg.py
+++ b/test/models/test_autoreg.py
@@ -310,9 +310,11 @@ class TestARNN:
         model1 = partial_model_pair[0](hilbert, param_dtype, machine_pow)
         model2 = partial_model_pair[1](hilbert, param_dtype, machine_pow)
 
-        key_spins, key_model = jax.random.split(jax.random.PRNGKey(0))
+        key_spins, key_model, key_cache = jax.random.split(jax.random.PRNGKey(0), 3)
         spins = hilbert.random_state(key_spins, size=batch_size)
-        variables = model2.init(key_model, spins, 0, method=model2.conditional)
+        variables_no_cache = model1.init(key_model, spins)
+        cache = model2.init_cache(variables_no_cache, spins, key_cache)
+        variables = {**variables_no_cache, "cache": cache}
 
         p1 = model1.apply(variables, spins, method=model1.conditionals)
         p2 = model2.apply(variables, spins, method=model2.conditionals)


### PR DESCRIPTION
As the PR for RNN is merged, now I can start upstreaming the changes in my branch for MPS-RNN into the master branch, and I'd like to split them into a few small and orthogonal PRs.

The motivation for this PR is, while the caches in ARNN are usually independent of the model parameters (such as currently implemented fast AR sampling caches and RNN memories), some of them actually depend on the parameters (such as the `gamma` in MPS-RNN). The `gamma` is the partial contraction of the MPS, and it does not change during the AR sampling procedure, so we want to precompute it before the sampling, rather than recompute it in every AR sampling step.

The independent caches need to be initialized before providing the variables, while the dependent caches need to be initialized after `Module.setup()`. Now the user can separately override `AbstractARNN._init_independent_cache` and `_init_dependent_cache` for them. An example usage is in https://github.com/cqsl/mps-rnn/blob/master/models/mps.py .

Note that `model.init_cache` is called like `model.init`, rather than `model.apply(..., method=model.init_cache)`.