### PR TITLE
Deprecation warning for #1722

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 * `MetropolisSampler.n_sweeps` has been renamed to {attr}`~netket.sampler.MetropolisSampler.MetropolisSampler.sweep_size` for clarity. Using `n_sweeps` when constructing the sampler now throws a deprecation warning; `sweep_size` should be used instead going forward [#1657](https://github.com/netket/netket/issues/1657).
 * Samplers and metropolis rules defined as {func}`netket.utils.struct.dataclass` are deprecated because the base class is now a {class}`netket.utils.struct.Pytree`. The only change needed is to remove the dataclass decorator and define a standard init method [#1653](https://github.com/netket/netket/issues/1653).
+* The `out` keyword of Discrete Hilbert indexing methods (`all_states`, `numbers_to_states` and `states_to_numbers`) is deprecated and will be removed in the next release. Plan ahead and remove usages to avoid breaking your code 3 months from now [#1725](https://github.com/netket/netket/issues/1725)!
 
 ### Internal changes
 * A new class {class}`netket.utils.struct.Pytree`, can be used to create Pytrees for which inheritance autoamtically works and for which it is possible to define `__init__`. Several structures such as samplers and rules have been transitioned to this new interface instead of old style `@struct.dataclass` [#1653](https://github.com/netket/netket/issues/1653).

--- a/netket/hilbert/discrete_hilbert.py
+++ b/netket/hilbert/discrete_hilbert.py
@@ -21,6 +21,7 @@ import numpy as np
 
 from netket.utils.types import Array
 from netket.errors import HilbertIndexingDuringTracingError, concrete_or_error
+from netket.utils.deprecation import warn_deprecation
 
 from .abstract_hilbert import AbstractHilbert
 
@@ -155,6 +156,23 @@ class DiscreteHilbert(AbstractHilbert):
 
         if out is None:
             out = np.empty((numbers_r.size, self.size))
+        else:
+            warn_deprecation(
+                """
+           +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+                The `out` keyword of `numbers_to_states(..., out=)` will be
+                deprecated in the next release.
+
+                We recommend to remove such usages.
+
+                Do note that the out keyword is deprecated for all the following
+                methods:
+                 - DiscreteHilbert.states_to_numbers
+                 - DiscreteHilbert.numbers_to_states
+                 - DiscreteHilbert.all_states
+            +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+                """
+            )
 
         if np.any(numbers >= self.n_states):
             raise ValueError("numbers outside the range of allowed states")
@@ -193,6 +211,23 @@ class DiscreteHilbert(AbstractHilbert):
 
         if out is None:
             out = np.empty(states_r.shape[:-1], dtype=np.int64)
+        else:
+            warn_deprecation(
+                """
+           +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+                The `out` keyword of `states_to_numbers(..., out=)` will be
+                deprecated in the next release.
+
+                We recommend to remove such usages.
+
+                Do note that the out keyword is deprecated for all the following
+                methods:
+                 - DiscreteHilbert.states_to_numbers
+                 - DiscreteHilbert.numbers_to_states
+                 - DiscreteHilbert.all_states
+            +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+                """
+            )
 
         out = self._states_to_numbers(states_r, out=out.reshape(-1))
 
@@ -223,6 +258,24 @@ class DiscreteHilbert(AbstractHilbert):
             A (n_states x size) batch of states. this corresponds
             to the pre-allocated array if it was passed.
         """
+        if out is not None:
+            warn_deprecation(
+                """
+           +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+                The `out` keyword of `all_states(out=)` will be
+                deprecated in the next release.
+
+                We recommend to remove such usages.
+
+                Do note that the out keyword is deprecated for all the following
+                methods:
+                 - DiscreteHilbert.states_to_numbers
+                 - DiscreteHilbert.numbers_to_states
+                 - DiscreteHilbert.all_states
+            +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+                """
+            )
+
         numbers = np.arange(0, self.n_states, dtype=np.int64)
 
         return self.numbers_to_states(numbers, out)

--- a/netket/hilbert/homogeneous.py
+++ b/netket/hilbert/homogeneous.py
@@ -18,6 +18,8 @@ from numbers import Real
 
 import numpy as np
 
+from netket.utils.deprecation import warn_deprecation
+
 from .discrete_hilbert import DiscreteHilbert
 from .index import HilbertIndex, UnconstrainedHilbertIndex, ConstrainedHilbertIndex
 
@@ -165,6 +167,24 @@ class HomogeneousHilbert(DiscreteHilbert):
             A (n_states x size) batch of states. this corresponds
             to the pre-allocated array if it was passed.
         """
+        if out is not None:
+            warn_deprecation(
+                """
+           +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+                The `out` keyword of `all_states(out=)` will be
+                deprecated in the next release.
+
+                We recommend to remove such usages.
+
+                Do note that the out keyword is deprecated for all the following
+                methods:
+                 - DiscreteHilbert.states_to_numbers
+                 - DiscreteHilbert.numbers_to_states
+                 - DiscreteHilbert.all_states
+            +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+                """
+            )
+
         return self._hilbert_index.all_states(out)
 
     @property


### PR DESCRIPTION
#1722 throws an error if `out` is used. As I am tagging a release today, I will add a deprecation warning so that there is a warning for normal users if anyone is using this functionality