### PR TITLE
Correction of Parallel Tempering

### DIFF
--- a/netket/experimental/sampler/metropolis_pt.py
+++ b/netket/experimental/sampler/metropolis_pt.py
@@ -391,7 +391,6 @@ class MetropolisPtSampler(MetropolisSampler):
 
         offsets = jnp.arange(0, sampler.n_batches, sampler.n_replicas)
 
-        idcs = s["beta_0_index"] + offsets
         new_state = state.replace(
             rng=new_rng,
             σ=s["σ"],
@@ -404,10 +403,12 @@ class MetropolisPtSampler(MetropolisSampler):
             beta_diffusion=s["beta_diffusion"],
             exchange_steps=state.exchange_steps + sampler.sweep_size,
             n_accepted_per_beta=s["n_accepted_per_beta"],
-            n_accepted_proc=jax.vmap(jnp.take)(s["n_accepted_per_beta"], idcs),
+            n_accepted_proc=jax.vmap(jnp.take)(
+                s["n_accepted_per_beta"], s["beta_0_index"]
+            ),
         )
 
-        return new_state, new_state.σ[idcs, :]
+        return new_state, new_state.σ[s["beta_0_index"] + offsets, :]
 
 
 def MetropolisLocalPt(hilbert, *args, **kwargs):

--- a/netket/experimental/sampler/metropolis_pt.py
+++ b/netket/experimental/sampler/metropolis_pt.py
@@ -51,16 +51,16 @@ class MetropolisPtSamplerState(MetropolisSamplerState):
         rule_state: Optional[Any],
         beta: jnp.ndarray,
     ):
-        n_chains_per_rank, n_replicas = beta.shape
+        n_chains, n_replicas = beta.shape
 
         self.beta = beta
-        self.n_accepted_per_beta = jnp.zeros((n_chains_per_rank, n_replicas), dtype=int)
-        self.beta_0_index = jnp.zeros((n_chains_per_rank,), dtype=int)
-        self.beta_position = jnp.zeros((n_chains_per_rank,), dtype=float)
-        self.beta_diffusion = jnp.zeros((n_chains_per_rank,), dtype=float)
+        self.n_accepted_per_beta = jnp.zeros((n_chains, n_replicas), dtype=int)
+        self.beta_0_index = jnp.zeros((n_chains,), dtype=int)
+        self.beta_position = jnp.zeros((n_chains,), dtype=float)
+        self.beta_diffusion = jnp.zeros((n_chains,), dtype=float)
         self.exchange_steps = jnp.zeros((), dtype=int)
         super().__init__(σ, rng, rule_state)
-        self.n_accepted_proc = jnp.zeros(n_chains_per_rank, dtype=int) # correct shape is (n_chains_per_rank,)
+        self.n_accepted_proc = jnp.zeros(n_chains, dtype=int) # correct shape is (n_chains,) and not (n_batches,)
 
     def __repr__(self):
         if self.n_steps > 0:

--- a/netket/experimental/sampler/metropolis_pt.py
+++ b/netket/experimental/sampler/metropolis_pt.py
@@ -404,7 +404,7 @@ class MetropolisPtSampler(MetropolisSampler):
             beta_diffusion=s["beta_diffusion"],
             exchange_steps=state.exchange_steps + sampler.sweep_size,
             n_accepted_per_beta=s["n_accepted_per_beta"],
-            n_accepted_proc=jax.vmap(lambda x, y: x[y])(s["n_accepted_per_beta"], idcs),
+            n_accepted_proc=jax.vmap(jnp.take)(s["n_accepted_per_beta"], idcs),
         )
 
         return new_state, new_state.σ[idcs, :]

--- a/netket/experimental/sampler/metropolis_pt.py
+++ b/netket/experimental/sampler/metropolis_pt.py
@@ -70,8 +70,7 @@ class MetropolisPtSamplerState(MetropolisSamplerState):
         else:
             acc_string = ""
 
-        text = "MetropolisNumpySamplerState(" + acc_string + f"rng state={self.rng})"
-        text = "MetropolisPtSamplerState(" + acc_string + f"rng state={self.rng}"
+        text = f"MetropolisPtSamplerState(# replicas = {self.beta.shape[-1]}, " + acc_string + f"rng state={self.rng}"
         return text
 
 
