### PR TITLE
Fix HashableArray being a pytree

### DIFF
--- a/netket/utils/array.py
+++ b/netket/utils/array.py
@@ -68,7 +68,12 @@ class HashableArray:
         return self._hash
 
     def __eq__(self, other):
-        return type(other) is HashableArray and np.all(self.wrapped == other.wrapped)
+        return (
+            type(other) is HashableArray
+            and self.shape == other.shape
+            and self.dtype == other.dtype
+            and np.all(self.wrapped == other.wrapped)
+        )
 
     def __array__(self, dtype: DType = None):
         if dtype is None:

--- a/netket/utils/array.py
+++ b/netket/utils/array.py
@@ -96,6 +96,14 @@ class HashableArray:
     def shape(self) -> Shape:
         return self.wrapped.shape
 
+    def __repr__(self) -> str:
+        return f"HashableArray({self.wrapped},\n shape={self.shape}, dtype={self.dtype}, hash={hash(self)})"
+
+    def __str__(self) -> str:
+        return (
+            f"HashableArray(shape={self.shape}, dtype={self.dtype}, hash={hash(self)})"
+        )
+
 
 def array_in(x, ys):
     """

--- a/netket/utils/array.py
+++ b/netket/utils/array.py
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Optional
+
 import numpy as np
 import jax
 
 from .types import Array, DType, Shape
-from .struct import dataclass
 
 
-@dataclass(cache_hash=True)
 class HashableArray:
     """
     This class wraps a numpy or jax array in order to make it hashable and
@@ -29,10 +29,20 @@ class HashableArray:
     The underlying array can also be accessed using :code:`numpy.asarray(self)`.
     """
 
-    wrapped: Array
-    """The wrapped array. Note that this array is read-only."""
+    def __init__(self, wrapped: Array):
+        """
+        Wraps an array into an object that is hashable, and that can be
+        converted again into an array.
 
-    def __pre_init__(self, wrapped):
+        Forces all arrays to numpy and sets them to readonly.
+        They can be converted back to jax later or a writeable numpy copy
+        can be created by using `np.array(...)`
+
+        The hash is computed by hashing the whole content of the array.
+
+        Args:
+            wrapped: array to be wrapped
+        """
         if isinstance(wrapped, HashableArray):
             wrapped = wrapped.wrapped
         else:
@@ -44,10 +54,18 @@ class HashableArray:
             if isinstance(wrapped, np.ndarray):
                 wrapped.flags.writeable = False
 
-        return (wrapped,), {}
+        self._wrapped: np.array = wrapped
+        self._hash: Optional[int] = None
+
+    @property
+    def wrapped(self):
+        """The read-only wrapped array."""
+        return self._wrapped
 
     def __hash__(self):
-        return hash(self.wrapped.tobytes())
+        if self._hash is None:
+            self._hash = hash(self.wrapped.tobytes())
+        return self._hash
 
     def __eq__(self, other):
         return type(other) is HashableArray and np.all(self.wrapped == other.wrapped)

--- a/netket/utils/array.py
+++ b/netket/utils/array.py
@@ -72,7 +72,7 @@ class HashableArray:
             type(other) is HashableArray
             and self.shape == other.shape
             and self.dtype == other.dtype
-            and np.all(self.wrapped == other.wrapped)
+            and hash(self) == hash(other)
         )
 
     def __array__(self, dtype: DType = None):

--- a/test/utils/test_utils.py
+++ b/test/utils/test_utils.py
@@ -63,6 +63,13 @@ def test_HashableArray(numpy):
     assert wa != a
     assert wa != wb
 
+    # check __eq__ does not fail on two arrays w/ different shape
+    wc = HashableArray(a[np.newaxis])
+    assert wc != wa
+    # check __eq__ does not fail on two arrays w/ different dtype
+    wd = HashableArray(a.astype(int))
+    assert wd != wa
+
     assert_equal(wa.wrapped, np.asarray(wa))
     assert_equal(wa.wrapped, jnp.asarray(wa))
     assert wa.wrapped is not wa
@@ -85,16 +92,6 @@ def test_HashableArray(numpy):
     leafs, _ = jax.tree_util.tree_flatten(wa)
     assert len(leafs) == 1
     assert leafs[0] == wa
-
-    # check eq different values
-    assert wa != wb
-
-    # check __eq__ does not fail on two arrays w/ different shape
-    wc = HashableArray(a[np.newaxis])
-    assert wc != wa
-    # check __eq__ does not fail on two arrays w/ different dtype
-    wd = HashableArray(a.astype(int))
-    assert wd != wa
 
 
 def test_Kahan_sum():

--- a/test/utils/test_utils.py
+++ b/test/utils/test_utils.py
@@ -84,7 +84,7 @@ def test_HashableArray(numpy):
     # Check that it is a leaf object, and not a pytree
     leafs, _ = jax.tree_util.tree_flatten(wa)
     assert len(leafs) == 1
-    assert leafs[0] == wa 
+    assert leafs[0] == wa
 
 
 def test_Kahan_sum():

--- a/test/utils/test_utils.py
+++ b/test/utils/test_utils.py
@@ -93,6 +93,10 @@ def test_HashableArray(numpy):
     assert len(leafs) == 1
     assert leafs[0] == wa
 
+    # ensure that repr and str work
+    assert isinstance(repr(wa), str)
+    assert isinstance(str(wa), str)
+
 
 def test_Kahan_sum():
     ksum1 = KahanSum(0.0)

--- a/test/utils/test_utils.py
+++ b/test/utils/test_utils.py
@@ -86,6 +86,16 @@ def test_HashableArray(numpy):
     assert len(leafs) == 1
     assert leafs[0] == wa
 
+    # check eq different values
+    assert wa != wb
+
+    # check __eq__ does not fail on two arrays w/ different shape
+    wc = HashableArray(a[np.newaxis])
+    assert wc != wa
+    # check __eq__ does not fail on two arrays w/ different dtype
+    wd = HashableArray(a.astype(int))
+    assert wd != wa
+
 
 def test_Kahan_sum():
     ksum1 = KahanSum(0.0)

--- a/test/utils/test_utils.py
+++ b/test/utils/test_utils.py
@@ -14,6 +14,8 @@
 
 import pytest
 import numpy as np
+
+import jax
 import jax.numpy as jnp
 
 from numpy.testing import assert_equal
@@ -78,6 +80,11 @@ def test_HashableArray(numpy):
     assert wa == wa3
     assert_equal(wa3.wrapped, np.asarray(wa))
     assert_equal(wa3.wrapped, jnp.asarray(wa))
+
+    # Check that it is a leaf object, and not a pytree
+    leafs, _ = jax.tree_util.tree_flatten(wa)
+    assert len(leafs) == 1
+    assert leafs[0] == wa 
 
 
 def test_Kahan_sum():


### PR DESCRIPTION
An HashableArray cannot be a PyTree, otherwise it's content (a numpy array) would be either a leaf (it's not) or a washable object (it's not either).

Make it a non - mashable object.

All current usages within netket use it as a static argument to jax functions, so it will break nothing.
Might break user code, but that was buggy already anyway.

cc @inailuig 