### PR TITLE
Formalize operator dtypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 ### Internal changes
 * A new class {class}`netket.utils.struct.Pytree`, can be used to create Pytrees for which inheritance autoamtically works and for which it is possible to define `__init__`. Several structures such as samplers and rules have been transitioned to this new interface instead of old style `@struct.dataclass` [#1653](https://github.com/netket/netket/issues/1653).
 * The {class}`~netket.experimental.operator.FermionOperator2nd` and related classes now store the constant diagonal shift as another term instead of a completely special cased scalar value. The same operators now also respect the `cutoff` keyword argument more strictly [#1686](https://github.com/netket/netket/issues/1686).
+* Dtypes of the matrix elements of operators are now handled more correctly, and fewer warnings are raised when running NetKet in X32 mode. Moreover, operators like Ising now default to floating point dtype even if the coefficients are integers [#1697](https://github.com/netket/netket/issues/1697).
 
 ### Bug Fixes
 * Support multiplication of Discrete Operators by Sparse arrays [#1661](https://github.com/netket/netket/issues/1661).

--- a/netket/experimental/operator/_fermion_operator_2nd_base.py
+++ b/netket/experimental/operator/_fermion_operator_2nd_base.py
@@ -57,7 +57,7 @@ class FermionOperator2ndBase(DiscreteOperator):
         weights: Optional[list[Union[float, complex]]] = None,
         constant: Number = 0,
         cutoff: float = 1e-10,
-        dtype: DType = None,
+        dtype: Optional[DType] = None,
     ):
         r"""
         Constructs a fermion operator given the single terms (set of
@@ -83,6 +83,8 @@ class FermionOperator2ndBase(DiscreteOperator):
             constant: constant contribution, corresponding to the
                 identity operator * constant (default = 0)
             cutoff: threshold for the weights, if the absolute value of a weight is below the cutoff, it's discarded.
+            dtype: The datatype to use for the matrix elements. Defaults to double precision if
+                available.
 
         Returns:
             A FermionOperator2nd object.

--- a/netket/experimental/operator/_fermion_operator_2nd_utils.py
+++ b/netket/experimental/operator/_fermion_operator_2nd_utils.py
@@ -6,8 +6,7 @@ import numpy as np
 from numbers import Number
 import copy
 
-import jax
-
+from netket.jax import canonicalize_dtypes
 from netket.utils.types import DType, PyTree
 
 OperatorTuple = tuple[int, int]
@@ -297,12 +296,7 @@ def _canonicalize_input(
         terms = [()] + list(terms)
         weights = [constant] + weights
 
-    if dtype is None:
-        dtype = np.array(weights).dtype
-        dtype = jax.numpy.promote_types(float, dtype)
-
-    # Fallback to x32 when x64 is disabled in JAX
-    dtype = jax.dtypes.canonicalize_dtype(dtype)
+    dtype = canonicalize_dtypes(float, *weights, constant, dtype=dtype)
 
     weights = np.array(weights, dtype=dtype).tolist()
 

--- a/netket/experimental/operator/_fermion_operator_2nd_utils.py
+++ b/netket/experimental/operator/_fermion_operator_2nd_utils.py
@@ -300,7 +300,7 @@ def _canonicalize_input(
     if dtype is None:
         dtype = np.array(weights).dtype
         dtype = jax.numpy.promote_types(float, dtype)
-        
+
     # Fallback to x32 when x64 is disabled in JAX
     dtype = jax.dtypes.canonicalize_dtype(dtype)
 

--- a/netket/experimental/operator/_fermion_operator_2nd_utils.py
+++ b/netket/experimental/operator/_fermion_operator_2nd_utils.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import re
 from collections import defaultdict
 import numpy as np
@@ -263,7 +265,7 @@ def _convert_terms_to_spin_blocks(
 def _canonicalize_input(
     terms: OperatorTermsList,
     weights: OperatorWeightsList,
-    dtype: DType,
+    dtype: Optional[DType],
     cutoff: float,
     constant: Number = 0,
 ) -> tuple[OperatorDict, Number, DType]:

--- a/netket/experimental/operator/_fermion_operator_2nd_utils.py
+++ b/netket/experimental/operator/_fermion_operator_2nd_utils.py
@@ -6,6 +6,8 @@ import numpy as np
 from numbers import Number
 import copy
 
+import jax
+
 from netket.utils.types import DType, PyTree
 
 OperatorTuple = tuple[int, int]
@@ -297,6 +299,11 @@ def _canonicalize_input(
 
     if dtype is None:
         dtype = np.array(weights).dtype
+        dtype = jax.numpy.promote_types(float, dtype)
+        
+    # Fallback to x32 when x64 is disabled in JAX
+    dtype = jax.dtypes.canonicalize_dtype(dtype)
+
     weights = np.array(weights, dtype=dtype).tolist()
 
     if not len(weights) == len(terms):

--- a/netket/experimental/operator/fermion.py
+++ b/netket/experimental/operator/fermion.py
@@ -24,7 +24,7 @@ def destroy(
     site: int,
     sz: _Optional[int] = None,
     cutoff: float = 1e-10,
-    dtype: _DType = None,
+    dtype: _Optional[_DType] = None,
 ):
     """
     Builds the fermion destruction operator :math:`\\hat{a}` acting
@@ -52,7 +52,7 @@ def create(
     site: int,
     sz: _Optional[int] = None,
     cutoff: float = 1e-10,
-    dtype: _DType = None,
+    dtype: _Optional[_DType] = None,
 ):
     """
     Builds the fermion creation operator :math:`\\hat{a}^\\dagger` acting
@@ -80,7 +80,7 @@ def number(
     site: int,
     sz: _Optional[int] = None,
     cutoff: float = 1e-10,
-    dtype: _DType = None,
+    dtype: _Optional[_DType] = None,
 ):
     """
     Builds the number operator :math:`\\hat{a}^\\dagger\\hat{a}`  acting on the
@@ -136,7 +136,9 @@ def _get_index(hilbert: _AbstractHilbert, site: int, sz: _Optional[int] = None):
         )
 
 
-def identity(hilbert: _AbstractHilbert, cutoff: float = 1e-10, dtype: _DType = None):
+def identity(
+    hilbert: _AbstractHilbert, cutoff: float = 1e-10, dtype: _Optional[_DType] = None
+):
     """
     Builds the :math:`\\mathbb{I}` identity operator.
 
@@ -150,7 +152,9 @@ def identity(hilbert: _AbstractHilbert, cutoff: float = 1e-10, dtype: _DType = N
     return _FermionOperator2nd(hilbert, constant=1, dtype=dtype, cutoff=cutoff)
 
 
-def zero(hilbert: _AbstractHilbert, cutoff: float = 1e-10, dtype: _DType = None):
+def zero(
+    hilbert: _AbstractHilbert, cutoff: float = 1e-10, dtype: _Optional[_DType] = None
+):
     """
     Builds the :math:`0` operator, which has no connected components.
 

--- a/netket/jax/__init__.py
+++ b/netket/jax/__init__.py
@@ -19,6 +19,7 @@ from ._utils_dtype import (
     dtype_complex,
     dtype_real,
     maybe_promote_to_complex,
+    canonicalize_dtypes,
 )
 
 from ._utils_tree import (

--- a/netket/jax/_utils_dtype.py
+++ b/netket/jax/_utils_dtype.py
@@ -90,7 +90,7 @@ def maybe_promote_to_complex(*types):
 def canonicalize_dtypes(*values, dtype=None):
     """
     If `dtype` is None, determine it by promoting `values` in JAX.
-    The returned dtype is always cast to x32 if x64 is disabled.
+    The returned dtype is cast to x32 if x64 is disabled.
     """
     if dtype is None:
         dtype = jnp.result_type(*[_dtype(x) for x in values])

--- a/netket/jax/_utils_dtype.py
+++ b/netket/jax/_utils_dtype.py
@@ -89,8 +89,20 @@ def maybe_promote_to_complex(*types):
 
 def canonicalize_dtypes(*values, dtype=None):
     """
-    If `dtype` is None, determine it by promoting `values` in JAX.
-    The returned dtype is cast to x32 if x64 is disabled.
+    Return the canonicalised result dtype of an operation combining several
+    values, with a possible default dtype.
+
+    Equivalent to
+
+    .. code-block:: python
+
+        if dtype is None:
+            dtype = jnp.result_type(*[_dtype(x) for x in values])
+        return jax.dtypes.canonicalize_dtype(dtype)
+
+    Args:
+        *values: all values to combine. Ignored if dtype is not None
+        dtype: default value overriding values.
     """
     if dtype is None:
         dtype = jnp.result_type(*[_dtype(x) for x in values])

--- a/netket/jax/_utils_dtype.py
+++ b/netket/jax/_utils_dtype.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import numpy as np
 
+import jax
 from jax import numpy as jnp
+
+from netket.utils.numbers import dtype as _dtype
 
 
 def is_complex_dtype(typ):
@@ -83,3 +85,15 @@ def maybe_promote_to_complex(*types):
             return dtype_complex(main_typ)
     else:
         return main_typ
+
+
+def canonicalize_dtypes(*values, dtype=None):
+    """
+    If `dtype` is None, determine it by promoting `values` in JAX.
+    The returned dtype is always cast to x32 if x64 is disabled.
+    """
+    if dtype is None:
+        dtype = jnp.result_type(*[_dtype(x) for x in values])
+    # Fallback to x32 when x64 is disabled in JAX
+    dtype = jax.dtypes.canonicalize_dtype(dtype)
+    return dtype

--- a/netket/operator/_bose_hubbard.py
+++ b/netket/operator/_bose_hubbard.py
@@ -16,14 +16,12 @@ from typing import Optional
 from numba import jit
 
 import numpy as np
-import jax
-import jax.numpy as jnp
 import math
 
 from netket.graph import AbstractGraph, Graph
 from netket.hilbert import Fock
+from netket.jax import canonicalize_dtypes
 from netket.utils.types import DType
-from netket.utils.numbers import dtype as _dtype
 from netket.errors import concrete_or_error, NumbaOperatorGetConnDuringTracingError
 
 from . import boson
@@ -78,13 +76,7 @@ class BoseHubbard(SpecialHamiltonian):
         assert isinstance(hilbert, Fock)
         super().__init__(hilbert)
 
-        if dtype is None:
-            dtype = jnp.promote_types(float, _dtype(U))
-            dtype = jnp.promote_types(dtype, _dtype(V))
-            dtype = jnp.promote_types(dtype, _dtype(J))
-            dtype = jnp.promote_types(dtype, _dtype(mu))
-        # Fallback to x32 when x64 is disabled in JAX
-        dtype = jax.dtypes.canonicalize_dtype(dtype)
+        dtype = canonicalize_dtypes(float, U, V, J, mu, dtype=dtype)
         self._dtype = dtype
 
         self._U = np.asarray(U, dtype=dtype)

--- a/netket/operator/_bose_hubbard.py
+++ b/netket/operator/_bose_hubbard.py
@@ -16,6 +16,7 @@ from typing import Optional
 from numba import jit
 
 import numpy as np
+import jax
 import jax.numpy as jnp
 import math
 
@@ -82,7 +83,8 @@ class BoseHubbard(SpecialHamiltonian):
             dtype = jnp.promote_types(dtype, _dtype(V))
             dtype = jnp.promote_types(dtype, _dtype(J))
             dtype = jnp.promote_types(dtype, _dtype(mu))
-        dtype = np.empty((), dtype=dtype).dtype
+        # Fallback to x32 when x64 is disabled in JAX
+        dtype = jax.dtypes.canonicalize_dtype(dtype)
         self._dtype = dtype
 
         self._U = np.asarray(U, dtype=dtype)

--- a/netket/operator/_bose_hubbard.py
+++ b/netket/operator/_bose_hubbard.py
@@ -78,10 +78,10 @@ class BoseHubbard(SpecialHamiltonian):
         super().__init__(hilbert)
 
         if dtype is None:
-            dtype = jnp.promote_types(_dtype(U), _dtype(V))
+            dtype = jnp.promote_types(float, _dtype(U))
+            dtype = jnp.promote_types(dtype, _dtype(V))
             dtype = jnp.promote_types(dtype, _dtype(J))
             dtype = jnp.promote_types(dtype, _dtype(mu))
-        dtype = jnp.promote_types(float, dtype)
         dtype = np.empty((), dtype=dtype).dtype
         self._dtype = dtype
 

--- a/netket/operator/_continuous_operator.py
+++ b/netket/operator/_continuous_operator.py
@@ -28,16 +28,18 @@ class ContinuousOperator(AbstractOperator):
     `ContinuousOperator` and implement its interface.
     """
 
-    def __init__(self, hilbert: AbstractHilbert, dtype: DType = float):
+    def __init__(self, hilbert: AbstractHilbert, dtype: Optional[DType] = None):
         r"""
         Constructs the continuous operator acting on the given hilbert space and
         with a certain data type.
 
         Args:
             hilbert: The underlying Hilbert space on which the operator is defined
-            dtype: Data type of the matrix elements. Defaults to `np.float64`
+            dtype: Data type of the operator, which is used to infer the dtype of
+                expectation values. Defaults to `float`
         """
-
+        if dtype is None:
+            dtype = float
         self._dtype = dtype
         self._hash = None
         super().__init__(hilbert)

--- a/netket/operator/_continuous_operator.py
+++ b/netket/operator/_continuous_operator.py
@@ -15,6 +15,8 @@ import abc
 from typing import Callable, Optional
 from collections.abc import Hashable
 
+import jax
+
 from netket.utils.types import DType, PyTree, Array
 
 from netket.hilbert import AbstractHilbert
@@ -36,10 +38,11 @@ class ContinuousOperator(AbstractOperator):
         Args:
             hilbert: The underlying Hilbert space on which the operator is defined
             dtype: Data type of the operator, which is used to infer the dtype of
-                expectation values. Defaults to `float`
+                expectation values
         """
         if dtype is None:
-            dtype = float
+            # Fallback to x32 when x64 is disabled in JAX
+            dtype = jax.dtypes.canonicalize_dtype(float)
         self._dtype = dtype
         self._hash = None
         super().__init__(hilbert)

--- a/netket/operator/_continuous_operator.py
+++ b/netket/operator/_continuous_operator.py
@@ -11,12 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import abc
 from typing import Callable, Optional
 from collections.abc import Hashable
 
-import jax
-
+from netket.jax import canonicalize_dtypes
 from netket.utils.types import DType, PyTree, Array
 
 from netket.hilbert import AbstractHilbert
@@ -40,9 +40,7 @@ class ContinuousOperator(AbstractOperator):
             dtype: Data type of the operator, which is used to infer the dtype of
                 expectation values
         """
-        if dtype is None:
-            # Fallback to x32 when x64 is disabled in JAX
-            dtype = jax.dtypes.canonicalize_dtype(float)
+        dtype = canonicalize_dtypes(float, dtype=dtype)
         self._dtype = dtype
         self._hash = None
         super().__init__(hilbert)

--- a/netket/operator/_graph_operator.py
+++ b/netket/operator/_graph_operator.py
@@ -79,7 +79,7 @@ class GraphOperator(LocalOperator):
              specified, the user must give a list of site operators.
          bond_ops_colors: A list of edge colors, specifying the color each
              bond operator acts on. The default is an empty list.
-         dtype: Data type type of the matrix elements.
+         dtype: Data type of the matrix elements.
          acting_on_subspace: Specifies the mapping between nodes of the graph and
             Hilbert space sites, so that graph node :code:`i ∈ [0, ..., graph.n_nodes]`,
             corresponds to :code:`acting_on_subspace[i] ∈ [0, ..., hilbert.n_sites]`.

--- a/netket/operator/_graph_operator.py
+++ b/netket/operator/_graph_operator.py
@@ -53,7 +53,7 @@ class GraphOperator(LocalOperator):
         site_ops=[],
         bond_ops=[],
         bond_ops_colors=[],
-        dtype: DType = None,
+        dtype: Optional[DType] = None,
         *,
         acting_on_subspace: Union[None, list[int], int] = None,
     ):

--- a/netket/operator/_heisenberg.py
+++ b/netket/operator/_heisenberg.py
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Union
+from typing import Optional, Union
 from collections.abc import Sequence
 
 import numpy as np
 
 from netket.graph import AbstractGraph, Graph
 from netket.hilbert import AbstractHilbert
+from netket.utils.types import DType
 
 from ._graph_operator import GraphOperator
 
@@ -34,6 +35,7 @@ class Heisenberg(GraphOperator):
         graph: AbstractGraph,
         J: Union[float, Sequence[float]] = 1.0,
         sign_rule=None,
+        dtype: Optional[DType] = None,
         *,
         acting_on_subspace: Union[None, list[int], int] = None,
     ):
@@ -54,6 +56,7 @@ class Heisenberg(GraphOperator):
                 bipartite, False otherwise.
                 If a sequence of coupling strengths is passed, defaults to False
                 and a matching sequence of sign_rule must be specified to override it
+            dtype: Data type of the matrix elements.
             acting_on_subspace: Specifies the mapping between nodes of the graph and
                 Hilbert space sites, so that graph node :code:`i ∈ [0, ..., graph.n_nodes - 1]`,
                 corresponds to :code:`acting_on_subspace[i] ∈ [0, ..., hilbert.n_sites]`.
@@ -125,6 +128,7 @@ class Heisenberg(GraphOperator):
             graph,
             bond_ops=bond_ops,
             bond_ops_colors=bond_ops_colors,
+            dtype=dtype,
             acting_on_subspace=acting_on_subspace,
         )
 

--- a/netket/operator/_heisenberg.py
+++ b/netket/operator/_heisenberg.py
@@ -34,7 +34,7 @@ class Heisenberg(GraphOperator):
         hilbert: AbstractHilbert,
         graph: AbstractGraph,
         J: Union[float, Sequence[float]] = 1.0,
-        sign_rule: Optional[Union[bool, Sequence[bool]]] = None,
+        sign_rule: Union[None, bool, Sequence[bool]] = None,
         dtype: Optional[DType] = None,
         *,
         acting_on_subspace: Union[None, list[int], int] = None,

--- a/netket/operator/_heisenberg.py
+++ b/netket/operator/_heisenberg.py
@@ -34,7 +34,7 @@ class Heisenberg(GraphOperator):
         hilbert: AbstractHilbert,
         graph: AbstractGraph,
         J: Union[float, Sequence[float]] = 1.0,
-        sign_rule=None,
+        sign_rule: Optional[Union[bool, Sequence[bool]]] = None,
         dtype: Optional[DType] = None,
         *,
         acting_on_subspace: Union[None, list[int], int] = None,

--- a/netket/operator/_ising/base.py
+++ b/netket/operator/_ising/base.py
@@ -67,9 +67,10 @@ class IsingBase(SpecialHamiltonian):
         super().__init__(hilbert)
 
         if dtype is None:
-            dtype = jnp.promote_types(_dtype(h), _dtype(J))
-            # Fallback to float32 when float64 is disabled in JAX
-            dtype = jax.dtypes.canonicalize_dtype(dtype)
+            dtype = jnp.promote_types(float, _dtype(h))
+            dtype = jnp.promote_types(dtype, _dtype(J))
+        # Fallback to x32 when x64 is disabled in JAX
+        dtype = jax.dtypes.canonicalize_dtype(dtype)
 
         if isinstance(graph, AbstractGraph):
             if graph.n_nodes != hilbert.size:

--- a/netket/operator/_ising/base.py
+++ b/netket/operator/_ising/base.py
@@ -42,7 +42,7 @@ class IsingBase(SpecialHamiltonian):
         graph: Union[AbstractGraph, Array],
         h: float,
         J: float,
-        dtype: DType,
+        dtype: Optional[DType],
     ):
         r"""
         Constructs the Ising Operator from an hilbert space and a

--- a/netket/operator/_ising/base.py
+++ b/netket/operator/_ising/base.py
@@ -16,11 +16,11 @@ from typing import Optional, Union
 
 import numpy as np
 
-import jax
 from jax import numpy as jnp
 
 from netket.graph import AbstractGraph
 from netket.hilbert import AbstractHilbert
+from netket.jax import canonicalize_dtypes
 from netket.utils.numbers import dtype as _dtype
 from netket.utils.types import Array, DType
 
@@ -66,11 +66,7 @@ class IsingBase(SpecialHamiltonian):
         """
         super().__init__(hilbert)
 
-        if dtype is None:
-            dtype = jnp.promote_types(float, _dtype(h))
-            dtype = jnp.promote_types(dtype, _dtype(J))
-        # Fallback to x32 when x64 is disabled in JAX
-        dtype = jax.dtypes.canonicalize_dtype(dtype)
+        dtype = canonicalize_dtypes(float, h, J, dtype=dtype)
 
         if isinstance(graph, AbstractGraph):
             if graph.n_nodes != hilbert.size:

--- a/netket/operator/_ising/jax.py
+++ b/netket/operator/_ising/jax.py
@@ -24,9 +24,7 @@ from netket.hilbert import AbstractHilbert
 from netket.utils.numbers import StaticZero
 from netket.utils.types import DType
 
-from .. import spin
 from .._discrete_operator_jax import DiscreteJaxOperator
-from .._local_operator import LocalOperator
 
 from .base import IsingBase
 
@@ -110,13 +108,7 @@ def _ising_mels_jax(x, edges, h, J):
         max_conn_size = 1
     else:
         max_conn_size = x.shape[-1] + 1
-    mels = jnp.zeros(
-        (
-            *batch_dims,
-            max_conn_size,
-        ),
-        dtype=J.dtype,
-    )
+    mels = jnp.zeros((*batch_dims, max_conn_size), dtype=J.dtype)
 
     same_spins = x[..., edges[:, 0]] == x[..., edges[:, 1]]
     mels = mels.at[..., 0].set(J * (2 * same_spins - 1).sum(axis=-1))

--- a/netket/operator/_kinetic.py
+++ b/netket/operator/_kinetic.py
@@ -64,7 +64,7 @@ class KineticEnergy(ContinuousOperator):
         r"""Args:
         hilbert: The underlying Hilbert space on which the operator is defined
         mass: float if all masses are the same, list indicating the mass of each particle otherwise
-        dtype: Data type of the matrix elements. Defaults to `np.float64`
+        dtype: Data type of the mass
         """
 
         self._mass = jnp.asarray(mass, dtype=dtype)

--- a/netket/operator/_local_liouvillian.py
+++ b/netket/operator/_local_liouvillian.py
@@ -12,12 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import functools
 from typing import Optional
 
 import numpy as np
-import jax
-import jax.numpy as jnp
 import numba
 from numba import jit
 from numba.typed import List
@@ -25,6 +22,7 @@ from numba.typed import List
 from scipy.sparse.linalg import LinearOperator
 
 import netket.jax as nkjax
+from netket.jax import canonicalize_dtypes
 from netket.utils.optional_deps import import_optional_dependency
 from netket.utils.types import DType
 
@@ -76,13 +74,7 @@ class LocalLiouvillian(AbstractSuperOperator):
     ):
         super().__init__(ham.hilbert)
 
-        if dtype is None:
-            dtype = jnp.promote_types(complex, ham.dtype)
-            dtype = functools.reduce(
-                lambda dt, op: jnp.promote_types(dt, op.dtype), jump_ops, dtype
-            )
-        # Fallback to x32 when x64 is disabled in JAX
-        dtype = jax.dtypes.canonicalize_dtype(dtype)
+        dtype = canonicalize_dtypes(complex, ham, *jump_ops, dtype=dtype)
 
         if not nkjax.is_complex_dtype(dtype):
             raise TypeError(f"A complex dtype is required (dtype={dtype} specified).")

--- a/netket/operator/_local_liouvillian.py
+++ b/netket/operator/_local_liouvillian.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import functools
-import warnings
+from typing import Optional
 
 import numpy as np
 import jax.numpy as jnp
@@ -25,6 +25,7 @@ from scipy.sparse.linalg import LinearOperator
 
 import netket.jax as nkjax
 from netket.utils.optional_deps import import_optional_dependency
+from netket.utils.types import DType
 
 from ._discrete_operator import DiscreteOperator
 from ._local_operator import LocalOperator
@@ -70,7 +71,7 @@ class LocalLiouvillian(AbstractSuperOperator):
         self,
         ham: DiscreteOperator,
         jump_ops: list[DiscreteOperator] = [],
-        dtype=None,
+        dtype: Optional[DType] = None,
     ):
         super().__init__(ham.hilbert)
 
@@ -79,15 +80,9 @@ class LocalLiouvillian(AbstractSuperOperator):
             dtype = functools.reduce(
                 lambda dt, op: jnp.promote_types(dt, op.dtype), jump_ops, dtype
             )
-        elif not nkjax.is_complex_dtype(dtype):
-            old_dtype = dtype
-            dtype = jnp.promote_types(complex, old_dtype)
-            warnings.warn(
-                np.ComplexWarning(
-                    f"A complex dtype is required (dtype={old_dtype} specified). "
-                    f"Promoting to dtype={dtype}."
-                )
-            )
+
+        if not nkjax.is_complex_dtype(dtype):
+            raise TypeError(f"A complex dtype is required (dtype={dtype} specified).")
 
         dtype = np.empty((), dtype=dtype).dtype
 

--- a/netket/operator/_local_liouvillian.py
+++ b/netket/operator/_local_liouvillian.py
@@ -16,6 +16,7 @@ import functools
 from typing import Optional
 
 import numpy as np
+import jax
 import jax.numpy as jnp
 import numba
 from numba import jit
@@ -80,7 +81,8 @@ class LocalLiouvillian(AbstractSuperOperator):
             dtype = functools.reduce(
                 lambda dt, op: jnp.promote_types(dt, op.dtype), jump_ops, dtype
             )
-        dtype = np.empty((), dtype=dtype).dtype
+        # Fallback to x32 when x64 is disabled in JAX
+        dtype = jax.dtypes.canonicalize_dtype(dtype)
 
         if not nkjax.is_complex_dtype(dtype):
             raise TypeError(f"A complex dtype is required (dtype={dtype} specified).")

--- a/netket/operator/_local_liouvillian.py
+++ b/netket/operator/_local_liouvillian.py
@@ -80,11 +80,10 @@ class LocalLiouvillian(AbstractSuperOperator):
             dtype = functools.reduce(
                 lambda dt, op: jnp.promote_types(dt, op.dtype), jump_ops, dtype
             )
+        dtype = np.empty((), dtype=dtype).dtype
 
         if not nkjax.is_complex_dtype(dtype):
             raise TypeError(f"A complex dtype is required (dtype={dtype} specified).")
-
-        dtype = np.empty((), dtype=dtype).dtype
 
         self._H = ham
         self._jump_ops = [op.copy(dtype=dtype) for op in jump_ops]  # to accept dicts

--- a/netket/operator/_local_operator/base.py
+++ b/netket/operator/_local_operator/base.py
@@ -82,6 +82,8 @@ class LocalOperatorBase(DiscreteOperator):
                 corresponding sites.
            constant: Constant diagonal shift of the operator, equivalent to
                 :math:`+\text{c}\hat{I}`. Default is 0.0.
+           dtype: The datatype to use for the matrix elements. Defaults to double precision if
+                available.
 
         Examples:
            Constructs a ``LocalOperator`` without any operators.

--- a/netket/operator/_local_operator/convert.py
+++ b/netket/operator/_local_operator/convert.py
@@ -194,6 +194,7 @@ def local_operators_to_pauli_strings(hilbert, operators, acting_on, constant, dt
 
     # the calculation above returns complex weights even for operators that are
     # purely real, so we discard their imaginary parts
+    # We compare x.imag with exact float zero
     weights = [x.real if x.imag == 0 else x for x in weights]
 
     res = PauliStrings(hilbert, operators=pauli_strings, weights=weights, dtype=dtype)

--- a/netket/operator/_local_operator/convert.py
+++ b/netket/operator/_local_operator/convert.py
@@ -194,8 +194,7 @@ def local_operators_to_pauli_strings(hilbert, operators, acting_on, constant, dt
 
     # the calculation above returns complex weights even for operators that are
     # purely real, so we discard their imaginary parts
-    # We compare x.imag with exact float zero
-    weights = [x.real if x.imag == 0 else x for x in weights]
+    weights = [x.real if np.isreal(x) else x for x in weights]
 
     res = PauliStrings(hilbert, operators=pauli_strings, weights=weights, dtype=dtype)
     return res

--- a/netket/operator/_local_operator/convert.py
+++ b/netket/operator/_local_operator/convert.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import warnings
 
 import jax
 import jax.numpy as jnp
@@ -20,7 +19,6 @@ import numpy as np
 import itertools
 from scipy.sparse import issparse
 
-from netket.jax import is_complex_dtype
 from netket.operator import PauliStrings
 
 # Pauli Matrices: shape (2, 2)
@@ -194,17 +192,9 @@ def local_operators_to_pauli_strings(hilbert, operators, acting_on, constant, dt
         pauli_strings.append("I" * hilbert.size)
         weights.append(constant)
 
-    # the calculation above returns complex coefficients even for operators that are
-    # purely real. So we suppress complexwarnings in that case
+    # the calculation above returns complex weights even for operators that are
+    # purely real, so we discard their imaginary parts
+    weights = [x.real if x.imag == 0 else x for x in weights]
 
-    if not is_complex_dtype(dtype):
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=np.ComplexWarning)
-            res = PauliStrings(
-                hilbert, operators=pauli_strings, weights=weights, dtype=dtype
-            )
-    else:
-        res = PauliStrings(
-            hilbert, operators=pauli_strings, weights=weights, dtype=dtype
-        )
+    res = PauliStrings(hilbert, operators=pauli_strings, weights=weights, dtype=dtype)
     return res

--- a/netket/operator/_local_operator/helpers.py
+++ b/netket/operator/_local_operator/helpers.py
@@ -18,6 +18,7 @@ import numbers
 
 import numpy as np
 import jax
+import jax.numpy as jnp
 
 from scipy import sparse
 from scipy.sparse import spmatrix
@@ -120,9 +121,9 @@ def canonicalize_input(
 
     # If we asked for a specific dtype, enforce it.
     if dtype is None:
-        dtype = np.promote_types(float, _dtype(constant))
+        dtype = jnp.promote_types(float, _dtype(constant))
         dtype = functools.reduce(
-            lambda dt, op: np.promote_types(dt, op.dtype), operators, dtype
+            lambda dt, op: jnp.promote_types(dt, op.dtype), operators, dtype
         )
     # Fallback to float32 when float64 is disabled in JAX
     dtype = jax.dtypes.canonicalize_dtype(dtype)

--- a/netket/operator/_local_operator/helpers.py
+++ b/netket/operator/_local_operator/helpers.py
@@ -125,7 +125,7 @@ def canonicalize_input(
         dtype = functools.reduce(
             lambda dt, op: jnp.promote_types(dt, op.dtype), operators, dtype
         )
-    # Fallback to float32 when float64 is disabled in JAX
+    # Fallback to x32 when x64 is disabled in JAX
     dtype = jax.dtypes.canonicalize_dtype(dtype)
 
     canonicalized_operators = []

--- a/netket/operator/_local_operator/helpers.py
+++ b/netket/operator/_local_operator/helpers.py
@@ -12,20 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-import functools
 import numbers
 
 import numpy as np
-import jax
-import jax.numpy as jnp
 
 from scipy import sparse
 from scipy.sparse import spmatrix
 
 from netket.hilbert import AbstractHilbert, Fock
+from netket.jax import canonicalize_dtypes
 from netket.utils.types import DType, Array
-from netket.utils.numbers import dtype as _dtype
 
 
 def cast_operator_matrix_dtype(matrix: Array, dtype: DType):
@@ -119,14 +115,7 @@ def canonicalize_input(
     # operators = [np.asarray(operator) for operator in operators]
     operators = [_standardize_matrix_input_type(op) for op in operators]
 
-    # If we asked for a specific dtype, enforce it.
-    if dtype is None:
-        dtype = jnp.promote_types(float, _dtype(constant))
-        dtype = functools.reduce(
-            lambda dt, op: jnp.promote_types(dt, op.dtype), operators, dtype
-        )
-    # Fallback to x32 when x64 is disabled in JAX
-    dtype = jax.dtypes.canonicalize_dtype(dtype)
+    dtype = canonicalize_dtypes(float, *operators, constant, dtype=dtype)
 
     canonicalized_operators = []
     canonicalized_acting_on = []

--- a/netket/operator/_local_operator/helpers.py
+++ b/netket/operator/_local_operator/helpers.py
@@ -120,7 +120,7 @@ def canonicalize_input(
 
     # If we asked for a specific dtype, enforce it.
     if dtype is None:
-        dtype = np.promote_types(np.float32, _dtype(constant))
+        dtype = np.promote_types(float, _dtype(constant))
         dtype = functools.reduce(
             lambda dt, op: np.promote_types(dt, op.dtype), operators, dtype
         )

--- a/netket/operator/_pauli_strings/base.py
+++ b/netket/operator/_pauli_strings/base.py
@@ -100,8 +100,9 @@ def canonicalize_input(hilbert: AbstractHilbert, operators, weights, *, dtype=No
         )
 
     weights = _standardize_matrix_input_type(weights)
-
     operators = np.asarray(operators, dtype=str)
+
+    operators, weights = _reduce_pauli_string(operators, weights)
 
     # When there is an odd number of 'Y' in any string, the whole operator must be complex
     op_is_complex = any(s.count("Y") % 2 == 1 for s in operators)

--- a/netket/operator/_pauli_strings/base.py
+++ b/netket/operator/_pauli_strings/base.py
@@ -584,7 +584,7 @@ def _matmul(op_arr1, w_arr1, op_arr2, w_arr2, *, dtype):
         weights.append(w)
     # so here we recast to the desired dtype
     operators, weights = np.array(operators), np.array(weights)
-    # explicit real part ot avoid warning
+    # explicit real part to avoid warning
     if not nkjax.is_complex_dtype(dtype):
         weights = weights.real
     weights = weights.astype(dtype)

--- a/netket/operator/_pauli_strings/base.py
+++ b/netket/operator/_pauli_strings/base.py
@@ -317,7 +317,7 @@ class PauliStringsBase(DiscreteOperator):
         if not isinstance(other, PauliStringsBase):
             return NotImplemented
         op = self.copy(
-            dtype=np.promote_types(self.dtype, _dtype(other)),
+            dtype=jnp.promote_types(self.dtype, _dtype(other)),
             cutoff=max(self._cutoff, other._cutoff),
         )
         return op._op_imatmul_(other)

--- a/netket/operator/_pauli_strings/base.py
+++ b/netket/operator/_pauli_strings/base.py
@@ -18,13 +18,13 @@ from collections.abc import Iterable
 from netket.utils.types import DType, Array
 
 import numpy as np
-import jax
 import jax.numpy as jnp
 from numba import jit
 from itertools import product
 from numbers import Number
 
 from netket import jax as nkjax
+from netket.jax import canonicalize_dtypes
 from netket.hilbert import Qubit, AbstractHilbert
 from netket.utils.numbers import dtype as _dtype, is_scalar
 
@@ -108,11 +108,9 @@ def canonicalize_input(hilbert: AbstractHilbert, operators, weights, *, dtype=No
     # When there is an odd number of 'Y' in any string, the whole operator must be complex
     op_is_complex = any(s.count("Y") % 2 == 1 for s in operators)
 
-    # If we asked for a specific dtype, enforce it.
-    if dtype is None:
-        dtype = jnp.promote_types(complex if op_is_complex else float, _dtype(weights))
-    # Fallback to x32 when x64 is disabled in JAX
-    dtype = jax.dtypes.canonicalize_dtype(dtype)
+    dtype = canonicalize_dtypes(
+        complex if op_is_complex else float, weights, dtype=dtype
+    )
 
     if not nkjax.is_complex_dtype(dtype):
         if op_is_complex:

--- a/netket/operator/_pauli_strings/base.py
+++ b/netket/operator/_pauli_strings/base.py
@@ -18,6 +18,7 @@ from collections.abc import Iterable
 from netket.utils.types import DType, Array
 
 import numpy as np
+import jax
 import jax.numpy as jnp
 from numba import jit
 from itertools import product
@@ -110,8 +111,8 @@ def canonicalize_input(hilbert: AbstractHilbert, operators, weights, *, dtype=No
     # If we asked for a specific dtype, enforce it.
     if dtype is None:
         dtype = jnp.promote_types(complex if op_is_complex else float, _dtype(weights))
-    # Fallback to float32 when float64 is disabled in JAX
-    dtype = jnp.empty((), dtype=dtype).dtype
+    # Fallback to x32 when x64 is disabled in JAX
+    dtype = jax.dtypes.canonicalize_dtype(dtype)
 
     if not nkjax.is_complex_dtype(dtype):
         if op_is_complex:

--- a/netket/operator/_pauli_strings/base.py
+++ b/netket/operator/_pauli_strings/base.py
@@ -148,6 +148,8 @@ class PauliStringsBase(DiscreteOperator):
            operators (list(string)): A list of Pauli operators in string format, e.g. ['IXX', 'XZI'].
            weights: A list of amplitudes of the corresponding Pauli operator.
            cutoff (float): a cutoff to remove small matrix elements
+           dtype: The datatype to use for the matrix elements. Defaults to double precision if
+                available.
 
         Examples:
            Constructs a new ``PauliStrings`` operator X_0*X_1 + 3.*Z_0*Z_1 with both construction schemes.

--- a/netket/operator/_pauli_strings/jax.py
+++ b/netket/operator/_pauli_strings/jax.py
@@ -110,6 +110,11 @@ def pack_internals(operators, weights, cutoff=0):
         # sort b_z_check in ascending order, for better locality
         b_z_check = list(sorted(b_z_check))
 
+        # If there is an even number of Y in a string, the weight should be real
+        # We compare b_weight.imag with exact float zero
+        if b_weight.imag == 0:
+            b_weight = b_weight.real
+
         append(b_to_change, (b_weight, b_z_check))
     return acting
 

--- a/netket/operator/_pauli_strings/jax.py
+++ b/netket/operator/_pauli_strings/jax.py
@@ -151,20 +151,6 @@ def pack_internals_jax(
 
     Returns a dictionary with all the data fields
     """
-
-    # Check if there are Y operators in the strings, and in that
-    # case uppromote float to complex
-    # Should never happen because we check in init...
-    if not jnp.issubdtype(weight_dtype, jnp.complexfloating):
-        # this checks if there is an Y in one of the strings
-        if np.any(np.char.find(operators, "Y") != -1):
-            # weight_dtype = jnp.promote_types(jnp.complex64, weight_dtype)
-            raise TypeError(
-                "Found PauliStringsJax with real dtype but with Y paulis.\n"
-                "This should not be happening.\n"
-                "Please open an issue on the netket repository.\n"
-            )
-
     # index_dtype needs to be signed (we use -1 for padding)
 
     _check_mode(mode)

--- a/netket/operator/_pauli_strings/jax.py
+++ b/netket/operator/_pauli_strings/jax.py
@@ -111,8 +111,7 @@ def pack_internals(operators, weights, cutoff=0):
         b_z_check = list(sorted(b_z_check))
 
         # If there is an even number of Y in a string, the weight should be real
-        # We compare b_weight.imag with exact float zero
-        if b_weight.imag == 0:
+        if np.isreal(b_weight):
             b_weight = b_weight.real
 
         append(b_to_change, (b_weight, b_z_check))

--- a/netket/operator/_pauli_strings/jax.py
+++ b/netket/operator/_pauli_strings/jax.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from functools import partial, wraps
-from typing import Union, TYPE_CHECKING
+from typing import Optional, Union, TYPE_CHECKING
 
 import numpy as np
 
@@ -292,7 +292,7 @@ class PauliStringsJax(PauliStringsBase, DiscreteJaxOperator):
         weights: Union[None, float, complex, list[Union[float, complex]]] = None,
         *,
         cutoff: float = 0.0,
-        dtype: DType = None,
+        dtype: Optional[DType] = None,
         _mode: str = "index",
     ):
         super().__init__(hilbert, operators, weights, cutoff=cutoff, dtype=dtype)

--- a/netket/operator/_pauli_strings/numba.py
+++ b/netket/operator/_pauli_strings/numba.py
@@ -18,7 +18,6 @@ from functools import wraps
 import numpy as np
 from numba import jit
 
-import jax.numpy as jnp
 
 from netket.hilbert import AbstractHilbert, HomogeneousHilbert
 from netket.errors import concrete_or_error, NumbaOperatorGetConnDuringTracingError
@@ -51,13 +50,6 @@ def pack_internals_numba(
     _n_op_max = max(
         list(map(lambda x: len(x), list(acting.values()))), default=n_operators
     )
-
-    # Check if there are Y operators in the strings, and in that
-    # case uppromote float to complex
-    if not jnp.issubdtype(dtype, jnp.complexfloating):
-        # this checks if there is an Y in one of the strings
-        if np.any(np.char.find(operators, "Y") != -1):
-            dtype = jnp.promote_types(jnp.complex64, dtype)
 
     # unpacking the dictionary into fixed-size arrays
 

--- a/netket/operator/_pauli_strings/numba.py
+++ b/netket/operator/_pauli_strings/numba.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Union, TYPE_CHECKING
+from typing import Optional, Union, TYPE_CHECKING
 from functools import wraps
 
 import numpy as np
@@ -101,7 +101,7 @@ class PauliStrings(PauliStringsBase):
         weights: Union[None, float, complex, list[Union[float, complex]]] = None,
         *,
         cutoff: float = 1.0e-10,
-        dtype: DType = None,
+        dtype: Optional[DType] = None,
     ):
         super().__init__(hilbert, operators, weights, cutoff=cutoff, dtype=dtype)
 

--- a/netket/operator/_potential.py
+++ b/netket/operator/_potential.py
@@ -50,14 +50,14 @@ class PotentialEnergy(ContinuousOperator):
         hilbert: AbstractHilbert,
         afun: Callable,
         coefficient: float = 1.0,
-        dtype: Optional[DType] = float,
+        dtype: Optional[DType] = None,
     ):
         r"""
         Args:
             hilbert: The underlying Hilbert space on which the operator is defined
             afun: The potential energy as function of x
-            coefficients: A coefficient for the ContinuousOperator object
-            dtype: Data type of the matrix elements. Defaults to `np.float64`
+            coefficient: A coefficient for the ContinuousOperator object
+            dtype: Data type of the coefficient
         """
 
         self._afun = afun
@@ -65,7 +65,7 @@ class PotentialEnergy(ContinuousOperator):
 
         self.__attrs = None
 
-        super().__init__(hilbert, self.coefficient.dtype)
+        super().__init__(hilbert, self._coefficient.dtype)
 
     @property
     def coefficient(self) -> Array:

--- a/netket/operator/_sumoperators.py
+++ b/netket/operator/_sumoperators.py
@@ -18,10 +18,10 @@ from collections.abc import Hashable, Iterable
 from netket.utils.numbers import is_scalar
 from netket.utils.types import DType, PyTree, Array
 
+from netket.jax import canonicalize_dtypes
 from netket.operator import ContinuousOperator
 from netket.utils import struct, HashableArray
 
-import jax
 import jax.numpy as jnp
 
 
@@ -90,12 +90,7 @@ class SumOperator(ContinuousOperator):
 
         operators, coefficients = _flatten_sumoperators(operators, coefficients)
 
-        if dtype is None:
-            dtype = jnp.result_type(
-                float, *[op.dtype for op in operators], *coefficients
-            )
-        # Fallback to x32 when x64 is disabled in JAX
-        dtype = jax.dtypes.canonicalize_dtype(dtype)
+        dtype = canonicalize_dtypes(float, *operators, *coefficients, dtype=dtype)
 
         self._operators = tuple(operators)
         self._coefficients = jnp.asarray(coefficients, dtype=dtype)

--- a/netket/utils/numbers.py
+++ b/netket/utils/numbers.py
@@ -37,6 +37,13 @@ def dtype(x: None):  # noqa: F811, E0102
 
 
 @dispatch
+def dtype(x: type):  # noqa: F811, E0102
+    if issubclass(x, Number):
+        return x
+    raise TypeError(f"type {x} is not a numeric type")
+
+
+@dispatch
 def dtype(x: Any):  # noqa: F811, E0102
     if hasattr(x, "dtype"):
         return x.dtype

--- a/test/operator/test_continuous_operator.py
+++ b/test/operator/test_continuous_operator.py
@@ -100,22 +100,19 @@ def test_potential_energy():
 
 
 def test_kinetic_energy():
-    for dtype in (jnp.float32, jnp.float64):
-        x = jnp.array([[1, 2, 3], [1, 2, 3]], dtype=dtype)
-        energy1 = kin1._expect_kernel(model2, 0.0, x, kin1._pack_arguments())
-        assert energy1.dtype == dtype
-        # dtype changes here
-        energy2 = kin1._expect_kernel(model3, 1.0 + 1.0j, x, kin1._pack_arguments())
-        kinen1 = kinexact(x) / kin1.mass
-        kinen2 = kinexact2(1.0 + 1.0j, x) / kin1.mass
-        np.testing.assert_allclose(energy1, kinen1)
-        np.testing.assert_allclose(energy2, kinen2)
-        np.testing.assert_allclose(kin1.mass * kin1._pack_arguments(), 1.0)
-        np.testing.assert_equal("KineticEnergy(m=20.0)", repr(kin1))
+    x = jnp.array([[1.0, 2.0, 3.0], [1.0, 2.0, 3.0]])
+    energy1 = kin1._expect_kernel(model2, 0.0, x, kin1._pack_arguments())
+    energy2 = kin1._expect_kernel(model3, 1.0 + 1.0j, x, kin1._pack_arguments())
+    kinen1 = kinexact(x) / kin1.mass
+    kinen2 = kinexact2(1.0 + 1.0j, x) / kin1.mass
+    np.testing.assert_allclose(energy1, kinen1)
+    np.testing.assert_allclose(energy2, kinen2)
+    np.testing.assert_allclose(kin1.mass * kin1._pack_arguments(), 1.0)
+    np.testing.assert_equal("KineticEnergy(m=20.0)", repr(kin1))
 
 
 def test_sumoperator():
-    x = jnp.array([[1, 2, 3], [1, 2, 3]], dtype=float)
+    x = jnp.array([[1.0, 2.0, 3.0], [1.0, 2.0, 3.0]])
     potenergy = pottot._expect_kernel(model2, 0.0, x, pottot._pack_arguments())
     energy10p52 = pot10p52._expect_kernel(model2, 0.0, x, pot10p52._pack_arguments())
 
@@ -137,10 +134,21 @@ def test_sumoperator():
     np.testing.assert_allclose(enertot2, enerexact)
 
     with pytest.raises(AssertionError):
-        netket.operator.SumOperator(
-            etot,
-            etot2,
-            coefficients=[
-                1.0,
-            ],
-        )
+        netket.operator.SumOperator(etot, etot2, coefficients=[1.0])
+
+
+@pytest.mark.parametrize(
+    "dtype", [jnp.float32, jnp.float64, jnp.complex64, jnp.complex128]
+)
+def test_dtype(dtype):
+    pot = netket.operator.PotentialEnergy(hilb, v1, coefficient=1.0, dtype=dtype)
+    assert pot.dtype == dtype
+    assert pot.coefficient.dtype == dtype
+
+    kin = netket.operator.KineticEnergy(hilb, mass=1.0, dtype=dtype)
+    assert kin.dtype == dtype
+    assert kin.mass.dtype == dtype
+
+    etot = pot + kin
+    assert etot.dtype == dtype
+    assert etot.coefficients.dtype == dtype

--- a/test/operator/test_hamiltonian.py
+++ b/test/operator/test_hamiltonian.py
@@ -121,6 +121,21 @@ def _colored_graph(graph):
             ),
             id="pauli",
         ),
