### PR TITLE
Prepare for changing spin convention to 1=↑ -1=↓

### DIFF
--- a/netket/errors.py
+++ b/netket/errors.py
@@ -1061,7 +1061,7 @@ class UndeclaredSpinOderingWarning(NetketWarning):
                 - To opt-in today in the future default, specify `inverted_ordering=False` (so your code will
                     work without changes in the future)
 
-                If you do not care about this warning, you can silence it by setting the environment variable 
+                If you do not care about this warning, you can silence it by setting the environment variable
                 `NETKET_SPIN_ORDERING_WARNING=0` or by executing `nk.config.netket_spin_ordering_warning = False`
 
                 This warning will be shown once per day during interactive sessions, and always in scripts and MPI/SLURM jobs unless silenced.

--- a/netket/errors.py
+++ b/netket/errors.py
@@ -982,6 +982,94 @@ class NetKetPyTreeUndeclaredAttributeAssignmentError(AttributeError, NetketError
         )
 
 
+class UndeclaredSpinOderingWarning(NetketWarning):
+    """
+    Warning thrown when a Spin Hilbert space is created without specifying the spin ordering.
+
+    This warning is thrown in the transition period of NetKet 3.14 to NetKet 3.15 (september to
+    december 2024), to warn users that the correspondence between ±1 and spin up/down will change
+    according to the table below.
+
+    +----------+----------------------------------+-----------------------------------+
+    | State    | Old Behavior                     | New Behavior                      |
+    |          | :code:`inverted_ordering=True`   | :code:`inverted_ordering=False`   |
+    +==========+==================================+===================================+
+    | ↑ ↑ ↑    | -1 -1 -1                         | +1 +1 +1                          |
+    +----------+----------------------------------+-----------------------------------+
+    | ↑ ↑ ↓    | -1 -1 +1                         | +1 +1 -1                          |
+    +----------+----------------------------------+-----------------------------------+
+    | ↑ ↓ ↑    | -1 +1 -1                         | +1 -1 +1                          |
+    +----------+----------------------------------+-----------------------------------+
+    | ↑ ↓ ↓    | -1 +1 +1                         | +1 -1 -1                          |
+    +----------+----------------------------------+-----------------------------------+
+    | ↓ ↑ ↑    | +1 -1 -1                         | -1 +1 +1                          |
+    +----------+----------------------------------+-----------------------------------+
+    | ↓ ↑ ↓    | +1 -1 +1                         | -1 +1 -1                          |
+    +----------+----------------------------------+-----------------------------------+
+    | ↓ ↓ ↑    | +1 +1 -1                         | -1 -1 +1                          |
+    +----------+----------------------------------+-----------------------------------+
+    | ↓ ↓ ↓    | +1 +1 +1                         | -1 -1 -1                          |
+    +----------+----------------------------------+-----------------------------------+
+
+    The old behaviour is the default behaviour of NetKet 3.14 and before, while the new
+    behaviour will become the default starting 1st january 2025.
+    For that reason, in the transition period, we will print warnings asking to explicitly
+    specify which ordering you want
+
+    .. warning::
+
+        The ordering of the Spin Hilbert space basis has historically always been
+        such that `-1=↑, 1=↓`, but it will be changed 1st january 2025 to
+        be such that `1=↑, -1=↓`.
+
+        The change will break:
+            - code that relies on the assumption that -1=↑;
+            - all saves because the inputs to the network will change;
+            - custom operators that rely on the basis being ordered;
+
+        To avoid distruption, NetKet will support **both** conventions in the (near)
+        future. You can specify the ordering you need with :code:`inverted_ordering = True`
+        (historical ordering) or :code:`inverted_ordering=False` (future default behaviour).
+
+        If you do not specify this flag, a future version of NetKet might break your
+        serialized weights or other logic, so we strongly reccomend that you either
+        limit yourself to NetKet 3.14, or that you specify :code:`inverted_ordering`
+        explicitly.
+
+    To avoid this warning, you can :
+
+     - explicitly specify the ordering you want wit the `inverted_ordering` flag, which will
+       ensure that your code will still work in the future with no changes. If possible,
+       we suggest you use the new ordering `inverted_ordering=False`, but if you want to
+       keep loading parameters serialized before th switch, you should use `inverted_ordering=True`.
+
+     - You can silence this warning by setting the environment variable
+       ``NETKET_SPIN_ORDERING_WARNING=0`` or by setting
+       ``nk.config.netket_spin_ordering_warning = False`` in your code.
+
+    """
+
+    def __init__(self):
+        super().__init__(
+            _dedent(
+                """
+                You have not explicitly specified the spin ordering for the Hilbert space.
+                The default behaviour is currently `-1=↑, 1=↓`, but it will be changed 1st january 2025 to `1=↑, -1=↓`.
+
+                - To maintain the current behaviour in the future, specify `inverted_ordering=True` (this
+                    allows you to load NN parameters you have saved in the past)
+                - To opt-in today in the future default, specify `inverted_ordering=False` (so your code will
+                    work without changes in the future)
+
+                If you do not care about this warning, you can silence it by setting the environment variable 
+                `NETKET_SPIN_ORDERING_WARNING=0` or by executing `nk.config.netket_spin_ordering_warning = False`
+
+                This warning will be shown once per day during interactive sessions, and always in scripts and MPI/SLURM jobs unless silenced.
+                """
+            )
+        )
+
+
 #################################################
 # Functions to throw errors                     #
 #################################################

