### PR TITLE
Hilbert with dtypes

### DIFF
--- a/netket/hilbert/fock.py
+++ b/netket/hilbert/fock.py
@@ -17,6 +17,7 @@ from typing import Optional, Union
 import numpy as np
 
 from netket.utils import StaticRange
+from netket.utils.types import DType
 
 from .homogeneous import HomogeneousHilbert
 from .index.constraints import SumConstraint
@@ -37,6 +38,7 @@ class Fock(HomogeneousHilbert):
         n_max: Optional[int] = None,
         N: int = 1,
         n_particles: Optional[int] = None,
+        dtype: DType = None,
     ):
         r"""
         Constructs a new ``Boson`` given a maximum occupation number, number of sites
@@ -88,10 +90,10 @@ class Fock(HomogeneousHilbert):
             self._n_particles = None
 
         if self._n_max is not None:
+            if dtype is None:
+                dtype = np.int8 if self._n_max < 2**6 else int
             # assert self._n_max > 0
-            local_states = StaticRange(
-                0, 1, self._n_max + 1, dtype=np.int8 if self._n_max < 2**6 else int
-            )
+            local_states = StaticRange(0, 1, self._n_max + 1, dtype=dtype)
         else:
             self._n_max = FOCK_MAX
             local_states = None

--- a/netket/hilbert/qubit.py
+++ b/netket/hilbert/qubit.py
@@ -17,6 +17,7 @@ from typing import Optional, Union
 import numpy as np
 
 from netket.utils import StaticRange
+from netket.utils.types import DType
 
 from .homogeneous import HomogeneousHilbert
 
@@ -24,7 +25,7 @@ from .homogeneous import HomogeneousHilbert
 class Qubit(HomogeneousHilbert):
     r"""Hilbert space obtained as tensor product of local qubit states."""
 
-    def __init__(self, N: int = 1):
+    def __init__(self, N: int = 1, dtype: DType = np.int8):
         r"""Initializes a qubit hilbert space.
 
         Args:
@@ -38,7 +39,7 @@ class Qubit(HomogeneousHilbert):
             >>> print(hi.size)
             100
         """
-        super().__init__(StaticRange(0, 1, 2, dtype=np.int8), N)
+        super().__init__(StaticRange(0, 1, 2, dtype=dtype), N)
 
     def __pow__(self, n):
         return Qubit(self.size * n)

--- a/netket/hilbert/spin.py
+++ b/netket/hilbert/spin.py
@@ -18,6 +18,7 @@ from typing import Optional, Union
 import numpy as np
 
 from netket.utils import StaticRange
+from netket.utils.types import DType
 
 from .homogeneous import HomogeneousHilbert
 
@@ -60,6 +61,7 @@ class Spin(HomogeneousHilbert):
         s: float,
         N: int = 1,
         total_sz: Optional[float] = None,
+        dtype: DType = None,
     ):
         r"""Hilbert space obtained as tensor product of local spin states.
 
@@ -78,12 +80,11 @@ class Spin(HomogeneousHilbert):
            4
         """
         local_size = round(2 * s + 1)
-        local_states = np.empty(local_size)
-
         assert int(2 * s + 1) == local_size
-        local_states = StaticRange(
-            1 - local_size, 2, local_size, dtype=np.int8 if local_size < 2**7 else int
-        )
+        if dtype is None:
+            dtype = np.int8 if local_size < 2**7 else int
+
+        local_states = StaticRange(1 - local_size, 2, local_size, dtype=dtype)
 
         _check_total_sz(total_sz, s, N)
         if total_sz is not None:

--- a/test/hilbert/test_hilbert.py
+++ b/test/hilbert/test_hilbert.py
@@ -700,7 +700,7 @@ def test_constrained_eq_hash():
     assert hash(hi1) != hash(hi2)
 
 
-@pytest.mark.parametrize("hi", discrete_hilbert_params)
+@pytest.mark.parametrize("hi", discrete_indexable_hilbert_params)
 def test_hilbert_numba_throws(hi):
     """Check that get conn throws an error"""
     from netket.errors import HilbertIndexingDuringTracingError


### PR DESCRIPTION
Prototyping Hilbert spaces with dtypes. 
On top of #1720 it's very, very straightforward.
Maybe it's worth doing this (even if I keep asking myself why should we do that).

```python
In [2]: hi=Spin(0.5, 4, dtype=np.int8, total_sz=0.0)

In [3]: hi.all_states()
Out[3]:
Array([[-1, -1,  1,  1],
       [-1,  1, -1,  1],
       [-1,  1,  1, -1],
       [ 1, -1, -1,  1],
       [ 1, -1,  1, -1],
       [ 1,  1, -1, -1]], dtype=int8)
```