### PR TITLE
Fix #1735: repr and integer t0 in RKSolverState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,15 @@
 ### Bug Fixes
 
 
+
+## NetKet 3.11.2 (27 february 2024)
+
+Bugfix release to solve the following issues:
+* Fix error thrown in repr method of error thrown in TDVP integrators. 
+* Fix repr error of {class}`nk.sampler.rules.MultipleRules` [#1729](https://github.com/netket/netket/pull/1729).
+* Solve an issue with RK Integrators that could not be initialised with integer `t0` initial time if `dt` was a float, as well as a wrong `repr` method leading to uncomprehensible stacktraces [#1736](https://github.com/netket/netket/pull/1736).
+
+
 ## NetKet 3.11.1 (19 february 2024)
 
 Bugfix release to solve two issues:

--- a/netket/experimental/dynamics/_rk_solver_structures.py
+++ b/netket/experimental/dynamics/_rk_solver_structures.py
@@ -143,13 +143,22 @@ class RungeKuttaState:
     """Flags containing information on the solver state."""
 
     def __repr__(self):
-        return "RKState(step_no(total)={}({}), t={}, dt={:.2e}{}{})".format(
+        try:
+            dt = "{self.dt:.2e}"
+            last_norm = f", {self.last_norm:.2e}" if self.last_norm is not None else ""
+            accepted = (f", {'A' if self.accepted else 'R'}",)
+        except (ValueError, TypeError):
+            dt = f"{self.dt}"
+            last_norm = f"{self.last_norm}"
+            accepted = f"{SolverFlags.INFO_STEP_ACCEPTED}"
+
+        return "RKState(step_no(total)={}({}), t={}, dt={}{}{})".format(
             self.step_no,
             self.step_no_total,
             self.t.value,
-            self.dt,
-            f", {self.last_norm:.2e}" if self.last_norm is not None else "",
-            f", {'A' if self.accepted else 'R'}",
+            dt,
+            last_norm,
+            accepted,
         )
 
     @property

--- a/netket/experimental/dynamics/_rk_solver_structures.py
+++ b/netket/experimental/dynamics/_rk_solver_structures.py
@@ -341,8 +341,8 @@ class RungeKuttaIntegrator:
             self.dt_limits = (None, 10 * self.initial_dt)
 
         t_dtype = jnp.result_type(_dtype(self.t0), _dtype(self.initial_dt))
-        setattr(self, 't0', jnp.array(self.t0, dtype=t_dtype))
-        setattr(self, 'initial_dt', jnp.array(self.initial_dt, dtype=t_dtype))
+        setattr(self, "t0", jnp.array(self.t0, dtype=t_dtype))
+        setattr(self, "initial_dt", jnp.array(self.initial_dt, dtype=t_dtype))
 
         self._rkstate = RungeKuttaState(
             step_no=0,

--- a/netket/experimental/dynamics/_rk_solver_structures.py
+++ b/netket/experimental/dynamics/_rk_solver_structures.py
@@ -24,6 +24,7 @@ from netket import config
 from netket.utils.mpi.primitives import mpi_all_jax
 from netket.utils.struct import dataclass, field
 from netket.utils.types import Array, PyTree
+from netket.utils.numbers import dtype as _dtype
 
 from . import _rk_tableau as rkt
 
@@ -338,6 +339,10 @@ class RungeKuttaIntegrator:
 
         if self.dt_limits is None:
             self.dt_limits = (None, 10 * self.initial_dt)
+
+        t_dtype = jnp.result_type(_dtype(self.t0), _dtype(self.initial_dt))
+        setattr(self, 't0', jnp.array(self.t0, dtype=t_dtype))
+        setattr(self, 'initial_dt', jnp.array(self.initial_dt, dtype=t_dtype))
 
         self._rkstate = RungeKuttaState(
             step_no=0,

--- a/test/dynamics/test_solvers.py
+++ b/test/dynamics/test_solvers.py
@@ -161,6 +161,26 @@ def test_ode_repr():
     _test_jit_repr(solv._rkstate)
     # _test_jit_repr(solv) # this is broken. should be fixed in the zukumft
 
+
+def test_solver_t0_is_integer():
+    # See issue netket/netket#1735
+    # https://github.com/netket/netket/issues/1735
+
+    def df(t, y, stage=None):
+        return np.sin(t) ** 2 * y
+
+    int_config = RK23(
+        dt=0.04, adaptive=True, atol=1e-3, rtol=1e-3, dt_limits=[1e-3, 1e-1]
+    )
+    integrator = int_config(
+        df, 0, np.array([1.0])
+    )  # <-- the second argument has to be a float
+
+    integrator.step()
+    assert integrator.t > 0.0
+    assert integrator.t.dtype == integrator.dt.dtype
+
+
 @pytest.mark.parametrize("solver", explicit_adaptive_solvers_params)
 def test_adaptive_solver(solver):
     tol = 1e-7

--- a/test/dynamics/test_solvers.py
+++ b/test/dynamics/test_solvers.py
@@ -15,6 +15,7 @@
 import pytest
 import numpy as np
 
+import jax
 import scipy.integrate as sci
 
 from netket.experimental.dynamics import Euler, Heun, Midpoint, RK4, RK12, RK23, RK45
@@ -137,6 +138,28 @@ def test_ode_solver(method):
     }.get(solver.tableau.name, 1e-3)
     np.testing.assert_allclose(y_t[:, 0], y_ref, rtol=rtol)
 
+
+def test_ode_repr():
+    dt = 0.01
+
+    def ode(t, x, **_):
+        return -t * x
+
+    solver = RK23(dt=dt, adaptive=True)
+
+    y0 = np.array([1.0])
+    solv = solver(ode, 0.0, y0)
+
+    assert isinstance(repr(solv), str)
+    assert isinstance(repr(solv._rkstate), str)
+
+    @jax.jit
+    def _test_jit_repr(x):
+        assert isinstance(repr(x), str)
+        return 1
+
+    _test_jit_repr(solv._rkstate)
+    # _test_jit_repr(solv) # this is broken. should be fixed in the zukumft
 
 @pytest.mark.parametrize("solver", explicit_adaptive_solvers_params)
 def test_adaptive_solver(solver):


### PR DESCRIPTION
fix #1735 