--- a/netket/hilbert/spin.py
+++ b/netket/hilbert/spin.py
@@ -82,11 +82,12 @@ class Spin(HomogeneousHilbert):
            4
         """
         local_size = round(2 * s + 1)
-        local_states = np.empty(local_size)
-
         assert int(2 * s + 1) == local_size
         local_states = StaticRange(
-            1 - local_size, 2, local_size, dtype=np.int8 if local_size < 2**7 else int
+            local_size - 1,
+            -2,
+            local_size,
+            dtype=np.int8 if local_size < 2**7 else int,
         )
 
         _check_total_sz(total_sz, s, N)

--- a/netket/hilbert/spin.py
+++ b/netket/hilbert/spin.py
@@ -52,7 +52,30 @@ def _check_total_sz(total_sz, S, size):
 
 
 class Spin(HomogeneousHilbert):
-    r"""Hilbert space obtained as tensor product of local spin states."""
+    r"""Hilbert space obtained as tensor product of local spin states.
+
+    .. warning::
+
+        The ordering of the Spin Hilbert space basis has historically always been
+        such that `-1=↑, 1=↓`, but it will be changed 1st january 2025 to
+        be such that `1=↑, -1=↓`.
+
+        The change will break:
+            - code that relies on the assumption that -1=↑;
+            - all saves because the inputs to the network will change;
+            - custom operators that rely on the basis being ordered;
+
+        To avoid distruption, NetKet will support **both** conventions in the (near)
+        future. You can specify the ordering you need with :code:`inverted_ordering = True`
+        (historical ordering) or :code:`inverted_ordering=False` (future default behaviour).
+
+        If you do not specify this flag, a future version of NetKet might break your
+        serialized weights or other logic, so we strongly reccomend that you either
+        limit yourself to NetKet 3.14, or that you specify :code:`inverted_ordering`
+        explicitly.
+
+
+    """
 
     def __init__(
         self,
@@ -61,17 +84,27 @@ class Spin(HomogeneousHilbert):
         *,
         total_sz: float | None = None,
         constraint: DiscreteHilbertConstraint | None = None,
+        inverted_ordering: bool = True,
     ):
         r"""Hilbert space obtained as tensor product of local spin states.
 
         Args:
-           s: Spin at each site. Must be integer or half-integer.
-           N: Number of sites (default=1)
-           total_sz: If given, constrains the total spin of system to a particular
+            s: Spin at each site. Must be integer or half-integer.
+            N: Number of sites (default=1)
+            total_sz: If given, constrains the total spin of system to a particular
                 value.
-          constraint: A custom constraint on the allowed configurations. This argument
+            constraint: A custom constraint on the allowed configurations. This argument
                 cannot be specified at the same time as :code:`total_sz`. The constraint
                 must be a subclass of :class:`~netket.hilbert.DiscreteHilbertConstraint`.
