### PR TITLE
Support matmul between `DiscreteOperator` and sparse array

### DIFF
--- a/netket/operator/_discrete_operator.py
+++ b/netket/operator/_discrete_operator.py
@@ -13,14 +13,15 @@
 # limitations under the License.
 
 import numpy as np
-import jax.numpy as jnp
 
 from numba import jit
 from scipy.sparse import csr_matrix as _csr_matrix
+from scipy.sparse import issparse
 
 from netket.hilbert import DiscreteHilbert
 from netket.operator import AbstractOperator
 from netket.utils.optional_deps import import_optional_dependency
+from netket.utils.types import Array
 from netket.jax.sharding import replicate_sharding_decorator_for_get_conn_padded
 
 
@@ -256,7 +257,7 @@ class DiscreteOperator(AbstractOperator):
         return op @ v
 
     def __matmul__(self, other):
-        if isinstance(other, np.ndarray) or isinstance(other, jnp.ndarray):
+        if isinstance(other, Array) or issparse(other):
             return self.apply(other)
         elif isinstance(other, AbstractOperator):
             return self._op__matmul__(other)
@@ -268,7 +269,7 @@ class DiscreteOperator(AbstractOperator):
         return NotImplemented
 
     def __rmatmul__(self, other):
-        if isinstance(other, np.ndarray) or isinstance(other, jnp.ndarray):
+        if isinstance(other, Array) or issparse(other):
             # return self.apply(other)
             return NotImplemented
         elif isinstance(other, AbstractOperator):

--- a/netket/operator/_discrete_operator.py
+++ b/netket/operator/_discrete_operator.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import numpy as np
+import jax.numpy as jnp
 
 from numba import jit
 from scipy.sparse import csr_matrix as _csr_matrix
@@ -21,7 +22,6 @@ from scipy.sparse import issparse
 from netket.hilbert import DiscreteHilbert
 from netket.operator import AbstractOperator
 from netket.utils.optional_deps import import_optional_dependency
-from netket.utils.types import Array
 from netket.jax.sharding import replicate_sharding_decorator_for_get_conn_padded
 
 
@@ -257,7 +257,11 @@ class DiscreteOperator(AbstractOperator):
         return op @ v
 
     def __matmul__(self, other):
-        if isinstance(other, Array) or issparse(other):
+        if (
+            isinstance(other, np.ndarray)
+            or isinstance(other, jnp.ndarray)
+            or issparse(other)
+        ):
             return self.apply(other)
         elif isinstance(other, AbstractOperator):
             return self._op__matmul__(other)
@@ -269,7 +273,11 @@ class DiscreteOperator(AbstractOperator):
         return NotImplemented
 
     def __rmatmul__(self, other):
-        if isinstance(other, Array) or issparse(other):
+        if (
+            isinstance(other, np.ndarray)
+            or isinstance(other, jnp.ndarray)
+            or issparse(other)
+        ):
             # return self.apply(other)
             return NotImplemented
         elif isinstance(other, AbstractOperator):

--- a/netket/operator/_discrete_operator_jax.py
+++ b/netket/operator/_discrete_operator_jax.py
@@ -223,7 +223,7 @@ class DiscreteJaxOperator(DiscreteOperator):
         return self.to_sparse().todense()
 
     def __matmul__(self, other):
-        if isinstance(other, (Array, JAXSparse)):
+        if isinstance(other, Array) or isinstance(other, JAXSparse):
             return self.apply(other)
         elif isinstance(other, AbstractOperator):
             return self._op__matmul__(other)
@@ -231,7 +231,7 @@ class DiscreteJaxOperator(DiscreteOperator):
             return NotImplemented
 
     def __rmatmul__(self, other):
-        if isinstance(other, (Array, JAXSparse)):
+        if isinstance(other, Array) or isinstance(other, JAXSparse):
             return NotImplemented
         elif isinstance(other, AbstractOperator):
             return self._op__rmatmul__(other)

--- a/netket/operator/_discrete_operator_jax.py
+++ b/netket/operator/_discrete_operator_jax.py
@@ -16,10 +16,10 @@ import abc
 
 import numpy as np
 import jax.numpy as jnp
