### PR TITLE
enable changing the mode of PauliStrings

### DIFF
--- a/netket/operator/_pauli_strings/jax.py
+++ b/netket/operator/_pauli_strings/jax.py
@@ -344,11 +344,15 @@ class PauliStringsJax(PauliStringsBase, DiscreteJaxOperator):
     @property
     def _mode(self):
         """
-        (Experimental) changes the indexing mode of the operator. 
+        (Internal) Indexing mode of the operator. 
 
-        Valid values are "index" or "mask". The latter uses constant-size
-        masks and does not change the shapes if same number of strings in the
-        PauliString.
+        Valid values are "index" or "mask".
+
+        'Index' uses the standard LocalOperator-like indexing of changed points,
+        while the latter uses constant-size masks.
+
+        The latter does not really need recompilation for paulistrings with
+        different values, and this could be changed in the future.
         """
         return self._mode_attr
 

--- a/netket/operator/_pauli_strings/jax.py
+++ b/netket/operator/_pauli_strings/jax.py
@@ -344,7 +344,7 @@ class PauliStringsJax(PauliStringsBase, DiscreteJaxOperator):
     @property
     def _mode(self):
         """
-        (Internal) Indexing mode of the operator. 
+        (Internal) Indexing mode of the operator.
 
         Valid values are "index" or "mask".
 

--- a/netket/operator/_pauli_strings/jax.py
+++ b/netket/operator/_pauli_strings/jax.py
@@ -337,10 +337,26 @@ class PauliStringsJax(PauliStringsBase, DiscreteJaxOperator):
         #          (and possibly on gpu)
         # By adapting pack_internals_jax hybrid approaches are also possible.
         # depending on performance tests we might expose or remove it
-        _check_mode(_mode)
-        self._mode = _mode
         self._hi_local_states = tuple(self.hilbert.local_states)
         self._initialized = False
+        self._mode = _mode
+
+    @property
+    def _mode(self):
+        """
+        (Experimental) changes the indexing mode of the operator. 
+
+        Valid values are "index" or "mask". The latter uses constant-size
+        masks and does not change the shapes if same number of strings in the
+        PauliString.
+        """
+        return self._mode_attr
+
+    @_mode.setter
+    def _mode(self, mode):
+        _check_mode(mode)
+        self._mode_attr = mode
+        self._reset_caches()
 
     @property
     def max_conn_size(self) -> int:


### PR DESCRIPTION
To facilitate internal experimentations. Not for public consumption.