### PR TITLE
reset the sampler cache when changing number of samples

### DIFF
--- a/netket/vqs/mc/mc_state/state.py
+++ b/netket/vqs/mc/mc_state/state.py
@@ -340,6 +340,7 @@ class MCState(VariationalState):
     def n_samples(self, n_samples: int):
         chain_length = compute_chain_length(self.sampler.n_chains, n_samples)
         self.chain_length = chain_length
+        self.reset()
 
     @property
     def n_samples_per_rank(self) -> int:


### PR DESCRIPTION
This is necessary to make it possible to do
```python
vs.expect(ha)
vs.n_samples = 100000
vs.expect(ha)
```
and get different estimates.

Without this, the two expect return exactly the same values.