### PR TITLE
Cleanup VMC SRt

### DIFF
--- a/netket/driver/vmc.py
+++ b/netket/driver/vmc.py
@@ -78,7 +78,6 @@ class VMC(AbstractVariationalDriver):
 
         self._dp: PyTree = None
         self._S = None
-        self._sr_info = None
 
     @property
     def preconditioner(self):


### PR DESCRIPTION
Makes it a Variational Driver, not inheriting from VMC, so that it does not have irrelevant variables such as preconditioner.