### PR TITLE
Remove constant in fermion operator and include an explicit cutoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@
 
 * `MetropolisSampler.n_sweeps` has been renamed to `MetropolisSampler.sweep_size` for clarity. Using `n_sweeps` when constructing the sampler now throws a deprecation warning; `sweep_size` should be used instead going forward. [#1657](https://github.com/netket/netket/issues/1657)
 
+### Internal changes
+* A new class {class}`netket.utils.struct.Pytree`, can be used to create Pytrees for which inheritance autoamtically works and for which it is possible to define `__init__`. Several structures such as samplers and rules have been transitioned to this new interface instead of old style `@struct.dataclass` [#1653](https://github.com/netket/netket/issues/1653).
+* The {class}`~netket.experimental.operator.FermionOperator2nd` and related classes now store the constant diagonal shift as another term instead of a completely special cased scalar value. The same operators now also respect the `cutoff` keyword argument more strictly [#1686](https://github.com/netket/netket/issues/1686).
+
+
 ## NetKet 3.10.2 (14 november 2023)
 
 ### Bug Fixes

--- a/netket/experimental/operator/_fermion_operator_2nd_base.py
+++ b/netket/experimental/operator/_fermion_operator_2nd_base.py
@@ -264,7 +264,7 @@ class FermionOperator2ndBase(DiscreteOperator):
     @property
     def operators(self) -> OperatorDict:
         """Returns a dictionary with (term, weight) key-value pairs, with terms in tuple notation.
-        
+
         The constant diagonal shift of the operator is associated with a term represented as an empty tuple.
         """
         return self._operators

--- a/netket/experimental/operator/_fermion_operator_2nd_base.py
+++ b/netket/experimental/operator/_fermion_operator_2nd_base.py
@@ -249,7 +249,10 @@ class FermionOperator2ndBase(DiscreteOperator):
 
     @property
     def operators(self) -> OperatorDict:
-        """Returns a dictionary with (term, weight) key-value pairs, with terms in tuple notation."""
+        """Returns a dictionary with (term, weight) key-value pairs, with terms in tuple notation.
+        
+        The constant diagonal shift of the operator is associated with a term represented as an empty tuple.
+        """
         return self._operators
 
     def copy(self, *, dtype: Optional[DType] = None, cutoff=None):

--- a/netket/experimental/operator/_fermion_operator_2nd_base.py
+++ b/netket/experimental/operator/_fermion_operator_2nd_base.py
@@ -15,7 +15,6 @@
 from typing import Union, Optional
 
 import numpy as np
-from numbers import Number
 
 from netket.utils.types import DType
 from netket.operator._discrete_operator import DiscreteOperator
@@ -28,14 +27,11 @@ from netket.experimental.hilbert import SpinOrbitalFermions
 
 from ._fermion_operator_2nd_utils import (
     _convert_terms_to_spin_blocks,
-    _collect_constants,
     _canonicalize_input,
     _check_hermitian,
     _herm_conj,
-    _make_tuple_tree,
     _remove_dict_zeros,
     _verify_input,
-    _reduce_operators,
     OperatorDict,
     OperatorTermsList,
     OperatorWeightsList,
@@ -57,7 +53,7 @@ class FermionOperator2ndBase(DiscreteOperator):
         hilbert: AbstractHilbert,
         terms: Union[list[str], list[list[list[int]]]] = None,
         weights: Optional[list[Union[float, complex]]] = None,
-        constant: Union[float, complex] = 0.0,
+        cutoff: float = 1e-10,
         dtype: DType = None,
     ):
         r"""
@@ -81,8 +77,7 @@ class FermionOperator2ndBase(DiscreteOperator):
                 example below)
             weights: corresponding coefficients of the single term operators
                 (defaults to a list of 1)
-            constant: constant contribution, corresponding to the
-                identity operator * constant (default = 0)
+            cutoff: threshold for the weights, if the absolute value of a weight is below the cutoff, it's discarded.
 
         Returns:
             A FermionOperator2nd object.
@@ -109,17 +104,17 @@ class FermionOperator2ndBase(DiscreteOperator):
         """
         super().__init__(hilbert)
 
+        if not np.isscalar(cutoff) or cutoff < 0:
+            raise ValueError(f"invalid cutoff in FermionOperator2ndBase: {cutoff}.")
+        self._cutoff = cutoff
+
         # bring terms, weights into consistent form, autopromote dtypes if necessary
-        _operators, _constant, dtype = _canonicalize_input(
-            terms, weights, constant, dtype
-        )
+        _operators, dtype = _canonicalize_input(terms, weights, dtype, cutoff)
         _verify_input(hilbert, _operators, raise_error=True)
         self._dtype = dtype
 
         # we keep the input, in order to be able to add terms later
         self._operators = _operators
-        self._constant = _constant
-
         self._initialized = False
         self._is_hermitian = None  # set when requested
         self._max_conn_size = None
@@ -144,6 +139,8 @@ class FermionOperator2ndBase(DiscreteOperator):
         *,
         n_orbitals: Optional[int] = None,
         convert_spin_blocks: bool = False,
+        cutoff: float = 1e-10,
+        dtype: DType = None,
     ) -> "FermionOperator2ndBase":
         r"""
         Converts an openfermion FermionOperator into a netket FermionOperator2nd.
@@ -167,6 +164,7 @@ class FermionOperator2ndBase(DiscreteOperator):
             convert_spin_blocks: whether or not we need to convert the FermionOperator
                 to our convention. Only works if hilbert is provided and if it has
                 spin != 0
+            cutoff: threshold for the weights, if the absolute value of a weight is below the cutoff, it's discarded.
 
         """
         openfermion = import_optional_dependency(
@@ -193,7 +191,6 @@ class FermionOperator2ndBase(DiscreteOperator):
 
         terms = list(of_fermion_operator.terms.keys())
         weights = list(of_fermion_operator.terms.values())
-        terms, weights, constant = _collect_constants(terms, weights)
 
         if hilbert is not None:
             # no warning, just overwrite
@@ -212,7 +209,7 @@ class FermionOperator2ndBase(DiscreteOperator):
         if hilbert is None:
             hilbert = SpinOrbitalFermions(n_orbitals)  # no spin splitup assumed
 
-        return cls(hilbert, terms, weights=weights, constant=constant)
+        return cls(hilbert, terms, weights=weights, cutoff=cutoff, dtype=dtype)
 
     def __repr__(self):
         return (
@@ -220,19 +217,20 @@ class FermionOperator2ndBase(DiscreteOperator):
             f"n_operators={len(self._operators)}, dtype={self.dtype})"
         )
 
-    def reduce(self, order: bool = True, inplace: bool = True):
+    def reduce(self, order: bool = True, inplace: bool = True, cutoff: float = None):
         """Prunes the operator by removing all terms with zero weights, grouping, and normal ordering (inplace)."""
+        if cutoff is None:
+            cutoff = self._cutoff
+
         operators = self._operators
         terms, weights = list(operators.keys()), list(operators.values())
 
         if order:
             terms, weights = _normal_ordering(terms, weights)
 
-        terms, weights, constant = _collect_constants(terms, weights)
-        operators = dict(zip(terms, weights))
-
-        self._operators = _reduce_operators(operators, self.dtype)
-        self._constant = self._constant + constant
+        obj = self if inplace else self.copy()
+        obj._operators, _ = _canonicalize_input(terms, weights, self.dtype, cutoff)
+        return obj
 
     @property
     def dtype(self) -> DType:
@@ -250,22 +248,18 @@ class FermionOperator2ndBase(DiscreteOperator):
         return list(self._operators.values())
 
     @property
-    def constant(self) -> Number:
-        """Returns the operator constant term."""
-        return self._constant
-
-    @property
     def operators(self) -> OperatorDict:
-        """Returns a dictionary with (term, weight) key-value pairs, with terms in tuple notation. Does not include the constant."""
+        """Returns a dictionary with (term, weight) key-value pairs, with terms in tuple notation."""
         return self._operators
 
-    def copy(self, *, dtype: Optional[DType] = None):
+    def copy(self, *, dtype: Optional[DType] = None, cutoff=None):
         """
         Creates a deep copy of this operator, potentially changing the dtype of the
         operator and internal arrays.
 
         Args:
             dtype: Optional new dtype. Must be compatible with the current dtype.
+            cutoff: Optional new cutoff.
 
         Returns:
             An identical operator that does not reference the internal arrays of
@@ -275,8 +269,10 @@ class FermionOperator2ndBase(DiscreteOperator):
             dtype = self.dtype
         if not np.can_cast(self.dtype, dtype, casting="same_kind"):
             raise ValueError(f"Cannot cast {self.dtype} to {dtype}")
+        if cutoff is None:
+            cutoff = self._cutoff
 
-        op = type(self)(self.hilbert, constant=self._constant, dtype=dtype)
+        op = type(self)(self.hilbert, cutoff=self._cutoff, dtype=dtype)
 
         if dtype == self.dtype:
             operators_new = self._operators.copy()
@@ -288,10 +284,12 @@ class FermionOperator2ndBase(DiscreteOperator):
         op._operators = operators_new
         return op
 
-    def _remove_zeros(self):
+    def _remove_zeros(self, cutoff: float = None):
         """Reduce the number of operators by removing unnecessary zeros"""
-        op = type(self)(self.hilbert, constant=self._constant, dtype=self.dtype)
-        op._operators = _remove_dict_zeros(self._operators)
+        if cutoff is None:
+            cutoff = self._cutoff
+        op = type(self)(self.hilbert, cutoff=cutoff, dtype=self.dtype)
+        op._operators = _remove_dict_zeros(self._operators, cutoff)
         return op
 
     @property
@@ -307,14 +305,13 @@ class FermionOperator2ndBase(DiscreteOperator):
         if self._is_hermitian is None:  # only compute when needed, is expensive
             terms = list(self._operators.keys())
             weights = list(self._operators.values())
-            self._is_hermitian = _check_hermitian(terms, weights)
+            cutoff = self._cutoff
+            self._is_hermitian = _check_hermitian(terms, weights, cutoff)
         return self._is_hermitian
 
     def operator_string(self) -> str:
         """Return a readable string describing all the operator terms"""
         op_string = []
-        if not np.isclose(self._constant, 0.0):
-            op_string.append(f"{self._constant} []")
         for term, weight in self._operators.items():
             s = []
             for idx, dag in term:
@@ -344,19 +341,11 @@ class FermionOperator2ndBase(DiscreteOperator):
             for to, wo in other._operators.items():
                 # if the last operator of t and the first of to are
                 # equal, we have a ...ĉᵢĉᵢ... which is null.
-                if t[-1] != to[0]:
+                if len(t) == 0 or len(to) == 0 or t[-1] != to[0]:
                     new_t = t + to
                     new_operators[new_t] = new_operators.get(new_t, 0) + w * wo
 
-        if not np.isclose(other._constant, 0.0):
-            for t, w in self._operators.items():
-                new_operators[t] = w * other._constant
-        if not np.isclose(self._constant, 0.0):
-            for t, w in other._operators.items():
-                new_operators[t] = w * self._constant
-
         self._operators = new_operators
-        self._constant = self._constant * other._constant
         self._reset_caches()
         return self
 
@@ -364,7 +353,8 @@ class FermionOperator2ndBase(DiscreteOperator):
         if not isinstance(other, FermionOperator2ndBase):  # pragma: no cover
             return NotImplemented
         dtype = np.promote_types(self.dtype, other.dtype)
-        op = self.copy(dtype=dtype)
+        cutoff = max(self._cutoff, other._cutoff)
+        op = self.copy(dtype=dtype, cutoff=cutoff)
         return op._op__imatmul__(other)
 
     def __radd__(self, other):
@@ -377,9 +367,9 @@ class FermionOperator2ndBase(DiscreteOperator):
 
     def __iadd__(self, other):
         if is_scalar(other):
-            if not np.isclose(other, 0.0):
-                self._constant += other
-            return self
+            return self + self.__class__(
+                self.hilbert, [""], [other], dtype=self.dtype, cutoff=self._cutoff
+            )
         if not isinstance(other, FermionOperator2ndBase):  # pragma: no cover
             raise NotImplementedError(
                 f"In-place addition not implemented for {type(self)} "
@@ -406,8 +396,6 @@ class FermionOperator2ndBase(DiscreteOperator):
                     del self_ops[t]
                 else:
                     self_ops[t] = w
-
-        self._constant += other._constant
         self._reset_caches()
         return self
 
@@ -440,7 +428,6 @@ class FermionOperator2ndBase(DiscreteOperator):
             new_operators = {o: scalar * v for o, v in self._operators.items()}
 
         self._operators = new_operators
-        self._constant *= scalar
         self._reset_caches()
         return self
 
@@ -458,15 +445,16 @@ class FermionOperator2ndBase(DiscreteOperator):
         terms = list(self._operators.keys())
         weights = list(self._operators.values())
         terms, weights = _herm_conj(terms, weights)  # changes also the terms
-        terms = _make_tuple_tree(terms)
 
         cls = type(self)
         new = cls(
             self.hilbert,
-            constant=np.conjugate(self._constant),
             dtype=self.dtype,
         )
-        new._operators = dict(zip(terms, weights))
+        new._operators, _ = _canonicalize_input(
+            terms, weights, self.dtype, self._cutoff
+        )
+        new._cutoff = self._cutoff
         return new
 
     def to_normal_order(self):
@@ -479,11 +467,13 @@ class FermionOperator2ndBase(DiscreteOperator):
         terms, weights = _normal_ordering(self.terms, self.weights)
         new = type(self)(
             self.hilbert,
-            constant=self._constant,
             dtype=self.dtype,
         )
-        new._operators = dict(zip(terms, weights))
-        new.reduce()
+        new._operators, _ = _canonicalize_input(
+            terms, weights, self.dtype, self._cutoff
+        )
+        new._cutoff = self._cutoff
+        new.reduce(order=False)  # already ordered
         return new
 
     def to_pair_order(self):
@@ -495,9 +485,11 @@ class FermionOperator2ndBase(DiscreteOperator):
         terms, weights = _pair_ordering(self.terms, self.weights)
         new = type(self)(
             self.hilbert,
-            constant=self._constant,
             dtype=self.dtype,
         )
-        new._operators = dict(zip(terms, weights))
-        new.reduce()
+        new._operators, _ = _canonicalize_input(
+            terms, weights, self.dtype, self._cutoff
+        )
+        new._cutoff = self._cutoff
+        new.reduce(order=False)  # already ordered
         return new

--- a/netket/experimental/operator/_fermion_operator_2nd_jax.py
+++ b/netket/experimental/operator/_fermion_operator_2nd_jax.py
@@ -18,6 +18,7 @@ from typing import Optional, Union
 import jax
 import jax.numpy as jnp
 import numpy as np
+from numbers import Number
 
 from jax.tree_util import register_pytree_node_class
 
@@ -520,11 +521,14 @@ class FermionOperator2ndJax(FermionOperator2ndBase, DiscreteJaxOperator):
         hilbert: AbstractHilbert,
         terms: Union[list[str], list[list[list[int]]]] = None,
         weights: Optional[list[Union[float, complex]]] = None,
+        constant: Number = 0,
         cutoff: float = 1e-10,
         dtype: DType = None,
         _mode: str = "scan",
     ):
-        super().__init__(hilbert, terms, weights, cutoff=cutoff, dtype=dtype)
+        super().__init__(
+            hilbert, terms, weights, constant=constant, cutoff=cutoff, dtype=dtype
+        )
         self._mode = _mode
 
     @property

--- a/netket/experimental/operator/_fermion_operator_2nd_numba.py
+++ b/netket/experimental/operator/_fermion_operator_2nd_numba.py
@@ -57,12 +57,10 @@ class FermionOperator2nd(FermionOperator2ndBase):
                 self._diag_idxs,
                 self._off_diag_idxs,
                 self._term_split_idxs,
-                _collected_constant,
             ) = out
-            self._constant += _collected_constant
 
             self._max_conn_size = 0
-            if not _isclose(self._constant, 0) or len(self._diag_idxs) > 0:
+            if len(self._diag_idxs) > 0:
                 self._max_conn_size += 1
             # the following could be reduced further
             self._max_conn_size += len(self._off_diag_idxs)
@@ -77,7 +75,7 @@ class FermionOperator2nd(FermionOperator2ndBase):
         from ._fermion_operator_2nd_jax import FermionOperator2ndJax
 
         new_op = FermionOperator2ndJax(
-            self.hilbert, constant=self._constant, dtype=self.dtype
+            self.hilbert, cutoff=self._cutoff, dtype=self.dtype
         )
         new_op._operators = self._operators.copy()
         return new_op
@@ -91,8 +89,8 @@ class FermionOperator2nd(FermionOperator2ndBase):
         _diag_idxs = self._diag_idxs
         _off_diag_idxs = self._off_diag_idxs
         _term_split_idxs = self._term_split_idxs
+        _cutoff = self._cutoff
 
-        _constant = self._constant
         fun = self._flattened_kernel
 
         def gccf_fun(x, sections):
@@ -106,7 +104,7 @@ class FermionOperator2nd(FermionOperator2ndBase):
                 _diag_idxs,
                 _off_diag_idxs,
                 _term_split_idxs,
-                _constant,
+                _cutoff,
             )
 
         return numba.jit(nopython=True)(gccf_fun)
@@ -154,7 +152,7 @@ class FermionOperator2nd(FermionOperator2ndBase):
             self._diag_idxs,
             self._off_diag_idxs,
             self._term_split_idxs,
-            self._constant,
+            self._cutoff,
             pad,
         )
 
@@ -170,7 +168,7 @@ class FermionOperator2nd(FermionOperator2ndBase):
         diag_idxs,
         off_diag_idxs,
         term_split_idxs,
-        constant,
+        cutoff,
         pad=False,
     ):
         x_prime = np.empty((x.shape[0] * max_conn, x.shape[1]), dtype=x.dtype)
@@ -180,8 +178,6 @@ class FermionOperator2nd(FermionOperator2ndBase):
         term_split_idxs = term_split_idxs[:-1]
         orb_idxs_list = np.split(orb_idxs, term_split_idxs)
         daggers_list = np.split(daggers, term_split_idxs)
-
-        has_constant = not _isclose(constant, 0.0)
 
         # loop over the batch dimension
         n_c = 0
@@ -193,11 +189,6 @@ class FermionOperator2nd(FermionOperator2ndBase):
                 x_prime[b * max_conn : (b + 1) * max_conn, :] = np.copy(xb)
 
             non_zero_diag = False
-            if has_constant:
-                non_zero_diag = True
-                x_prime[n_c, :] = np.copy(xb)
-                mels[n_c] += constant
-
             # first do the diagonal terms, they all generate just 1 term
             for term_idx in diag_idxs:
                 mel = weights[term_idx]
@@ -206,10 +197,14 @@ class FermionOperator2nd(FermionOperator2ndBase):
                 for orb_idx, dagger in zip(
                     orb_idxs_list[term_idx], daggers_list[term_idx]
                 ):
-                    _, mel, op_has_xp = _apply_operator(xt, orb_idx, dagger, mel)
+                    _, mel, op_has_xp = _apply_operator(
+                        xt, orb_idx, dagger, mel, cutoff
+                    )
                     if not op_has_xp:
                         has_xp = False
                         continue
+                if has_xp and _isclose(mel, 0, cutoff):
+                    has_xp = False
                 if has_xp:
                     x_prime[n_c, :] = np.copy(xb)  # should be untouched
                     mels[n_c] += mel
@@ -228,10 +223,14 @@ class FermionOperator2nd(FermionOperator2ndBase):
                 for orb_idx, dagger in zip(
                     orb_idxs_list[term_idx], daggers_list[term_idx]
                 ):
-                    xt, mel, op_has_xp = _apply_operator(xt, orb_idx, dagger, mel)
+                    xt, mel, op_has_xp = _apply_operator(
+                        xt, orb_idx, dagger, mel, cutoff
+                    )
                     if not op_has_xp:  # detect zeros
                         has_xp = False
                         continue
+                if has_xp and _isclose(mel, 0, cutoff):
+                    has_xp = False
                 if has_xp:
                     x_prime[n_c, :] = np.copy(xt)  # should be different
                     mels[n_c] += mel
@@ -264,15 +263,11 @@ def _pack_internals(operators: OperatorDict, dtype: DType):
     off_diag_idxs = []
     # below connect the second type to the first type (used to split single-fermion lists)
     term_split_idxs = []
-    constants = []
 
     term_counter = 0
     single_op_counter = 0
     for term, weight in operators.items():
-        if len(term) == 0:
-            constants.append(weight)
-            continue
-        if not all(len(t) == 2 for t in term):  # pragma: no cover
+        if len(term) > 0 and not all(len(t) == 2 for t in term):  # pragma: no cover
             raise ValueError(f"terms must contain (i, dag) pairs, but received {term}")
 
         # fill some info about the term
@@ -297,12 +292,9 @@ def _pack_internals(operators: OperatorDict, dtype: DType):
     orb_idxs = np.array(orb_idxs, dtype=np.intp)
     daggers = np.array(daggers, dtype=bool)
     weights = np.array(weights, dtype=dtype)
-    # term_ends = np.array(term_ends, dtype=bool)
-    # herm_term = np.array(herm_term, dtype=bool)
     diag_idxs = np.array(diag_idxs, dtype=np.intp)
     off_diag_idxs = np.array(off_diag_idxs, dtype=np.intp)
     term_split_idxs = np.array(term_split_idxs, dtype=np.intp)
-    constant = sum(constants)
 
     return (
         orb_idxs,
@@ -311,18 +303,17 @@ def _pack_internals(operators: OperatorDict, dtype: DType):
         diag_idxs,
         off_diag_idxs,
         term_split_idxs,
-        constant,
     )
 
 
 @numba.jit(nopython=True)
-def _isclose(a, b, cutoff=1e-6):  # pragma: no cover
+def _isclose(a, b, cutoff):  # pragma: no cover
     return np.abs(a - b) < cutoff
 
 
 @numba.jit(nopython=True)
 def _is_empty(site):  # pragma: no cover
-    return _isclose(site, 0)
+    return _isclose(site, 0, 1e-10)
 
 
 @numba.jit(nopython=True)
@@ -331,7 +322,7 @@ def _flip(site):  # pragma: no cover
 
 
 @numba.jit(nopython=True)
-def _apply_operator(xt, orb_idx, dagger, mel):  # pragma: no cover
+def _apply_operator(xt, orb_idx, dagger, mel, cutoff):  # pragma: no cover
     has_xp = True
     empty_site = _is_empty(xt[orb_idx])
     if dagger:
@@ -346,6 +337,6 @@ def _apply_operator(xt, orb_idx, dagger, mel):  # pragma: no cover
         else:
             mel *= (-1) ** np.sum(xt[:orb_idx])  # jordan wigner sign
             xt[orb_idx] = _flip(xt[orb_idx])
-    if _isclose(mel, 0):
+    if _isclose(mel, 0, cutoff):
         has_xp = False
     return xt, mel, has_xp

--- a/netket/experimental/operator/_fermion_operator_2nd_numba.py
+++ b/netket/experimental/operator/_fermion_operator_2nd_numba.py
@@ -203,8 +203,6 @@ class FermionOperator2nd(FermionOperator2ndBase):
                     if not op_has_xp:
                         has_xp = False
                         continue
-                if has_xp and _isclose(mel, 0, cutoff):
-                    has_xp = False
                 if has_xp:
                     x_prime[n_c, :] = np.copy(xb)  # should be untouched
                     mels[n_c] += mel
@@ -229,8 +227,6 @@ class FermionOperator2nd(FermionOperator2ndBase):
                     if not op_has_xp:  # detect zeros
                         has_xp = False
                         continue
-                if has_xp and _isclose(mel, 0, cutoff):
-                    has_xp = False
                 if has_xp:
                     x_prime[n_c, :] = np.copy(xt)  # should be different
                     mels[n_c] += mel

--- a/netket/experimental/operator/_fermion_operator_2nd_utils.py
+++ b/netket/experimental/operator/_fermion_operator_2nd_utils.py
@@ -265,6 +265,7 @@ def _canonicalize_input(
     weights: OperatorWeightsList,
     dtype: DType,
     cutoff: float,
+    constant: Number = 0,
 ) -> tuple[OperatorDict, Number, DType]:
     r"""
     The canonical form is a tree tuple with a tuple pair of integers at the
@@ -285,6 +286,12 @@ def _canonicalize_input(
 
     if weights is None:
         weights = [1.0] * len(terms)
+
+    weights = list(weights)
+    # convert a constant to a diagonal operator
+    if not np.isclose(constant, 0.0, atol=cutoff):
+        terms = [()] + list(terms)
+        weights = [constant] + weights
 
     if dtype is None:
         dtype = np.array(weights).dtype

--- a/netket/experimental/operator/_fermion_operator_2nd_utils.py
+++ b/netket/experimental/operator/_fermion_operator_2nd_utils.py
@@ -41,6 +41,9 @@ def _normal_order_term(
     parity = -1
     term = copy.deepcopy(list(term))
     weight = copy.copy(weight)
+
+    if len(term) == 0:  # a constant
+        return [term], [weight]
     ordered_terms = []
     ordered_weights = []
     # the arguments given to this function will be transformed in a normal ordered way
@@ -114,6 +117,8 @@ def _pair_order_term(
     parity = -1
     term = copy.deepcopy(list(term))
     weight = copy.copy(weight)
+    if len(term) == 0:
+        return [term], [weight]
     ordered_terms = []
     ordered_weights = []
     # the arguments given to this function will be transformed in a normal ordered way
@@ -123,7 +128,6 @@ def _pair_order_term(
         for j in range(i, 0, -1):
             right_term = term[j]
             left_term = term[j - 1]
-            # print("consider term:", left_term, right_term)
 
             ## exchange operators if biggest is on the right (need commutataion relations)
             # exchange operators if biggest is on the left (need commutataion relations)
@@ -179,7 +183,7 @@ def _pair_ordering(
 
 
 def _check_hermitian(
-    terms: OperatorTermsList, weights: OperatorWeightsList = 1.0
+    terms: OperatorTermsList, weights: OperatorWeightsList, cutoff: float
 ) -> bool:
     """
     Check whether a set of terms and weights for a hermitian operator
@@ -207,8 +211,8 @@ def _check_hermitian(
     dict_normal = dict(dict_normal)
     dict_hc_normal = dict(dict_hc_normal)
 
-    # compare dict up to a tolerance
-    is_hermitian = _dict_compare(dict_normal, dict_hc_normal)
+    # compare dict up to a tolerance (1e-10)
+    is_hermitian = _dict_compare(dict_normal, dict_hc_normal, cutoff)
 
     return is_hermitian
 
@@ -256,30 +260,11 @@ def _convert_terms_to_spin_blocks(
     return tuple(list(map(_convert_term, terms)))
 
 
-def _collect_constants(
-    terms: OperatorTermsList, weights: OperatorWeightsList
-) -> tuple[OperatorTermsList, OperatorWeightsList, Number]:
-    """
-    Openfermion has the convention to store constants as empty terms
-    Returns new terms and weights list, and the collected constants
-    """
-    new_terms = []
-    new_weights = []
-    constant = 0.0
-    for t, w in zip(terms, weights):
-        if len(t) == 0:
-            constant += w
-        else:
-            new_terms.append(t)
-            new_weights.append(w)
-    return new_terms, new_weights, constant
-
-
 def _canonicalize_input(
     terms: OperatorTermsList,
     weights: OperatorWeightsList,
-    constant: Number,
     dtype: DType,
+    cutoff: float,
 ) -> tuple[OperatorDict, Number, DType]:
     r"""
     The canonical form is a tree tuple with a tuple pair of integers at the
@@ -301,14 +286,9 @@ def _canonicalize_input(
     if weights is None:
         weights = [1.0] * len(terms)
 
-    # promote dtype iwth constant
     if dtype is None:
-        constant_dtype = np.array(constant).dtype
-        weights_dtype = np.array(weights).dtype
-        dtype = np.promote_types(constant_dtype, weights_dtype)
-
+        dtype = np.array(weights).dtype
     weights = np.array(weights, dtype=dtype).tolist()
-    constant = np.array(constant, dtype=dtype).item()
 
     if not len(weights) == len(terms):
         raise ValueError(
@@ -320,13 +300,10 @@ def _canonicalize_input(
     # add the weights of terms that occur multiple times
     operators = zero_defaultdict(dtype)
     for t, w in zip(terms, weights):
-        if len(t) == 0:  # take the constant out
-            constant += w
-        else:
-            operators[t] += w
-    operators = _remove_dict_zeros(dict(operators))
+        operators[t] += w
+    operators = _remove_dict_zeros(dict(operators), cutoff)
 
-    return operators, constant, dtype
+    return operators, dtype
 
 
 def _verify_input(hilbert, operators, raise_error=True) -> bool:
@@ -356,9 +333,9 @@ def _verify_input(hilbert, operators, raise_error=True) -> bool:
     return all(_check_term(term) for term in terms)
 
 
-def _remove_dict_zeros(d: dict) -> dict:
+def _remove_dict_zeros(d: dict, cutoff: float) -> dict:
     """Remove redundant zero values from a dictionary"""
-    return {k: v for k, v in d.items() if not np.isclose(v, 0.0)}
+    return {k: v for k, v in d.items() if np.abs(v) > cutoff}
 
 
 def _parse_term_tree(terms: OperatorTermsList) -> OperatorTermsList:
@@ -394,19 +371,19 @@ def _parse_string(s: str) -> OperatorTerm:
     return tuple(processed_terms)
 
 
-def _dict_compare(d1: dict, d2: dict) -> bool:
+def _dict_compare(d1: dict, d2: dict, cutoff: float) -> bool:
     """
     Compare two dicts and return True if their keys and values
     are all the same (up to some tolerance)
     """
-    d1 = _remove_dict_zeros(d1)
-    d2 = _remove_dict_zeros(d2)
+    d1 = _remove_dict_zeros(d1, cutoff)
+    d2 = _remove_dict_zeros(d2, cutoff)
     d1_keys = set(d1.keys())
     d2_keys = set(d2.keys())
     if d1_keys != d2_keys:
         return False
     # We checked that d1 and d2 have the same keys. Now check the values.
-    return all(np.isclose(d1[o], d2[o]) for o in d1_keys)
+    return all(np.isclose(d1[o], d2[o], atol=cutoff) for o in d1_keys)
 
 
 def _make_tuple_tree(terms: PyTree) -> PyTree:
@@ -446,7 +423,9 @@ def _check_tree_structure(terms: OperatorTermsList) -> OperatorTermsList:
     if not np.all(np.array(depths) == 3):
         raise ValueError(f"terms is not a depth 3 tree, found depths {depths}")
     if not np.all(pairs):
-        raise ValueError("terms should be provided in (i, dag) pairs")
+        raise ValueError(
+            "terms should be provided in (i, dag) pairs or empty for a constant"
+        )
 
 
 def _is_diag_term(term: OperatorTerm) -> bool:
@@ -460,24 +439,13 @@ def _is_diag_term(term: OperatorTerm) -> bool:
             0,
         ]  # first one counts number of daggers, second number of non-daggers
 
+    if len(term) == 0:
+        return True  # constant
+
     ops = defaultdict(_init_empty_arr)
     for orb_idx, dagger in term:
         ops[orb_idx][int(dagger)] += 1
     return all((x[0] == x[1]) for x in ops.values())
-
-
-def _reduce_operators(operators: OperatorDict, dtype: DType) -> OperatorDict:
-    """
-    Reduce the operators by adding equivalent terms together
-    """
-
-    red_ops = zero_defaultdict(dtype)
-    terms = list(operators.keys())
-    weights = list(operators.values())
-    for term, weight in zip(*_normal_ordering(terms, weights)):
-        red_ops[term] += weight
-    red_ops = _remove_dict_zeros(dict(red_ops))
-    return red_ops
 
 
 def zero_defaultdict(dtype: DType) -> defaultdict:

--- a/netket/experimental/operator/fermion.py
+++ b/netket/experimental/operator/fermion.py
@@ -147,7 +147,7 @@ def identity(hilbert: _AbstractHilbert, cutoff: float = 1e-10, dtype: _DType = N
     Returns:
         An instance of {class}`nk.operator.LocalOperator`.
     """
-    return _FermionOperator2nd(hilbert, [""], [1.0], dtype=dtype, cutoff=cutoff)
+    return _FermionOperator2nd(hilbert, constant=1, dtype=dtype, cutoff=cutoff)
 
 
 def zero(hilbert: _AbstractHilbert, cutoff: float = 1e-10, dtype: _DType = None):
@@ -162,4 +162,4 @@ def zero(hilbert: _AbstractHilbert, cutoff: float = 1e-10, dtype: _DType = None)
 
     Returns:
         An instance of {class}`nk.operator.LocalOperator`."""
-    return _FermionOperator2nd(hilbert, [""], [0.0], dtype=dtype, cutoff=cutoff)
+    return _FermionOperator2nd(hilbert, constant=0, dtype=dtype, cutoff=cutoff)

--- a/netket/experimental/operator/fermion.py
+++ b/netket/experimental/operator/fermion.py
@@ -23,6 +23,7 @@ def destroy(
     hilbert: _AbstractHilbert,
     site: int,
     sz: _Optional[int] = None,
+    cutoff: float = 1e-10,
     dtype: _DType = None,
 ):
     """
@@ -50,6 +51,7 @@ def create(
     hilbert: _AbstractHilbert,
     site: int,
     sz: _Optional[int] = None,
+    cutoff: float = 1e-10,
     dtype: _DType = None,
 ):
     """
@@ -77,6 +79,7 @@ def number(
     hilbert: _AbstractHilbert,
     site: int,
     sz: _Optional[int] = None,
+    cutoff: float = 1e-10,
     dtype: _DType = None,
 ):
     """
@@ -133,7 +136,7 @@ def _get_index(hilbert: _AbstractHilbert, site: int, sz: _Optional[int] = None):
         )
 
 
-def identity(hilbert: _AbstractHilbert, dtype: _DType = None):
+def identity(hilbert: _AbstractHilbert, cutoff: float = 1e-10, dtype: _DType = None):
     """
     Builds the :math:`\\mathbb{I}` identity operator.
 
@@ -144,10 +147,10 @@ def identity(hilbert: _AbstractHilbert, dtype: _DType = None):
     Returns:
         An instance of {class}`nk.operator.LocalOperator`.
     """
-    return _FermionOperator2nd(hilbert, [], [], constant=1.0, dtype=dtype)
+    return _FermionOperator2nd(hilbert, [""], [1.0], dtype=dtype, cutoff=cutoff)
 
 
-def zero(hilbert: _AbstractHilbert, dtype: _DType = None):
+def zero(hilbert: _AbstractHilbert, cutoff: float = 1e-10, dtype: _DType = None):
     """
     Builds the :math:`0` operator, which has no connected components.
 
@@ -159,4 +162,4 @@ def zero(hilbert: _AbstractHilbert, dtype: _DType = None):
 
     Returns:
         An instance of {class}`nk.operator.LocalOperator`."""
-    return _FermionOperator2nd(hilbert, [], [], constant=0.0, dtype=dtype)
+    return _FermionOperator2nd(hilbert, [""], [0.0], dtype=dtype, cutoff=cutoff)

--- a/test/operator/test_fermions.py
+++ b/test/operator/test_fermions.py
@@ -852,11 +852,13 @@ def test_fermion_constants():
     # order
     op1 = nkx.operator.FermionOperator2nd(hi, ["1 1^", ""], [2, 3 + 7j])
     op2 = nkx.operator.FermionOperator2nd(hi, ["1 1^"], [2]) + (3 + 7j)
+    op3 = nkx.operator.FermionOperator2nd(hi, ["1 1^"], [2], constant=3 + 7j)
     np.testing.assert_allclose(op1.to_dense(), op2.to_dense())
+    np.testing.assert_allclose(op1.to_dense(), op3.to_dense())
 
     op = op1 + op2
-    op3 = nkx.operator.FermionOperator2nd(hi, ["1 1^"], [4]) + 2 * (3 + 7j)
-    np.testing.assert_allclose(op.to_dense(), op3.to_dense())
+    op4 = nkx.operator.FermionOperator2nd(hi, ["1 1^"], [4]) + 2 * (3 + 7j)
+    np.testing.assert_allclose(op.to_dense(), op4.to_dense())
 
 
 def test_fermion_reduce():

--- a/test/operator/test_fermions.py
+++ b/test/operator/test_fermions.py
@@ -285,12 +285,8 @@ def test_operations_fermions(Op):
     op2 = Op(hi, terms=("3^ 4"), weights=(1.3,), constant=5.7)
     op2copy = op2.copy()
     assert op2copy.hilbert == op2.hilbert
-    _test_close_trees(
-        list(op2._operators.keys()), list(op2copy._operators.keys())
-    )
-    _test_close_trees(
-        list(op2._operators.values()), list(op2copy._operators.values())
-    )
+    _test_close_trees(list(op2._operators.keys()), list(op2copy._operators.keys()))
+    _test_close_trees(list(op2._operators.values()), list(op2copy._operators.values()))
     assert op2.is_hermitian == op2copy.is_hermitian
     np.testing.assert_allclose(op2.to_dense(), op2copy.to_dense())
 

--- a/test/operator/test_fermions.py
+++ b/test/operator/test_fermions.py
@@ -889,36 +889,34 @@ def test_fermion_reduce():
     # order
     op1 = nkx.operator.FermionOperator2nd(
         hi,
-        terms=("0^ 1", "0^ 1", "0^ 1^", "0 1^", "1 1^", ""),
-        weights=(1, 1, 3, 4j, 7j, 1),
+        terms=("0^ 1", "0^ 1", "0^ 1^", "0 1^", "1 1^"),
+        weights=(1, 1, 3, 4j, 7j),
+        constant=1,
     )
     op1_ordered = op1.copy()
     op1_ordered.reduce(order=True)
     op2 = nkx.operator.FermionOperator2nd(
         hi,
-        terms=("0^ 1", "1^ 0^", "1^ 0", "1^ 1", ""),
-        weights=(2, -3, -4j, -7j, 1 + 7j),
+        terms=("0^ 1", "1^ 0^", "1^ 0", "1^ 1"),
+        weights=(2, -3, -4j, -7j),
+        constant=1 + 7j,
     )
     np.testing.assert_allclose(op1_ordered.to_dense(), op1.to_dense())
     np.testing.assert_allclose(op1_ordered.to_dense(), op2.to_dense())
     _dict_compare(op1_ordered.operators, op2.operators, 1e-8)
 
     # no ordering
-    op1 = (
-        nkx.operator.FermionOperator2nd(
-            hi,
-            terms=("0^ 1", "0^ 1", "0^ 1^", "0 1^", "1 1^"),
-            weights=(1, 1, 0, 4j, 7j),
-        )
-        + 1
+    op1 = nkx.operator.FermionOperator2nd(
+        hi,
+        terms=("0^ 1", "0^ 1", "0^ 1^", "0 1^", "1 1^"),
+        weights=(1, 1, 0, 4j, 7j),
+        constant=1,
     )
     op1_operators = op1.operators.copy()
     op1_ordered = op1.copy()
     op1_ordered.reduce(order=False)
     op2 = nkx.operator.FermionOperator2nd(
-        hi,
-        terms=("0^ 1", "0 1^", "1 1^", ""),
-        weights=(2, 4j, 7j, 1),
+        hi, terms=("0^ 1", "0 1^", "1 1^"), weights=(2, 4j, 7j), constant=1
     )
     np.testing.assert_allclose(op1_ordered.to_dense(), op1.to_dense())
     np.testing.assert_allclose(op1_ordered.to_dense(), op2.to_dense())

--- a/test/operator/test_fermions.py
+++ b/test/operator/test_fermions.py
@@ -927,7 +927,8 @@ def test_fermion_reduce():
     hi = nkx.hilbert.SpinOrbitalFermions(3)
     op1 = nkx.operator.FermionOperator2nd(
         hi,
-        terms=("0 0^ 0 0^ 1^ 1 0^ 0 2 2^ 2 2^ 2 2^", ""),
+        terms=("0 0^ 0 0^ 1^ 1 0^ 0 2 2^ 2 2^ 2 2^",),
+        constant=1,
     )
     op1_ordered = op1.to_normal_order()
     op2 = nkx.operator.FermionOperator2nd(hi, terms=[""], weights=[1])
@@ -942,6 +943,7 @@ def test_fermion_reduce():
         op1 = nkx.operator.FermionOperator2nd(
             hi,
             terms=(op_term,),
+            constant=0,
         )
         op1_ordered = op1.to_normal_order()
         np.testing.assert_allclose(op1_ordered.to_dense(), op1.to_dense())

--- a/test/operator/test_fermions.py
+++ b/test/operator/test_fermions.py
@@ -953,39 +953,29 @@ def test_fermion_ordering():
     from netket.experimental.operator._fermion_operator_2nd_utils import _dict_compare
 
     hi = nkx.hilbert.SpinOrbitalFermions(2)
-    op1 = (
-        nkx.operator.FermionOperator2nd(
-            hi,
-            terms=("0^ 1", "0^ 1^", "0 1^", "1 1^"),
-            weights=(2, 3, 4j, 7j),
-        )
-        + 1
+    op1 = nkx.operator.FermionOperator2nd(
+        hi, terms=("0^ 1", "0^ 1^", "0 1^", "1 1^"), weights=(2, 3, 4j, 7j), constant=1
     )
     op1_ordered = op1.to_normal_order()
     op2 = nkx.operator.FermionOperator2nd(
         hi,
         terms=("0^ 1", "1^ 0^", "1^ 0", "1^ 1"),
         weights=(2, -3, -4j, -7j),
-    ) + (1 + 7j)
+        constant=1 + 7j,
+    )
     np.testing.assert_allclose(op1_ordered.to_dense(), op1.to_dense())
     np.testing.assert_allclose(op1_ordered.to_dense(), op2.to_dense())
     _dict_compare(op1_ordered.operators, op2.operators, 1e-8)
 
-    op1 = (
-        nkx.operator.FermionOperator2nd(
-            hi, terms=("0^ 1", "0^ 1^", "0 1^", "1 1^"), weights=(2, 3, 4j, 7j)
-        )
-        + 1
+    op1 = nkx.operator.FermionOperator2nd(
+        hi, terms=("0^ 1", "0^ 1^", "0 1^", "1 1^"), weights=(2, 3, 4j, 7j), constant=1
     )
     op1_ordered = op1.to_pair_order()
-    op2 = (
-        nkx.operator.FermionOperator2nd(
-            hi,
-            terms=("1 0^", "1^ 0^", "1^ 0", "1^ 1"),
-            weights=(-2, -3, -4j, -7j),
-        )
-        + 1
-        + 7j
+    op2 = nkx.operator.FermionOperator2nd(
+        hi,
+        terms=("1 0^", "1^ 0^", "1^ 0", "1^ 1"),
+        weights=(-2, -3, -4j, -7j),
+        constant=1 + 7j,
     )
     np.testing.assert_allclose(op1_ordered.to_dense(), op1.to_dense())
     np.testing.assert_allclose(op1_ordered.to_dense(), op2.to_dense())


### PR DESCRIPTION
This removes the "constant" in the FermionOperator2nd and uses an explicit cutoff everywhere to make things consistent.
@inailuig @imi-hub 