### PR TITLE
Add utilities to profile netket optimisation loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@
 
 ### Improvements
 * Rewrite the code for generating random states of `netket.hilbert.Fock` and `netket.hilbert.Spin` in Jax and jit the `init` and `reset` functions of `netket.sampler.MetropolisSampler` for better performance and improved compatibility with sharding [#1721](https://github.com/netket/netket/pull/1721).
-
 * Rewrite `netket.hilbert.index` used by `HomogeneousHilbert` (including `Spin` and `Fock`) so that larger spaces with a sum constraint can be indexed. This can be useful for `netket.sampler.Exactsampler`, `netket.vqs.FullSumState` as well as for ED calculations [#1720](https://github.com/netket/netket/pull/1720).
+* Support QuTiP 5, released in march 2024 [#1762](https://github.com/netket/netket/pull/1762).
 
 ### Internal changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### New Features
 * Discrete Hilbert spaces now use a special {class}`nk.utils.StaticRange` object to store the local values that label the local degree of freedom. This special object is jax friendly and can be converted to arrays, and allows for easy conversion from the local degrees of freedom to integers that can be used to index into arrays, and back. While those objects are not really used internally yet, in the future they will be used to simplify the implementations of operators and other objects [#1732](https://github.com/netket/netket/issues/1732).
+* Some utilities to time execution of training loop are now provided, that can be used to coarsely see what part of the algorithm is dominating the training cost. To use it, pass `driver.run(..., timeit=True)` to all drivers when running them.
 
 
 ### Breaking Changes

--- a/Examples/Dynamics/ising1d.py
+++ b/Examples/Dynamics/ising1d.py
@@ -42,7 +42,7 @@ op = nk.optimizer.Sgd(0.01)
 sr = nk.optimizer.SR(diag_shift=1e-4)
 
 # Variational monte carlo driver
-gs = nk.VMC(ha, op, variational_state=vs, n_samples=1000, n_discard_per_chain=50)
+gs = nk.VMC(ha, op, variational_state=vs)
 
 # Create observable
 Sx = sum([nk.operator.spin.sigmax(hi, i) for i in range(L)])

--- a/Examples/Dynamics/ising_schmitt_1d.py
+++ b/Examples/Dynamics/ising_schmitt_1d.py
@@ -41,7 +41,7 @@ op = nk.optimizer.Sgd(0.01)
 sr = nk.optimizer.SR(diag_shift=1e-4)
 
 # Variational monte carlo driver
-gs = nk.VMC(ha, op, variational_state=vs, n_samples=1000, n_discard_per_chain=50)
+gs = nk.VMC(ha, op, variational_state=vs)
 
 # Create observable
 Sx = sum([nk.operator.spin.sigmax(hi, i) for i in range(L)])

--- a/Examples/Ising1d/ising1d_hk.py
+++ b/Examples/Ising1d/ising1d_hk.py
@@ -55,8 +55,11 @@ sa = nk.sampler.MetropolisLocal(hi, n_chains=16)
 # Optimizer
 op = nk.optimizer.Sgd(learning_rate=0.1)
 
+# Variational State
+vs = nk.vqs.MCState(sa, ma, n_samples=1008, n_discard_per_chain=10)
+
 # Variational monte carlo driver
-gs = nk.VMC(ha, op, sa, ma, n_samples=1000, n_discard_per_chain=50)
+gs = nk.VMC(ha, op, variational_state=vs)
 
 # Run the optimization for 300 iterations
 gs.run(n_iter=300, out="test")

--- a/Examples/Ising1d/ising1d_jastrow.py
+++ b/Examples/Ising1d/ising1d_jastrow.py
@@ -36,8 +36,11 @@ sa = nk.sampler.MetropolisLocal(hi, n_chains=16)
 op = nk.optimizer.Sgd(learning_rate=0.05)
 sr = nk.optimizer.SR(diag_shift=0.01)
 
+# Variational State
+vs = nk.vqs.MCState(sa, ma, n_samples=8000, n_discard_per_chain=20)
+
 # Variational monte carlo driver
-gs = nk.VMC(ha, op, sa, ma, n_samples=8000, sr=sr)
+gs = nk.VMC(ha, op, variational_state=vs, preconditioner=sr)
 
 # Run the optimization for 300 iterations
 gs.run(

--- a/Examples/Ising1d/ising1d_sr.py
+++ b/Examples/Ising1d/ising1d_sr.py
@@ -44,4 +44,4 @@ vs = nk.vqs.MCState(sa, ma, n_samples=1008, n_discard_per_chain=10)
 gs = nk.VMC(ha, op, variational_state=vs, preconditioner=sr)
 
 # Run the optimization for 500 iterations
-gs.run(n_iter=500, out="test")
+gs.run(n_iter=500, out="test", timeit=True)

--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -64,7 +64,7 @@ Utility functions and classes.
 
 ## Symmetry Group Manipulation
 
- ```{eval-rst}
+```{eval-rst}
 .. autosummary::
    :toctree: _generated/utils
    :nosignatures:
@@ -75,5 +75,21 @@ Utility functions and classes.
    group.FiniteGroup
    group.PointGroup
 
+```
+
+## Timing utils
+
+Use those utilities to coarsely profile some netket functions or scopes. The timer here
+can be nested and can be used in low-level library functions.
+
+
+```{eval-rst}
+.. autosummary::
+   :toctree: _generated/utils
+   :nosignatures:
+
+   timing.Timer
+   timing.timed_scope 
+   timing.timed 
 ```
 

--- a/netket/driver/abstract_variational_driver.py
+++ b/netket/driver/abstract_variational_driver.py
@@ -25,7 +25,7 @@ import jax
 
 from netket.logging import AbstractLog, JsonLog
 from netket.operator._abstract_observable import AbstractObservable
-from netket.utils import mpi
+from netket.utils import mpi, timing
 from netket.utils.types import Optimizer, PyTree
 from netket.vqs import VariationalState
 
@@ -104,6 +104,7 @@ class AbstractVariationalDriver(abc.ABC):
         self._loss_stats = None
         self._loss_name = minimized_quantity_name
         self._step_count = 0
+        self._timer = None
 
         self._variational_state = variational_state
         self.optimizer = optimizer
@@ -245,6 +246,7 @@ class AbstractVariationalDriver(abc.ABC):
         callback: Callable[
             [int, dict, "AbstractVariationalDriver"], bool
         ] = lambda *x: True,
+        timeit: bool = False,
     ):
         """
         Runs this variational driver, updating the weights of the network stored in
@@ -287,6 +289,7 @@ class AbstractVariationalDriver(abc.ABC):
                 serialized to disk (ignored if logger is provided)
             write_every: Every how many steps the json data should be flushed to disk (ignored if
                 logger is provided)
+            timeit: If True, provide timing information.
         """
 
         if not isinstance(n_iter, numbers.Number):
@@ -313,51 +316,61 @@ class AbstractVariationalDriver(abc.ABC):
         callbacks = _to_iterable(callback)
         callback_stop = False
 
-        with tqdm(
-            total=n_iter,
-            disable=not show_progress,
-            dynamic_ncols=True,
-        ) as pbar:
-            old_step = self.step_count
-            first_step = True
-
-            for step in self.iter(n_iter, step_size):
-                log_data = self.estimate(obs)
-                self._log_additional_data(log_data, step)
-
-                # if the cost-function is defined then report it in the progress bar
-                if self._loss_stats is not None:
-                    pbar.set_postfix_str(self._loss_name + "=" + str(self._loss_stats))
-                    log_data[self._loss_name] = self._loss_stats
-
-                # Execute callbacks before loggers because they can append to log_data
-                for callback in callbacks:
-                    if not callback(step, log_data, self):
-                        callback_stop = True
-
-                for logger in loggers:
-                    logger(self.step_count, log_data, self.state)
-
-                if len(callbacks) > 0:
-                    if mpi.mpi_any(callback_stop):
-                        break
-
-                # Reset the timing of tqdm after the first step, to ignore compilation time
-                if first_step:
-                    first_step = False
-                    pbar.unpause()
-
-                # Update the progress bar
-                pbar.update(self.step_count - old_step)
+        with timing.timed_scope(force=timeit) as timer:
+            with tqdm(
+                total=n_iter,
+                disable=not show_progress,
+                dynamic_ncols=True,
+            ) as pbar:
                 old_step = self.step_count
+                first_step = True
 
-            # Final update so that it shows up filled.
-            pbar.update(self.step_count - old_step)
+                for step in self.iter(n_iter, step_size):
+                    with timing.timed_scope(name="observables"):
+                        log_data = self.estimate(obs)
+                        self._log_additional_data(log_data, step)
+
+                    # if the cost-function is defined then report it in the progress bar
+                    if self._loss_stats is not None:
+                        pbar.set_postfix_str(
+                            self._loss_name + "=" + str(self._loss_stats)
+                        )
+                        log_data[self._loss_name] = self._loss_stats
+
+                    # Execute callbacks before loggers because they can append to log_data
+                    for callback in callbacks:
+                        if not callback(step, log_data, self):
+                            callback_stop = True
+
+                    with timing.timed_scope(name="loggers"):
+                        for logger in loggers:
+                            logger(self.step_count, log_data, self.state)
+
+                    if len(callbacks) > 0:
+                        if mpi.mpi_any(callback_stop):
+                            break
+
+                    # Reset the timing of tqdm after the first step, to ignore compilation time
+                    if first_step:
+                        first_step = False
+                        pbar.unpause()
+
+                    # Update the progress bar
+                    pbar.update(self.step_count - old_step)
+                    old_step = self.step_count
+
+                # Final update so that it shows up filled.
+                pbar.update(self.step_count - old_step)
 
         # flush at the end of the evolution so that final values are saved to
         # file
         for logger in loggers:
             logger.flush(self.state)
+
+        if timeit:
+            self._timer = timer
+            if self._is_root:
+                print(timer)
 
         return loggers
 

--- a/netket/experimental/driver/tdvp_schmitt.py
+++ b/netket/experimental/driver/tdvp_schmitt.py
@@ -25,6 +25,7 @@ from netket.optimizer.qgt import QGTJacobianDense
 from netket.optimizer.qgt.qgt_jacobian_dense import convert_tree_to_dense_format
 from netket.vqs import VariationalState, VariationalMixedState, MCState
 from netket.jax import tree_cast
+from netket.utils import timing
 
 from netket.experimental.dynamics import RKIntegratorConfig
 
@@ -190,6 +191,7 @@ class TDVPSchmitt(TDVPBaseDriver):
 # MIT License, Copyright (c) 2021 Markus Schmitt
 
 
+@timing.timed
 @partial(jax.jit, static_argnames=("n_samples"))
 def _impl(parameters, n_samples, E_loc, S, rhs_coeff, rcond, rcond_smooth, snr_atol):
     E = stats.statistics(E_loc)

--- a/netket/experimental/driver/vmc_srt.py
+++ b/netket/experimental/driver/vmc_srt.py
@@ -28,13 +28,14 @@ from netket.driver import AbstractVariationalDriver
 from netket.errors import UnoptimalSRtWarning
 from netket.jax import sharding
 from netket.operator import AbstractOperator
-from netket.utils import mpi
+from netket.utils import mpi, timing
 from netket.utils.types import ScalarOrSchedule, Optimizer, PyTree
 from netket.vqs import MCState
 
 from jax.flatten_util import ravel_pytree
 
 
+@timing.timed
 @partial(jax.jit, static_argnames=("mode", "solver_fn"))
 def SRt(
     O_L, local_energies, diag_shift, *, mode, solver_fn, e_mean=None, params_structure

--- a/netket/jax/_jacobian/logic.py
+++ b/netket/jax/_jacobian/logic.py
@@ -21,7 +21,7 @@ import jax.numpy as jnp
 from jax.tree_util import Partial
 
 from netket.stats import subtract_mean, sum as sum_mpi
-from netket.utils import mpi
+from netket.utils import mpi, timing
 from netket.utils.types import Array, Callable, PyTree
 from netket.jax import (
     tree_to_real,
@@ -32,6 +32,7 @@ from . import jacobian_dense
 from . import jacobian_pytree
 
 
+@timing.timed
 @partial(
     jax.jit,
     static_argnames=(

--- a/netket/optimizer/linear_operator.py
+++ b/netket/optimizer/linear_operator.py
@@ -18,6 +18,7 @@ import jax
 from jax import numpy as jnp
 from flax import struct
 
+from netket.utils import timing
 from netket.utils.types import PyTree
 
 
@@ -81,6 +82,7 @@ class LinearOperator:
         return solve_fun(self, y, **kwargs)
 
     # PUBLIC API: Extend _solve
+    @timing.timed
     def solve(
         self, solve_fun: SolverT, y: PyTree, *, x0: Optional[PyTree] = None, **kwargs
     ) -> PyTree:
@@ -100,6 +102,7 @@ class LinearOperator:
         return self._solve(jax.tree_util.Partial(solve_fun), y, x0=x0, **kwargs)
 
     # PUBLIC API: METHOD TO EXTEND IF YOU WANT TO DEFINE A NEW S object
+    @timing.timed
     def to_dense(self) -> jnp.ndarray:
         """
         Convert the lazy matrix representation to a dense matrix representation.s

--- a/netket/optimizer/preconditioner.py
+++ b/netket/optimizer/preconditioner.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass
 from textwrap import dedent
 
 from netket.utils.types import PyTree, Scalar
-from netket.utils import warn_deprecation
+from netket.utils import warn_deprecation, timing
 from netket.vqs import VariationalState
 
 from .linear_operator import LinearOperator, SolverT
@@ -82,6 +82,7 @@ class AbstractLinearPreconditioner:
         self.solver = solver
         self.solver_restart = solver_restart
 
+    @timing.timed
     def __call__(
         self, vstate: VariationalState, gradient: PyTree, step: Optional[Scalar] = None
     ) -> PyTree:

--- a/netket/optimizer/qgt/qgt_jacobian_dense.py
+++ b/netket/optimizer/qgt/qgt_jacobian_dense.py
@@ -20,7 +20,7 @@ from jax import numpy as jnp
 from flax import struct
 
 from netket.utils.types import Scalar, PyTree
-from netket.utils import mpi
+from netket.utils import mpi, timing
 import netket.jax as nkjax
 from netket.nn import split_array_mpi
 
@@ -34,6 +34,7 @@ from .qgt_jacobian_common import (
 )
 
 
+@timing.timed
 def QGTJacobianDense(
     vstate=None,
     *,

--- a/netket/optimizer/qgt/qgt_jacobian_pytree.py
+++ b/netket/optimizer/qgt/qgt_jacobian_pytree.py
@@ -20,7 +20,7 @@ from jax import numpy as jnp
 from flax import struct
 
 from netket.utils.types import PyTree, Array
-from netket.utils import mpi
+from netket.utils import mpi, timing
 import netket.jax as nkjax
 from netket.nn import split_array_mpi
 
@@ -35,6 +35,7 @@ from .qgt_jacobian_common import (
 )
 
 
+@timing.timed
 def QGTJacobianPyTree(
     vstate=None,
     *,

--- a/netket/optimizer/qgt/qgt_onthefly.py
+++ b/netket/optimizer/qgt/qgt_onthefly.py
@@ -21,6 +21,7 @@ from jax import numpy as jnp
 from flax import struct
 
 import netket.jax as nkjax
+from netket.utils import timing
 from netket.utils.types import PyTree
 
 from netket.errors import (
@@ -36,6 +37,7 @@ from .qgt_onthefly_logic import mat_vec_factory, mat_vec_chunked_factory
 from ..linear_operator import LinearOperator, Uninitialized
 
 
+@timing.timed
 def QGTOnTheFly(
     vstate=None, *, chunk_size=None, holomorphic: Optional[bool] = None, **kwargs
 ) -> "QGTOnTheFlyT":

--- a/netket/utils/__init__.py
+++ b/netket/utils/__init__.py
@@ -26,6 +26,7 @@ from . import numbers
 from . import types
 from . import float
 from . import optional_deps
+from . import timing
 
 from .array import HashableArray, array_in
 from .partial import HashablePartial

--- a/netket/utils/__init__.py
+++ b/netket/utils/__init__.py
@@ -27,6 +27,7 @@ from . import types
 from . import float
 from . import optional_deps
 from . import timing
+from . import display
 
 from .array import HashableArray, array_in
 from .partial import HashablePartial
@@ -53,5 +54,14 @@ from .static_range import StaticRange
 _hide_submodules(
     __name__,
     remove_self=False,
-    ignore=["numbers", "types", "float", "dispatch", "errors", "plum"],
+    ignore=[
+        "numbers",
+        "types",
+        "float",
+        "dispatch",
+        "errors",
+        "plum",
+        "timing",
+        "display",
+    ],
 )

--- a/netket/utils/display/__init__.py
+++ b/netket/utils/display/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2022 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .repr import rich_repr

--- a/netket/utils/display/repr.py
+++ b/netket/utils/display/repr.py
@@ -1,0 +1,56 @@
+# Copyright 2022 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any
+from collections.abc import Iterable
+
+
+import rich
+
+
+def __repr_from_rich__(self):
+    """
+    default __repr__ that calls __rich__
+    """
+    console = rich.get_console()
+    with console.capture() as capture:
+        console.print(self, end="")
+    return capture.get()
+
+
+def _repr_mimebundle_from_rich_(
+    self, include: Iterable[str], exclude: Iterable[str], **kwargs: Any
+) -> dict[str, str]:
+    from rich.jupyter import _render_segments
+
+    console = rich.get_console()
+    segments = list(console.render(self, console.options))  # type: ignore
+    html = _render_segments(segments)
+    text = console._render_buffer(segments)
+    data = {"text/plain": text, "text/html": html}
+    if include:
+        data = {k: v for (k, v) in data.items() if k in include}
+    if exclude:
+        data = {k: v for (k, v) in data.items() if k not in exclude}
+    return data
+
+
+def rich_repr(clz):
+    """
+    Class decorator setting the repr method to use
+    `rich`.
+    """
+    setattr(clz, "__repr__", __repr_from_rich__)
+    setattr(clz, "_repr_mimebundle_", _repr_mimebundle_from_rich_)
+    return clz

--- a/netket/utils/timing.py
+++ b/netket/utils/timing.py
@@ -1,0 +1,175 @@
+# Copyright 2024 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional, Callable
+
+import time
+import inspect
+import functools
+import contextlib
+
+from rich.tree import Tree
+from rich.panel import Panel
+
+
+from netket.utils import struct, display
+
+CURRENT_TIMER_STACK = []
+
+
+@display.rich_repr
+class Timer(struct.Pytree, mutable=True):
+    """
+    Measures how much time was spent in a timer, with possible
+    sub-timers.
+    """
+
+    total: float
+    sub_timers: dict
+    _start_time: float = 0.0
+
+    def __init__(self, name: str = None):
+        self.total = 0.0
+        self.sub_timers = {}
+
+    def __rich__(self, indent=0, total_above=None):
+        # The initial part of the string representation for the current object
+
+        tree = Tree(f"Total: {self.total:.3f}")
+        self._rich_walk_tree_(tree)
+        return Panel(tree, title="Timing Information")
+
+    def _rich_walk_tree_(self, tree):
+        attributed = 0.0
+        for key, sub_timer in self.sub_timers.items():
+            if sub_timer.total / self.total > 0.01:
+                percentage = 100 * (sub_timer.total / self.total)
+                attributed += sub_timer.total
+
+                sub_tree = tree.add(
+                    f"({percentage:.1f}%) | {key} : {sub_timer.total:.3f} s"
+                )
+                sub_timer._rich_walk_tree_(sub_tree)
+
+        # This prints an 'other' line
+        # if attributed > 0 and attributed / self.total < 0.98:
+        #    rest = self.total - attributed
+        #    percentage = 100 * (rest / self.total)
+        #    tree.add(f"({percentage:.1f}%) | other : {rest:.3f} s")
+
+    def __iadd__(self, o):
+        if not isinstance(o, Timer):
+            return NotImplemented
+        self.total += o.total
+        for k, v in o.sub_timers.items():
+            if k in self.sub_timers:
+                self.sub_timers[k] += v
+            else:
+                self.sub_timers[k] = v
+        return self
+
+    def get_subtimer(self, name: str):
+        if name not in self.sub_timers:
+            self.sub_timers[name] = Timer()
+        return self.sub_timers[name]
+
+    def __enter__(self):
+        global CURRENT_TIMER_STACK
+        CURRENT_TIMER_STACK.append(self)
+        self._start_time = time.perf_counter()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        t_end = time.perf_counter()
+        current_timer = t_end - self._start_time
+        self.total += current_timer
+        _ = CURRENT_TIMER_STACK.pop()
+        assert _ is self
+
+
+@contextlib.contextmanager
+def timed_scope(name: str = None, force: bool = True):
+    """
+    Context manager used to mark a scope to be timed individually
+    by NetKet timers.
+
+    If name is not specified, the file name and line number
+    is used.
+
+    Args:
+        name: Name to use for the timing of this line.
+        force: whether to always time, even if no top level timer
+            is in use
+    """
+    __tracebackhide__ = True
+
+    global CURRENT_TIMER_STACK
+    if force or len(CURRENT_TIMER_STACK) > 0:
+        if name is None:
+            # If no name specified look 2 frames up (1 frame is
+            # @contextmanager, 2 frames is caller) to get filename and
+            # line number.
+            caller_frame = inspect.stack()[2]
+            frame = caller_frame[0]
+            info = inspect.getframeinfo(frame)
+            name = f"{info.filename}:{info.lineno}"
+
+        if len(CURRENT_TIMER_STACK) == 0:
+            timer = Timer()
+        else:
+            timer = CURRENT_TIMER_STACK[-1].get_subtimer(name)
+        with timer:
+            yield timer
+    else:  # disabled
+        yield None
+
+
+def timed(fun: Callable = None, name: Optional[str] = None):
+    """
+    Marks the decorated function to be timed individually in
+    NetKet timing scopes.
+
+    If name is not specified, the qualified name of the
+    function is used.
+
+    The profiling is disabled if no global timer is active.
+
+    Args:
+        fun: Function to be decorated
+        name: Name to use for the timing of this line.
+    """
+    if fun is None:
+        return functools.partial(timed, name=name)
+
+    if name is None:
+        if hasattr(fun, "__qualname__"):
+            name = fun.__qualname__
+        else:
+            name = fun.__name__
+
+    @functools.wraps(fun)
+    def timed_function(*args, **kwargs):
+        __tracebackhide__ = True
+        with timed_scope(name):
+            return fun(*args, **kwargs)
+
+    return timed_function
+
+
+def clear_timers():
+    """
+    Resets all timers.
+    """
+    global CURRENT_TIMER_STACK
+    CURRENT_TIMER_STACK.clear()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "numpy~=1.20",
     "scipy>=1.5.3, <2",
     "tqdm>=4.60, <5",
+    "rich>=10.0",
     "numba>=0.52, <0.60",
     "igraph>=0.10.0, <0.12.0",
     "jax>=0.4.16, <0.5",
@@ -46,7 +47,6 @@ dependencies = [
     # TODO: Remove once we unvendor plum
     "beartype>=0.16.2",
     "typing-extensions; python_version<='3.10'",
-    "rich>=10.0",
     # TODO: Reinsert once we unvedor it and bump
     # version
     # "plum-dispatch>=2.2.2, <3",


### PR DESCRIPTION
This PR adds some coarse profiling utilities to netket.

By adding a `timeit=True` to `driver.run`, as 
```python
gs.run(n_iter=500, out="test", timeit=True)
```

We profile the total runtime as well as some inner functions in the driver. The functions that are shown in the profile are those decorated with a `@nk.utils.timing.timed`. This is very low-overhead, so for reasonable sizes and as long as we don't decorate every tiny function this will not slow down optimisation..

The idea is that this allows to see quickly, for example, if we are spending a lot of time sampling discarded elements in the Markov chain (for example, in this example we spend 20% of the sampling time sampling discarded entries), as well as seeing if we are dominated by SR or other parts of the algorithm.


```python
~/Dropbox/Ricerca/Codes/Python/netket pv/timer ⇡ 2m 13s
python-3.11.2 ❯ ipython -i Examples/Ising1d/ising1d_sr.py
Python 3.11.2 (main, Apr  7 2023, 16:35:55) [Clang 14.0.3 (clang-1403.0.22.14.1)]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.15.0 -- An enhanced Interactive Python. Type '?' for help.
100%|██████████████████████████████████████████████████████████████████████████████| 500/500 [00:13<00:00, 37.75it/s, Energy=-25.4869 ± 0.0029 [σ²=0.0132, R̂=1.0044, τ=0.9<1.7]]]
╭───────────────────────────────────────────────────────────────────────────── Timing Information ──────────────────────────────────────────────────────────────────────────────╮
│ Total: 14.848                                                                                                                                                                 │
│ ├── (43.4%) | MCState.expect_and_grad : 6.440 s                                                                                                                               │
│ │   └── (67.1%) | MCState.sample : 4.318 s                                                                                                                                    │
│ │       └── (19.9%) | sampling n_discarded samples : 0.861 s                                                                                                                  │
│ ├── (53.7%) | AbstractLinearPreconditioner.__call__ : 7.976 s                                                                                                                 │
│ │   ├── (2.8%) | QGTOnTheFly : 0.222 s                                                                                                                                        │
│ │   └── (96.7%) | LinearOperator.solve : 7.714 s                                                                                                                              │
│ └── (1.1%) | loggers : 0.165 s                                                                                                                                                │
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```