@@ -103,15 +102,17 @@ class MetropolisPtSampler(MetropolisSampler):
         .. math::
             A(s\rightarrow s^\prime) = \mathrm{min}\left (1,\frac{P(s^\prime)}{P(s)} e^{L(s,s^\prime)} \right),
 
-        where the probability being sampled from is :math:`P(s)=|M(s)|^p`. Here :math:`M(s)` is a
+        where the probability being sampled from is :math:`P(s)=β|M(s)|^p`. Here :math:`M(s)` is a
         user-provided function (the machine), :math:`p` is also user-provided with default value :math:`p=2`,
-        and :math:`L(s,s^\prime)` is a suitable correcting factor computed by the transition kernel.
+        :math:`β` is the temperature of the Markov Chain and :math:`L(s,s^\prime)` is a suitable correcting factor 
+        computed by the transition kernel.
 
 
         Args:
             hilbert: The hilbert space to sample
             rule: A `MetropolisRule` to generate random transitions from a given state as
                     well as uniform random states.
+            n_replicas: The number of different temperatures β for the sampling.
             n_chains: The number of Markov Chain to be run in parallel on a single process.
             sweep_size: The number of exchanges that compose a single sweep.
                     If None, sweep_size is equal to the number of degrees of freedom being sampled

--- a/netket/experimental/sampler/metropolis_pt.py
+++ b/netket/experimental/sampler/metropolis_pt.py
@@ -66,9 +66,7 @@ class MetropolisPtSamplerState(MetropolisSamplerState):
 
     def __repr__(self):
         if self.n_steps > 0:
-            acc_string = "# accepted = {}/{} ({}%), ".format(
-                self.n_accepted, self.n_steps, self.acceptance * 100
-            )
+            acc_string = f"# accepted = {self.n_accepted}/{self.n_steps} ({self.acceptance * 100}%), "
         else:
             acc_string = ""
 

--- a/test/sampler/test_pt.py
+++ b/test/sampler/test_pt.py
@@ -53,6 +53,7 @@ def test_acceptance():
         sweep_size=hi.size * 4,
     )
     vs = nk.vqs.MCState(sa, ma, n_samples=1000, seed=WEIGHT_SEED)
+    vs.sample()
 
     assert jnp.isclose(vs.sampler_state.acceptance, 1.0)
 

--- a/test/sampler/test_pt.py
+++ b/test/sampler/test_pt.py
@@ -1,0 +1,98 @@
+# Copyright 2021 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import flax
+from jax import numpy as jnp
+
+from .. import common
+
+import numpy as np
+import pytest
+from scipy.stats import combine_pvalues, chisquare, multivariate_normal, kstest
+import jax
+from jax.nn.initializers import normal
+
+import netket as nk
+from netket.hilbert import DiscreteHilbert, Particle
+from netket.utils import array_in, mpi
+from netket.jax.sharding import device_count_per_rank
+
+from netket import experimental as nkx
+
+
+pytestmark = common.onlyif_mpi
+
+nk.config.update("NETKET_EXPERIMENTAL", True)
+np.random.seed(1234)
+
+WEIGHT_SEED = 1234
+SAMPLER_SEED = 15324
+
+
+# The following fixture initialises a model and it's weights
+# for tests that require it.
+@pytest.fixture
+def model_and_weights(request):
+    def build_model(hilb, sampler=None):
+        if isinstance(sampler, nk.sampler.ARDirectSampler):
+            ma = nk.models.ARNNDense(
+                hilbert=hilb, machine_pow=sampler.machine_pow, layers=3, features=5
+            )
+        elif isinstance(hilb, Particle):
+            ma = nk.models.Gaussian()
+        else:
+            # Build RBM by default
+            ma = nk.models.RBM(
+                alpha=1,
+                param_dtype=complex,
+                kernel_init=normal(stddev=0.1),
+                hidden_bias_init=normal(stddev=0.1),
+            )
+
+        # init network
+        w = ma.init(jax.random.PRNGKey(WEIGHT_SEED), jnp.zeros((1, hilb.size)))
+
+        return ma, w
+
+    # Do something with the data
+    return build_model
+
+
+def test_multiplerules_pt_mpi(model_and_weights):
+    g = nk.graph.Hypercube(length=4, n_dim=1)
+    hi = nk.hilbert.Spin(s=0.5, N=g.n_nodes)
+    ha = nk.operator.Ising(hilbert=hi, graph=g, h=1.0)
+    hib_u = nk.hilbert.Fock(n_max=3, N=g.n_nodes)
+
+    sa = nkx.sampler.MetropolisPtSampler(
+        hi,
+        rule=nk.sampler.rules.MultipleRules(
+            [nk.sampler.rules.LocalRule(), nk.sampler.rules.HamiltonianRule(ha)],
+            [0.8, 0.2],
+        ),
+        n_replicas=4,
+        sweep_size=hib_u.size * 4,
+    )
+
+    ma, w = model_and_weights(hi, sa)
+
+    sampler_state = sa.init_state(ma, w, seed=SAMPLER_SEED)
+    sampler_state = sa.reset(ma, w, state=sampler_state)
+    samples, sampler_state = sa.sample(
+        ma,
+        w,
+        state=sampler_state,
+        chain_length=10,
+    )
+    assert samples.shape == (sa.n_chains, 10, hi.size)

