### PR TITLE
Move Hilbert spaces to Lazy range objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@
 ## NetKet 3.12 (⚙️ In development)
 
 ### New Features
+* Discrete Hilbert spaces now use a special {class}`nk.utils.StaticRange` object to store the local values that label the local degree of freedom. This special object is jax friendly and can be converted to arrays, and allows for easy conversion from the local degrees of freedom to integers that can be used to index into arrays, and back. While those objects are not really used internally yet, in the future they will be used to simplify the implementations of operators and other objects [#1732](https://github.com/netket/netket/issues/1732).
 
 
 ### Breaking Changes
 * The `out` keyword of Discrete Hilbert indexing methods (`all_states`, `numbers_to_states` and `states_to_numbers`) deprecated in the last release has been removed completely [#1722](https://github.com/netket/netket/issues/1722).
+* The Homogeneous Hilbert spaces now must store the list of valid local values for the states with a {class}`nk.utils.StaticRange` objects instead of list of floats. The constructors have been updated accordingly. {class}`~nk.utils.StaticRange` is a range-like object that is jax-compatible and from now on should be used to index into local hilbert spaces [#1732](https://github.com/netket/netket/issues/1732).
 
 ### Deprecations
 

--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -40,6 +40,8 @@ Utility functions and classes.
    :nosignatures:
 
    HashableArray
+   StaticRange
+   numbers.StaticZero
    
 ```
 

--- a/netket/experimental/hilbert/spin_orbital_fermions.py
+++ b/netket/experimental/hilbert/spin_orbital_fermions.py
@@ -23,6 +23,7 @@ from netket.hilbert.fock import Fock
 from netket.hilbert.tensor_hilbert_discrete import TensorDiscreteHilbert
 from netket.hilbert.homogeneous import HomogeneousHilbert
 from netket.utils.dispatch import dispatch
+from netket.utils import StaticRange
 
 
 class SpinOrbitalFermions(HomogeneousHilbert):
@@ -156,7 +157,7 @@ class SpinOrbitalFermions(HomogeneousHilbert):
         self._fock = hilbert
         """Internal representation of this Hilbert space (Fock or TensorHilbert)."""
         # local states are the occupation numbers (0, 1)
-        local_states = np.array((0.0, 1.0))
+        local_states = StaticRange(0.0, 1.0, 2, dtype=float)
 
         # we use the constraints from the Fock spaces, and override `constrained`
         super().__init__(local_states, N=total_size, constraint_fn=None)

--- a/netket/hilbert/custom_hilbert.py
+++ b/netket/hilbert/custom_hilbert.py
@@ -15,8 +15,6 @@
 from typing import Optional, Callable
 
 
-import jax.numpy as jnp
-
 from netket.utils import StaticRange
 
 from .homogeneous import HomogeneousHilbert

--- a/netket/hilbert/custom_hilbert.py
+++ b/netket/hilbert/custom_hilbert.py
@@ -80,19 +80,6 @@ class CustomHilbert(HomogeneousHilbert):
         """
         super().__init__(local_states, N, constraint_fn)
 
-    def states_to_local_indices(self, x):
-        local_states = jnp.asarray(self.local_states)
-        local_states = local_states.reshape(tuple(1 for _ in range(x.ndim)) + (-1,))
-        x = x.reshape(
-            (
-                *x.shape,
-                1,
-            )
-        )
-        x_idmap = x == local_states
-        idxs = jnp.arange(self.local_size).reshape(local_states.shape)
-        return jnp.sum(x_idmap * idxs, axis=-1)
-
     def _mul_sametype_(self, other):
         assert type(self) == type(other)
         if not self.constrained:

--- a/netket/hilbert/custom_hilbert.py
+++ b/netket/hilbert/custom_hilbert.py
@@ -18,6 +18,8 @@ from numbers import Real
 
 import jax.numpy as jnp
 
+from netket.utils import StaticRange
+
 from .homogeneous import HomogeneousHilbert
 
 
@@ -26,7 +28,7 @@ class CustomHilbert(HomogeneousHilbert):
 
     def __init__(
         self,
-        local_states: Optional[list[Real]],
+        local_states: Optional[StaticRange],
         N: int = 1,
         constraint_fn: Optional[Callable] = None,
     ):
@@ -35,21 +37,45 @@ class CustomHilbert(HomogeneousHilbert):
         a number of sites, or modes, within this hilbert space.
 
         Args:
-            local_states (list or None): Eigenvalues of the states. If the allowed
-                states are an infinite number, None should be passed as an argument.
+            local_states: :class:`~netket.utils.StaticRange` object describing the
+                numbers used to encode the local degree of freedom of this Hilbert
+                Space.
             N: Number of modes in this hilbert space (default 1).
             constraint_fn: A function specifying constraints on the quantum numbers.
                 Given a batch of quantum numbers it should return a vector
                 of bools specifying whether those states are valid or not.
 
-        Examples:
-           Simple custom hilbert space.
+        The :class:`netket.utils.StaticRange` object works like a standard `range`
+        object and is used to define the valid configurations of the local degrees
+        of freedom. 
 
-           >>> import netket
-           >>> g = netket.graph.Hypercube(length=10,n_dim=2,pbc=True)
-           >>> hi = netket.hilbert.CustomHilbert(local_states=[-1232, 132, 0], N=100)
-           >>> print(hi.size)
-           100
+        For example, the :class:`~netket.utils.StaticRange` of a Fock Hilbert space
+        is constructed as 
+
+        .. code-block:: python
+
+            >>> import netket as nk
+            >>> n_max = 10
+            >>> nk.utils.StaticRange(start=0, step=1, length=n_max)
+
+        and the range of a Spin-1/2 Hilbert space is constructed as:
+
+        .. code-block:: python
+
+            >>> import netket as nk
+            >>> n_max = 10
+            >>> nk.utils.StaticRange(start=-1, step=2, length=2)
+
+
+        Examples:
+            Simple custom hilbert space.
+
+            >>> import netket as nk
+            >>> g = nk.graph.Hypercube(length=10,n_dim=2,pbc=True)
+            >>> local_states = nk.utils.StaticRange(start=-2.0, step=1.0, length=4)
+            >>> hi = nk.hilbert.CustomHilbert(local_states=local_states, N=100)
+            >>> print(hi.size)
+            100
         """
         super().__init__(local_states, N, constraint_fn)
 

--- a/netket/hilbert/custom_hilbert.py
+++ b/netket/hilbert/custom_hilbert.py
@@ -14,7 +14,6 @@
 
 from typing import Optional, Callable
 
-from numbers import Real
 
 import jax.numpy as jnp
 
@@ -47,10 +46,10 @@ class CustomHilbert(HomogeneousHilbert):
 
         The :class:`netket.utils.StaticRange` object works like a standard `range`
         object and is used to define the valid configurations of the local degrees
-        of freedom. 
+        of freedom.
 
         For example, the :class:`~netket.utils.StaticRange` of a Fock Hilbert space
-        is constructed as 
+        is constructed as
 
         .. code-block:: python
 

--- a/netket/hilbert/custom_hilbert.py
+++ b/netket/hilbert/custom_hilbert.py
@@ -56,6 +56,7 @@ class CustomHilbert(HomogeneousHilbert):
             >>> import netket as nk
             >>> n_max = 10
             >>> nk.utils.StaticRange(start=0, step=1, length=n_max)
+            StaticRange(start=0, step=1, length=10, dtype=int64)
 
         and the range of a Spin-1/2 Hilbert space is constructed as:
 
@@ -64,6 +65,7 @@ class CustomHilbert(HomogeneousHilbert):
             >>> import netket as nk
             >>> n_max = 10
             >>> nk.utils.StaticRange(start=-1, step=2, length=2)
+            StaticRange(start=-1, step=2, length=2, dtype=int64)
 
 
         Examples:

--- a/netket/hilbert/fock.py
+++ b/netket/hilbert/fock.py
@@ -96,7 +96,7 @@ class Fock(HomogeneousHilbert):
 
         if self._n_max is not None:
             # assert self._n_max > 0
-            local_states = StaticRange(0, 1, self._n_max + 1)
+            local_states = StaticRange(0, 1, self._n_max + 1, dtype=int)
         else:
             self._n_max = FOCK_MAX
             local_states = None

--- a/netket/hilbert/fock.py
+++ b/netket/hilbert/fock.py
@@ -99,7 +99,7 @@ class Fock(HomogeneousHilbert):
             local_states = StaticRange(0, 1, self._n_max + 1, dtype=int)
         else:
             self._n_max = FOCK_MAX
-            local_states = StaticRange(0, 1, self._n_max + 1, dtype=int)
+            local_states = None
 
         super().__init__(local_states, N, constraints)
 

--- a/netket/hilbert/fock.py
+++ b/netket/hilbert/fock.py
@@ -99,7 +99,7 @@ class Fock(HomogeneousHilbert):
             local_states = StaticRange(0, 1, self._n_max + 1, dtype=int)
         else:
             self._n_max = FOCK_MAX
-            local_states = None
+            local_states = StaticRange(0, 1, self._n_max + 1, dtype=int)
 
         super().__init__(local_states, N, constraints)
 

--- a/netket/hilbert/fock.py
+++ b/netket/hilbert/fock.py
@@ -17,6 +17,7 @@ from functools import partial
 
 import numpy as np
 from numba import jit
+from netket.utils import StaticRange
 
 from .homogeneous import HomogeneousHilbert
 
@@ -95,7 +96,7 @@ class Fock(HomogeneousHilbert):
 
         if self._n_max is not None:
             # assert self._n_max > 0
-            local_states = np.arange(self._n_max + 1)
+            local_states = StaticRange(0, 1, self._n_max + 1)
         else:
             self._n_max = FOCK_MAX
             local_states = None

--- a/netket/hilbert/fock.py
+++ b/netket/hilbert/fock.py
@@ -160,9 +160,6 @@ class Fock(HomogeneousHilbert):
         nmax = self._n_max if self._n_max < FOCK_MAX else "FOCK_MAX"
         return f"Fock(n_max={nmax}{n_particles}, N={self.size})"
 
-    def states_to_local_indices(self, x):
-        return x.astype(np.int32)
-
     @property
     def _attrs(self):
         return (self.size, self._n_max, self._n_particles)

--- a/netket/hilbert/homogeneous.py
+++ b/netket/hilbert/homogeneous.py
@@ -72,14 +72,10 @@ class HomogeneousHilbert(DiscreteHilbert):
         self._is_finite = local_states is not None
 
         if self._is_finite:
-            self._local_states = np.asarray(local_states)
-            assert self._local_states.ndim == 1
-            self._local_size = self._local_states.shape[0]
-            self._local_states = self._local_states.tolist()
-            self._local_states_frozen = frozenset(self._local_states)
+            self._local_states = local_states
+            self._local_size = len(self._local_states)
         else:
             self._local_states = None
-            self._local_states_frozen = None
             self._local_size = np.iinfo(np.intp).max
 
         self._constraint_fn = constraint_fn
@@ -106,6 +102,8 @@ class HomogeneousHilbert(DiscreteHilbert):
     def local_states(self) -> Optional[list[float]]:
         r"""A list of discrete local quantum numbers.
         If the local states are infinitely many, None is returned."""
+        if self.is_finite:
+            return list(self._local_states)
         return self._local_states
 
     def states_at_index(self, i: int):
@@ -176,13 +174,13 @@ class HomogeneousHilbert(DiscreteHilbert):
 
             if self.constrained:
                 self.__hilbert_index = ConstrainedHilbertIndex(
-                    np.asarray(self.local_states, dtype=np.float64),
+                    np.asarray(self.local_states),
                     self.size,
                     self._constraint_fn,
                 )
             else:
                 self.__hilbert_index = UnconstrainedHilbertIndex(
-                    np.asarray(self.local_states, dtype=np.float64), self.size
+                    np.asarray(self.local_states), self.size
                 )
 
         return self.__hilbert_index
@@ -198,7 +196,7 @@ class HomogeneousHilbert(DiscreteHilbert):
         return (
             self.size,
             self.local_size,
-            self._local_states_frozen,
+            self._local_states,
             self.constrained,
             self._constraint_fn,
         )

--- a/netket/hilbert/homogeneous.py
+++ b/netket/hilbert/homogeneous.py
@@ -71,8 +71,15 @@ class HomogeneousHilbert(DiscreteHilbert):
         if not isinstance(local_states, StaticRange):
             raise TypeError("local_states must be a StaticRange.")
 
-        self._local_states = local_states
-        self._local_size = len(self._local_states)
+        self._is_finite = local_states is not None
+
+        if self._is_finite:
+            self._local_states = local_states
+            self._local_size = len(local_states)
+        else:
+            self._local_states = None
+            self._local_size = np.iinfo(np.intp).max
+
         self._constraint_fn = constraint_fn
 
         self.__hilbert_index = None

--- a/netket/hilbert/homogeneous.py
+++ b/netket/hilbert/homogeneous.py
@@ -59,8 +59,9 @@ class HomogeneousHilbert(DiscreteHilbert):
         This method should only be called from the subclasses `__init__` method.
 
         Args:
-            local_states: Eigenvalues of the states. If the allowed
-                states are an infinite number, None should be passed as an argument.
+            local_states: :class:`~netket.utils.StaticRange` object describing the
+                numbers used to encode the local degree of freedom of this Hilbert
+                Space.
             N: Number of modes in this hilbert space (default 1).
             constraint_fn: A function specifying constraints on the quantum numbers.
                 Given a batch of quantum numbers it should return a vector of bools
@@ -68,7 +69,7 @@ class HomogeneousHilbert(DiscreteHilbert):
         """
         assert isinstance(N, int)
 
-        if not isinstance(local_states, StaticRange):
+        if not (isinstance(local_states, StaticRange) or local_states is None):
             raise TypeError("local_states must be a StaticRange.")
 
         self._is_finite = local_states is not None

--- a/netket/hilbert/homogeneous.py
+++ b/netket/hilbert/homogeneous.py
@@ -120,7 +120,7 @@ class HomogeneousHilbert(DiscreteHilbert):
     @property
     def is_finite(self) -> bool:
         r"""Whether the local hilbert space is finite."""
-        return True
+        return self._is_finite
 
     @property
     def constrained(self) -> bool:

--- a/netket/hilbert/homogeneous.py
+++ b/netket/hilbert/homogeneous.py
@@ -118,6 +118,25 @@ class HomogeneousHilbert(DiscreteHilbert):
         Throws an exception iff the space is not indexable."""
         return self._hilbert_index.n_states
 
+    def states_to_local_indices(self, x: Array):
+        r"""Returns a tensor with the same shape of `x`, where all local
+        values are converted to indices in the range `0...self.shape[i]`.
+        This function is guaranteed to be jax-jittable.
+
+        For the `Fock` space this returns `x`, but for other hilbert spaces
+        such as `Spin` this returns an array of indices.
+
+        .. warning::
+            This function is experimental. Use at your own risk.
+
+        Args:
+            x: a tensor containing samples from this hilbert space
+
+        Returns:
+            a tensor containing integer indices into the local hilbert
+        """
+        self._local_states.states_to_numbers(x, dtype=np.int32)
+
     @property
     def is_finite(self) -> bool:
         r"""Whether the local hilbert space is finite."""

--- a/netket/hilbert/homogeneous.py
+++ b/netket/hilbert/homogeneous.py
@@ -14,10 +14,9 @@
 
 from typing import Optional, Callable
 
-from numbers import Real
-
 import numpy as np
 
+from netket.utils import StaticRange
 
 from .discrete_hilbert import DiscreteHilbert
 from .index import HilbertIndex, UnconstrainedHilbertIndex, ConstrainedHilbertIndex
@@ -48,7 +47,7 @@ class HomogeneousHilbert(DiscreteHilbert):
 
     def __init__(
         self,
-        local_states: Optional[list[Real]],
+        local_states: StaticRange,
         N: int = 1,
         constraint_fn: Optional[Callable] = None,
     ):
@@ -69,15 +68,11 @@ class HomogeneousHilbert(DiscreteHilbert):
         """
         assert isinstance(N, int)
 
-        self._is_finite = local_states is not None
+        if not isinstance(local_states, StaticRange):
+            raise TypeError("local_states must be a StaticRange.")
 
-        if self._is_finite:
-            self._local_states = local_states
-            self._local_size = len(self._local_states)
-        else:
-            self._local_states = None
-            self._local_size = np.iinfo(np.intp).max
-
+        self._local_states = local_states
+        self._local_size = len(self._local_states)
         self._constraint_fn = constraint_fn
 
         self.__hilbert_index = None
@@ -118,7 +113,7 @@ class HomogeneousHilbert(DiscreteHilbert):
     @property
     def is_finite(self) -> bool:
         r"""Whether the local hilbert space is finite."""
-        return self._is_finite
+        return True
 
     @property
     def constrained(self) -> bool:

--- a/netket/hilbert/homogeneous.py
+++ b/netket/hilbert/homogeneous.py
@@ -47,7 +47,7 @@ class HomogeneousHilbert(DiscreteHilbert):
 
     def __init__(
         self,
-        local_states: StaticRange,
+        local_states: Optional[StaticRange],
         N: int = 1,
         constraint_fn: Optional[Callable] = None,
     ):

--- a/netket/hilbert/homogeneous.py
+++ b/netket/hilbert/homogeneous.py
@@ -17,6 +17,7 @@ from typing import Optional, Callable
 import numpy as np
 
 from netket.utils import StaticRange
+from netket.utils.types import Array
 
 from .discrete_hilbert import DiscreteHilbert
 from .index import HilbertIndex, UnconstrainedHilbertIndex, ConstrainedHilbertIndex

--- a/netket/hilbert/homogeneous.py
+++ b/netket/hilbert/homogeneous.py
@@ -136,7 +136,7 @@ class HomogeneousHilbert(DiscreteHilbert):
         Returns:
             a tensor containing integer indices into the local hilbert
         """
-        self._local_states.states_to_numbers(x, dtype=np.int32)
+        return self._local_states.states_to_numbers(x, dtype=np.int32)
 
     @property
     def is_finite(self) -> bool:

--- a/netket/hilbert/qubit.py
+++ b/netket/hilbert/qubit.py
@@ -38,7 +38,7 @@ class Qubit(HomogeneousHilbert):
             >>> print(hi.size)
             100
         """
-        super().__init__(StaticRange(0, 1, 2), N)
+        super().__init__(StaticRange(0, 1, 2, dtype=float), N)
 
     def states_to_local_indices(self, x):
         return x.astype(np.int32)

--- a/netket/hilbert/qubit.py
+++ b/netket/hilbert/qubit.py
@@ -14,7 +14,6 @@
 
 from typing import Optional, Union
 
-import numpy as np
 
 from netket.utils import StaticRange
 

--- a/netket/hilbert/qubit.py
+++ b/netket/hilbert/qubit.py
@@ -40,9 +40,6 @@ class Qubit(HomogeneousHilbert):
         """
         super().__init__(StaticRange(0, 1, 2, dtype=float), N)
 
-    def states_to_local_indices(self, x):
-        return x.astype(np.int32)
-
     def __pow__(self, n):
         return Qubit(self.size * n)
 

--- a/netket/hilbert/qubit.py
+++ b/netket/hilbert/qubit.py
@@ -14,6 +14,7 @@
 
 from typing import Optional, Union
 
+import numpy as np
 
 from netket.utils import StaticRange
 

--- a/netket/hilbert/qubit.py
+++ b/netket/hilbert/qubit.py
@@ -16,6 +16,8 @@ from typing import Optional, Union
 
 import numpy as np
 
+from netket.utils import StaticRange
+
 from .homogeneous import HomogeneousHilbert
 
 
@@ -36,7 +38,7 @@ class Qubit(HomogeneousHilbert):
             >>> print(hi.size)
             100
         """
-        super().__init__([0.0, 1.0], N)
+        super().__init__(StaticRange(0, 1, 2), N)
 
     def states_to_local_indices(self, x):
         return x.astype(np.int32)

--- a/netket/hilbert/spin.py
+++ b/netket/hilbert/spin.py
@@ -134,10 +134,6 @@ class Spin(HomogeneousHilbert):
         else:
             return Spin(s=self._s, N=self.size - Nsites)
 
-    def states_to_local_indices(self, x):
-        numbers = (x + self.local_size - 1) / 2
-        return numbers.astype(np.int32)
-
     def __repr__(self):
         total_sz = f", total_sz={self._total_sz}" if self._total_sz is not None else ""
         return f"Spin(s={Fraction(self._s)}{total_sz}, N={self.size})"

--- a/netket/hilbert/spin.py
+++ b/netket/hilbert/spin.py
@@ -18,6 +18,7 @@ from functools import partial
 
 import numpy as np
 from numba import jit
+from netket.utils import StaticRange
 
 from .homogeneous import HomogeneousHilbert
 
@@ -84,10 +85,7 @@ class Spin(HomogeneousHilbert):
         local_states = np.empty(local_size)
 
         assert int(2 * s + 1) == local_size
-
-        for i in range(local_size):
-            local_states[i] = -round(2 * s) + 2 * i
-        local_states = local_states.tolist()
+        local_states = StaticRange(1 - local_size, 2, local_size)
 
         _check_total_sz(total_sz, s, N)
         if total_sz is not None:

--- a/netket/hilbert/spin.py
+++ b/netket/hilbert/spin.py
@@ -85,7 +85,7 @@ class Spin(HomogeneousHilbert):
         local_states = np.empty(local_size)
 
         assert int(2 * s + 1) == local_size
-        local_states = StaticRange(1 - local_size, 2, local_size)
+        local_states = StaticRange(1 - local_size, 2, local_size, dtype=float)
 
         _check_total_sz(total_sz, s, N)
         if total_sz is not None:

--- a/netket/hilbert/tensor_hilbert_discrete.py
+++ b/netket/hilbert/tensor_hilbert_discrete.py
@@ -65,7 +65,7 @@ class TensorDiscreteHilbert(TensorHilbert, DiscreteHilbert):
     def is_indexable(self) -> bool:
         """Whether the space can be indexed with an integer"""
         return all(hi.is_indexable for hi in self._hilbert_spaces) and _is_indexable(
-            self.shape
+            list(hi.n_states for hi in self._hilbert_spaces)
         )
 
     def _setup(self):

--- a/netket/operator/_graph_operator.py
+++ b/netket/operator/_graph_operator.py
@@ -96,7 +96,7 @@ class GraphOperator(LocalOperator):
          ... [8, 9], [9, 10], [10, 11], [11, 12], [12, 13], [13, 14], [14, 15],
          ... [15, 16], [16, 17], [17, 18], [18, 19], [19, 0]]
          >>> g = nk.graph.Graph(edges=edges)
-         >>> hi = nk.hilbert.CustomHilbert(local_states=[-1, 1], N=g.n_nodes)
+         >>> hi = nk.hilbert.Spin(0.5, N=g.n_nodes)
          >>> op = nk.operator.GraphOperator(
          ... hi, site_ops=[sigmax], bond_ops=[mszsz], graph=g)
          >>> print(op)

--- a/netket/operator/_local_operator/base.py
+++ b/netket/operator/_local_operator/base.py
@@ -91,9 +91,9 @@ class LocalOperatorBase(DiscreteOperator):
         Examples:
            Constructs a ``LocalOperator`` without any operators.
 
-           >>> from netket.hilbert import CustomHilbert
+           >>> from netket.hilbert import Spin
            >>> from netket.operator import LocalOperator
-           >>> hi = CustomHilbert(local_states=[-1, 1])**20
+           >>> hi = Spin(0.5)**20
            >>> empty_hat = LocalOperator(hi)
            >>> print(len(empty_hat.acting_on))
            0

--- a/netket/utils/__init__.py
+++ b/netket/utils/__init__.py
@@ -47,7 +47,7 @@ from .history import History, accum_in_tree, accum_histories_in_tree
 
 from . import mpi
 
-from .static_range import Range as StaticRange
+from .static_range import StaticRange
 
 _hide_submodules(
     __name__,

--- a/netket/utils/__init__.py
+++ b/netket/utils/__init__.py
@@ -47,6 +47,8 @@ from .history import History, accum_in_tree, accum_histories_in_tree
 
 from . import mpi
 
+from .static_range import Range as StaticRange
+
 _hide_submodules(
     __name__,
     remove_self=False,

--- a/netket/utils/static_range.py
+++ b/netket/utils/static_range.py
@@ -1,0 +1,105 @@
+# Copyright 2022 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from numbers import Number
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from netket.utils import struct
+from netket.utils.types import DType
+from netket.jax import canonicalize_dtypes
+
+class Range(struct.Pytree):
+    """
+    An object representing a range similar to python's range, but that
+    works with `jax.jit` and can be used within Numba-blocks.
+
+    This range object can also be used to convert 'computational basis'
+    configurations to integer indices ∈ [0,length].
+    """
+
+    start : Number = struct.field(pytree_node=False)
+    step : Number = struct.field(pytree_node=False)
+    length : int = struct.field(pytree_node=False)
+    dtype: DType = struct.field(pytree_node=False)
+
+    def __init__(self, 
+            start: Number, 
+            step: Number, 
+            length: int, 
+            dtype: DType = None
+            ):
+        """
+        Constructs a Static Range object.
+
+        Args:
+            start: Value of the first entry
+            step: step between the entries
+            length: Length of this range
+        """
+        dtype = canonicalize_dtypes(start, step, dtype=dtype)
+        
+        self.start = jnp.array(start, dtype=dtype)
+        self.step = jnp.array(step, dtype=dtype)
+        self.length = length
+
+        self.dtype = dtype
+
+
+    def __len__(self):
+        return self.length
+
+    def __getitem__(self, i):
+        if i >= self.length:
+            raise IndexError
+        return self.start + self.step * i
+
+    def find(self, val):
+        return int((val - self.start) / self.step)
+
+    @jax.jit
+    def states_to_numbers(self, x, dtype : DType=None):
+        idx = ((x - self.start) / self.step)
+        if dtype is not None:
+            idx = idx.astype(dtype)
+        return idx
+
+    @jax.jit
+    def numbers_to_states(self, i):
+        return self.start + self.step * i
+
+    def flip_state(self, state):
+        if not len(self) == 2:
+            raise ValueError
+        constant_sum = 2 * self.start + self.step
+        return constant_sum - state
+
+    def __array__(self, dtype=None):
+        return self.start + np.arange(self.length, dtype=dtype) * self.step
+
+    def __hash__(self):
+        return hash(("StaticRange", self.start, self.step, self.length))
+
+    def __eq__(self, o):
+        if isinstance(o, Range):
+            return self.start == o.start and self.step == o.step and self.length == o.length
+        else:
+            return self.__array__() == o
+
+    def __repr__(self):
+        return (
+            f"StaticRange(start={self.start}, step={self.step}, length={self.length})"
+        )

--- a/netket/utils/static_range.py
+++ b/netket/utils/static_range.py
@@ -53,11 +53,11 @@ class StaticRange(struct.Pytree):
         >>> import netket as nk; import numpy as np
         >>> ran = nk.utils.StaticRange(start=-2, step=2, length=3)
         >>> np.array(ran)
-        array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        array([-2,  0,  2])
         >>> len(ran)
         3
         >>> ran.states_to_numbers(0)
-        Array(1., dtype=float64, weak_type=True)
+        Array(1, dtype=int64)
         >>> ran.numbers_to_states(0)
         Array(-2, dtype=int64)
 
@@ -94,6 +94,7 @@ class StaticRange(struct.Pytree):
             >>> import netket as nk
             >>> n_max = 10
             >>> nk.utils.StaticRange(start=0, step=1, length=n_max)
+            StaticRange(start=0, step=1, length=10, dtype=int64)
 
         and the range of a Spin-1/2 Hilbert space is constructed as:
 
@@ -102,6 +103,7 @@ class StaticRange(struct.Pytree):
             >>> import netket as nk
             >>> n_max = 10
             >>> nk.utils.StaticRange(start=-1, step=2, length=2)
+            StaticRange(start=-1, step=2, length=2, dtype=int64)
 
         Args:
             start: Value of the first entry

--- a/netket/utils/static_range.py
+++ b/netket/utils/static_range.py
@@ -13,11 +13,9 @@
 # limitations under the License.
 
 from numbers import Number
-from functools import partial
 
 import numpy as np
 
-import jax
 import jax.numpy as jnp
 
 from netket.utils import struct

--- a/netket/utils/static_range.py
+++ b/netket/utils/static_range.py
@@ -16,6 +16,7 @@ from numbers import Number
 
 import numpy as np
 
+import jax
 import jax.numpy as jnp
 
 from netket.utils import struct
@@ -152,7 +153,10 @@ class StaticRange(struct.Pytree):
         """
         idx = (x - self.start) / self.step
         if dtype is not None:
-            idx = idx.astype(dtype)
+            if not hasattr(idx, "astype"):
+                idx = np.array(idx, dtype=dtype)
+            else:
+                idx = idx.astype(dtype)
         return idx
 
     def numbers_to_states(self, i, dtype: DType = None):
@@ -169,8 +173,11 @@ class StaticRange(struct.Pytree):
 
         if dtype is None:
             dtype = self.dtype
-        start = jnp.array(self.start, dtype=dtype)
-        step = jnp.array(self.step, dtype=dtype)
+
+        npx = jnp if isinstance(i, jax.Array) else np
+
+        start = npx.array(self.start, dtype=dtype)
+        step = npx.array(self.step, dtype=dtype)
         return (start + step * i).astype(dtype)
 
     def flip_state(self, state):

--- a/netket/utils/static_range.py
+++ b/netket/utils/static_range.py
@@ -48,8 +48,8 @@ class Range(struct.Pytree):
         """
         dtype = canonicalize_dtypes(start, step, dtype=dtype)
 
-        self.start = np.array(start, dtype=dtype)
-        self.step = np.array(step, dtype=dtype)
+        self.start = np.array(start, dtype=dtype).item()
+        self.step = np.array(step, dtype=dtype).item()
         self.length = int(length)
 
         self.dtype = dtype
@@ -76,7 +76,9 @@ class Range(struct.Pytree):
     def numbers_to_states(self, i, dtype: DType = None):
         if dtype is None:
             dtype = self.dtype
-        return (self.start + self.step * i).astype(dtype)
+        start = jnp.array(self.start, dtype=dtype)
+        step = jnp.array(self.step, dtype=dtype)
+        return (start + step * i).astype(dtype)
 
     def flip_state(self, state):
         if not len(self) == 2:

--- a/netket/utils/static_range.py
+++ b/netket/utils/static_range.py
@@ -60,10 +60,10 @@ class StaticRange(struct.Pytree):
         Array(1., dtype=float64, weak_type=True)
         >>> ran.numbers_to_states(0)
         Array(-2, dtype=int64)
-        
+
         >>> ran.numbers_to_states(1)
         Array(0, dtype=int64)
-        
+
         >>> ran.numbers_to_states(2)
         Array(2, dtype=int64)
 
@@ -80,14 +80,14 @@ class StaticRange(struct.Pytree):
 
     def __init__(self, start: Number, step: Number, length: int, dtype: DType = None):
         """
-        Constructs a Static Range object. 
+        Constructs a Static Range object.
 
         To construct it, one must specify the start value, the step and the length.
         It is also possible to specify a `dtype`. In case it's not specified, it's
         inferred from the input arguments.
 
         For example, the :class:`~netket.utils.StaticRange` of a Fock Hilbert space
-        is constructed as 
+        is constructed as
 
         .. code-block:: python
 
@@ -180,7 +180,7 @@ class StaticRange(struct.Pytree):
         return hash(("StaticRange", self.start, self.step, self.length))
 
     def __eq__(self, o):
-        if isinstance(o, Range):
+        if isinstance(o, StaticRange):
             return (
                 self.start == o.start
                 and self.step == o.step

--- a/netket/utils/static_range.py
+++ b/netket/utils/static_range.py
@@ -15,8 +15,10 @@
 from numbers import Number
 from functools import partial
 
-import jax
 import numpy as np
+
+import jax
+import jax.numpy as jnp
 
 from netket.utils import struct
 from netket.utils.types import DType

--- a/netket/utils/static_range.py
+++ b/netket/utils/static_range.py
@@ -56,15 +56,13 @@ class StaticRange(struct.Pytree):
         >>> len(ran)
         3
         >>> ran.states_to_numbers(0)
-        Array(1, dtype=int64)
+        array(1)
         >>> ran.numbers_to_states(0)
-        Array(-2, dtype=int64)
-
+        -2
         >>> ran.numbers_to_states(1)
-        Array(0, dtype=int64)
-
+        0
         >>> ran.numbers_to_states(2)
-        Array(2, dtype=int64)
+        2
 
     """
 

--- a/netket/utils/static_range.py
+++ b/netket/utils/static_range.py
@@ -141,7 +141,6 @@ class StaticRange(struct.Pytree):
             raise IndexError
         return self.start + self.step * i
 
-    @partial(jax.jit, static_argnames="dtype")
     def states_to_numbers(self, x, dtype: DType = int):
         """Given an element in the range, returns it's index.
 
@@ -158,7 +157,6 @@ class StaticRange(struct.Pytree):
             idx = idx.astype(dtype)
         return idx
 
-    @partial(jax.jit, static_argnames="dtype")
     def numbers_to_states(self, i, dtype: DType = None):
         """Given an integer index, returns the i-th elements in the range.
 

--- a/test/hilbert/test_hilbert.py
+++ b/test/hilbert/test_hilbert.py
@@ -29,6 +29,7 @@ from netket.hilbert import (
     Spin,
 )
 import netket.experimental as nkx
+from netket.utils import StaticRange
 
 import jax
 import jax.numpy as jnp
@@ -69,7 +70,7 @@ hilberts["Fock * Fock (non-indexable)"] = Fock(n_max=4, N=40) * Fock(n_max=7, N=
 hilberts["Qubit"] = nk.hilbert.Qubit(100)
 
 # Custom Hilbert
-hilberts["Custom Hilbert"] = CustomHilbert(local_states=[-1232, 132, 0], N=70)
+hilberts["Custom Hilbert"] = CustomHilbert(local_states=StaticRange(-153, 44, 3), N=70)
 
 # Heisenberg 1d
 hilberts["Heisenberg 1d"] = Spin(s=0.5, total_sz=0.0, N=20)
@@ -94,7 +95,9 @@ hilberts["Fock Small"] = Fock(n_max=3, N=5)
 hilberts["Qubit Small"] = Qubit(N=1)
 
 # Custom Hilbert
-hilberts["Custom Hilbert Small"] = CustomHilbert(local_states=[-1232, 132, 0], N=5)
+hilberts["Custom Hilbert Small"] = CustomHilbert(
+    local_states=StaticRange(-123, 10, 3), N=5
+)
 
 # Custom Hilbert
 hilberts["DoubledHilbert[Spin]"] = DoubledHilbert(Spin(0.5, N=5))
@@ -106,7 +109,7 @@ hilberts["DoubledHilbert[Spin(total_sz=0.5)]"] = DoubledHilbert(
 hilberts["DoubledHilbert[Fock]"] = DoubledHilbert(Spin(0.5, N=5))
 
 hilberts["DoubledHilbert[CustomHilbert]"] = DoubledHilbert(
-    CustomHilbert(local_states=[-1232, 132, 0], N=5)
+    CustomHilbert(local_states=StaticRange(-123, 10, 3), N=5)
 )
 
 # hilberts["Tensor: Spin x Fock"] = Spin(s=0.5, N=4) * Fock(4, N=2)

--- a/test/operator/test_local_operator.py
+++ b/test/operator/test_local_operator.py
@@ -28,7 +28,7 @@ sz = [[1, 0], [0, -1]]
 sm = [[0, 0], [1, 0]]
 sp = [[0, 1], [0, 0]]
 g = nk.graph.Graph(edges=[[i, i + 1] for i in range(8)])
-hi = nk.hilbert.CustomHilbert(local_states=[-1, 1], N=g.n_nodes)
+hi = nk.hilbert.CustomHilbert(local_states=nk.utils.StaticRange(-1, 2, 2), N=g.n_nodes)
 
 sy_sparse = sparse.csr_matrix(sy)
 
@@ -368,7 +368,7 @@ def test_copy(op):
 
 
 def test_raises_unsorted_hilbert():
-    hi = nk.hilbert.CustomHilbert([-1, 1, 0], N=3)
+    hi = nk.hilbert.CustomHilbert(nk.utils.StaticRange(1, -2, 2), N=3)
     with pytest.raises(ValueError):
         nk.operator.LocalOperator(hi)
 

--- a/test/operator/test_operator.py
+++ b/test/operator/test_operator.py
@@ -39,7 +39,7 @@ mszsz = np.asarray([[1, 0, 0, 0], [0, -1, 0, 0], [0, 0, -1, 0], [0, 0, 0, 1]])
 edges = [[i, i + 1] for i in range(N - 1)] + [[N - 1, 0]]
 
 g = nk.graph.Graph(edges=edges)
-hi = nk.hilbert.CustomHilbert(local_states=[-1, 1], N=g.n_nodes)
+hi = nk.hilbert.CustomHilbert(local_states=nk.utils.StaticRange(-1, 2, 2), N=g.n_nodes)
 operators["Graph Hamiltonian"] = nk.operator.GraphOperator(
     hi, g, site_ops=[sigmax], bond_ops=[mszsz]
 )
@@ -56,7 +56,7 @@ operators["Graph Hamiltonian (on subspace)"] = nk.operator.GraphOperator(
 # Graph Hamiltonian with colored edges
 edges_c = [(i, j, i % 2) for i, j in edges]
 g = nk.graph.Graph(edges=edges_c)
-hi = nk.hilbert.CustomHilbert(local_states=[-1, 1], N=g.n_nodes)
+hi = nk.hilbert.CustomHilbert(local_states=nk.utils.StaticRange(-1, 2, 2), N=g.n_nodes)
 operators["Graph Hamiltonian (colored edges)"] = nk.operator.GraphOperator(
     hi,
     g,
@@ -75,7 +75,7 @@ sx = [[0, 1], [1, 0]]
 sy = [[0, -1.0j], [1.0j, 0]]
 sz = [[1, 0], [0, -1]]
 g = nk.graph.Graph(edges=[[i, i + 1] for i in range(20)])
-hi = nk.hilbert.CustomHilbert(local_states=[-1, 1], N=g.n_nodes)
+hi = nk.hilbert.CustomHilbert(local_states=nk.utils.StaticRange(-1, 2, 2), N=g.n_nodes)
 
 for name, LocalOp_impl in [
     ("numba", nk.operator.LocalOperator),

--- a/test/utils/test_range.py
+++ b/test/utils/test_range.py
@@ -1,7 +1,9 @@
-import jax
 import pytest
 
 import numpy as np
+
+import jax
+import jax.numpy as jnp
 
 from netket.utils import StaticRange
 
@@ -54,16 +56,23 @@ def test_staticrange_array_interface():
     )
     assert ran.states_to_numbers(10).dtype == int
     assert ran.states_to_numbers(10, dtype=float).dtype == float
+    assert isinstance(ran.states_to_numbers(10), np.ndarray)
+    assert isinstance(ran.states_to_numbers(np.array([10, 20])), np.ndarray)
+    assert isinstance(ran.states_to_numbers(jnp.array(10)), jax.Array)
 
     np.testing.assert_allclose(
         ran.numbers_to_states(np.array([0, 1, 10])), np.array([0, 10, 100])
     )
     assert ran.numbers_to_states(1).dtype == int
+    assert isinstance(ran.numbers_to_states(1), np.int_)
+    assert isinstance(ran.numbers_to_states(np.array([1, 2])), np.ndarray)
+    assert isinstance(ran.numbers_to_states(jnp.array(1)), jax.Array)
 
     ran = StaticRange(0, 10, 100, dtype=float)
     assert ran.dtype == float
     assert ran.states_to_numbers(1).dtype == int
     assert ran.numbers_to_states(1).dtype == float
+    assert isinstance(ran.numbers_to_states(1), float)
     assert np.array(ran).dtype == float
     np.testing.assert_allclose(
         np.array(StaticRange(0, 10, 100)),

--- a/test/utils/test_range.py
+++ b/test/utils/test_range.py
@@ -1,0 +1,81 @@
+import jax
+import pytest
+
+import numpy as np
+
+from netket.utils import StaticRange
+
+from .. import common
+
+pytestmark = common.skipif_mpi
+
+
+def test_staticrange_eq():
+    ran = StaticRange(0, 10, 100)
+
+    assert hash(StaticRange(0, 10, 100)) == hash(StaticRange(0, 10, 100))
+    assert StaticRange(0, 10, 100) == StaticRange(0, 10, 100)
+
+    assert hash(StaticRange(0, 10, 100)) != hash(StaticRange(0, 11, 10))
+    assert StaticRange(0, 10, 100) != StaticRange(0, 11, 100)
+
+    assert hash(StaticRange(0, 10, 100, dtype=int)) != hash(
+        StaticRange(0, 11, 10, dtype=float)
+    )
+    assert StaticRange(0, 10, 100) != StaticRange(0, 11, 100)
+
+    leaves, treedef1 = jax.tree_util.tree_flatten(ran)
+    _, treedef2 = jax.tree_util.tree_flatten(ran)
+    assert len(leaves) == 0
+    assert hash(treedef1) == hash(treedef2)
+
+    assert ran == jax.tree_util.tree_unflatten(treedef1, leaves)
+
+    isinstance(repr(ran), str)
+
+
+def test_staticrange_array_interface():
+    ran = StaticRange(0, 10, 100)
+
+    assert ran.dtype == int
+    assert ran.ndim == 1
+    assert ran.shape == (100,)
+    assert len(ran) == 100
+    np.testing.assert_allclose(np.array(ran), np.arange(0, 1000, 10))
+
+    assert StaticRange(0, 10, 100, dtype=float).astype(int) == ran
+
+    assert ran[10] == 10 * 10
+    with pytest.raises(IndexError):
+        ran[101]
+
+    np.testing.assert_allclose(
+        ran.states_to_numbers(np.array([0, 10, 100])), np.array([0, 1, 10])
+    )
+    assert ran.states_to_numbers(10).dtype == int
+    assert ran.states_to_numbers(10, dtype=float).dtype == float
+
+    np.testing.assert_allclose(
+        ran.numbers_to_states(np.array([0, 1, 10])), np.array([0, 10, 100])
+    )
+    assert ran.numbers_to_states(1).dtype == int
+
+    ran = StaticRange(0, 10, 100, dtype=float)
+    assert ran.dtype == float
+    assert ran.states_to_numbers(1).dtype == int
+    assert ran.numbers_to_states(1).dtype == float
+    assert np.array(ran).dtype == float
+    np.testing.assert_allclose(
+        np.array(StaticRange(0, 10, 100)),
+        np.array(StaticRange(0, 10, 100, dtype=float).astype(int)),
+    )
+
+
+def test_staticrange_flip():
+    ran = StaticRange(0, 10, 100, dtype=float)
+
+    with pytest.raises(ValueError):
+        ran.flip_state(10)
+
+    ran = StaticRange(0, 1, 2)
+    ran.flip_state(0) == 1


### PR DESCRIPTION
~Investigate using lazy range objects for local states in Hilbert spaces.~

The PR makes some changes that could be used in #1720 to support jax-based Hilbert indexing in a more elegant way, as well as lays preliminary groundwork to simplify our implementation of operators.

The biggest addition of the PR is a new class, `StaticRange`, which behaves like a python `range` object with static start, step and length, and which plays well with Jax.  The static range object can be used to convert local states (-1, 1...) to indices starting at 0.

The PR then changes Hilbert spaces to internally use those range objects instead of np arrays when storing the local states.

No user-facing API changes are exposed except for the fact that `CustomHilbert` now requires a `StaticRange` object to specify the values of the Hilbert space. 
`CustomHilbert` is not covered by stability guarantees so that is fine.
