### PR TITLE
Fix #1742, Fix conjugation of fermionic operators to be only conjugation, not conjugate-transposition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 
 
 ### Bug Fixes
-
+* Fixes a bug where the conjugate of a fermionic operator was the conjugate-transpose, and the hermitian transpose `.H` was the identity [#1743](https://github.com/netket/netket/pull/1743).
 
 
 ## NetKet 3.11.2 (27 february 2024)

--- a/netket/experimental/operator/_fermion_operator_2nd_utils.py
+++ b/netket/experimental/operator/_fermion_operator_2nd_utils.py
@@ -224,13 +224,29 @@ def _herm_conj(
     terms: OperatorTermsList, weights: OperatorWeightsList = 1
 ) -> tuple[OperatorTermsList, OperatorWeightsList]:
     """Returns the hermitian conjugate of the terms and weights."""
-    conj_term = []
-    conj_weight = []
-    # loop over all terms and weights and get the hermitian conjugate
-    for term, weight in zip(terms, weights):
-        conj_term.append([(op, 1 - int(dag)) for (op, dag) in reversed(term)])
-        conj_weight.append(np.conjugate(weight))
+    conj_term = transpose_terms(terms)
+    conj_weight = [np.conjugate(weight) for weight in weights]
     return conj_term, conj_weight
+
+
+def transpose_terms(terms: OperatorTermsList) -> OperatorTermsList:
+    """Returns the transpose of the terms (creation/destruction operators).
+    The transpose is equivalent to the hermitian transpose because they are
+    real.
+    """
+    conj_term = []
+    for term in terms:
+        conj_term.append([(op, 1 - int(dag)) for (op, dag) in reversed(term)])
+    return conj_term
+
+
+def transpose_term(term: OperatorTerm) -> OperatorTerm:
+    """Returns the transpose of a single term (creation/destruction operators).
+    The transpose is equivalent to the hermitian transpose because they are
+    real.
+    """
+    # equivalent to transpose_terms
+    return tuple((op, 1 - int(dag)) for (op, dag) in reversed(term))
 
 
 def _convert_terms_to_spin_blocks(

--- a/test/operator/test_fermions.py
+++ b/test/operator/test_fermions.py
@@ -315,7 +315,8 @@ def test_operations_fermions(Op):
     op8_trueconj = Op(
         hi, terms=("1^ 0", "3^ 2"), weights=(1 - 1j, 2 + 0.5j), constant=1.0 - 3j
     )
-    np.testing.assert_allclose(op8.conjugate().to_dense(), op8_trueconj.to_dense())
+    np.testing.assert_allclose(op8.transpose(concrete=False).conjugate().to_dense(), op8_trueconj.to_dense())
+    np.testing.assert_allclose(op8.transpose(concrete=True).conjugate().to_dense(), op8_trueconj.to_dense())
 
     op9 = nkx.operator.FermionOperator2nd(
         hi, terms=("",), weights=(1,), constant=2, dtype=complex

--- a/test/operator/test_fermions.py
+++ b/test/operator/test_fermions.py
@@ -310,13 +310,31 @@ def test_operations_fermions(Op):
     op67 += op7
     np.testing.assert_allclose((op6 + op7).to_dense(), op8.to_dense())
     np.testing.assert_allclose(op67.to_dense(), op8.to_dense())
+    np.testing.assert_allclose(
+        op67.transpose(concrete=True).to_dense(), op8.to_dense().transpose()
+    )
+    np.testing.assert_allclose(
+        op67.conjugate(concrete=True).to_dense(), op8.to_dense().conjugate()
+    )
+    np.testing.assert_allclose(
+        op67.H.collect().to_dense(), op8.to_dense().conjugate().transpose()
+    )
+    np.testing.assert_allclose(
+        op67.conjugate(concrete=True).transpose(concrete=True).to_dense(),
+        op8.to_dense().conjugate().transpose(),
+    )
 
     op8 = Op(hi, terms=("0^ 1", "2^ 3"), weights=(1 + 1j, 2 - 0.5j), constant=1.0 + 3j)
     op8_trueconj = Op(
         hi, terms=("1^ 0", "3^ 2"), weights=(1 - 1j, 2 + 0.5j), constant=1.0 - 3j
     )
-    np.testing.assert_allclose(op8.transpose(concrete=False).conjugate().to_dense(), op8_trueconj.to_dense())
-    np.testing.assert_allclose(op8.transpose(concrete=True).conjugate().to_dense(), op8_trueconj.to_dense())
+    np.testing.assert_allclose(
+        op8.transpose(concrete=False).conjugate().to_dense(), op8_trueconj.to_dense()
+    )
+    np.testing.assert_allclose(
+        op8.transpose(concrete=True).conjugate().to_dense(), op8_trueconj.to_dense()
+    )
+    np.testing.assert_allclose(op8.H.collect().to_dense(), op8_trueconj.to_dense())
 
     op9 = nkx.operator.FermionOperator2nd(
         hi, terms=("",), weights=(1,), constant=2, dtype=complex


### PR DESCRIPTION
Fixes #1742
Fixes #1232

With this PR
```python
   ...: In [3]: hi=nkx.hilbert.SpinOrbitalFermions(2)
   ...:
   ...: In [4]: c=nkx.operator.fermion.destroy(hi, 1)
   ...:
   ...: In [5]: cd=nkx.operator.fermion.create(hi, 1)
   ...:
   ...: In [6]: np.allclose(c.to_dense().conj(), c.conj().to_dense())
   ...: Out[6]: True
   ...:
   ...: In [7]: c.to_dense()
   ...: Out[7]:
   ...: array([[ 0.,  1.,  0.,  0.],
   ...:        [ 0.,  0.,  0.,  0.],
   ...:        [ 0.,  0.,  0., -1.],
   ...:        [ 0.,  0.,  0.,  0.]])
   ...:
   ...: In [8]: c.conj().to_dense()
   ...: Out[8]:
   ...: array([[ 0.,  1.,  0.,  0.],
   ...:        [ 0.,  0.,  0.,  0.],
   ...:        [ 0.,  0.,  0., -1.],
   ...:        [ 0.,  0.,  0.,  0.]])
```

This also fixes hermitian transpose that was broken before (it was basically the identity).

This might break some codes around cc @inailuig 