### PR TITLE
Make variational state samples reproducible in more situations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### Improvements
 * Rewrite the code for generating random states of `netket.hilbert.Fock` and `netket.hilbert.Spin` in Jax and jit the `init` and `reset` functions of `netket.sampler.MetropolisSampler` for better performance and improved compatibility with sharding [#1721](https://github.com/netket/netket/pull/1721).
 * Rewrite `netket.hilbert.index` used by `HomogeneousHilbert` (including `Spin` and `Fock`) so that larger spaces with a sum constraint can be indexed. This can be useful for `netket.sampler.Exactsampler`, `netket.vqs.FullSumState` as well as for ED calculations [#1720](https://github.com/netket/netket/pull/1720).
+* Duplicating a `netket.vqs.MCState` now leads to perfectly deterministic, identical samples between two different copies of the same `MCState` even if the sampler is changed. Previously, duplicating an `MCState` and changing the sampler on two copies of the same state would lead to some completely random seed being used and therefore different samples to be generated. This change is needed to eventually achieve proper checkpointing of our calculations [#177X](https://github.com/netket/netket/pull/177X).
 
 ### Internal changes
 

--- a/netket/vqs/mc/mc_state/state.py
+++ b/netket/vqs/mc/mc_state/state.py
@@ -241,7 +241,7 @@ class MCState(VariationalState):
             key, key2 = jax.random.split(nkjax.PRNGKey(seed), 2)
             sampler_seed = key2
 
-        self._sampler_seed = sampler_seed
+        self._sampler_seed = nkjax.PRNGKey(sampler_seed)
         self.sampler = sampler
 
         if n_samples is not None:
@@ -296,6 +296,8 @@ class MCState(VariationalState):
                 )
             )
 
+        self._sampler_seed, seed = jax.random.split(self._sampler_seed, 2)
+
         # Save the old `n_samples` before the new `sampler` is set.
         # `_chain_length == 0` means that this `MCState` is being constructed.
         if self._chain_length > 0:
@@ -303,7 +305,7 @@ class MCState(VariationalState):
 
         self._sampler = sampler
         self.sampler_state = self.sampler.init_state(
-            self.model, self.variables, seed=self._sampler_seed
+            self.model, self.variables, seed=seed
         )
         self._sampler_state_previous = self.sampler_state
 


### PR DESCRIPTION
In particular, when changing the sampler.

This PR should not change the behaviour for anyone, but will make it possible to create deterministic copies of variational states (needed for checkpoints) that work in more complex situations, where the sampler is changed through a calculation.