### PR TITLE
Cache sparse matrix in the operator and experiment with dataclass operators

### DIFF
--- a/netket/operator/__init__.py
+++ b/netket/operator/__init__.py
@@ -15,7 +15,7 @@
 from ._abstract_operator import AbstractOperator
 
 from ._discrete_operator import DiscreteOperator
-from ._discrete_operator_jax import DiscreteJaxOperator
+from ._discrete_operator_jax import DiscreteJaxOperator, DiscreteJaxOperatorPytree
 
 from ._pauli_strings import PauliStrings, PauliStringsJax
 from ._local_operator import LocalOperator, LocalOperatorJax

--- a/netket/operator/_discrete_operator.py
+++ b/netket/operator/_discrete_operator.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from functools import lru_cache
+
 import numpy as np
 import jax.numpy as jnp
 
@@ -185,6 +187,7 @@ class DiscreteOperator(AbstractOperator):
 
         return out
 
+    @lru_cache(5)
     def to_sparse(self) -> _csr_matrix:
         r"""Returns the sparse matrix representation of the operator. Note that,
         in general, the size of the matrix is exponential in the number of quantum

--- a/netket/operator/_local_operator/base.py
+++ b/netket/operator/_local_operator/base.py
@@ -276,6 +276,8 @@ class LocalOperatorBase(DiscreteOperator):
         return op
 
     def __iadd__(self, other):
+        # copy so that we get a new hash
+        self = self.copy()
         if isinstance(other, LocalOperatorBase):
             if self.hilbert != other.hilbert:
                 return NotImplemented
@@ -327,6 +329,8 @@ class LocalOperatorBase(DiscreteOperator):
         return NotImplemented
 
     def __imul__(self, other):
+        # copy so that we get a new hash
+        self = self.copy()
         if isinstance(other, DiscreteOperator):
             return self.__imatmul__(other)
         elif is_scalar(other):
@@ -371,6 +375,9 @@ class LocalOperatorBase(DiscreteOperator):
     def _op_imatmul_(self, other: "LocalOperatorBase") -> "LocalOperatorBase":
         if not isinstance(other, LocalOperatorBase):
             return NotImplemented
+
+        # copy so that we get a new hash
+        self = self.copy()
 
         self.mel_cutoff = min(other.mel_cutoff, self.mel_cutoff)
 

--- a/netket/operator/_pauli_strings/base.py
+++ b/netket/operator/_pauli_strings/base.py
@@ -338,6 +338,9 @@ class PauliStringsBase(DiscreteOperator):
             dtype=self.dtype,
         )
 
+        # copy so that we get a new hash
+        self = self.copy()
+
         self._operators = operators
         self._weights = weights
         self._reset_caches()
@@ -378,6 +381,10 @@ class PauliStringsBase(DiscreteOperator):
                     f"Cannot multiply inplace operator of type {type(self)} and "
                     f"dtype {self.dtype} to scalar with dtype {_dtype(other)}"
                 )
+
+            # copy so that we get a new hash
+            self = self.copy()
+
             other = np.asarray(
                 other, dtype=jnp.promote_types(self.dtype, _dtype(other))
             )
@@ -414,6 +421,9 @@ class PauliStringsBase(DiscreteOperator):
                 raise ValueError(
                     f"Can only add identical hilbert spaces (got A+B, A={self.hilbert}, B={other.hilbert})"
                 )
+
+            # copy so that we get a new hash
+            self = self.copy()
 
             operators = np.concatenate((self.operators, other.operators))
             weights = np.concatenate((self.weights, other.weights), dtype=self.dtype)

--- a/netket/vqs/full_summ/expect.py
+++ b/netket/vqs/full_summ/expect.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from functools import partial, lru_cache
+from functools import partial
 from typing import Callable, Optional
 
 import jax
@@ -38,21 +38,11 @@ def _check_hilbert(A, B):
         )
 
 
-# TODO: This cache is here so that we don't re-compute the sparse representation of the operators at every VMC step
-# but instead we cache the last 5 used. Should investigate a better way to implement this caching.
-@lru_cache(5)
-def sparsify(Ô):
-    """
-    Converts to sparse but also cache the sparsificated result to speed up.
-    """
-    return Ô.to_sparse()
-
-
 @dispatch
 def expect(vstate: FullSumState, Ô: DiscreteOperator) -> Stats:  # noqa: F811
     _check_hilbert(vstate, Ô)
 
-    O = sparsify(Ô)
+    O = Ô.to_sparse()
     Ψ = vstate.to_array()
 
     # TODO: This performs the full computation on all MPI ranks.
@@ -104,7 +94,7 @@ def expect_and_forces_fullsum(
 
     _check_hilbert(vstate, Ô)
 
-    O = sparsify(Ô)
+    O = Ô.to_sparse()
     Ψ = vstate.to_array()
     OΨ = O @ Ψ
 

--- a/test/operator/test_operator.py
+++ b/test/operator/test_operator.py
@@ -387,7 +387,16 @@ def test_operator_jax_conversion(op):
             op_jax2.to_numba_operator()
 
     # check that it is hash stable
-    _, structure2 = jax.tree_util.tree_flatten(op.to_jax_operator())
+    if not isinstance(op_jax, nk.operator.DiscreteJaxOperatorPytree):
+        _, structure2 = jax.tree_util.tree_flatten(op.to_jax_operator())
+    else:
+        # If its a nk.operator.DiscreteJaxOperatorPytree the structure has changed,
+        # compared to the original op.to_jax_operator()
+        # because we cached the sparse array when to_dense was called
+        # therefore only compare to that structure here
+        op_jax2.to_dense()
+        _, structure2 = jax.tree_util.tree_flatten(op_jax2)
+
     assert hash(structure) == hash(structure2)
     assert structure == structure2
 


### PR DESCRIPTION
I've recently written a lot of operators which are dataclasses (because writing boilerplate tree_flatten/unflatten is annoying).

They are incompatible with vanilla netket as the current sparse matrix caching needs a hash, thus requiring some changes.

This moves the caching into the operators, in a way that is easy to override.
As an example I transformed IsingJax into a Pytree, to showcase how to do the caching for dataclass operators.