### PR TITLE
Fix tests like `x in ys` where `x` is an array

### DIFF
--- a/netket/utils/__init__.py
+++ b/netket/utils/__init__.py
@@ -27,7 +27,7 @@ from . import types
 from . import float
 from . import optional_deps
 
-from .array import HashableArray
+from .array import HashableArray, array_in
 from .partial import HashablePartial
 from .jax import get_afun_if_module, wrap_afun, wrap_to_support_scalar
 from .seed import random_seed

--- a/netket/utils/array.py
+++ b/netket/utils/array.py
@@ -72,3 +72,16 @@ class HashableArray:
     @property
     def shape(self) -> Shape:
         return self.wrapped.shape
+
+
+def array_in(x, ys):
+    """
+    Interpret ys as a list of arrays, and test if x is equal to any y in ys,
+    with exactly the same shape but not exactly the same dtype.
+
+    Note:
+        In numpy, :code:`x in ys` is equivalent to :code:`any(x == ys)`,
+        which is usually not what we intend when :code:`x.size > 1`.
+        JAX arrays will raise an error rather than silently compute it.
+    """
+    return any(np.array_equal(x, y) for y in ys)

--- a/netket/utils/array.py
+++ b/netket/utils/array.py
@@ -84,4 +84,6 @@ def array_in(x, ys):
         which is usually not what we intend when :code:`x.size > 1`.
         JAX arrays will raise an error rather than silently compute it.
     """
-    return any(np.array_equal(x, y) for y in ys)
+    x = x.reshape(1, -1)
+    ys = ys.reshape(ys.shape[0], -1)
+    return (x == ys).all(axis=1).any()

--- a/test/dynamics/test_solvers.py
+++ b/test/dynamics/test_solvers.py
@@ -119,7 +119,6 @@ def test_ode_solver(method):
     t = []
     y_t = []
     for _ in range(n_steps):
-        # print(solv.t, solv.y)
         t.append(solv.t)
         y_t.append(solv.y)
         solv.step()

--- a/test/dynamics/test_solvers.py
+++ b/test/dynamics/test_solvers.py
@@ -119,7 +119,7 @@ def test_ode_solver(method):
     t = []
     y_t = []
     for _ in range(n_steps):
-        print(solv.t, solv.y)
+        # print(solv.t, solv.y)
         t.append(solv.t)
         y_t.append(solv.y)
         solv.step()
@@ -153,7 +153,7 @@ def test_adaptive_solver(solver):
     y_t = []
     last_step = -1
     while solv.t <= 2.0:
-        print(solv._rkstate)
+        # print(solv._rkstate)
         if solv._rkstate.step_no != last_step:
             last_step = solv._rkstate.step_no
             t.append(solv.t)
@@ -161,7 +161,7 @@ def test_adaptive_solver(solver):
         solv.step()
     y_t = np.asarray(y_t)
 
-    print(t)
+    # print(t)
     sol = sci.solve_ivp(
         ode, (0.0, 2.0), y0, t_eval=t, atol=0.0, rtol=tol, method="RK45"
     )

--- a/test/operator/test_pauli.py
+++ b/test/operator/test_pauli.py
@@ -19,6 +19,7 @@ import jax
 import jax.numpy as jnp
 
 import netket as nk
+from netket.utils import array_in
 
 
 def test_deduced_hilbert_pauli():
@@ -31,13 +32,13 @@ def test_deduced_hilbert_pauli():
 
 def test_pauli_tensorhilbert():
     hi = nk.hilbert.Spin(0.5, 2, total_sz=0) * nk.hilbert.Spin(0.5, 1)
-    op = nk.operator.PauliStrings(hi, ["XXI", "YZX", "IZX"], [0.1, 0.2, -1.4])
+    op = nk.operator.PauliStrings(hi, ["XXI", "YYY", "IZX"], [0.1, 0.2, -1.4])
     assert op.hilbert.size == 3
     s = hi.all_states()
     sp, _ = op.get_conn_padded(s)
     sp = sp.reshape(-1, 3)
     for _s in sp:
-        assert _s in s
+        assert array_in(_s, s)
 
 
 @pytest.mark.parametrize(

--- a/test/sampler/test_sampler.py
+++ b/test/sampler/test_sampler.py
@@ -19,7 +19,7 @@ from .. import common
 
 import netket as nk
 from netket.hilbert import DiscreteHilbert, Particle
-from netket.utils import mpi
+from netket.utils import array_in, mpi
 from netket.jax.sharding import device_count_per_rank
 
 from netket import experimental as nkx
@@ -264,7 +264,7 @@ def test_states_in_hilbert(sampler, model_and_weights):
         samples, _ = sampler.sample(ma, w, chain_length=chain_length)
         assert samples.shape == (sampler.n_chains, chain_length, hi.size)
         for sample in np.asarray(samples).reshape(-1, hi.size):
-            assert sample in all_states
+            assert array_in(sample, all_states)
 
     elif isinstance(hi, Particle):
         ma, w = model_and_weights(hi, sampler)


### PR DESCRIPTION
I'm tracing some weird behavior of `PauliStrings` on constrained Hilbert spaces and I noticed that a test was wrong and really misleading, so let me first fix the tests.

In numpy, `x in y` is equivalent to `any(x == y)`, which is usually not what we intend when `x.size > 1`. It returns true if any one element of `x` is in `y`, rather than `x` as a whole is in `y`. I checked our codebase and found two usages of that.

Now the operator used in the test for `PauliStrings` actually conserves `total_sz = 0` on the first two spins. The other test for samplers is actually correct. This PR only fixes the tests and I did not find other problems in our sources for now.

By the way, I commented out all `print` in the tests for ODE solvers, so they're much faster when we redirect the output.

## Technical details

I hope there is a Flake8 plugin to check that but I guess it's hard using only static analysis. I added a hook to `np.ndarray.__contains__`, and because `np.ndarray` is compiled in C, I had to do that in a dirty way:
```python
def pytest_configure(config):
    import traceback

    import numpy as np
    from forbiddenfruit import curse

    old_contains = np.ndarray.__contains__

    def new_contains(self, item):
        ret = old_contains(self, item)

        if hasattr(item, "size") and item.size > 1:
            tb = traceback.extract_stack()
            while tb[0].filename and "netket" not in tb[0].filename:
                del tb[0]
            print()
            print("".join(traceback.format_list(tb)), end="")
            print("contains", self, item, ret)

        return ret

    curse(np.ndarray, "__contains__", new_contains)
    print("np.ndarray.__contains__ is cursed")
```
Add this to `test/conftest.py`, then run `pytest -n 0 -s some_test`, and it will print the stack trace whenever that usage is found. This is not included in the PR.