+        pytest.param(
+            (
+                lambda hi, g: nk.operator.PauliStrings(
+                    hi,
+                    [s + "I" * (g.n_nodes - len(s)) for s in ["XXI", "YZY", "IZX"]],
+                    [0.1, 0.2, -1.4],
+                ),
+                lambda hi, g: nk.operator.PauliStringsJax(
+                    hi,
+                    [s + "I" * (g.n_nodes - len(s)) for s in ["XXI", "YZY", "IZX"]],
+                    [0.1, 0.2, -1.4],
+                ),
+            ),
+            id="pauli_real",
+        ),
     ],
 )
 @pytest.mark.parametrize(

--- a/test/operator/test_liouvillian.py
+++ b/test/operator/test_liouvillian.py
@@ -127,10 +127,9 @@ dtypes = dtypes_r + dtypes_c
 @pytest.mark.parametrize("dtype", dtypes)
 def test_dtype(dtype):
     if not nk.jax.is_complex_dtype(dtype):
-        with pytest.warns(np.ComplexWarning):
+        with pytest.raises(TypeError):
             lind = nk.operator.LocalLiouvillian(ha, j_ops, dtype=dtype)
-            dtype_c = nk.jax.dtype_complex(dtype)
-
+        return
     else:
         lind = nk.operator.LocalLiouvillian(ha, j_ops, dtype=dtype)
         dtype_c = dtype

--- a/test/operator/test_local_operator_jax.py
+++ b/test/operator/test_local_operator_jax.py
@@ -5,8 +5,6 @@ from netket.operator import IsingJax
 from netket.hilbert import Spin
 from netket.graph import Chain
 
-import pytest
-
 
 def test_casting():
     hi = Spin(s=0.5, N=8)

--- a/test/operator/test_operator.py
+++ b/test/operator/test_operator.py
@@ -96,16 +96,17 @@ for name, LocalOp_impl in [
     operators[f"Custom Hamiltonian Prod ({name})"] = sx_hat * 1.5 + (2.0 * sy_hat)
 
 operators["Pauli Hamiltonian (XX)"] = nk.operator.PauliStrings(["XX"], [0.1])
+operators["Pauli Hamiltonian (YY)"] = nk.operator.PauliStrings(["YY"], [0.1])
 operators["Pauli Hamiltonian (XX+YZ+IZ)"] = nk.operator.PauliStrings(
     ["XX", "YZ", "IZ"], [0.1, 0.2, -1.4]
 )
 operators["Pauli Hamiltonian Jax (_mode=index)"] = nk.operator.PauliStringsJax(
     ["XX", "YZ", "IZ"], [0.1, 0.2, -1.4], _mode="index"
 )
-
 operators["Pauli Hamiltonian Jax (_mode=mask)"] = nk.operator.PauliStringsJax(
     ["XX", "YZ", "IZ"], [0.1, 0.2, -1.4], _mode="mask"
 )
+
 hi = nkx.hilbert.SpinOrbitalFermions(5)
 operators["FermionOperator2nd"] = nkx.operator.FermionOperator2nd(
     hi,

--- a/test/operator/test_operator.py
+++ b/test/operator/test_operator.py
@@ -100,6 +100,7 @@ operators["Pauli Hamiltonian (YY)"] = nk.operator.PauliStrings(["YY"], [0.1])
 operators["Pauli Hamiltonian (XX+YZ+IZ)"] = nk.operator.PauliStrings(
     ["XX", "YZ", "IZ"], [0.1, 0.2, -1.4]
 )
+operators["Pauli Hamiltonian Jax (YY)"] = nk.operator.PauliStringsJax(["YY"], [0.1])
 operators["Pauli Hamiltonian Jax (_mode=index)"] = nk.operator.PauliStringsJax(
     ["XX", "YZ", "IZ"], [0.1, 0.2, -1.4], _mode="index"
 )

--- a/test/operator/test_operator.py
+++ b/test/operator/test_operator.py
@@ -307,6 +307,15 @@ def test_to_local_operator(op):
     np.testing.assert_allclose(op.to_dense(), op_l.to_dense(), atol=1e-13)
 
 
+def test_enforce_float_Ising():
+    g = nk.graph.Hypercube(5, 1)
+    hi = nk.hilbert.Spin(s=1 / 2, N=g.n_nodes)
+    op = nk.operator.Ising(hilbert=hi, graph=g, J=1, h=1)
+    assert np.issubdtype(op.dtype, np.floating)
+    op = nk.operator.IsingJax(hilbert=hi, graph=g, J=1, h=1)
+    assert np.issubdtype(op.dtype, np.floating)
+
+
 def test_enforce_float_BoseHubbard():
     g = nk.graph.Hypercube(5, 1)
     hi = nk.hilbert.Fock(N=g.n_nodes, n_particles=3)

--- a/test/operator/test_pauli.py
+++ b/test/operator/test_pauli.py
@@ -15,6 +15,7 @@
 import pytest
 
 import numpy as np
+import jax
 import jax.numpy as jnp
 
 import netket as nk
@@ -310,22 +311,45 @@ def test_pauli_problem():
     x1 = nk.operator.PauliStringsJax("XII")
     x2 = nk.operator.PauliStringsJax("IXI")
     x3 = x1 @ x2
-    assert x1.weights.dtype == jnp.float32
-    assert x2.weights.dtype == jnp.float32
-    assert x3.weights.dtype == jnp.float32
+    dtype = jax.dtypes.canonicalize_dtype(float)
+    assert x1.weights.dtype == dtype
+    assert x2.weights.dtype == dtype
+    assert x3.weights.dtype == dtype
 
-    assert (x1 + x1 @ x2).weights.dtype == jnp.float32
+    assert (x1 + x1 @ x2).weights.dtype == dtype
 
 
-def test_pauliY_promotion_to_complex():
+def test_pauliY_dtype():
     ham = nk.operator.PauliStrings("XXX", dtype=np.float32)
     assert ham.dtype == np.float32
-    ham = nk.operator.PauliStrings("XXY", dtype=np.float32)
-    assert ham.dtype == np.complex64
-    ham = nk.operator.PauliStrings(["XXX", "XXY"], dtype=np.float32)
+    ham = nk.operator.PauliStrings("XYY", dtype=np.float32)
+    assert ham.dtype == np.float32
+    ham = nk.operator.PauliStrings(["XXX", "XYY"], dtype=np.float32)
+    assert ham.dtype == np.float32
+
+    ham = nk.operator.PauliStrings("XXY", dtype=np.complex64)
     assert ham.dtype == np.complex64
     ham = nk.operator.PauliStrings(["XXX", "XXY"], dtype=np.complex64)
     assert ham.dtype == np.complex64
+
+    ham = nk.operator.PauliStrings("XXX", [1j], dtype=np.complex64)
+    assert ham.dtype == np.complex64
+    ham = nk.operator.PauliStrings("XYY", [1j], dtype=np.complex64)
+    assert ham.dtype == np.complex64
+    ham = nk.operator.PauliStrings(["XXX", "XYY"], [1, 1j], dtype=np.complex64)
+    assert ham.dtype == np.complex64
+
+    with pytest.raises(TypeError):
+        ham = nk.operator.PauliStrings("XXY", dtype=np.float32)
+    with pytest.raises(TypeError):
+        ham = nk.operator.PauliStrings(["XXX", "XXY"], dtype=np.float32)
+
+    with pytest.raises(TypeError):
+        ham = nk.operator.PauliStrings("XXX", [1j], dtype=np.float32)
+    with pytest.raises(TypeError):
+        ham = nk.operator.PauliStrings("XYY", [1j], dtype=np.float32)
+    with pytest.raises(TypeError):
+        ham = nk.operator.PauliStrings(["XXX", "XYY"], [1, 1j], dtype=np.float32)
 
 
 def test_pauli_empty_constructor_error():


### PR DESCRIPTION
The discussion started in #1543 , and now I finally have some time to thoroughly check it.

I think the most important intuition is that, if `dtype` is specified in `__init__`, the property `operator.dtype` should return the same value. (Except when the specified dtype is 64-bit, and `NETKET_ENABLE_X64` is disabled, it will become 32-bit.) This behavior is consistent with `jnp.array`.

If not specified in `__init__`, it will be inferred from all other arguments, and whether the operator is required to be complex, using JAX's promotion rules. If no other argument can be used to infer it, it defaults to float64 if `NETKET_ENABLE_X64` is enabled, and float32 otherwise.

If the inferred dtype is different from the specified one, `__init__` may cast it to the specified dtype, or raise a `TypeError` if it's unphysical or hard to implement.
* If the inferred dtype is lower than the specified one, we silently upcast it as in numpy.
* If the inferred dtype is higher than the specified one, and both are real or both are complex, we silently truncate it as in numpy. (I guess people don't like to see a lot of warnings when they already decide to specify 32-bit...)
* If the inferred dtype is float64 but the specified one is complex64, we also silently truncate it as in numpy.
* If the inferred dtype is complex but the specified one is real, we may give a warning and discard the imaginary part, which may be already done by numpy. Or we may raise the error.

If the dtype is not specified and it's inferred to be int, we promote it to float, as suggested previously by [this test](https://github.com/netket/netket/blob/dce4e23ee839386279bc8a91f5e2606117d1ffab/test/operator/test_operator.py#L308). (I think it's intuitive for physicists who are too lazy to type .0, rather than dtype lawers)

It's also possible to specify an int dtype and it just works in many cases. In future we can make it work with `PauliStrings`, and raise an error for uint and other dtypes, if someone really needs that.

Note that when doing in-place arithmetic, some operators actually modify the underlying arrays, so their dtypes never change, and they raise a `TypeError` if casting complex to real. Other operators just call the out-of-place methods, so their dtypes may change. This PR only cleans up `__init__` and does not touch those methods.

## Discrete operators

Their `dtype` is the dtype of matrix elements, and we already explicitly ensured that in most cases. The dtype of expectation values will be inferred from both the matrix elements and the wave function.

For `Ising` and `IsingJax`, previously the dtype was inferred to be int if `J` and `h` are ints, now it's promoted to float.

For `Heisenberg`, previously there was no argument `dtype` in `__init__`, now we've added it and it's handled by `LocalOperator`.

For `BoseHubbard`, previously we didn't cast it to x32 when x64 is disabled, now we cast it. Although this operator doesn't have a JAX version yet, we still do the cast to make things more consistent.

For `LocalLiouvillian`, we also cast it to x32 when x64 is disabled. Previously we cast the specified real dtype to complex, now we raise a `TypeError` because it's unphysical.

### Pauli strings

Now we infer that the dtype is complex if any string has an odd number of Y (previously if it has any Y), or if any weight is complex. Previously we cast the specified real dtype to complex when needed, now we raise a `TypeError` because it's unphysical.

I've added a `_reduce_pauli_string` in `__init__`. After that, those strings with Y cannot cancel out.

It's still possible that a term has an odd number of Y and a purely imaginary weight, so that the whole Hamiltonian is real and non-Hermitian, and we have to work with a complex array of `weights`. We don't specially handle that for now.

Also, there is a (maybe subtle) change: When `dtype` is not specified and cannot be inferred from `weights`, previously it defaulted to x32 because of [this line](https://github.com/netket/netket/blob/bb86b0234d2941f9cb4e8cf6d6afc939c8d722f1/netket/operator/_pauli_strings/base.py#L106), now it defaults to x64 when x64 is enabled.

## Continuous operators

They don't compute matrix elements, and we never explicitly cast the output dtype, so I think their `dtype` should behave like `param_dtype` in Flax.

For `PotentialEnergy` and `KineticEnergy`, the dtype is only used to cast `coefficient` and `mass`, so nothing is changed.

For `SumOperator`, there is a subtle change: Previously we only inferred the dtype from the operators, now we also infer it from the coefficients. Note that the `dtype` is only the dtype of `coefficients`, and the dtypes of `operators` are unaffected. The reason is like how we define Flax modules: If we write
```python
small_module_1 = SmallModule(param_dtype=dtype1)
small_module_2 = SmallModule(param_dtype=dtype2)
big_module = BigModule(small_module_1, small_module_2, param_dtype=dtype3)
```
then we usually expect that `BigModule` will not change the dtypes of parameters in `small_module_1` and `small_module_2`, and only the parameters newly defined in `BigModule` have dtype3. On the contrary, if we write
```python
big_module = BigModule(module_type="SmallModule", param_dtype=dtype3)
```
then we expect that it constructs some `SmallModule` using dtype3.