### PR TITLE
SPRING (Kaczmarz) optimizer

### DIFF
--- a/test/driver/test_srt.py
+++ b/test/driver/test_srt.py
@@ -110,7 +110,9 @@ def test_SRt_vs_linear_solver_complexpars():
 
     H, opt, vstate_srt = _setup(machine=model)
     gs = VMC_SRt(
-        H, opt, variational_state=vstate_srt, diag_shift=0.1, jacobian_mode="complex"
+        H, opt, variational_state=vstate_srt, diag_shift=0.1, jacobian_mode="complex",
+        proj_reg=0.0,
+        momentum=0.0,
     )
     logger_srt = nk.logging.RuntimeLog()
     gs.run(n_iter=n_iters, out=logger_srt)
@@ -141,7 +143,9 @@ def test_SRt_vs_linear_solver():
 
     H, opt, vstate_srt = _setup()
     gs = VMC_SRt(
-        H, opt, variational_state=vstate_srt, diag_shift=0.1, jacobian_mode="complex"
+        H, opt, variational_state=vstate_srt, diag_shift=0.1, jacobian_mode="complex",
+        proj_reg=0.0,
+        momentum=0.0,
     )
     logger_srt = nk.logging.RuntimeLog()
     gs.run(n_iter=n_iters, out=logger_srt)
@@ -177,13 +181,17 @@ def test_SRt_real_vs_complex():
         variational_state=vstate_complex,
         diag_shift=0.1,
         jacobian_mode="complex",
+        proj_reg=0.0,
+        momentum=0.0,
     )
     logger_complex = nk.logging.RuntimeLog()
     gs.run(n_iter=n_iters, out=logger_complex)
 
     H, opt, vstate_real = _setup(complex=False)
     gs = VMC_SRt(
-        H, opt, variational_state=vstate_real, diag_shift=0.1, jacobian_mode="real"
+        H, opt, variational_state=vstate_real, diag_shift=0.1, jacobian_mode="real",
+        proj_reg=0.0,
+        momentum=0.0,
     )
     logger_real = nk.logging.RuntimeLog()
     gs.run(n_iter=n_iters, out=logger_real)


### PR DESCRIPTION
The discussion started in #1696 . It's particularly interesting to me because it may fulfill my wish for years to properly have a running estimation of `S^-1`, so I hurried this while away for a meeting, and let's see if it really works well in our use cases.

We need to test if it fully supports complex numbers and MPI, and also discuss the API.

I added the arguments `proj_reg` and `momentum` to the current API of `VMC_SRt`. When `momentum = 0`, it degenerates to the previous SRt, and the matrix `P` will not affect the training as long as the training was already numerically stable.

Here I call the matrix `P` 'projector regularization', or maybe we can call it 'ones regularization'. Multiplying it by any factor will not change the updates, as long as it's numerically stable, even if we split the complex parameters. I've tested it numerically.

A `N * N` matrix of ones has only one nonzero eigenvalue, which is `N`. To make it not too large, we divide it by `N` by default. In principle the user can adjust the factor `proj_reg` but I guess it's not needed in most cases.

The momentum subtracted from `dv` and added to `updates` are implemented in the preconditioner. For the gradient norm clipping, however, we can use optax to do it after the preconditioner.

By the way, after we clean up the driver API (e.g. in #1674 ), maybe it's a good time to factor out SRt to be actually a preconditioner.

cc @attila-i-szabo @riccardo-rende @llviteritti 