### PR TITLE
Consistency fixes for constraints in hilbert

### DIFF
--- a/netket/hilbert/index/constraints/base.py
+++ b/netket/hilbert/index/constraints/base.py
@@ -58,7 +58,7 @@ class ConstrainedHilbertIndex(HilbertIndex):
     unconstrained_index: HilbertIndex
     constraint_fun: Callable[[Array], Array] = struct.field(pytree_node=False)
 
-    @struct.property_cached(pytree_node=True)
+    @property
     def _bare_numbers(self) -> Array:
         return compute_constrained_to_bare_conversion_table(
             self.unconstrained_index, self.constraint_fun
@@ -118,7 +118,7 @@ def optimalConstrainedHilbertindex_generic(local_states, size, constraint):
 # This function has exponential runtime in self.size, so we cache it in order to
 # only compute it once.
 # TODO: distribute over devices/MPI (expensive constraint_fun),  choose better chunk size
-@partial(jax.jit, static_argnames=("chunk_size"))
+@partial(jax.jit, static_argnames=("chunk_size", "constraint_fun"))
 def compute_constrained_to_bare_conversion_table(
     hilbert_index: HilbertIndex,
     constraint_fun: Callable[[Array], Array],


### PR DESCRIPTION
 - Change the `_bare_number` to be a property, not a cached property: this happens because the caching is done anyway by jax, in the output of the function `compute_constrained_to_bare_conversion_table`, which will return a statically computed value. Moreover property cached was not playing nice with jitting inside of other contexts.

- Make `compute_constrained_to_bare_conversion_table` have `constraint_fun` as a static argument. This is in order to be consistent with the HilbertIndex itself, which has `constraint_fun = pytree_node=False`. If we were to make the constraint a pytree node, then we could change this for consistency.

Those changes are necessary to make work some legacy custom operators.