### PR TITLE
Refining Continuous Operators: make them Jax-compatible pytrees

### DIFF
--- a/netket/operator/_continuous_operator.py
+++ b/netket/operator/_continuous_operator.py
@@ -28,7 +28,7 @@ class ContinuousOperator(AbstractOperator):
     continuous Hilbert space. They are valid jax-pytrees and can
     be manipulated inside of jax function transformations.
 
-    Any operator inheriting from this base class can additionally 
+    Any operator inheriting from this base class can additionally
     be used inside of :func:`jax.jit`,
     :func:`jax.grad`, :func:`jax.vmap` or similar transformations.
     When passed to those functions, jax-compatible operators
@@ -80,7 +80,10 @@ class ContinuousOperator(AbstractOperator):
 
     @abc.abstractmethod
     def _expect_kernel(
-        self, logpsi: Callable, params: PyTree, x: Array,
+        self,
+        logpsi: Callable,
+        params: PyTree,
+        x: Array,
     ):
         r"""This method defines the action of the local operator on a given quantum state
         `logpsi` for a given configuration `x`.

--- a/netket/operator/_continuous_operator.py
+++ b/netket/operator/_continuous_operator.py
@@ -96,15 +96,6 @@ class ContinuousOperator(AbstractOperator):
             x: a sample of particle positions
         """
 
