### PR TITLE
Add metropolis exchange rule for fermions

### DIFF
--- a/Examples/Fermions/fermi_hubbard.py
+++ b/Examples/Fermions/fermi_hubbard.py
@@ -54,7 +54,7 @@ print("Hamiltonian =", ham.operator_string())
 
 # g.n_nodes == L*L --> disj_graph == 2*L*L
 disj_graph = nk.graph.disjoint_union(g, g)
-sa = nk.sampler.MetropolisExchange(hi, graph=disj_graph, n_chains=16)
+sa = nk.sampler.MetropolisFermionExchange(hi, graph=disj_graph, n_chains=16)
 
 # since the hilbert basis is a set of occupation numbers, we can take a general RBM
 # we take complex parameters, since it learns sign structures more easily, and for even fermion number, the wave function might be complex

--- a/Examples/Fermions/fermi_hubbard.py
+++ b/Examples/Fermions/fermi_hubbard.py
@@ -52,9 +52,12 @@ print("Hamiltonian =", ham.operator_string())
 # move the fermions around independently for both spins
 # and therefore conserve the number of fermions with up and down spin
 
+# we can do this explicitly
 # g.n_nodes == L*L --> disj_graph == 2*L*L
 disj_graph = nk.graph.disjoint_union(g, g)
-sa = nkx.sampler.MetropolisFermionExchange(hi, graph=disj_graph, n_chains=16)
+sa = nkx.sampler.MetropolisFermionExchange(hi, graph=g, n_chains=16)
+# or let netket copy the graph per spin sector
+sa = nkx.sampler.MetropolisFermionExchange(hi, graph=g, n_chains=16, copy_per_spin=True)
 
 # since the hilbert basis is a set of occupation numbers, we can take a general RBM
 # we take complex parameters, since it learns sign structures more easily, and for even fermion number, the wave function might be complex

--- a/Examples/Fermions/fermi_hubbard.py
+++ b/Examples/Fermions/fermi_hubbard.py
@@ -58,7 +58,7 @@ disj_graph = nk.graph.disjoint_union(g, g)
 sa = nkx.sampler.MetropolisParticleExchange(hi, graph=g, n_chains=16, sweep_size=64)
 # or let netket copy the graph per spin sector
 sa = nkx.sampler.MetropolisParticleExchange(
-    hi, graph=g, n_chains=16, sweep_size=64, exhange_spins=False
+    hi, graph=g, n_chains=16, sweep_size=64, exchange_spins=False
 )
 
 # since the hilbert basis is a set of occupation numbers, we can take a general RBM

--- a/Examples/Fermions/fermi_hubbard.py
+++ b/Examples/Fermions/fermi_hubbard.py
@@ -15,7 +15,7 @@ g = nk.graph.Hypercube(length=L, n_dim=D, pbc=True)
 n_sites = g.n_nodes
 
 # create a hilbert space with 2 up and 2 down spins
-hi = nkx.hilbert.SpinOrbitalFermions(n_sites, s=1 / 2, n_fermions=(2, 2))
+hi = nkx.hilbert.SpinOrbitalFermions(n_sites, s=1 / 2, n_fermions_per_spin=(2, 2))
 
 
 # create an operator representing fermi hubbard interactions
@@ -54,7 +54,7 @@ print("Hamiltonian =", ham.operator_string())
 
 # g.n_nodes == L*L --> disj_graph == 2*L*L
 disj_graph = nk.graph.disjoint_union(g, g)
-sa = nk.sampler.MetropolisFermionExchange(hi, graph=disj_graph, n_chains=16)
+sa = nkx.sampler.MetropolisFermionExchange(hi, graph=disj_graph, n_chains=16)
 
 # since the hilbert basis is a set of occupation numbers, we can take a general RBM
 # we take complex parameters, since it learns sign structures more easily, and for even fermion number, the wave function might be complex
@@ -63,7 +63,7 @@ vs = nk.vqs.MCState(sa, ma, n_discard_per_chain=100, n_samples=512)
 
 # we will use sgd with Stochastic Reconfiguration
 opt = nk.optimizer.Sgd(learning_rate=0.01)
-sr = nk.optimizer.SR(diag_shift=0.1)
+sr = nk.optimizer.SR(diag_shift=0.1, holomorphic=True)
 
 gs = nk.driver.VMC(ham, opt, variational_state=vs, preconditioner=sr)
 

--- a/Examples/Fermions/fermi_hubbard.py
+++ b/Examples/Fermions/fermi_hubbard.py
@@ -55,12 +55,10 @@ print("Hamiltonian =", ham.operator_string())
 # we can do this explicitly
 # g.n_nodes == L*L --> disj_graph == 2*L*L
 disj_graph = nk.graph.disjoint_union(g, g)
-sa = nkx.sampler.MetropolisParticleExchange(
-    hi, graph=g, n_chains=16, sweep_size=64, copy_per_spin=False
-)
+sa = nkx.sampler.MetropolisParticleExchange(hi, graph=g, n_chains=16, sweep_size=64)
 # or let netket copy the graph per spin sector
 sa = nkx.sampler.MetropolisParticleExchange(
-    hi, graph=g, n_chains=16, sweep_size=64, copy_per_spin=True
+    hi, graph=g, n_chains=16, sweep_size=64, exhange_spins=False
 )
 
 # since the hilbert basis is a set of occupation numbers, we can take a general RBM