+            inverted_ordering: Flag to specify the ordering of the Local basis. Historically
+                NetKet has always used the convention `-1=↑, 1=↓` (corresponding to
+                :code:`inverted_ordering=True`, but we will change it to `1=↑, -1=↓` (
+                :code:`inverted_ordering=False`).
+                The default as of September 2024 (NetKet 3.14) is :code:`inverted_ordering=True`, but
+                we will change it in the near future.
+                The change will (i) break code that relies on the assumption that -1=↑, and
+                (ii) will break all saves because the inputs to the network will change.
+
 
         Examples:
            Simple spin hilbert space.
@@ -83,12 +116,23 @@ class Spin(HomogeneousHilbert):
         """
         local_size = round(2 * s + 1)
         assert int(2 * s + 1) == local_size
-        local_states = StaticRange(
-            local_size - 1,
-            -2,
-            local_size,
-            dtype=np.int8 if local_size < 2**7 else int,
-        )
+
+        if not inverted_ordering:
+            # Reasonable, new ordering where  1=↑ -1=↓
+            local_states = StaticRange(
+                local_size - 1,
+                -2,
+                local_size,
+                dtype=np.int8 if local_size < 2**7 else int,
+            )
+        else:
+            # Old ordering where -1=↑ 1=↓
+            local_states = StaticRange(
+                1 - local_size,
+                2,
+                local_size,
+                dtype=np.int8 if local_size < 2**7 else int,
+            )
 
         _check_total_sz(total_sz, s, N)
         if total_sz is not None:
@@ -101,6 +145,7 @@ class Spin(HomogeneousHilbert):
 
         self._total_sz = total_sz
         self._s = s
+        self._inverted_ordering = inverted_ordering
 
         super().__init__(local_states, N, constraint=constraint)
 
@@ -145,8 +190,9 @@ class Spin(HomogeneousHilbert):
             constraint = f", {self._constraint}"
         else:
             constraint = ""
-        return f"Spin(s={Fraction(self._s)}, N={self.size}{constraint})"
+        ordering = "inverted" if self._inverted_ordering else "new"
+        return f"Spin(s={Fraction(self._s)}, N={self.size}, ordering={ordering}{constraint})"
 
     @property
     def _attrs(self):
-        return (self.size, self._s, self.constraint)
+        return (self.size, self._s, self._inverted_ordering, self.constraint)

--- a/netket/hilbert/tensor_hilbert_discrete.py
+++ b/netket/hilbert/tensor_hilbert_discrete.py
@@ -38,7 +38,7 @@ class TensorDiscreteHilbert(TensorHilbert, DiscreteHilbert):
         >>> from netket.hilbert import Spin, Fock
         >>> hi = Fock(3)*Spin(0.5, 5)
         >>> print(hi)
-        Fock(n_max=3, N=1)⊗Spin(s=1/2, N=5)
+        Fock(n_max=3, N=1)⊗Spin(s=1/2, N=5, ordering=inverted)
         >>> isinstance(hi, nk.hilbert.TensorHilbert)
         True
         >>> type(hi)

--- a/netket/operator/_pauli_strings/base.py
+++ b/netket/operator/_pauli_strings/base.py
@@ -162,7 +162,7 @@ class PauliStringsBase(DiscreteOperator):
            >>> hilbert = nk.hilbert.Spin(1/2, 2)
            >>> op = nk.operator.PauliStrings(hilbert, operators, weights)
            >>> op.hilbert
-           Spin(s=1/2, N=2)
+           Spin(s=1/2, N=2, ordering=inverted)
         """
         if hilbert is None:
             raise ValueError("None-valued hilbert passed.")

--- a/netket/utils/config_flags.py
+++ b/netket/utils/config_flags.py
@@ -421,3 +421,17 @@ config.define(
         """
     ),
 )
+
+
+config.define(
+    "NETKET_SPIN_ORDERING_WARNING",
+    bool,
+    default=True,
+    runtime=True,
+    help=dedent(
+        """
+        If True (Defaults True) warns if the ordering of spins in the Hilbert space
+        is not declared.
+        """
+    ),
+)

--- a/test/hilbert/test_hilbert.py
+++ b/test/hilbert/test_hilbert.py
@@ -476,7 +476,7 @@ def test_local_indices_to_states(hi):
 
 
 @pytest.mark.parametrize("inverted_ordering", [True, False])
-def test_spin_state_iteration(inverted_ordering:bool):
+def test_spin_state_iteration(inverted_ordering: bool):
     hilbert = Spin(s=0.5, N=5, inverted_ordering=inverted_ordering)
 
     if inverted_ordering:

--- a/test/hilbert/test_hilbert.py
+++ b/test/hilbert/test_hilbert.py
@@ -476,9 +476,9 @@ def test_local_indices_to_states(hi):
 
 
 def test_state_iteration():
-    hilbert = Spin(s=0.5, N=10)
+    hilbert = Spin(s=0.5, N=5)
 
-    reference = [np.array(el) for el in itertools.product([-1.0, 1.0], repeat=10)]
+    reference = [np.array(el) for el in itertools.product([1.0, -1.0], repeat=5)]
 
     for state, ref in zip(hilbert.states(), reference):
         np.testing.assert_allclose(state, ref)

--- a/test/hilbert/test_hilbert.py
+++ b/test/hilbert/test_hilbert.py
@@ -475,10 +475,14 @@ def test_local_indices_to_states(hi):
         np.testing.assert_allclose(local_states[idxs[..., s]], x[..., s])
 
 
-def test_state_iteration():
-    hilbert = Spin(s=0.5, N=5)
+@pytest.mark.parametrize("inverted_ordering", [True, False])
+def test_spin_state_iteration(inverted_ordering: bool):
+    hilbert = Spin(s=0.5, N=5, inverted_ordering=inverted_ordering)
 
-    reference = [np.array(el) for el in itertools.product([1.0, -1.0], repeat=5)]
+    if inverted_ordering:
+        reference = [np.array(el) for el in itertools.product([-1.0, 1.0], repeat=5)]
+    else:
+        reference = [np.array(el) for el in itertools.product([1.0, -1.0], repeat=5)]
 
     for state, ref in zip(hilbert.states(), reference):
         np.testing.assert_allclose(state, ref)


### PR DESCRIPTION
Fixes #710 

WIP, requires #1730 to pass tests.

```python
In [4]: nk.operator.spin.sigmaz(nk.hilbert.Spin(0.5, 2), 0).get_conn(np.array([-1, -1]))
Out[4]: (array([[-1, -1]]), array([-1.]))
```

Removes the requirement that the local values of the Hilbert space be sorted. Makes all discrete operators work on 'fock' like bases (0,1,2,3...) and simply converts to/from this basis.