### PR TITLE
Use `np.testing` for better error messages

### DIFF
--- a/test/exact/test_steadystate.py
+++ b/test/exact/test_steadystate.py
@@ -71,7 +71,7 @@ def test_exact_ss_ed(liouvillian, sparse):
 
     # mat = np.abs(dm_ss - dm_ss_d)
     # print(mat)
-    # assert np.all(mat == approx(0.0, rel=1e-4, abs=1e-4))
+    # np.testing.assert_allclose(mat, 0.0, rtol=1e-4, atol=1e-4)
 
 
 @pytest.mark.parametrize("sparse", [True, False])

--- a/test/models/test_deepset.py
+++ b/test/models/test_deepset.py
@@ -71,7 +71,7 @@ def test_rel_dist_deepsets(cusp_exponent, L):
     )
     p = ds.init(jax.random.PRNGKey(42), x)
 
-    assert jnp.allclose(ds.apply(p, x), ds.apply(p, xp))
+    np.testing.assert_allclose(ds.apply(p, x), ds.apply(p, xp))
 
 
 def test_rel_dist_deepsets_error():

--- a/test/models/test_gcnn.py
+++ b/test/models/test_gcnn.py
@@ -15,7 +15,6 @@
 import netket as nk
 import numpy as np
 import jax
-import jax.numpy as jnp
 from jax.nn.initializers import uniform
 
 import pytest
@@ -62,7 +61,7 @@ def test_gcnn_equivariance(parity, symmetries, lattice, mode):
     vals = ma.apply(pars, v).reshape(len(perms), 3)
 
     for val in vals:
-        assert jnp.allclose(val, vals[0])
+        np.testing.assert_allclose(val, vals[0])
 
 
 @pytest.mark.parametrize("mode", ["fft", "irreps"])

--- a/test/models/test_nn.py
+++ b/test/models/test_nn.py
@@ -122,7 +122,7 @@ def test_DenseSymm(symmetries, use_bias, mode):
     v = hi.random_state(rng.next(), (3, 1))
     vals = [ma.apply(pars, v[..., p]) for p in np.asarray(perms)]
     for val in vals:
-        assert jnp.allclose(jnp.sort(val, -1), jnp.sort(vals[0], -1))
+        np.testing.assert_allclose(jnp.sort(val, -1), jnp.sort(vals[0], -1))
 
 
 @pytest.mark.parametrize("symmetries", ["trans", "space_group"])
@@ -156,7 +156,7 @@ def test_DenseSymm_infeatures(symmetries, use_bias, mode):
     v = hi.random_state(rng.next(), 6).reshape(3, 2, -1)
     vals = [ma.apply(pars, v[..., p]) for p in np.asarray(perms)]
     for val in vals:
-        assert jnp.allclose(jnp.sort(val, -1), jnp.sort(vals[0], -1))
+        np.testing.assert_allclose(jnp.sort(val, -1), jnp.sort(vals[0], -1))
 
 
 @pytest.mark.parametrize("mode", ["fft", "matrix", "irreps"])
@@ -281,7 +281,7 @@ def test_DenseEquivariant(symmetries, use_bias, lattice, mode, mask):
     out_trans = ma.apply(pars, v_trans)
 
     # output should be involution
-    assert jnp.allclose(jnp.matmul(out, sym_op), out_trans)
+    np.testing.assert_allclose(jnp.matmul(out, sym_op), out_trans)
 
 
 @pytest.mark.parametrize("lattice", [nk.graph.Chain, nk.graph.Square])
@@ -309,15 +309,17 @@ def test_modes_DenseSymm(lattice, symmetries):
     pars = ma_fft.init(rng.next(), dum_input)
     _ = ma_matrix.init(rng.next(), dum_input)
 
-    assert jnp.allclose(ma_fft.apply(pars, dum_input), ma_matrix.apply(pars, dum_input))
+    np.testing.assert_allclose(
+        ma_fft.apply(pars, dum_input), ma_matrix.apply(pars, dum_input)
+    )
 
     # Test Deprecation warning
     dum_input_nofeatures = dum_input.reshape((dum_input.shape[0], dum_input.shape[2]))
     with pytest.warns(FutureWarning):
