### PR TITLE
Override `to_local_operator` to return `LocalOperatorJax` instead of `LocalOperator`

### DIFF
--- a/netket/operator/_ising/jax.py
+++ b/netket/operator/_ising/jax.py
@@ -86,18 +86,7 @@ class IsingJax(IsingBase, DiscreteJaxOperator):
 
     def to_local_operator(self):
         # The hamiltonian
-        ha = LocalOperator(self.hilbert, dtype=self.dtype)
-
-        if self.h != 0:
-            for i in range(self.hilbert.size):
-                ha -= self.h * spin.sigmax(self.hilbert, int(i), dtype=self.dtype)
-
-        if self.J != 0:
-            for i, j in self.edges:
-                ha += self.J * (
-                    spin.sigmaz(self.hilbert, int(i), dtype=self.dtype)
-                    * spin.sigmaz(self.hilbert, int(j), dtype=self.dtype)
-                )
+        ha = super().to_local_operator()
 
         return ha.to_jax_operator()
 

--- a/netket/operator/_ising/jax.py
+++ b/netket/operator/_ising/jax.py
@@ -100,7 +100,7 @@ class IsingJax(IsingBase, DiscreteJaxOperator):
                 )
 
         return ha.to_jax_operator()
-    
+
     def tree_flatten(self):
         data = (self.h, self.J, self.edges)
         metadata = {"hilbert": self.hilbert, "dtype": self.dtype}

--- a/test/operator/test_local_operator_jax.py
+++ b/test/operator/test_local_operator_jax.py
@@ -1,0 +1,21 @@
+import jax.numpy as jnp
+
+from netket.operator import LocalOperatorJax
+from netket.operator import IsingJax
+from netket.hilbert import Spin
+from netket.graph import Chain
+
+import pytest
+
+
+def test_casting():
+    hi = Spin(s=0.5, N=8)
+    g = Chain(length=8)
+    H = IsingJax(hi, g, h=1.0)
+
+    a = 42
+    b = jnp.pi
+
+    H = b * (H + a)
+
+    assert isinstance(H, LocalOperatorJax)

--- a/test/operator/test_operator.py
+++ b/test/operator/test_operator.py
@@ -301,7 +301,7 @@ def test_get_conn_padded(op, shape, dtype):
 )
 def test_to_local_operator(op):
     op_l = op.to_local_operator()
-    assert isinstance(op_l, nk.operator.LocalOperator)
+    assert isinstance(op_l, nk.operator._local_operator.LocalOperatorBase)
     np.testing.assert_allclose(op.to_dense(), op_l.to_dense(), atol=1e-13)
 
 


### PR DESCRIPTION
When rescaling and/or shifting `IsingJax` by numbers, the operator is casted to a `LocalOperator`, while it is desirable to keep it as a `LocalOperatorJax` (for instance if you want to sample from H|psi> where H is the rescaled and/or shifted `IsingJax` Hamiltonian and |psi> an arbitrary state, you need H to be `LocalOperatorJax`). In this PR, the function `to_local_operator` inside `IsingJax` is overridden to achieve this. 