### PR TITLE
Automatic checkpointing

### DIFF
--- a/Examples/Checkpointing/sample.py
+++ b/Examples/Checkpointing/sample.py
@@ -1,0 +1,37 @@
+from etils import epath
+import orbax.checkpoint as ocp
+
+import netket as nk
+from netket import experimental as nkx
+import optax
+
+# Keeps a maximum of 3 checkpoints, and only saves every other step.
+path = epath.Path("/tmp/nkcheckpt-04")
+
+checkpointer = ocp.CheckpointManager(
+    path,
+    ocp.AsyncCheckpointer(ocp.PyTreeCheckpointHandler()),
+    options=ocp.CheckpointManagerOptions(max_to_keep=3, save_interval_steps=1),
+)
+
+L = 20
+g = nk.graph.Hypercube(length=L, n_dim=1, pbc=True)
+hi = nk.hilbert.Spin(s=1 / 2, N=g.n_nodes)
+ha = nk.operator.Ising(hilbert=hi, graph=g, h=1.0)
+ma = nk.models.RBM(alpha=1, param_dtype=float)
+sa = nk.sampler.MetropolisLocal(hi, n_chains=16)
+op = nk.optimizer.Sgd(learning_rate=optax.linear_schedule(0.1, 0.0001, 500))
+sr = nk.optimizer.SR(diag_shift=0.01)
+vs = nk.vqs.MCState(sa, ma, n_samples=1008, n_discard_per_chain=10)
+
+# Variational monte carlo driver with a variational state
+gs = nk.VMC(ha, op, variational_state=vs, preconditioner=sr, checkpointer=checkpointer)
+# maybe restore checkpoint
+if checkpointer.latest_step() is not None:
+    gs.restore_checkpoint()
+
+log = nkx.logging.HDF5Log("log2", mode="append")
+log = nk.logging.RuntimeLog()
+
+# Run the optimization for 500 iterations
+gs.run(n_iter=49, out=log, show_progress=False)

--- a/Examples/Checkpointing/sample.py
+++ b/Examples/Checkpointing/sample.py
@@ -10,7 +10,6 @@ path = epath.Path("/tmp/nkcheckpt-04")
 
 checkpointer = ocp.CheckpointManager(
     path,
-    ocp.AsyncCheckpointer(ocp.PyTreeCheckpointHandler()),
     options=ocp.CheckpointManagerOptions(max_to_keep=3, save_interval_steps=1),
 )
 
@@ -34,4 +33,4 @@ log = nkx.logging.HDF5Log("log2", mode="append")
 log = nk.logging.RuntimeLog()
 
 # Run the optimization for 500 iterations
-gs.run(n_iter=49, out=log, show_progress=False)
+gs.run(n_iter=49, out=log, show_progress=True)

--- a/netket/driver/vmc.py
+++ b/netket/driver/vmc.py
@@ -43,6 +43,7 @@ class VMC(AbstractVariationalDriver):
         *,
         variational_state: VariationalState,
         preconditioner: PreconditionerT = identity_preconditioner,
+        checkpointer=None,
     ):
         """
         Initializes the driver class.
@@ -70,7 +71,12 @@ class VMC(AbstractVariationalDriver):
                 )
             )
 
-        super().__init__(variational_state, optimizer, minimized_quantity_name="Energy")
+        super().__init__(
+            variational_state,
+            optimizer,
+            minimized_quantity_name="Energy",
+            checkpointer=checkpointer,
+        )
 
         self._ham = hamiltonian.collect()  # type: AbstractOperator
 

--- a/netket/experimental/driver/tdvp_common.py
+++ b/netket/experimental/driver/tdvp_common.py
@@ -64,6 +64,7 @@ class TDVPBaseDriver(AbstractVariationalDriver):
         *,
         t0: float = 0.0,
         error_norm: Union[str, Callable] = "qgt",
+        checkpointer=None,
     ):
         r"""
         Initializes the time evolution driver.
@@ -90,7 +91,10 @@ class TDVPBaseDriver(AbstractVariationalDriver):
         self._t0 = t0
 
         super().__init__(
-            variational_state, optimizer=None, minimized_quantity_name="Generator"
+            variational_state,
+            optimizer=None,
+            minimized_quantity_name="Generator",
+            checkpointer=checkpointer,
         )
 
         self._generator_repr = repr(operator)
@@ -403,6 +407,12 @@ class TDVPBaseDriver(AbstractVariationalDriver):
     def _log_additional_data(self, log_dict, step):
         super()._log_additional_data(log_dict, step)
         log_dict["t"] = self.t
+
+    def _checkpoint_state(self) -> dict:
+        state = super()._checkpoint_state()
+        state["_integrator"] = self._integrator
+        state["_stop_count"] = self._stop_count
+        return state
 
     @property
     def _default_step_size(self):

--- a/netket/experimental/driver/vmc_srt.py
+++ b/netket/experimental/driver/vmc_srt.py
@@ -156,6 +156,7 @@ class VMC_SRt(AbstractVariationalDriver):
         linear_solver_fn: Callable[[jax.Array, jax.Array], jax.Array] = linear_solver,
         jacobian_mode: Optional[str] = None,
         variational_state: MCState = None,
+        checkpointer=None,
     ):
         """
         Initializes the driver class.
@@ -174,7 +175,12 @@ class VMC_SRt(AbstractVariationalDriver):
             variational_state: The :class:`netket.vqs.MCState` to be optimised. Other
                 variational states are not supported.
         """
-        super().__init__(variational_state, optimizer, minimized_quantity_name="Energy")
+        super().__init__(
+            variational_state,
+            optimizer,
+            minimized_quantity_name="Energy",
+            checkpointer=checkpointer,
+        )
 
         if variational_state.hilbert != hamiltonian.hilbert:
             raise TypeError(


### PR DESCRIPTION
A long way to go...

Will need some help to make this play nice with sharding and MPI.

Must decide what to do with loggers. Right now we override the old ones. Can't really concatenate.


temporary interface.

```python
from etils import epath
import orbax.checkpoint as ocp
import numpy as np

# Keeps a maximum of 3 checkpoints, and only saves every other step.
path = epath.Path('/tmp/nkcheck3')
checkpointer = ocp.CheckpointManager(
    path,
    options=ocp.CheckpointManagerOptions(max_to_keep=3, save_interval_steps=1),
)

import netket as nk
import optax

L = 10
g = nk.graph.Hypercube(length=L, n_dim=1, pbc=True)
hi = nk.hilbert.Spin(s=1 / 2, N=g.n_nodes)
ha = nk.operator.Ising(hilbert=hi, graph=g, h=1.0)
ma = nk.models.RBM(alpha=1, param_dtype=float)
sa = nk.sampler.MetropolisLocal(hi, n_chains=16)
op = nk.optimizer.Sgd(learning_rate=optax.linear_schedule(0.1, 0.0001, 500))
sr = nk.optimizer.SR(diag_shift=0.01)
vs = nk.vqs.MCState(sa, ma, n_samples=1008, n_discard_per_chain=10)

# Variational monte carlo driver with a variational state
gs = nk.VMC(ha, op, variational_state=vs, preconditioner=sr, checkpointer= checkpointer)

# Run the optimization for 500 iterations
gs.run(n_iter=50, out="test")
```

if you run it twice, the second run goes from 50 to 100 steps