-        assert jnp.allclose(
+        np.testing.assert_allclose(
             ma_fft.apply(pars, dum_input), ma_fft.apply(pars, dum_input_nofeatures)
         )
-        assert jnp.allclose(
+        np.testing.assert_allclose(
             ma_matrix.apply(pars, dum_input),
             ma_matrix.apply(pars, dum_input_nofeatures),
         )
@@ -347,7 +349,9 @@ def test_modes_DenseSymm_infeatures(lattice, symmetries):
     pars = ma_fft.init(rng.next(), dum_input)
     _ = ma_matrix.init(rng.next(), dum_input)
 
-    assert jnp.allclose(ma_fft.apply(pars, dum_input), ma_matrix.apply(pars, dum_input))
+    np.testing.assert_allclose(
+        ma_fft.apply(pars, dum_input), ma_matrix.apply(pars, dum_input)
+    )
 
 
 @pytest.mark.parametrize("lattice", [nk.graph.Chain, nk.graph.Square])
@@ -385,8 +389,8 @@ def test_modes_DenseEquivariant(lattice, symmetries):
     irreps_out = ma_irreps.apply(pars, dum_input)
     matrix_out = ma_matrix.apply(pars, dum_input)
 
-    assert jnp.allclose(fft_out, irreps_out)
-    assert jnp.allclose(fft_out, matrix_out)
+    np.testing.assert_allclose(fft_out, irreps_out)
+    np.testing.assert_allclose(fft_out, matrix_out)
 
 
 def test_deprecated_inout_features_DenseEquivariant():

--- a/test/models/test_rbm.py
+++ b/test/models/test_rbm.py
@@ -44,8 +44,8 @@ def test_RBMSymm(use_hidden_bias, use_visible_bias, symmetries):
     v = hi.random_state(jax.random.PRNGKey(1), 3)
     vals = [ma.apply(pars, v[..., p]) for p in np.asarray(perms)]
 
-    for val in vals:
-        assert jnp.allclose(val, vals[0])
+    for val in vals[1:]:
+        np.testing.assert_allclose(val, vals[0])
 
     vmc = nk.VMC(
         nk.operator.Ising(hi, g, h=1.0),

--- a/test/nn/test_blocks.py
+++ b/test/nn/test_blocks.py
@@ -120,7 +120,7 @@ def test_deepset():
     assert out.shape == outp.shape
     assert out.shape[-1] == 1
 
-    assert jnp.allclose(out, outp)
+    np.testing.assert_allclose(out, outp)
 
     ds = nk.nn.blocks.DeepSetMLP(
         features_phi=16, features_rho=32, output_activation=nknn.gelu

--- a/test/operator/test_fermions.py
+++ b/test/operator/test_fermions.py
@@ -169,11 +169,11 @@ def compare_openfermion_fermions():
     )
     fermop_dense = fermop.to_dense()
     # compare openfermion vs from_openfermion
-    assert np.array_equal(of_dense, fo_dense)
+    np.testing.assert_array_equal(of_dense, fo_dense)
     # compare openfermion vs FermionOperator2nd
-    assert np.array_equal(of_dense, fermop_dense)
+    np.testing.assert_array_equal(of_dense, fermop_dense)
     # compare from_openfermion vs FermionOperator 2nd
-    assert np.array_equal(fo_dense, fermop_dense)
+    np.testing.assert_array_equal(fo_dense, fermop_dense)
 
     # add a test from a non-hermitian operator
     of_fermion_operator = FermionOperator("") + FermionOperator(  # todo

--- a/test/operator/test_liouvillian.py
+++ b/test/operator/test_liouvillian.py
@@ -99,7 +99,7 @@ def test_linear_operator():
     res_sparse = l_sparse @ dm
     res_op = l_op @ dm
 
-    assert np.all(res_sparse - res_op == approx(0.0, rel=1e-6, abs=1e-6))
+    np.testing.assert_allclose(res_sparse, res_op, rtol=1e-6, atol=1e-6)
 
     assert res_sparse.reshape((hi.n_states, hi.n_states)).trace() == approx(
         0.0, rel=1e-6, abs=1e-6
@@ -113,7 +113,7 @@ def test_linear_operator():
     dmptr[:-1] = dm
     res_op2 = l_op @ dmptr
 
-    assert np.all(res_op2[:-1] - res_op == approx(0.0, rel=1e-8, abs=1e-8))
+    np.testing.assert_allclose(res_op2[:-1], res_op, rtol=1e-8, atol=1e-8)
     assert res_op2[-1] - dm.reshape((hi.n_states, hi.n_states)).trace() == approx(
         0.0, rel=1e-8, abs=1e-8
     )

--- a/test/variational/test_variational.py
+++ b/test/variational/test_variational.py
@@ -382,7 +382,7 @@ def test_expect(vstate, operator):
     if not operator.is_hermitian:
         assert O1_mean.imag == approx(O_mean.imag, abs=1e-5)
 
-    assert np.asarray(O_stat1.variance) == approx(np.asarray(O_stat.variance), abs=1e-5)
+    np.testing.assert_allclose(O_stat1.variance, O_stat.variance, atol=1e-5)
 
     # Prepare the exact estimations
     pars_0 = vstate.parameters

--- a/test/variational/test_variational_mixed.py
+++ b/test/variational/test_variational_mixed.py
@@ -425,7 +425,7 @@ def test_grad_finitedifferences(vstate, operator):
     if not operator.is_hermitian:
         assert O1_mean.imag == approx(O_mean.imag, abs=1e-5)
 
-    assert np.asarray(O_stat1.variance) == approx(np.asarray(O_stat.variance), abs=1e-5)
+    np.testing.assert_allclose(O_stat1.variance, O_stat.variance, atol=1e-5)
 
     # Prepare the exact estimations
     pars_0 = vstate.parameters


### PR DESCRIPTION
The utilities in `np.testing` show information like the mismatched element count and abs/rel errors when a test fails.

I hope there is a plugin like `flake8-pytest-style` for numpy but I didn't find one...