-
 from jax.experimental.sparse import JAXSparse, BCOO
 
-from netket.operator import DiscreteOperator
+from netket.operator import AbstractOperator, DiscreteOperator
+from netket.utils.types import Array
 
 
 class DiscreteJaxOperator(DiscreteOperator):
@@ -221,3 +221,19 @@ class DiscreteJaxOperator(DiscreteOperator):
             The dense matrix representation of the operator as a jax Array.
         """
         return self.to_sparse().todense()
+
+    def __matmul__(self, other):
+        if isinstance(other, (Array, JAXSparse)):
+            return self.apply(other)
+        elif isinstance(other, AbstractOperator):
+            return self._op__matmul__(other)
+        else:
+            return NotImplemented
+
+    def __rmatmul__(self, other):
+        if isinstance(other, (Array, JAXSparse)):
+            return NotImplemented
+        elif isinstance(other, AbstractOperator):
+            return self._op__rmatmul__(other)
+        else:
+            return NotImplemented

--- a/netket/operator/_discrete_operator_jax.py
+++ b/netket/operator/_discrete_operator_jax.py
@@ -19,7 +19,6 @@ import jax.numpy as jnp
 from jax.experimental.sparse import JAXSparse, BCOO
 
 from netket.operator import AbstractOperator, DiscreteOperator
-from netket.utils.types import Array
 
 
 class DiscreteJaxOperator(DiscreteOperator):
@@ -223,7 +222,11 @@ class DiscreteJaxOperator(DiscreteOperator):
         return self.to_sparse().todense()
 
     def __matmul__(self, other):
-        if isinstance(other, Array) or isinstance(other, JAXSparse):
+        if (
+            isinstance(other, np.ndarray)
+            or isinstance(other, jnp.ndarray)
+            or isinstance(other, JAXSparse)
+        ):
             return self.apply(other)
         elif isinstance(other, AbstractOperator):
             return self._op__matmul__(other)
@@ -231,7 +234,11 @@ class DiscreteJaxOperator(DiscreteOperator):
             return NotImplemented
 
     def __rmatmul__(self, other):
-        if isinstance(other, Array) or isinstance(other, JAXSparse):
+        if (
+            isinstance(other, np.ndarray)
+            or isinstance(other, jnp.ndarray)
+            or isinstance(other, JAXSparse)
+        ):
             return NotImplemented
         elif isinstance(other, AbstractOperator):
             return self._op__rmatmul__(other)

--- a/test/operator/test_operator.py
+++ b/test/operator/test_operator.py
@@ -1,6 +1,7 @@
 import netket as nk
 import numpy as np
 import netket.experimental as nkx
+import scipy
 from netket.operator import DiscreteJaxOperator
 
 import pytest
@@ -429,3 +430,20 @@ def test_pauli_string_operators_hashable_pytree():
     e1 = vs.expect(haj1)
     e2 = vs.expect(haj2)
     jax.tree_map(np.testing.assert_allclose, e1, e2)
+
+
+@pytest.mark.parametrize(
+    "op",
+    [pytest.param(op, id=name) for name, op in operators.items()],
+)
+def test_matmul_sparse_vector(op):
+    N = op.hilbert.size
+    v = np.zeros((N, 1), dtype=op.dtype)
+    v[0, 0] = 1
+
+    Ov_dense = op @ v
+
+    v = scipy.sparse.csr_array(v)
+    Ov_sparse = op @ v
+
+    np.testing.assert_equal(Ov_dense, Ov_sparse.todense())


### PR DESCRIPTION
So I'm going to make a bunch of PRs for small quality-of-life improvements when I was playing with RNN...

By default `DiscreteOperator.__matmul__` converts the operator to a CSR matrix, so it should be straightforward to multiply it onto a sparse array (usually but not necessarily a vector). For best performance the sparse array should be in CSR format.

Currently in jax there is no implicit conversion between jax sparse arrays and scipy sparse arrays, so we follow this limitation and `DiscreteOperator` only supports scipy sparse arrays, while `DiscreteJaxOperator` only supports jax sparse arrays. The most well supported jax sparse array format is BCOO currently.