### PR TITLE
Fix typos

### DIFF
--- a/netket/experimental/driver/tdvp_common.py
+++ b/netket/experimental/driver/tdvp_common.py
@@ -253,8 +253,7 @@ class TDVPBaseDriver(AbstractVariationalDriver):
                 step_accepted = self._integrator.step(max_dt=max_dt)
                 if self._integrator.errors:
                     raise RuntimeError(
-                        f"RK solver: {self._integrator.errors.message()}",
-                        stacklevel=3,
+                        f"RK solver: {self._integrator.errors.message()}"
                     )
                 elif self._integrator.warnings:
                     warnings.warn(

--- a/netket/models/mlp.py
+++ b/netket/models/mlp.py
@@ -59,7 +59,7 @@ class MLP(nn.Module):
     If None is provided, the output layer will be essentially linear."""
     use_hidden_bias: bool = True
     """if True uses a bias in the hidden layer."""
-    use_output_bias: bool = True
+    use_output_bias: bool = False
     """if True adds a bias to the output layer."""
     precision: Optional[jax.lax.Precision] = None
     """Numerical precision of the computation see :class:`jax.lax.Precision` for details."""

--- a/netket/models/mlp.py
+++ b/netket/models/mlp.py
@@ -59,7 +59,7 @@ class MLP(nn.Module):
     If None is provided, the output layer will be essentially linear."""
     use_hidden_bias: bool = True
     """if True uses a bias in the hidden layer."""
-    use_output_bias: bool = False
+    use_output_bias: bool = True
     """if True adds a bias to the output layer."""
     precision: Optional[jax.lax.Precision] = None
     """Numerical precision of the computation see :class:`jax.lax.Precision` for details."""

--- a/netket/sampler/rules/multiple.py
+++ b/netket/sampler/rules/multiple.py
@@ -149,4 +149,4 @@ class MultipleRules(MetropolisRule):
         return σp, log_prob_corr
 
     def __repr__(self):
-        return "MultipleRules(probabilities={self.probabilities}, rules={self.rules})"
+        return f"MultipleRules(probabilities={self.probabilities}, rules={self.rules})"


### PR DESCRIPTION
3 typos corrected
- formatting of multiple rules
- default argument of MLP model: output_bias -> True for consistency
- RuntimeError() takes no keyword arguments