### PR TITLE
Fix passing `diag_scale` through `QGTAuto`

### DIFF
--- a/netket/optimizer/qgt/default.py
+++ b/netket/optimizer/qgt/default.py
@@ -66,7 +66,7 @@ def default_qgt_matrix(variational_state, solver=False, **kwargs):
         return partial(QGTJacobianDense, **kwargs)
 
     # TODO: Remove this once all QGT support diag_scale.
-    has_diag_rescale = kwargs.pop("diag_scale", None) is not None
+    has_diag_rescale = kwargs.get("diag_scale") is not None
 
     # arbitrary heuristic: if the network's parameters has many leaves
     # (an rbm has 3) then JacobianDense might be faster

--- a/netket/sampler/rules/hamiltonian.py
+++ b/netket/sampler/rules/hamiltonian.py
@@ -208,7 +208,7 @@ def HamiltonianRule(operator):
 
     .. math::
 
-       T( \mathbf{s} \rightarrow \mathbf{s}^\prime) = 
+       T( \mathbf{s} \rightarrow \mathbf{s}^\prime) =
         \frac{1}{\mathcal{N}(\mathbf{s})}\theta(|H_{\mathbf{s},\mathbf{s}^\prime}|),
 
     This is a thin wrapper on top of the constructors of :class:`netket.sampler.rules.HamiltonianRuleJax` and

--- a/netket/sampler/rules/hamiltonian_numpy.py
+++ b/netket/sampler/rules/hamiltonian_numpy.py
@@ -38,7 +38,7 @@ class HamiltonianRuleNumpy(MetropolisRule):
 
     .. math::
 
-       T( \mathbf{s} \rightarrow \mathbf{s}^\prime) = 
+       T( \mathbf{s} \rightarrow \mathbf{s}^\prime) =
         \frac{1}{\mathcal{N}(\mathbf{s})}\theta(|H_{\mathbf{s},\mathbf{s}^\prime}|),
 
     """

--- a/test/optimizer/test_sr_api.py
+++ b/test/optimizer/test_sr_api.py
@@ -117,3 +117,24 @@ def test_schedule_err():
 def test_repr():
     sr = nk.optimizer.SR(diag_shift=lambda _: 0.01, diag_scale=lambda _: 0.01)
     assert "SR" in repr(sr)
+
+
+def test_qgt_auto_diag_scale_passed():
+    # See PR/Issue https://github.com/netket/netket/pull/1692
+    # diag_scale was not passed to the concrete type
+
+    # construct a vstate
+    N = 5
+    hi = nk.hilbert.Spin(1 / 2, N)
+    vstate = nk.vqs.MCState(
+        nk.sampler.MetropolisLocal(hi),
+        nk.models.RBM(alpha=1),
+    )
+    vstate.init_parameters()
+    vstate.sample()
+
+    qgt_constructor = nk.optimizer.qgt.QGTAuto(diag_scale=0.2)
+    # NOTE: This assumes that the qgt built is a jacobian
+    # in the future this might change...
+    qgt = qgt_constructor(vstate)
+    assert qgt.scale is not None


### PR DESCRIPTION
It was a typo if I read correctly. If we use `pop`, the argument won't get passed to the actual QGT