### PR TITLE
Fix gradients of variational states with complex parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 
 
 ### Bug Fixes
+* Fixed the gradient of variational states w.r.t. complex parameters which was missing a factor of 2. The learning rate needs to be halved to reproduce simulations made with previous versions of NetKet [#1785](https://github.com/netket/netket/pull/1785).
 
 
 

--- a/netket/experimental/driver/vmc_srt.py
+++ b/netket/experimental/driver/vmc_srt.py
@@ -103,7 +103,7 @@ def SRt(
     # To repack the real coefficients in order to get complex updates
     if mode == "complex" and nkjax.tree_leaf_iscomplex(params_structure):
         np = updates.shape[-1] // 2
-        updates = (updates[:np] + 1j * updates[np:]) / 2
+        updates = updates[:np] + 1j * updates[np:]
 
     return -updates
 

--- a/netket/vqs/mc/common.py
+++ b/netket/vqs/mc/common.py
@@ -70,10 +70,11 @@ def force_to_grad(Ō_grad, parameters):
     is 2 Re[F].
     """
     Ō_grad = jax.tree_util.tree_map(
-        lambda x, target: (x if jnp.iscomplexobj(target) else 2 * x.real).astype(
+        lambda x, target: (x if jnp.iscomplexobj(target) else x.real).astype(
             target.dtype
         ),
         Ō_grad,
         parameters,
     )
+    Ō_grad = jax.tree_util.tree_map(lambda x: 2 * x, Ō_grad)
     return Ō_grad

--- a/test/driver/test_vmc.py
+++ b/test/driver/test_vmc.py
@@ -146,7 +146,7 @@ def central_diff_grad(func, x, eps, *args):
         grad_r = 0.5 * (func(x + epsd, *args) - func(x - epsd, *args))
         if jnp.iscomplexobj(x):
             grad_i = 0.5 * (func(x + 1j * epsd, *args) - func(x - 1j * epsd, *args))
-            grad[i] = 0.5 * grad_r + 0.5j * grad_i
+            grad[i] = grad_r + 1j * grad_i
         else:
             # grad_i = 0.0
             grad[i] = grad_r

--- a/test/driver/test_vmc.py
+++ b/test/driver/test_vmc.py
@@ -5,12 +5,13 @@ from pytest import approx, raises
 
 import numpy as np
 import jax
-import jax.numpy as jnp
 import netket as nk
 
 from contextlib import redirect_stderr
 import tempfile
 import re
+
+from ..variational.finite_diff import central_diff_grad
 
 from .. import common
 
@@ -135,26 +136,6 @@ def _energy(par, vstate, H):
     vstate.parameters = par
     psi = vstate.to_array()
     return np.real(psi.conj() @ H @ psi)
-
-
-def central_diff_grad(func, x, eps, *args):
-    grad = np.zeros(len(x), dtype=x.dtype)
-    epsd = np.zeros(len(x), dtype=x.dtype)
-    epsd[0] = eps
-    for i in range(len(x)):
-        assert not np.any(np.isnan(x + epsd))
-        grad_r = 0.5 * (func(x + epsd, *args) - func(x - epsd, *args))
-        if jnp.iscomplexobj(x):
-            grad_i = 0.5 * (func(x + 1j * epsd, *args) - func(x - 1j * epsd, *args))
-            grad[i] = grad_r + 1j * grad_i
-        else:
-            # grad_i = 0.0
-            grad[i] = grad_r
-
-        assert not np.isnan(grad[i])
-        grad[i] /= eps
-        epsd = np.roll(epsd, 1)
-    return grad
 
 
 def same_derivatives(der_log, num_der_log, abs_eps=1.0e-6, rel_eps=1.0e-6):

--- a/test/variational/finite_diff.py
+++ b/test/variational/finite_diff.py
@@ -43,7 +43,7 @@ def central_diff_grad(func, x, eps, *args, dtype=None):
         grad_r = 0.5 * (func(x + epsd, *args) - func(x - epsd, *args))
         if jnp.iscomplexobj(x):
             grad_i = 0.5 * (func(x + 1j * epsd, *args) - func(x - 1j * epsd, *args))
-            grad[i] = 0.5 * grad_r + 0.5j * grad_i
+            grad[i] = grad_r + 1j * grad_i
         else:
             # grad_i = 0.0
             grad[i] = grad_r

--- a/test/variational/test_exact_state.py
+++ b/test/variational/test_exact_state.py
@@ -19,11 +19,12 @@ from pytest import raises
 
 import numpy as np
 import jax
-import jax.numpy as jnp
 import netket as nk
 from jax.nn.initializers import normal
 
 from netket.optimizer.linear_operator import LinearOperator
+
+from .finite_diff import central_diff_grad
 
 from .. import common
 
@@ -189,31 +190,6 @@ def _expval(par, vs, H):
     expval = psi.conj() @ (H @ psi)
 
     return np.real(expval)
-
-
-def central_diff_grad(func, x, eps, *args, dtype=None):
-    if dtype is None:
-        dtype = x.dtype
-
-    grad = np.zeros(
-        len(x), dtype=nk.jax.maybe_promote_to_complex(x.dtype, func(x, *args).dtype)
-    )
-    epsd = np.zeros(len(x), dtype=dtype)
-    epsd[0] = eps
-    for i in range(len(x)):
-        assert not np.any(np.isnan(x + epsd))
-        grad_r = 0.5 * (func(x + epsd, *args) - func(x - epsd, *args))
-        if jnp.iscomplexobj(x):
-            grad_i = 0.5 * (func(x + 1j * epsd, *args) - func(x - 1j * epsd, *args))
-            grad[i] = grad_r + 1j * grad_i
-        else:
-            # grad_i = 0.0
-            grad[i] = grad_r
-
-        assert not np.isnan(grad[i])
-        grad[i] /= eps
-        epsd = np.roll(epsd, 1)
-    return grad
 
 
 @common.skipif_mpi

--- a/test/variational/test_exact_state.py
+++ b/test/variational/test_exact_state.py
@@ -205,7 +205,7 @@ def central_diff_grad(func, x, eps, *args, dtype=None):
         grad_r = 0.5 * (func(x + epsd, *args) - func(x - epsd, *args))
         if jnp.iscomplexobj(x):
             grad_i = 0.5 * (func(x + 1j * epsd, *args) - func(x - 1j * epsd, *args))
-            grad[i] = 0.5 * grad_r + 0.5j * grad_i
+            grad[i] = grad_r + 1j * grad_i
         else:
             # grad_i = 0.0
             grad[i] = grad_r

--- a/test/variational/test_variational.py
+++ b/test/variational/test_variational.py
@@ -433,7 +433,7 @@ def test_forces(vstate, operator):
 
     _, f1 = vstate.expect_and_forces(operator)
     if nk.jax.tree_leaf_iscomplex(vstate.parameters):
-        g1 = f1
+        g1 = jax.tree_util.tree_map(lambda x: 2.0 * x, f1)
     else:
         g1 = jax.tree_util.tree_map(lambda x: 2.0 * np.real(x), f1)
     jax.tree_util.tree_map(np.testing.assert_array_equal, g1, O_grad1)
@@ -489,12 +489,12 @@ def test_forces_gradient_rule():
     _, g1 = vs1.expect_and_grad(ha)
     _, g2 = vs2.expect_and_grad(ha)
 
-    np.testing.assert_allclose(g1["weights"], f1["weights"])
+    np.testing.assert_allclose(g1["weights"], 2 * f1["weights"])
     np.testing.assert_allclose(g2["weights_re"], 2 * np.real(f2["weights_re"]))
     np.testing.assert_allclose(g2["weights_im"], 2 * np.real(f2["weights_im"]))
-    np.testing.assert_allclose(
-        g1["weights"], 0.5 * (g2["weights_re"] + 1j * g2["weights_im"])
-    )
+
+    # check that the gradient of the real-param and complex-param model are the same
+    np.testing.assert_allclose(g1["weights"], g2["weights_re"] + 1j * g2["weights_im"])
 
 
 @common.skipif_mpi

--- a/test/variational/test_variational.py
+++ b/test/variational/test_variational.py
@@ -471,30 +471,84 @@ def test_forces_gradient_rule():
             y = jnp.einsum("ij,...j", W, x)
             return jnp.sum(nk.nn.activation.reim_selu(y), axis=-1)
 
-    ma1 = M1(8)
-    ma2 = M2(8)
+    class M3(nn.Module):
+        n_h: int
+
+        @nn.compact
+        def __call__(self, x):
+            n_v = x.shape[-1]
+            W0r = self.param(
+                "weights_re",
+                nn.initializers.normal(),
+                (self.n_h // 2, n_v),
+                jnp.float64,
+            )
+            W0i = self.param(
+                "weights_im",
+                nn.initializers.normal(),
+                (self.n_h // 2, n_v),
+                jnp.float64,
+            )
+            W1 = self.param(
+                "weights",
+                nn.initializers.normal(),
+                (self.n_h // 2, n_v),
+                jnp.complex128,
+            )
+            W = jnp.concatenate([W0r + 1j * W0i, W1], axis=0)
+            y = jnp.einsum("ij,...j", W, x)
+            return jnp.sum(nk.nn.activation.reim_selu(y), axis=-1)
+
+    nh = 8
+    ma1 = M1(nh)
+    ma2 = M2(nh)
+    ma3 = M3(nh)
     hi = nk.hilbert.Spin(1 / 2, N=4)
     ha = nk.operator.Ising(hi, nk.graph.Chain(4), h=0.5)
     samp = nk.sampler.ExactSampler(hi)
     vs1 = nk.vqs.MCState(samp, model=ma1, n_samples=1024, sampler_seed=1234, seed=1234)
     vs2 = nk.vqs.MCState(samp, model=ma2, n_samples=1024, sampler_seed=1234, seed=1234)
+    vs3 = nk.vqs.MCState(samp, model=ma3, n_samples=1024, sampler_seed=1234, seed=1234)
+
     vs1.parameters = {
         "weights": vs2.parameters["weights_re"] + 1j * vs2.parameters["weights_im"]
     }
+    vs3.parameters = {
+        "weights": vs2.parameters["weights_re"][nh // 2 :]
+        + 1j * vs2.parameters["weights_im"][nh // 2 :],
+        "weights_re": vs2.parameters["weights_re"][: nh // 2],
+        "weights_im": vs2.parameters["weights_im"][: nh // 2],
+    }
 
     np.testing.assert_allclose(vs1.to_array(), vs2.to_array())
+    np.testing.assert_allclose(vs1.to_array(), vs3.to_array())
 
     _, f1 = vs1.expect_and_forces(ha)
     _, f2 = vs2.expect_and_forces(ha)
+    _, f3 = vs3.expect_and_forces(ha)
+
     _, g1 = vs1.expect_and_grad(ha)
     _, g2 = vs2.expect_and_grad(ha)
+    _, g3 = vs3.expect_and_grad(ha)
 
     np.testing.assert_allclose(g1["weights"], 2 * f1["weights"])
+
     np.testing.assert_allclose(g2["weights_re"], 2 * np.real(f2["weights_re"]))
     np.testing.assert_allclose(g2["weights_im"], 2 * np.real(f2["weights_im"]))
 
+    np.testing.assert_allclose(g3["weights"], 2 * f3["weights"])
+    np.testing.assert_allclose(g3["weights_re"], 2 * np.real(f3["weights_re"]))
+    np.testing.assert_allclose(g3["weights_im"], 2 * np.real(f3["weights_im"]))
+
     # check that the gradient of the real-param and complex-param model are the same
     np.testing.assert_allclose(g1["weights"], g2["weights_re"] + 1j * g2["weights_im"])
+    # check that the gradient of the mixed-param and complex-param model are the same
+    np.testing.assert_allclose(
+        g1["weights"],
+        jnp.concatenate(
+            [g3["weights_re"] + 1j * g3["weights_im"], g3["weights"]], axis=0
+        ),
+    )
 
 
 @common.skipif_mpi


### PR DESCRIPTION
Adds the missing factor 2 in force_to_grad for complex parameters.

We need to multiply the gradient of the complex parameters by 2, not only the real ones.
Otherwise the gradient is different between the complex-param model and the equivalent real one.

This in particular affects models with mixed real/complex parameters where so far the learning rate for the complex ones was half the learning rate of the real params.