--- a/test/sampler/test_pt.py
+++ b/test/sampler/test_pt.py
@@ -54,7 +54,7 @@ def test_acceptance():
     )
     vs = nk.vqs.MCState(sa, ma, n_samples=1000, seed=WEIGHT_SEED)
 
-    assert np.isclose(vs.sampler_state.acceptance, 1.0)
+    assert jnp.isclose(vs.sampler_state.acceptance, 1.0)
 
 
 # The following fixture initialises a model and it's weights

--- a/test/sampler/test_pt.py
+++ b/test/sampler/test_pt.py
@@ -19,14 +19,11 @@ from .. import common
 
 import numpy as np
 import pytest
-from scipy.stats import combine_pvalues, chisquare, multivariate_normal, kstest
 import jax
 from jax.nn.initializers import normal
 
 import netket as nk
-from netket.hilbert import DiscreteHilbert, Particle
-from netket.utils import array_in, mpi
-from netket.jax.sharding import device_count_per_rank
+from netket.hilbert import Particle
 
 from netket import experimental as nkx
 
@@ -39,22 +36,25 @@ np.random.seed(1234)
 WEIGHT_SEED = 1234
 SAMPLER_SEED = 15324
 
-# This test verifies that the acceptance is indeed a float 
+
+# This test verifies that the acceptance is indeed a float
 # It also verifies that its value is 1 for a state with flat distribution
 def test_acceptance():
     g = nk.graph.Hypercube(length=4, n_dim=1)
     hi = nk.hilbert.Spin(s=0.5, N=g.n_nodes)
 
-    ma = nk.models.Jastrow(kernel_init=flax.linen.initializers.constant(0.0)) # |psi> = |+>
+    ma = nk.models.Jastrow(
+        kernel_init=flax.linen.initializers.constant(0.0)
+    )  # |psi> = |+>
 
     sa = nkx.sampler.MetropolisLocalPt(
         hi,
         n_replicas=4,
         sweep_size=hi.size * 4,
     )
-    vs = nk.vqs.MCState(sa,ma,n_samples=1000,seed=WEIGHT_SEED)
+    vs = nk.vqs.MCState(sa, ma, n_samples=1000, seed=WEIGHT_SEED)
 
-    assert np.isclose(vs.sampler.acceptance,1.0)
+    assert np.isclose(vs.sampler_state.acceptance, 1.0)
 
 
 # The following fixture initialises a model and it's weights

--- a/test/sampler/test_pt.py
+++ b/test/sampler/test_pt.py
@@ -39,6 +39,23 @@ np.random.seed(1234)
 WEIGHT_SEED = 1234
 SAMPLER_SEED = 15324
 
