### PR TITLE
Declare correct sharding in MetropolisSamplerState.init

### DIFF
--- a/netket/sampler/metropolis.py
+++ b/netket/sampler/metropolis.py
@@ -37,7 +37,6 @@ from netket.jax.sharding import (
     gather,
     distribute_to_devices_along_axis,
     device_count,
-    device_count_per_rank,
     with_samples_sharding_constraint,
 )
 
@@ -73,9 +72,7 @@ class MetropolisSamplerState(SamplerState):
         self.n_accepted_proc = with_samples_sharding_constraint(
             jnp.zeros(σ.shape[0], dtype=int)
         )
-        self.n_steps_proc = with_samples_sharding_constraint(
-            jnp.zeros(device_count_per_rank(), dtype=int)
-        )
+        self.n_steps_proc = jnp.zeros((), dtype=int)
         super().__init__()
 
     @property
@@ -93,7 +90,7 @@ class MetropolisSamplerState(SamplerState):
     @property
     def n_steps(self) -> int:
         """Total number of moves performed across all processes since the last reset."""
-        return jnp.sum(self.n_steps_proc) * mpi.n_nodes
+        return self.n_steps_proc * mpi.n_nodes
 
     @property
     def n_accepted(self) -> int:
@@ -475,9 +472,7 @@ class MetropolisSampler(Sampler):
             rng=new_rng,
             σ=s["σ"],
             n_accepted_proc=s["accepted"],
-            # n_steps_proc is a per-device object, so we divide by number of devices on every rank.
-            n_steps_proc=state.n_steps_proc
-            + sampler.sweep_size * sampler.n_chains_per_rank,
+            n_steps_proc=state.n_steps_proc + sampler.sweep_size * sampler.n_batches,
         )
 
         return new_state, new_state.σ

--- a/netket/sampler/metropolis.py
+++ b/netket/sampler/metropolis.py
@@ -70,8 +70,12 @@ class MetropolisSamplerState(SamplerState):
         self.rng = rng
         self.rule_state = rule_state
 
-        self.n_accepted_proc = with_samples_sharding_constraint(jnp.zeros(σ.shape[0], dtype=int))
-        self.n_steps_proc = with_samples_sharding_constraint(jnp.zeros(device_count_per_rank(), dtype=int))
+        self.n_accepted_proc = with_samples_sharding_constraint(
+            jnp.zeros(σ.shape[0], dtype=int)
+        )
+        self.n_steps_proc = with_samples_sharding_constraint(
+            jnp.zeros(device_count_per_rank(), dtype=int)
+        )
         super().__init__()
 
     @property
@@ -472,7 +476,8 @@ class MetropolisSampler(Sampler):
             σ=s["σ"],
             n_accepted_proc=s["accepted"],
             # n_steps_proc is a per-device object, so we divide by number of devices on every rank.
-            n_steps_proc=state.n_steps_proc + sampler.sweep_size * sampler.n_chains_per_rank,
+            n_steps_proc=state.n_steps_proc
+            + sampler.sweep_size * sampler.n_chains_per_rank,
         )
 
         return new_state, new_state.σ


### PR DESCRIPTION
While reviewing #1769 I realised that our sampler states do not properly initialise some variables to be sharded, resulting in some (even if small) cross-GPU communication at every sampling step.

This should fix a few issues I noticed.