--- a/Examples/Fermions/fermi_hubbard.py
+++ b/Examples/Fermions/fermi_hubbard.py
@@ -55,14 +55,18 @@ print("Hamiltonian =", ham.operator_string())
 # we can do this explicitly
 # g.n_nodes == L*L --> disj_graph == 2*L*L
 disj_graph = nk.graph.disjoint_union(g, g)
-sa = nkx.sampler.MetropolisFermionExchange(hi, graph=g, n_chains=16)
+sa = nkx.sampler.MetropolisParticleExchange(
+    hi, graph=g, n_chains=16, sweep_size=64, copy_per_spin=False
+)
 # or let netket copy the graph per spin sector
-sa = nkx.sampler.MetropolisFermionExchange(hi, graph=g, n_chains=16, copy_per_spin=True)
+sa = nkx.sampler.MetropolisParticleExchange(
+    hi, graph=g, n_chains=16, sweep_size=64, copy_per_spin=True
+)
 
 # since the hilbert basis is a set of occupation numbers, we can take a general RBM
 # we take complex parameters, since it learns sign structures more easily, and for even fermion number, the wave function might be complex
 ma = nk.models.RBM(alpha=1, param_dtype=complex, use_visible_bias=False)
-vs = nk.vqs.MCState(sa, ma, n_discard_per_chain=100, n_samples=512)
+vs = nk.vqs.MCState(sa, ma, n_discard_per_chain=10, n_samples=512)
 
 # we will use sgd with Stochastic Reconfiguration
 opt = nk.optimizer.Sgd(learning_rate=0.01)

--- a/Examples/Fermions/fermi_hubbard_slater.py
+++ b/Examples/Fermions/fermi_hubbard_slater.py
@@ -48,7 +48,7 @@ print("Hamiltonian =", ham.operator_string())
 # g.n_nodes == L*L --> disj_graph == 2*L*L
 # this is handled by netket by passing the keyword copy_per_spin=True
 sa = nkx.sampler.MetropolisParticleExchange(
-    hi, graph=g, n_chains=16, copy_per_spin=True, sweep_size=64
+    hi, graph=g, n_chains=16, exhange_spins=False, sweep_size=64
 )
 
 # since the hilbert basis is a set of occupation numbers, we can take a general RBM

--- a/Examples/Fermions/fermi_hubbard_slater.py
+++ b/Examples/Fermions/fermi_hubbard_slater.py
@@ -46,8 +46,8 @@ print("Hamiltonian =", ham.operator_string())
 # and therefore conserve the number of fermions with up and down spin
 
 # g.n_nodes == L*L --> disj_graph == 2*L*L
-disj_graph = nk.graph.disjoint_union(g, g)
-sa = nkx.sampler.MetropolisFermionExchange(hi, graph=disj_graph, n_chains=16)
+# this is handled by netket by passing the keyword copy_per_spin=True
+sa = nkx.sampler.MetropolisFermionExchange(hi, graph=g, n_chains=16, copy_per_spin=True)
 
 # since the hilbert basis is a set of occupation numbers, we can take a general RBM
 # we take complex parameters, since it learns sign structures more easily, and for even fermion number, the wave function might be complex

--- a/Examples/Fermions/fermi_hubbard_slater.py
+++ b/Examples/Fermions/fermi_hubbard_slater.py
@@ -47,12 +47,14 @@ print("Hamiltonian =", ham.operator_string())
 
 # g.n_nodes == L*L --> disj_graph == 2*L*L
 # this is handled by netket by passing the keyword copy_per_spin=True
-sa = nkx.sampler.MetropolisFermionExchange(hi, graph=g, n_chains=16, copy_per_spin=True)
+sa = nkx.sampler.MetropolisParticleExchange(
+    hi, graph=g, n_chains=16, copy_per_spin=True, sweep_size=64
+)
 
 # since the hilbert basis is a set of occupation numbers, we can take a general RBM
 # we take complex parameters, since it learns sign structures more easily, and for even fermion number, the wave function might be complex
 ma = nkx.models.Slater2nd(hi, param_dtype=complex)
-vs = nk.vqs.MCState(sa, ma, n_discard_per_chain=100, n_samples=512)
+vs = nk.vqs.MCState(sa, ma, n_discard_per_chain=10, n_samples=512)
 
 # we will use sgd with Stochastic Reconfiguration
 opt = nk.optimizer.Sgd(learning_rate=0.01)

--- a/Examples/Fermions/fermi_hubbard_slater.py
+++ b/Examples/Fermions/fermi_hubbard_slater.py
@@ -48,7 +48,7 @@ print("Hamiltonian =", ham.operator_string())
 # g.n_nodes == L*L --> disj_graph == 2*L*L
 # this is handled by netket by passing the keyword copy_per_spin=True
 sa = nkx.sampler.MetropolisParticleExchange(
-    hi, graph=g, n_chains=16, exhange_spins=False, sweep_size=64
+    hi, graph=g, n_chains=16, exchange_spins=False, sweep_size=64
 )
 
 # since the hilbert basis is a set of occupation numbers, we can take a general RBM