+# This test verifies that the acceptance is indeed a float 
+# It also verifies that its value is 1 for a state with flat distribution
+def test_acceptance():
+    g = nk.graph.Hypercube(length=4, n_dim=1)
+    hi = nk.hilbert.Spin(s=0.5, N=g.n_nodes)
+
+    ma = nk.models.Jastrow(kernel_init=flax.linen.initializers.constant(0.0)) # |psi> = |+>
+
+    sa = nkx.sampler.MetropolisLocalPt(
+        hi,
+        n_replicas=4,
+        sweep_size=hi.size * 4,
+    )
+    vs = nk.vqs.MCState(sa,ma,n_samples=1000,seed=WEIGHT_SEED)
+
+    assert np.isclose(vs.sampler.acceptance,1.0)
+
 
 # The following fixture initialises a model and it's weights
 # for tests that require it.

--- a/test/sampler/test_pt.py
+++ b/test/sampler/test_pt.py
@@ -95,4 +95,4 @@ def test_multiplerules_pt_mpi(model_and_weights):
         state=sampler_state,
         chain_length=10,
     )
-    assert samples.shape == (sa.n_chains, 10, hi.size)
+    assert samples.shape == (sa.n_batches // sa.n_replicas, 10, hi.size)

--- a/test/sampler/test_sampler.py
+++ b/test/sampler/test_sampler.py
@@ -277,6 +277,7 @@ def findrng(rng):
     else:
         return rng
 
+
 @pytest.fixture(
     params=[
         pytest.param(

--- a/test/sampler/test_sampler.py
+++ b/test/sampler/test_sampler.py
@@ -277,23 +277,11 @@ def findrng(rng):
     else:
         return rng
 
-
-# Mark tests that we know are failing on correctedness
-def failing_test(sampler):
-    # PT Samplers are experimental and fail the correctness test.
-    if isinstance(sampler, nkx.sampler.MetropolisPtSampler):
-        return True
-    return False
-
-
 @pytest.fixture(
     params=[
         pytest.param(
             sampl,
             id=name,
-            marks=pytest.mark.xfail(reason="MUSTFIX: this sampler is known to fail")
-            if failing_test(sampl)
-            else [],
         )
         for name, sampl in samplers.items()
     ]

--- a/test_sharding/test_sharding.py
+++ b/test_sharding/test_sharding.py
@@ -114,14 +114,8 @@ def test_grad():
 
 @pytest.mark.parametrize(
     "Op",
-    (
-        [pytest.param(nk.operator.Ising, id="numba")]
-        if jax.process_count() < 2
-        else []
-        + [
-            pytest.param(nk.operator.IsingJax, id="jax"),
-        ]
-    ),
+    ([pytest.param(nk.operator.Ising, id="numba")] if jax.process_count() < 2 else [])
+    + [pytest.param(nk.operator.IsingJax, id="jax")],
 )
 @pytest.mark.parametrize(
     "qgt",
@@ -201,14 +195,8 @@ def test_qgt_onthefly():
 
 @pytest.mark.parametrize(
     "Op",
-    (
-        [pytest.param(nk.operator.Ising, id="numba")]
-        if jax.process_count() < 2
-        else []
-        + [
-            pytest.param(nk.operator.IsingJax, id="jax"),
-        ]
-    ),
+    ([pytest.param(nk.operator.Ising, id="numba")] if jax.process_count() < 2 else [])
+    + [pytest.param(nk.operator.IsingJax, id="jax")],
 )
 @pytest.mark.skipif(
     not nk.config.netket_experimental_sharding, reason="Only run with sharding"

--- a/test_sharding/test_sharding.py
+++ b/test_sharding/test_sharding.py
@@ -63,6 +63,9 @@ def test_sampling():
     _check_correct_sharding(x)
 
 
+@pytest.mark.skipif(
+    not nk.config.netket_experimental_sharding, reason="Only run with sharding"
+)
 def test_pt():
     vs, _, ha = _setup(8)
     hi = ha.hilbert


### PR DESCRIPTION
As indicated in #1763, correction of the `n_chains` by `n_batches//n_replicas` in the Parallel tempering sampler. 
I also added the computation of `n_samples_proc` to allow for the calculation of the acceptance, which was disabled until now. 