-    def _pack_arguments(self) -> Optional[PyTree]:
-        r"""This methods should return a PyTree that will be passed as the `data` argument
-        to the `_expect_kernel`. The PyTree should be composed of jax arrays or hashable
-        objects.
-
-        For example for the kinetic energy this method would return the masses of the
-        individual particles.
-        """
-
     @abc.abstractproperty
     def _attrs(self) -> tuple[Hashable, ...]:
         """This must return a tuple of (hashable) attributes used to compare two operators of

--- a/netket/operator/_kinetic.py
+++ b/netket/operator/_kinetic.py
@@ -112,9 +112,6 @@ class KineticEnergy(ContinuousOperator):
             logpsi, params, x
         )
 
-    def _pack_arguments(self) -> PyTree:
-        return None
-
     @property
     def _attrs(self):
         if self.__attrs is None:

--- a/netket/operator/_potential.py
+++ b/netket/operator/_potential.py
@@ -66,9 +66,6 @@ class PotentialEnergy(ContinuousOperator):
     def _expect_kernel(self, logpsi: Callable, params: PyTree, x: Array) -> Array:
         return self.coefficient * jax.vmap(self.potential_fun, in_axes=(0,))(x)
 
-    def _pack_arguments(self):
-        return None
-
     @property
     def _attrs(self) -> tuple[Hashable, ...]:
         if self.__attrs is None:

--- a/netket/operator/_sumoperators.py
+++ b/netket/operator/_sumoperators.py
@@ -108,9 +108,6 @@ class SumOperator(ContinuousOperator):
 
         return sum(result)
 
-    def _pack_arguments(self):
-        return None
-
     @property
     def _attrs(self) -> tuple[Hashable, ...]:
         if self.__attrs is None:

--- a/test/operator/test_continuous_operator.py
+++ b/test/operator/test_continuous_operator.py
@@ -91,8 +91,8 @@ def test_is_hermitean():
 
 def test_potential_energy():
     x = jnp.zeros((1, 1))
-    energy1 = pot1._expect_kernel(model1, None, x, pot1._pack_arguments())
-    energy2 = pot2._expect_kernel(model1, None, x, pot2._pack_arguments())
+    energy1 = pot1._expect_kernel(model1, None, x)
+    energy2 = pot2._expect_kernel(model1, None, x)
     np.testing.assert_allclose(energy1, v1(x))
     np.testing.assert_allclose(energy2, v2_vec(x))
     with np.testing.assert_raises(NotImplementedError):
@@ -101,34 +101,33 @@ def test_potential_energy():
 
 def test_kinetic_energy():
     x = jnp.array([[1.0, 2.0, 3.0], [1.0, 2.0, 3.0]])
-    energy1 = kin1._expect_kernel(model2, 0.0, x, kin1._pack_arguments())
-    energy2 = kin1._expect_kernel(model3, 1.0 + 1.0j, x, kin1._pack_arguments())
+    energy1 = kin1._expect_kernel(model2, 0.0, x)
+    energy2 = kin1._expect_kernel(model3, 1.0 + 1.0j, x )
     kinen1 = kinexact(x) / kin1.mass
     kinen2 = kinexact2(1.0 + 1.0j, x) / kin1.mass
     np.testing.assert_allclose(energy1, kinen1)
     np.testing.assert_allclose(energy2, kinen2)
-    np.testing.assert_allclose(kin1.mass * kin1._pack_arguments(), 1.0)
     np.testing.assert_equal("KineticEnergy(m=20.0)", repr(kin1))
 
 
 def test_sumoperator():
     x = jnp.array([[1.0, 2.0, 3.0], [1.0, 2.0, 3.0]])
-    potenergy = pottot._expect_kernel(model2, 0.0, x, pottot._pack_arguments())
-    energy10p52 = pot10p52._expect_kernel(model2, 0.0, x, pot10p52._pack_arguments())
+    potenergy = pottot._expect_kernel(model2, 0.0, x)
+    energy10p52 = pot10p52._expect_kernel(model2, 0.0, x)
 
     np.testing.assert_allclose(potenergy, v1(x) + v2_vec(x))
     np.testing.assert_allclose(energy10p52, v1(x) + 0.5 * v2_vec(x))
 
-    kinenergy = kintot._expect_kernel(model2, 0.0, x, kintot._pack_arguments())
+    kinenergy = kintot._expect_kernel(model2, 0.0, x)
     kinenergyex = kinexact(x) / kin1.mass + kinexact(x) / kin2.mass
     np.testing.assert_allclose(kinenergy, kinenergyex)
 
-    kinen10p52 = kin10p52._expect_kernel(model2, 0.0, x, kin10p52._pack_arguments())
+    kinen10p52 = kin10p52._expect_kernel(model2, 0.0, x)
     kinenergy10p52ex = kinexact(x) / kin1.mass + 0.5 * kinexact(x) / kin2.mass
     np.testing.assert_allclose(kinen10p52, kinenergy10p52ex)
 
-    enertot = etot._expect_kernel(model2, 0.0, x, etot._pack_arguments())
-    enertot2 = etot2._expect_kernel(model2, 0.0, x, etot2._pack_arguments())
+    enertot = etot._expect_kernel(model2, 0.0, x)
+    enertot2 = etot2._expect_kernel(model2, 0.0, x)
     enerexact = v1(x) + v2_vec(x) + kinexact(x) / kin1.mass + kinexact(x) / kin2.mass
     np.testing.assert_allclose(enertot, enerexact)
     np.testing.assert_allclose(enertot2, enerexact)
@@ -151,19 +150,19 @@ def test_dtype(dtype_op, dtype_x):
     assert pot.dtype == dtype_op
     assert pot.coefficient.dtype == dtype_op
 
-    energy = pot1._expect_kernel(model3, 0.0, x, pot._pack_arguments())
+    energy = pot1._expect_kernel(model3, 0.0, x)
     assert energy.dtype == dtype_energy
 
     kin = netket.operator.KineticEnergy(hilb, mass=1.0, dtype=dtype_op)
     assert kin.dtype == dtype_op
     assert kin.mass.dtype == dtype_op
 
-    energy = kin._expect_kernel(model3, 0.0, x, kin._pack_arguments())
+    energy = kin._expect_kernel(model3, 0.0, x)
     assert energy.dtype == dtype_energy
 
     etot = pot + kin
     assert etot.dtype == dtype_op
     assert etot.coefficients.dtype == dtype_op
 
-    energy = etot._expect_kernel(model3, 0.0, x, etot._pack_arguments())
+    energy = etot._expect_kernel(model3, 0.0, x)
     assert energy.dtype == dtype_energy


### PR DESCRIPTION
As the Jax operator interface for discrete operator is turning out very successful and extremely useful and easy to use, I'm thinking about turning ContinuousOperators into something very similar.

This also makes it much simpler to use them in custom codes.

This should be very low effort, as they already are simple jax transformations and are much simpler than their discrete counterparts...

Should be further discussed. 

cc @gpescia 