### PR TITLE
Substitute `variables` with `parameters` in automatic QGT selector

### DIFF
--- a/netket/optimizer/qgt/default.py
+++ b/netket/optimizer/qgt/default.py
@@ -72,7 +72,7 @@ def default_qgt_matrix(variational_state, solver=False, **kwargs):
     # (an rbm has 3) then JacobianDense might be faster
     # the numbers chosen below are rather arbitrary and should be tuned.
     if (n_param_leaves > 6 and n_params > 800) or has_diag_rescale:
-        if nkjax.tree_ishomogeneous(variational_state.variables):
+        if nkjax.tree_ishomogeneous(variational_state.parameters):
             return partial(QGTJacobianDense, **kwargs)
         else:
             return partial(QGTJacobianPyTree, **kwargs)


### PR DESCRIPTION
In the function `default_qgt_matrix`, which determines the default metric tensor depending on the variational state and the solver, it is used `variables` as argument of `nkjax.tree_ishomogeneous`. I think this should be substituted with `parameters`, since in general `variables` can contain quantities that are not numbers and are not differentiated (for instance an operator U if we want to sample from U|psi> where |psi> is an arbitrary state). 