### PR TITLE
Remove numba4jax, numba callback closures from operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Changes
 * Jax operators now use the same `chunk_size` as specified by the user when computing the forward pass. Prior to this change, Jax operators would be chunking the sample axis, but if an operator had a lot of connected elements this would end up increasing the effective sample size [#1875](https://github.com/netket/netket/pull/1875).
+* Metropolis Hamiltonian sampler for numba operators has been greatly simplified in order to remove the dependency on numba4jax. The new implementation will generally be slower than before, so we encourage you to use Jax Operators if possible. In the future, if people ask for it, we may reintroduce this implementation as a separate package [#1747](https://github.com/netket/netket/pull/1747).
 
 ### Improvements
 * Specialised lattice constructors like {func}`nk.graph.Grid` now accept a `point_group` argument, overriding the default (usually maximal) point groups [#1879](https://github.com/netket/netket/pull/1879).

--- a/netket/experimental/operator/_fermion_operator_2nd_numba.py
+++ b/netket/experimental/operator/_fermion_operator_2nd_numba.py
@@ -85,35 +85,6 @@ class FermionOperator2nd(FermionOperator2ndBase):
         new_op._operators = self._operators.copy()
         return new_op
 
-    def _get_conn_flattened_closure(self):
-        self._setup()
-        _max_conn_size = self.max_conn_size
-        _orb_idxs = self._orb_idxs
-        _daggers = self._daggers
-        _weights = self._numba_weights
-        _diag_idxs = self._diag_idxs
-        _off_diag_idxs = self._off_diag_idxs
-        _term_split_idxs = self._term_split_idxs
-        _cutoff = self._cutoff
-
-        fun = self._flattened_kernel
-
-        def gccf_fun(x, sections):
-            return fun(
-                x,
-                sections,
-                _max_conn_size,
-                _orb_idxs,
-                _daggers,
-                _weights,
-                _diag_idxs,
-                _off_diag_idxs,
-                _term_split_idxs,
-                _cutoff,
-            )
-
-        return numba.jit(nopython=True)(gccf_fun)
-
     def get_conn_flattened(self, x, sections, pad=False):
         r"""Finds the connected elements of the Operator.
 

--- a/netket/operator/_bose_hubbard/numba.py
+++ b/netket/operator/_bose_hubbard/numba.py
@@ -246,30 +246,3 @@ class BoseHubbard(BoseHubbardBase):
             self._max_xprime,
             pad,
         )
-
-    def _get_conn_flattened_closure(self):
-        _edges = self._edges
-        _U = self._U
-        _V = self._V
-        _J = self._J
-        _mu = self._mu
-        _n_max = self._n_max
-        _max_conn = self._max_conn
-        fun = self._flattened_kernel
-
-        # do not pass the preallocated self._max_mels and self._max_xprime because they are frozen in a closure
-        # and become read only
-        def gccf_fun(x, sections):  # pragma: no cover
-            return fun(
-                x,
-                sections,
-                _edges,
-                _U,
-                _V,
-                _J,
-                _mu,
-                _n_max,
-                _max_conn,
-            )
-
-        return jit(nopython=True)(gccf_fun)

--- a/netket/operator/_discrete_operator.py
+++ b/netket/operator/_discrete_operator.py
@@ -290,14 +290,3 @@ class DiscreteOperator(AbstractOperator):
 
     def to_linear_operator(self):
         return self.to_sparse()
-
-    def _get_conn_flattened_closure(self):
-        raise NotImplementedError(
-            """
-            _get_conn_flattened_closure not implemented for this operator type.
-            You were probably trying to use an operator with a sampler.
-            Please report this bug.
-
-            numba4jax won't work.
-            """
-        )

--- a/netket/operator/_ising/numba.py
+++ b/netket/operator/_ising/numba.py
@@ -162,14 +162,3 @@ class Ising(IsingBase):
         )
 
         return self._flattened_kernel(x, sections, self.edges, self._h, self._J)
-
-    def _get_conn_flattened_closure(self):
-        _edges = self._edges
-        _h = self._h
-        _J = self._J
-        fun = self._flattened_kernel
-
-        def gccf_fun(x, sections):  # pragma: no cover
-            return fun(x, sections, _edges, _h, _J)
-
-        return jit(nopython=True)(gccf_fun)

--- a/netket/operator/_local_operator/numba.py
+++ b/netket/operator/_local_operator/numba.py
@@ -105,40 +105,6 @@ class LocalOperator(LocalOperatorBase):
             pad,
         )
 
-    def _get_conn_flattened_closure(self):
-        self._setup()
-        _local_states = self._local_states
-        _basis = self._basis
-        _constant = self._constant
-        _diag_mels = self._diag_mels
-        _n_conns = self._n_conns
-        _mels = self._mels
-        _x_prime = self._x_prime
-        _acting_on = self._acting_on
-        _acting_size = self._acting_size
-        # workaround my painfully discovered Numba#6979 (cannot use numpy bools in closures)
-        _nonzero_diagonal = bool(self._nonzero_diagonal)
-
-        fun = self._get_conn_flattened_kernel
-
-        def gccf_fun(x, sections):
-            return fun(
-                x,
-                sections,
-                _local_states,
-                _basis,
-                _constant,
-                _diag_mels,
-                _n_conns,
-                _mels,
-                _x_prime,
-                _acting_on,
-                _acting_size,
-                _nonzero_diagonal,
-            )
-
-        return numba.jit(nopython=True)(gccf_fun)
-
     @staticmethod
     @numba.jit(nopython=True)
     def _get_conn_flattened_kernel(

--- a/netket/operator/_pauli_strings/numba.py
+++ b/netket/operator/_pauli_strings/numba.py
@@ -272,37 +272,3 @@ class PauliStrings(PauliStringsBase):
             self._local_states,
             pad,
         )
-
-    def _get_conn_flattened_closure(self):
-        self._setup()
-        _x_prime_max = self._x_prime_max
-        _mels_max = self._mels_max
-        _sites = self._sites
-        _ns = self._ns
-        _n_op = self._n_op
-        _weights = self._weights_numba
-        _nz_check = self._nz_check
-        _z_check = self._z_check
-        _cutoff = self._cutoff
-        _n_operators = self._n_operators
-        fun = self._flattened_kernel
-        _local_states = self._local_states
-
-        def gccf_fun(x, sections):
-            return fun(
-                x,
-                sections,
-                _x_prime_max,
-                _mels_max,
-                _sites,
-                _ns,
-                _n_op,
-                _weights,
-                _nz_check,
-                _z_check,
-                _cutoff,
-                _n_operators,
-                _local_states,
-            )
-
-        return jit(nopython=True)(gccf_fun)

--- a/netket/sampler/rules/hamiltonian.py
+++ b/netket/sampler/rules/hamiltonian.py
@@ -95,8 +95,8 @@ class HamiltonianRuleNumba(HamiltonianRuleBase):
         log_prob_dtype = jax.dtypes.canonicalize_dtype(float)
 
         def _transition(v, rand_vec):
-            log_prob_corr = np.zeros((σ.shape[0],), dtype=log_prob_dtype)
-            v_proposed = np.empty(σ.shape, dtype=σ.dtype)
+            log_prob_corr = np.zeros((v.shape[0],), dtype=log_prob_dtype)
+            v_proposed = np.empty(v.shape, dtype=v.dtype)
 
             sections = np.empty(v.shape[0], dtype=np.int32)
             vp, _ = rule.operator.get_conn_flattened(v, sections)
@@ -110,7 +110,7 @@ class HamiltonianRuleNumba(HamiltonianRuleBase):
 
         # ideally we would pass the key to python/numba in _choose, initialise a
         # np.random.default_rng(key) and use it to generate random uniform integers.
-        # However, numba dose not support np states, and reseeding it's MT1998 implementation
+        # However, numba does not support np states, and reseeding its MT1998 implementation
         # would be slow so we generate floats in the [0,1] range in jax and pass those
         # to python
         rand_vec = jax.random.uniform(key, shape=(σ.shape[0],))

--- a/netket/sampler/rules/hamiltonian.py
+++ b/netket/sampler/rules/hamiltonian.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import math
-from functools import partial
 
 import jax
 import jax.numpy as jnp
@@ -21,12 +20,10 @@ import jax.numpy as jnp
 import numpy as np
 
 from numba import jit
-from numba4jax import njit4jax
 
 from netket import config
 from netket.operator import DiscreteOperator, DiscreteJaxOperator
 from netket.utils import struct
-from netket.jax.sharding import sharding_decorator, with_samples_sharding_constraint
 
 from .base import MetropolisRule
 
@@ -93,35 +90,21 @@ class HamiltonianRuleNumba(HamiltonianRuleBase):
         implemented in Numba, relying on the `_get_conn_flattened_closure`
         hack to make it work in numba.
         """
-        get_conn_flattened = rule.operator._get_conn_flattened_closure()
-        n_conn_from_sections = rule.operator._n_conn_from_sections
+        log_prob_dtype = jax.dtypes.canonicalize_dtype(float)
 
-        @partial(sharding_decorator, sharded_args_tree=(True, True), check_rep=False)
         def _transition(v, rand_vec):
-            @njit4jax(
-                (
-                    jax.core.ShapedArray(v.shape, v.dtype),
-                    jax.core.ShapedArray((v.shape[0],), v.dtype),
-                )
-            )
-            def __transition(args):
-                # unpack arguments
-                v_proposed, log_prob_corr, v, rand_vec = args
+            log_prob_corr = np.zeros((σ.shape[0],), dtype=log_prob_dtype)
+            v_proposed = np.empty(σ.shape, dtype=σ.dtype)
 
-                log_prob_corr.fill(0)
-                sections = np.empty(v.shape[0], dtype=np.int32)
-                vp, _ = get_conn_flattened(v, sections)
+            sections = np.empty(v.shape[0], dtype=np.int32)
+            vp, _ = rule.operator.get_conn_flattened(v, sections)
 
-                _choose(vp, sections, rand_vec, v_proposed, log_prob_corr)
+            _choose(vp, sections, rand_vec, v_proposed, log_prob_corr)
 
-                # TODO: n_conn(v_proposed, sections) implemented below, but
-                # might be slower than fast implementations like ising
-                get_conn_flattened(v_proposed, sections)
-                n_conn_from_sections(sections)
+            rule.operator.n_conn(v_proposed, sections)
 
-                log_prob_corr -= np.log(sections)
-
-            return __transition(v, rand_vec)
+            log_prob_corr -= np.log(sections)
+            return v_proposed, log_prob_corr
 
         # ideally we would pass the key to python/numba in _choose, initialise a
         # np.random.default_rng(key) and use it to generate random uniform integers.
@@ -129,8 +112,17 @@ class HamiltonianRuleNumba(HamiltonianRuleBase):
         # would be slow so we generate floats in the [0,1] range in jax and pass those
         # to python
         rand_vec = jax.random.uniform(key, shape=(σ.shape[0],))
-        rand_vec = with_samples_sharding_constraint(rand_vec)
-        σp, log_prob_correction = _transition(σ, rand_vec)
+
+        σp, log_prob_correction = jax.pure_callback(
+            _transition,
+            (
+                jax.core.ShapedArray(σ.shape, σ.dtype),
+                jax.core.ShapedArray((σ.shape[0],), log_prob_dtype),
+            ),
+            σ,
+            rand_vec,
+            vectorized=True,
+        )
 
         return σp, log_prob_correction
 

--- a/netket/sampler/rules/hamiltonian.py
+++ b/netket/sampler/rules/hamiltonian.py
@@ -123,7 +123,7 @@ class HamiltonianRuleNumba(HamiltonianRuleBase):
             ),
             σ,
             rand_vec,
-            vectorized=True,
+            # vectorized=True, #TODO: Make the callback work with vectorized inputs
         )
 
         return σp, log_prob_correction

--- a/netket/sampler/rules/hamiltonian.py
+++ b/netket/sampler/rules/hamiltonian.py
@@ -87,8 +87,10 @@ class HamiltonianRuleNumba(HamiltonianRuleBase):
     def transition(rule, sampler, machine, parameters, state, key, σ):
         """
         This implements the transition rule for `DiscreteOperator`s that are
-        implemented in Numba, relying on the `_get_conn_flattened_closure`
-        hack to make it work in numba.
+        not jax-compatible by using a :ref:`jax.pure_callback`, which has a large
+        overhead.
+
+        If possible, consider using a jax-variant of the operators.
         """
         log_prob_dtype = jax.dtypes.canonicalize_dtype(float)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ dependencies = [
     "flax>=0.7.1, <0.9",
     "orjson>=3.4, <4",
     "optax>=0.1.3, <0.3",
-    "numba4jax>=0.0.10.post1, <0.1",
     "plum-dispatch>=2.4, <3",
 ]
 

--- a/test/operator/test_operator.py
+++ b/test/operator/test_operator.py
@@ -255,22 +255,6 @@ def test_repr(op):
 
 
 @pytest.mark.parametrize(
-    "op", [pytest.param(op, id=name) for name, op in operators_numba.items()]
-)
-def test_get_conn_numpy_closure(op):
-    hi = op.hilbert
-    closure = op._get_conn_flattened_closure()
-    v = hi.random_state(jax.random.PRNGKey(0), 120)
-    conn = np.empty(v.shape[0], dtype=np.intp)
-
-    vp, mels = closure(np.asarray(v), conn)
-    vp2, mels2 = op.get_conn_flattened(v, conn, pad=False)
-
-    np.testing.assert_equal(vp, vp2)
-    np.testing.assert_equal(mels, mels2)
-
-
-@pytest.mark.parametrize(
     "op", [pytest.param(op, id=name) for name, op in operators.items()]
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
I wrote Numba4jax to allow HamiltonianSampler to work with operators back when jax could not call back into python.
This necessitated also to introduce those pesky `get_conn_flattened_closure` functions that returned numba closures such that `numba4jax` could embed them in a `jax.jit` context.

This was all shaky and ugly, plus I know that it often crashes on GPUs (@inailuig you confirm, right?)

This PR removes completely `numba4jax` dependency from netket, which was only used in `HamiltonianSampler` rules replacing it with a callback into python. I am not planning on supporting numba4jax in the future if possible, and this buys me more time.

This implementation is a bit slower than before on CPU (though for large models this should be negligible), and works fine on GPU (before it was crashing).
Testing should be done to ensure that this is ok.

Another plus of this PR is that it removes those closure functions from operators, and makes it easier to define a custom operator that works fine with Hamiltonian samplers (while before it was actually complicated, as those closure are not documented and hard to create)