--- a/Examples/Fermions/fermi_hubbard_slater.py
+++ b/Examples/Fermions/fermi_hubbard_slater.py
@@ -47,7 +47,7 @@ print("Hamiltonian =", ham.operator_string())
 
 # g.n_nodes == L*L --> disj_graph == 2*L*L
 disj_graph = nk.graph.disjoint_union(g, g)
-sa = nk.sampler.MetropolisExchange(hi, graph=disj_graph, n_chains=16)
+sa = nkx.sampler.MetropolisFermionExchange(hi, graph=disj_graph, n_chains=16)
 
 # since the hilbert basis is a set of occupation numbers, we can take a general RBM
 # we take complex parameters, since it learns sign structures more easily, and for even fermion number, the wave function might be complex

--- a/Examples/Fermions/fermi_hubbard_slater.py
+++ b/Examples/Fermions/fermi_hubbard_slater.py
@@ -51,12 +51,12 @@ sa = nkx.sampler.MetropolisFermionExchange(hi, graph=disj_graph, n_chains=16)
 
 # since the hilbert basis is a set of occupation numbers, we can take a general RBM
 # we take complex parameters, since it learns sign structures more easily, and for even fermion number, the wave function might be complex
-ma = nkx.models.Slater2nd(hi, param_dtype=float)
+ma = nkx.models.Slater2nd(hi, param_dtype=complex)
 vs = nk.vqs.MCState(sa, ma, n_discard_per_chain=100, n_samples=512)
 
 # we will use sgd with Stochastic Reconfiguration
 opt = nk.optimizer.Sgd(learning_rate=0.01)
-sr = nk.optimizer.SR(diag_shift=0.1)
+sr = nk.optimizer.SR(diag_shift=0.1, holomorphic=True)
 
 gs = nk.driver.VMC(ham, opt, variational_state=vs, preconditioner=sr)
 

--- a/docs/api/api-experimental.md
+++ b/docs/api/api-experimental.md
@@ -47,6 +47,15 @@ The Quantum State Reconstruction algorithm performs an approximate tomographic r
 (experimental-sampler-api)=
 ## Samplers
 
+They are experimental, meaning that we could change them at some point, and we actively seeking for feedback and opinions on their usage and APIs.
+
+```{eval-rst}
+.. currentmodule:: netket.experimental.sampler
+
+```
+
+### Parallel tempering samplers
+
 This module contains the Metropolis Parallel Tempered sampler.
 This sampler is experimental because we believe it to be correct, but our tests
 fail. We believe it to be a false negative: possibly the implementation of the
