### PR TITLE
update macos CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,7 +33,7 @@ jobs:
             oldest_deps: false
 
           - os: macos-latest
-            python-version: "3.9"
+            python-version: "3.10"
             mpi: ""
             main_tests: true
             oldest_deps: false


### PR DESCRIPTION
Use python 3.10 in MacOS Github CI because some runners are ARM-M processors and Python 3.9 does not work there.