@@ -59,6 +68,7 @@ The other experimental sampler is MetropolisSamplerPmap, which makes use of {fun
 to use different GPUs/CPUs without having to use MPI. It should scale much better over
 several CPUs, but you have to start jax with a specific environment variable.
 
+
 ```{eval-rst}
 .. autosummary::
    :toctree: _generated/samplers
@@ -70,6 +80,31 @@ several CPUs, but you have to start jax with a specific environment variable.
    sampler.MetropolisExchangePt
 
    sampler.MetropolisSamplerPmap
+```
+
+### Particle-specific samplers
+
+The following samplers are for 2nd-quantisation fermionic hilbert spaces ({class}`netket.experimental.hilbert.SpinOrbitalFermions`).
+
+```{eval-rst}
+.. autosummary::
+   :toctree: _generated/samplers
+   :template: flax_module_or_default
+   :nosignatures:
+
+
+   MetropolisParticleExchange
+```
+
+And the corresponding rules
+```{eval-rst}
+.. autosummary::
+   :toctree: _generated/samplers
+   :template: flax_module_or_default
+   :nosignatures:
+
+
+   rules.ParticleExchangeRule
 ```
 
 (experimental-logging-api)=

--- a/docs/api/sampler.md
+++ b/docs/api/sampler.md
@@ -83,6 +83,7 @@ This is a list of shorthands that allow to construct a {class}`~netket.sampler.M
 
    MetropolisLocal
    MetropolisExchange
+   MetropolisFermionExchange
    MetropolisHamiltonian
    MetropolisGaussian
    MetropolisAdjustedLangevin

--- a/docs/api/sampler.md
+++ b/docs/api/sampler.md
@@ -83,7 +83,7 @@ This is a list of shorthands that allow to construct a {class}`~netket.sampler.M
 
    MetropolisLocal
    MetropolisExchange
-   MetropolisFermionExchange
+   MetropolisParticleExchange
    MetropolisHamiltonian
    MetropolisGaussian
    MetropolisAdjustedLangevin
@@ -118,6 +118,7 @@ Sampler. Rules with `Numpy` in their name can only be used with
   rules.LocalRule
   rules.CustomRuleNumpy
   rules.ExchangeRule
+  rules.ParticleExchangeRule
   rules.FixedRule
   rules.HamiltonianRule
   rules.HamiltonianRuleNumpy

--- a/docs/api/sampler.md
+++ b/docs/api/sampler.md
@@ -83,7 +83,6 @@ This is a list of shorthands that allow to construct a {class}`~netket.sampler.M
 
    MetropolisLocal
    MetropolisExchange
-   MetropolisParticleExchange
    MetropolisHamiltonian
    MetropolisGaussian
    MetropolisAdjustedLangevin
@@ -118,7 +117,6 @@ Sampler. Rules with `Numpy` in their name can only be used with
   rules.LocalRule
   rules.CustomRuleNumpy
   rules.ExchangeRule
-  rules.ParticleExchangeRule
   rules.FixedRule
   rules.HamiltonianRule
   rules.HamiltonianRuleNumpy

--- a/netket/experimental/sampler/__init__.py
+++ b/netket/experimental/sampler/__init__.py
@@ -20,6 +20,8 @@ from .metropolis_pt import (
     MetropolisExchangePt,
 )
 
+from .metropolis import MetropolisFermionExchange
+
 from netket.utils import _hide_submodules
 
 _hide_submodules(__name__)

--- a/netket/experimental/sampler/__init__.py
+++ b/netket/experimental/sampler/__init__.py
@@ -20,7 +20,7 @@ from .metropolis_pt import (
     MetropolisExchangePt,
 )
 
-from .metropolis import MetropolisFermionExchange
+from .metropolis import MetropolisParticleExchange
 
 from netket.utils import _hide_submodules
 

--- a/netket/experimental/sampler/metropolis.py
+++ b/netket/experimental/sampler/metropolis.py
@@ -8,7 +8,7 @@ def MetropolisParticleExchange(
     clusters=None,
     graph=None,
     d_max=1,
-    exhange_spins=False,
+    exchange_spins=False,
     dtype=np.int8,
     **kwargs,
 ) -> MetropolisSampler:
@@ -19,7 +19,7 @@ def MetropolisParticleExchange(
     Args:
         hilbert: The Hilbert space to sample.
         d_max: The maximum graph distance allowed for exchanges.
-        exhange_spins: (default False) If False, exchanges are only allowed between modes with the same spin projection.
+        exchange_spins: (default False) If False, exchanges are only allowed between modes with the same spin projection.
         n_chains: The total number of independent Markov chains across all MPI ranks. Either specify this or `n_chains_per_rank`.
         n_chains_per_rank: Number of independent chains on every MPI rank (default = 16).
         sweep_size: Number of sweeps for each step along the chain. Defaults to the number of sites in the Hilbert space.
@@ -35,6 +35,6 @@ def MetropolisParticleExchange(
         clusters=clusters,
         graph=graph,
         d_max=d_max,
-        exhange_spins=exhange_spins,
+        exchange_spins=exchange_spins,
     )
     return MetropolisSampler(hilbert, rule, dtype=dtype, **kwargs)

--- a/netket/experimental/sampler/metropolis.py
+++ b/netket/experimental/sampler/metropolis.py
@@ -19,7 +19,7 @@ def MetropolisParticleExchange(
     Args:
         hilbert: The Hilbert space to sample.
         d_max: The maximum graph distance allowed for exchanges.
-        exhange_spins: If False, exchanges are only allowed between modes with the same spin projection.
+        exhange_spins: (default False) If False, exchanges are only allowed between modes with the same spin projection.
         n_chains: The total number of independent Markov chains across all MPI ranks. Either specify this or `n_chains_per_rank`.
         n_chains_per_rank: Number of independent chains on every MPI rank (default = 16).
         sweep_size: Number of sweeps for each step along the chain. Defaults to the number of sites in the Hilbert space.

--- a/netket/experimental/sampler/metropolis.py
+++ b/netket/experimental/sampler/metropolis.py
@@ -1,9 +1,11 @@
 from netket.sampler import MetropolisSampler
 from netket.experimental.hilbert import SpinOrbitalFermions
+from netket.graph import disjoint_union
+import numpy as np
 
 
 def MetropolisFermionExchange(
-    hilbert, *, clusters=None, graph=None, d_max=1, **kwargs
+    hilbert, *, clusters=None, graph=None, d_max=1, copy_per_spin=True, **kwargs
 ) -> MetropolisSampler:
     r"""
     This sampler moves (or hops) a random fermion to a different but random empty mode.
@@ -26,6 +28,16 @@ def MetropolisFermionExchange(
         raise ValueError(
             "This sampler only works with SpinOrbitalFermions hilbert spaces."
         )
+    if copy_per_spin and hilbert.n_spin_subsectors > 1:
+        if graph is not None and graph.n_nodes == hilbert.n_orbitals:
+            graph = disjoint_union(*[graph] * hilbert.n_spin_subsectors)
+        if clusters is not None and np.max(clusters) < hilbert.n_orbitals:
+            clusters = np.concatenate(
+                [
+                    clusters + i * hilbert.n_orbitals
+                    for i in range(hilbert.n_spin_subsectors)
+                ]
+            )
 
     rule = FermionExchangeRule(clusters=clusters, graph=graph, d_max=d_max)
     return MetropolisSampler(hilbert, rule, **kwargs)

--- a/netket/experimental/sampler/metropolis.py
+++ b/netket/experimental/sampler/metropolis.py
@@ -1,14 +1,19 @@
 from netket.sampler import MetropolisSampler
-from netket.experimental.hilbert import SpinOrbitalFermions
-from netket.graph import disjoint_union
 import numpy as np
 
 
-def MetropolisFermionExchange(
-    hilbert, *, clusters=None, graph=None, d_max=1, copy_per_spin=True, **kwargs
+def MetropolisParticleExchange(
+    hilbert,
+    *,
+    clusters=None,
+    graph=None,
+    d_max=1,
+    copy_per_spin=True,
+    dtype=np.int8,
+    **kwargs,
 ) -> MetropolisSampler:
     r"""
-    This sampler moves (or hops) a random fermion to a different but random empty mode.
+    This sampler moves (or hops) a random particle to a different but random empty mode.
     It works similar to MetropolisExchange, but only allows exchanges between occupied and unoccupied modes.
 
     Args:
@@ -20,24 +25,15 @@ def MetropolisFermionExchange(
                 This is equivalent to subsampling the Markov chain.
         reset_chains: If True, resets the chain state when `reset` is called on every new sampling (default = False).
         machine_pow: The power to which the machine should be exponentiated to generate the pdf (default = 2).
-        dtype: The dtype of the states sampled (default = np.float64).
+        dtype: The dtype of the states sampled (default = np.int8).
     """
-    from .rules import FermionExchangeRule
+    from .rules import ParticleExchangeRule
 
-    if not isinstance(hilbert, SpinOrbitalFermions):
-        raise ValueError(
-            "This sampler only works with SpinOrbitalFermions hilbert spaces."
-        )
-    if copy_per_spin and hilbert.n_spin_subsectors > 1:
-        if graph is not None and graph.n_nodes == hilbert.n_orbitals:
-            graph = disjoint_union(*[graph] * hilbert.n_spin_subsectors)
-        if clusters is not None and np.max(clusters) < hilbert.n_orbitals:
-            clusters = np.concatenate(
-                [
-                    clusters + i * hilbert.n_orbitals
-                    for i in range(hilbert.n_spin_subsectors)
-                ]
-            )
-
-    rule = FermionExchangeRule(clusters=clusters, graph=graph, d_max=d_max)
-    return MetropolisSampler(hilbert, rule, **kwargs)
+    rule = ParticleExchangeRule(
+        hilbert,
+        clusters=clusters,
+        graph=graph,
+        d_max=d_max,
+        copy_per_spin=copy_per_spin,
+    )
+    return MetropolisSampler(hilbert, rule, dtype=dtype, **kwargs)

--- a/netket/experimental/sampler/metropolis.py
+++ b/netket/experimental/sampler/metropolis.py
@@ -8,7 +8,7 @@ def MetropolisParticleExchange(
     clusters=None,
     graph=None,
     d_max=1,
-    copy_per_spin=True,
+    exhange_spins=False,
     dtype=np.int8,
     **kwargs,
 ) -> MetropolisSampler:
@@ -19,6 +19,7 @@ def MetropolisParticleExchange(
     Args:
         hilbert: The Hilbert space to sample.
         d_max: The maximum graph distance allowed for exchanges.
+        exhange_spins: If False, exchanges are only allowed between modes with the same spin projection.
         n_chains: The total number of independent Markov chains across all MPI ranks. Either specify this or `n_chains_per_rank`.
         n_chains_per_rank: Number of independent chains on every MPI rank (default = 16).
         sweep_size: Number of sweeps for each step along the chain. Defaults to the number of sites in the Hilbert space.
@@ -34,6 +35,6 @@ def MetropolisParticleExchange(
         clusters=clusters,
         graph=graph,
         d_max=d_max,
-        copy_per_spin=copy_per_spin,
+        exhange_spins=exhange_spins,
     )
     return MetropolisSampler(hilbert, rule, dtype=dtype, **kwargs)

--- a/netket/experimental/sampler/metropolis.py
+++ b/netket/experimental/sampler/metropolis.py
@@ -1,0 +1,31 @@
+from netket.sampler import MetropolisSampler
+from netket.experimental.hilbert import SpinOrbitalFermions
+
+
+def MetropolisFermionExchange(
+    hilbert, *, clusters=None, graph=None, d_max=1, **kwargs
+) -> MetropolisSampler:
+    r"""
+    This sampler moves (or hops) a random fermion to a different but random empty mode.
+    It works similar to MetropolisExchange, but only allows exchanges between occupied and unoccupied modes.
+
+    Args:
+        hilbert: The Hilbert space to sample.
+        d_max: The maximum graph distance allowed for exchanges.
+        n_chains: The total number of independent Markov chains across all MPI ranks. Either specify this or `n_chains_per_rank`.
+        n_chains_per_rank: Number of independent chains on every MPI rank (default = 16).
+        sweep_size: Number of sweeps for each step along the chain. Defaults to the number of sites in the Hilbert space.
+                This is equivalent to subsampling the Markov chain.
+        reset_chains: If True, resets the chain state when `reset` is called on every new sampling (default = False).
+        machine_pow: The power to which the machine should be exponentiated to generate the pdf (default = 2).
+        dtype: The dtype of the states sampled (default = np.float64).
+    """
+    from .rules import FermionExchangeRule
+
+    if not isinstance(hilbert, SpinOrbitalFermions):
+        raise ValueError(
+            "This sampler only works with SpinOrbitalFermions hilbert spaces."
+        )
+
+    rule = FermionExchangeRule(clusters=clusters, graph=graph, d_max=d_max)
+    return MetropolisSampler(hilbert, rule, **kwargs)

--- a/netket/experimental/sampler/rules/__init__.py
+++ b/netket/experimental/sampler/rules/__init__.py
@@ -1,0 +1,1 @@
+from .fermion_2nd import FermionExchangeRule

--- a/netket/experimental/sampler/rules/__init__.py
+++ b/netket/experimental/sampler/rules/__init__.py
@@ -1,1 +1,1 @@
-from .fermion_2nd import FermionExchangeRule
+from .fermion_2nd import ParticleExchangeRule

--- a/netket/experimental/sampler/rules/fermion_2nd.py
+++ b/netket/experimental/sampler/rules/fermion_2nd.py
@@ -1,0 +1,63 @@
+import jax
+import jax.numpy as jnp
+from netket.sampler.rules import ExchangeRule
+
+
+class FermionExchangeRule(ExchangeRule):
+    """Exchange rule for fermions.
+
+    Works similarly to exchange rule, but:
+    takes into account that only occupied orbitals
+    can be exchanged with unoccupied ones.
+    """
+
+    def transition(rule, sampler, machine, parameters, state, key, σ):
+        n_chains = σ.shape[0]
+
+        hoppable_clusters = _compute_hoppable_clusters_mask(rule.clusters, σ)
+        # compute a mask for the clusters that can be hopped
+
+        keys = jnp.asarray(jax.random.split(key, n_chains))
+
+        def _update_sample(key, σ, hoppable_clusters):
+            # pick a random cluster, taking into account the mask
+            n_conn = hoppable_clusters.sum(axis=-1)
+            cluster = jax.random.choice(
+                key,
+                a=jnp.arange(rule.clusters.shape[0]),
+                p=hoppable_clusters,
+                replace=True,
+            )
+
+            # sites to be exchanged
+            si = rule.clusters[cluster, 0]
+            sj = rule.clusters[cluster, 1]
+
+            σp = σ.at[si].set(σ[sj])
+            σp = σp.at[sj].set(σ[si])
+
+            # compute the number of connected sites
+            hoppable_clusters_proposed = _compute_hoppable_clusters_mask(
+                rule.clusters, σp
+            )
+            n_conn_proposed = hoppable_clusters_proposed.sum(axis=-1)
+            log_prob_corr = jnp.log(n_conn) - jnp.log(n_conn_proposed)
+            return σp, log_prob_corr
+
+        return jax.vmap(_update_sample, in_axes=(0, 0, 0), out_axes=0)(
+            keys, σ, hoppable_clusters
+        )
+
+    def __repr__(self):
+        return f"FermionExchangeRule(# of clusters: {len(self.clusters)})"
+
+
+@jax.jit
+def _compute_hoppable_clusters_mask(clusters, σ):
+    # see which modes are occupied
+    occ = jnp.isclose(σ, 1)
+    # mask the clusters to include only feasible moves (occ -> unocc, or the inverse)
+    hoppable_clusters_mask = jnp.logical_xor(
+        occ[..., clusters[:, 0]], occ[..., clusters[:, 1]]
+    )
+    return hoppable_clusters_mask

--- a/netket/experimental/sampler/rules/fermion_2nd.py
+++ b/netket/experimental/sampler/rules/fermion_2nd.py
@@ -78,8 +78,8 @@ class ParticleExchangeRule(ExchangeRule):
     def transition(rule, sampler, machine, parameters, state, key, σ):
         n_chains = σ.shape[0]
 
-        hoppable_clusters = _compute_hoppable_clusters_mask(rule.clusters, σ)
         # compute a mask for the clusters that can be hopped
+        hoppable_clusters = _compute_hoppable_clusters_mask(rule.clusters, σ)
 
         keys = jnp.asarray(jax.random.split(key, n_chains))
 
@@ -113,7 +113,7 @@ class ParticleExchangeRule(ExchangeRule):
         )
 
     def __repr__(self):
-        return f"FermionExchangeRule(# of clusters: {len(self.clusters)})"
+        return f"ParticleExchangeRule(# of clusters: {len(self.clusters)})"
 
 
 @jax.jit

--- a/netket/experimental/sampler/rules/fermion_2nd.py
+++ b/netket/experimental/sampler/rules/fermion_2nd.py
@@ -15,6 +15,7 @@ class ParticleExchangeRule(ExchangeRule):
     Works similarly to :class:`netket.sampler.rules.ExchangeRule`, but
     takes into account that only occupied orbitals
     can be exchanged with unoccupied ones.
+
     This sampler conserves the number of particles.
     """
 

--- a/netket/experimental/sampler/rules/fermion_2nd.py
+++ b/netket/experimental/sampler/rules/fermion_2nd.py
@@ -26,7 +26,7 @@ class ParticleExchangeRule(ExchangeRule):
         clusters: Optional[list[tuple[int, int]]] = None,
         graph: Optional[AbstractGraph] = None,
         d_max: int = 1,
-        exhange_spins: bool = False,
+        exchange_spins: bool = False,
     ):
         r"""
         Constructs the ParticleExchange Rule.
@@ -46,7 +46,7 @@ class ParticleExchangeRule(ExchangeRule):
                 that can be exchanged.
             d_max: Only valid if a graph is passed in. The maximum distance
                 between two sites
-            exhange_spins: (default False) If exhange_spins, the graph must encode the
+            exchange_spins: (default False) If exchange_spins, the graph must encode the
                 connectivity  between the first N physical sites having same spin, and
                 it is replicated using :ref:`netket.graph.disjoint_union` other every
                 spin subsector. This option conserves the number of fermions per
@@ -57,7 +57,7 @@ class ParticleExchangeRule(ExchangeRule):
             raise ValueError(
                 "This sampler rule currently only works with SpinOrbitalFermions hilbert spaces."
             )
-        if not exhange_spins and hilbert.n_spin_subsectors > 1:
+        if not exchange_spins and hilbert.n_spin_subsectors > 1:
             if graph is not None and graph.n_nodes == hilbert.n_orbitals:
                 graph = disjoint_union(*[graph] * hilbert.n_spin_subsectors)
             if clusters is not None and np.max(clusters) < hilbert.n_orbitals:

--- a/netket/experimental/sampler/rules/fermion_2nd.py
+++ b/netket/experimental/sampler/rules/fermion_2nd.py
@@ -1,15 +1,79 @@
 import jax
 import jax.numpy as jnp
+from typing import Optional
+import numpy as np
+
 from netket.sampler.rules import ExchangeRule
+from netket.graph import AbstractGraph
+from netket.graph import disjoint_union
+from netket.experimental.hilbert import SpinOrbitalFermions
 
 
-class FermionExchangeRule(ExchangeRule):
-    """Exchange rule for fermions.
+class ParticleExchangeRule(ExchangeRule):
+    """Exchange rule for particles on a lattice.
 
     Works similarly to exchange rule, but:
     takes into account that only occupied orbitals
     can be exchanged with unoccupied ones.
+    This sampler conserves the number of particles.
     """
+
+    copy_per_spin: bool
+    """
+    Whether to copy the graph for each spin sector.
+    This only occurs if cluster indices or number of graph nodes
+    are lower than the number of orbitals per spin sector.
+    """
+
+    def __init__(
+        self,
+        hilbert,
+        *,
+        clusters: Optional[list[tuple[int, int]]] = None,
+        graph: Optional[AbstractGraph] = None,
+        d_max: int = 1,
+        copy_per_spin: bool = True,
+    ):
+        r"""
+        Constructs the ParticleExchange Rule.
+
+        Particles are only exchanged between modes where the particle number is different.
+        For fermions, only occupied orbitals can be exchanged with unoccupied ones.
+
+        You can pass either a list of clusters or a netket graph object to
+        determine the clusters to exchange.
+
+        Args:
+            hilbert: The hilbert space to be sampled.
+            clusters: The list of clusters that can be exchanged. This should be
+                a list of 2-tuples containing two integers. Every tuple is an edge,
+                or cluster of sites to be exchanged.
+            graph: A graph, from which the edges determine the clusters
+                that can be exchanged.
+            d_max: Only valid if a graph is passed in. The maximum distance
+                between two sites
+            copy_per_spin: (default True) If True, the graph must encode the
+                connectivity  between the first N physical sites having same spin, and
+                it is replicated using :ref:`netket.graph.disjoint_union` other every
+                spin subsector. This option conserves the number of fermions per
+                spin subsector.
+        """
+        if not isinstance(hilbert, SpinOrbitalFermions):
+            raise ValueError(
+                "This sampler rule currently only works with SpinOrbitalFermions hilbert spaces."
+            )
+        if copy_per_spin and hilbert.n_spin_subsectors > 1:
+            if graph is not None and graph.n_nodes == hilbert.n_orbitals:
+                graph = disjoint_union(*[graph] * hilbert.n_spin_subsectors)
+            if clusters is not None and np.max(clusters) < hilbert.n_orbitals:
+                clusters = np.concatenate(
+                    [
+                        clusters + i * hilbert.n_orbitals
+                        for i in range(hilbert.n_spin_subsectors)
+                    ]
+                )
+        self.copy_per_spin = copy_per_spin
+        super().__init__(clusters=clusters, graph=graph, d_max=d_max)
 
     def transition(rule, sampler, machine, parameters, state, key, σ):
         n_chains = σ.shape[0]
@@ -54,10 +118,8 @@ class FermionExchangeRule(ExchangeRule):
 
 @jax.jit
 def _compute_hoppable_clusters_mask(clusters, σ):
-    # see which modes are occupied
-    occ = jnp.isclose(σ, 1)
     # mask the clusters to include only feasible moves (occ -> unocc, or the inverse)
-    hoppable_clusters_mask = jnp.logical_xor(
-        occ[..., clusters[:, 0]], occ[..., clusters[:, 1]]
+    hoppable_clusters_mask = ~jnp.isclose(
+        σ[..., clusters[:, 0]], σ[..., clusters[:, 1]]
     )
     return hoppable_clusters_mask

--- a/netket/experimental/sampler/rules/fermion_2nd.py
+++ b/netket/experimental/sampler/rules/fermion_2nd.py
@@ -12,7 +12,7 @@ from netket.experimental.hilbert import SpinOrbitalFermions
 class ParticleExchangeRule(ExchangeRule):
     """Exchange rule for particles on a lattice.
 
-    Works similarly to ExchangeRule, but:
+    Works similarly to :class:`netket.sampler.rules.ExchangeRule`, but
     takes into account that only occupied orbitals
     can be exchanged with unoccupied ones.
     This sampler conserves the number of particles.

--- a/test/sampler/test_sampler.py
+++ b/test/sampler/test_sampler.py
@@ -92,8 +92,8 @@ samplers[
 )
 
 samplers[
-    "Metropolis(FermionExchange): SpinOrbitalFermions"
-] = nkx.sampler.MetropolisFermionExchange(hi_fermion, graph=g)
+    "Metropolis(ParticleExchange): SpinOrbitalFermions"
+] = nkx.sampler.MetropolisParticleExchange(hi_fermion, graph=g)
 
 samplers["Metropolis(Hamiltonian,Numpy): Spin"] = nk.sampler.MetropolisHamiltonianNumpy(
     hi,

--- a/test/sampler/test_sampler.py
+++ b/test/sampler/test_sampler.py
@@ -60,6 +60,9 @@ hi_spin1 = nk.hilbert.Spin(s=1, N=g.n_nodes)
 hib = nk.hilbert.Fock(n_max=1, N=g.n_nodes, n_particles=1)
 hib_u = nk.hilbert.Fock(n_max=3, N=g.n_nodes)
 hi_fermion = nk.experimental.hilbert.SpinOrbitalFermions(g.n_nodes, n_fermions=2)
+hi_fermion_spin = nk.experimental.hilbert.SpinOrbitalFermions(
+    g.n_nodes, s=1 / 2, n_fermions=(2, 2)
+)
 
 samplers["Exact: Spin"] = nk.sampler.ExactSampler(hi)
 samplers["Exact: Fock"] = nk.sampler.ExactSampler(hib_u)
@@ -94,6 +97,11 @@ samplers[
 samplers[
     "Metropolis(ParticleExchange): SpinOrbitalFermions"
 ] = nkx.sampler.MetropolisParticleExchange(hi_fermion, graph=g)
+samplers[
+    "Metropolis(ParticleExchange,Spinful): SpinOrbitalFermions"
+] = nkx.sampler.MetropolisParticleExchange(
+    hi_fermion_spin, graph=g, exchange_spins=False
+)
 
 samplers["Metropolis(Hamiltonian,Numpy): Spin"] = nk.sampler.MetropolisHamiltonianNumpy(
     hi,
@@ -528,3 +536,23 @@ def test_exact_sampler(sampler):
     else:
         assert sampler.is_exact is False
         assert sampler.n_chains == 16 * mpi.n_nodes * device_count_per_rank()
+
+
+def test_fermions_spin_exchange():
+    # test that the graph correctly creates a disjoint graph for the spinful case
+    g = nk.graph.Hypercube(length=4, n_dim=1)
+    hi_fermion_spin = nk.experimental.hilbert.SpinOrbitalFermions(
+        g.n_nodes, s=1 / 2, n_fermions=(2, 2)
+    )
+
+    sampler = nkx.sampler.MetropolisParticleExchange(
+        hi_fermion_spin, graph=g, exchange_spins=True
+    )
+    nodes = np.unique(sampler.rule.clusters)
+    assert np.allclose(nodes, np.arange(g.n_nodes))
+
+    sampler = nkx.sampler.MetropolisParticleExchange(
+        hi_fermion_spin, graph=g, exchange_spins=False
+    )
+    nodes = np.unique(sampler.rule.clusters)
+    assert np.allclose(nodes, np.arange(hi_fermion_spin.size))

--- a/test/sampler/test_sampler.py
+++ b/test/sampler/test_sampler.py
@@ -59,6 +59,7 @@ move_op = sum([nk.operator.spin.sigmax(hi, i) for i in range(hi.size)])
 hi_spin1 = nk.hilbert.Spin(s=1, N=g.n_nodes)
 hib = nk.hilbert.Fock(n_max=1, N=g.n_nodes, n_particles=1)
 hib_u = nk.hilbert.Fock(n_max=3, N=g.n_nodes)
+hi_fermion = nk.experimental.hilbert.SpinOrbitalFermions(g.n_nodes, n_fermions=2)
 
 samplers["Exact: Spin"] = nk.sampler.ExactSampler(hi)
 samplers["Exact: Fock"] = nk.sampler.ExactSampler(hib_u)
@@ -89,6 +90,10 @@ samplers[
     hamiltonian=ha,
     reset_chains=True,
 )
+
+samplers[
+    "Metropolis(FermionExchange): SpinOrbitalFermions"
+] = nkx.sampler.MetropolisFermionExchange(hi_fermion, graph=g)
 
 samplers["Metropolis(Hamiltonian,Numpy): Spin"] = nk.sampler.MetropolisHamiltonianNumpy(
     hi,


### PR DESCRIPTION
This sampler avoids proposing the same sample for fermions.
The previous approach was to use ExchangeSampler, which often applies an exchange between two occupied or two unoccupied fermionic modes.
Now we only consider clusters of one occupied and one unoccupied mode.
This should yield better acceptances.
Relevant for @inailuig and @imi-hub , and most specifically for the few-fermion case