### PR TITLE
List of betas for parallel tempering

### DIFF
--- a/netket/experimental/sampler/metropolis_pt.py
+++ b/netket/experimental/sampler/metropolis_pt.py
@@ -131,8 +131,8 @@ class MetropolisPtSampler(MetropolisSampler):
     """
     sorted_betas: jax.Array
     """
-    The sorted values of the temperatures for each _physical_ markov chain. 
-    The first value should be β = 1 and is the _physical_ temperature. 
+    The sorted values of the temperatures for each _physical_ markov chain.
+    The first value should be β = 1 and is the _physical_ temperature.
     """
 
     def __init__(
@@ -192,7 +192,7 @@ class MetropolisPtSampler(MetropolisSampler):
 
             if not (jnp.isclose(jnp.max(betas), 1) and jnp.min(betas) > 0):
                 raise ValueError(
-                    f"""The values for beta should be in (0,1] and obligatory contain β=1, 
+                    f"""The values for beta should be in (0,1] and obligatory contain β=1,
                     instead got [{jnp.min(betas):.2f},{jnp.max(betas):.8f}]."""
                 )
 

--- a/netket/experimental/sampler/metropolis_pt.py
+++ b/netket/experimental/sampler/metropolis_pt.py
@@ -171,7 +171,7 @@ class MetropolisPtSampler(MetropolisSampler):
                     For the distribution, possibility between "lin" for a linear distribution and
                     "log" for a logarithmic one.
                     For the explicit list of values, the value β=1 must obligatory be an element of betas,
-                    all other temperatures must be in (0,1]. In this case, if n_replicas is provided, it must 
+                    all other temperatures must be in (0,1]. In this case, if n_replicas is provided, it must
                     correspond to the length of the provided temperatures.
                     (default : "lin", i.e. linear distribution between (0,1]).
             n_chains: The number of Markov Chain to be run in parallel on a single process.

--- a/netket/experimental/sampler/metropolis_pt.py
+++ b/netket/experimental/sampler/metropolis_pt.py
@@ -182,8 +182,6 @@ class MetropolisPtSampler(MetropolisSampler):
             machine_pow: The power to which the machine should be exponentiated to generate the pdf (default = 2).
             dtype: The dtype of the states sampled (default = np.float32).
         """
-        beta_distribution = ""
-
         # if beta is not provided, linear distribution of 32 temperatures
         if betas is None:
             if n_replicas is None:
@@ -191,7 +189,7 @@ class MetropolisPtSampler(MetropolisSampler):
             beta_distribution = "lin"
 
         # beta is provided
-        elif betas is not None:
+        else:
             # either we know the distribution
             if isinstance(betas, str):
                 beta_distribution = betas

--- a/test/sampler/test_pt.py
+++ b/test/sampler/test_pt.py
@@ -44,32 +44,19 @@ def test_wrong_initialization():
     hib_u = nk.hilbert.Fock(n_max=3, N=g.n_nodes)
 
     for n_replicas in [-3, 0, 5, 2.1]:
-        with pytest.raises(ValueError, match="n_replicas must be an even integer > 0."):
+        with pytest.raises(
+            ValueError,
+        ):
             sa = nkx.sampler.MetropolisLocalPt(
                 hi,
                 n_replicas=n_replicas,
                 sweep_size=hib_u.size * 4,
             )
 
-    with pytest.raises(
-        ValueError,
-        match="""To initialize the temperatures with a string, you must choose between "lin" for a linear distribution and "log" for a logarithmic distribution. Instead got "custom".""",
-    ):
+    with pytest.raises(ValueError):
         sa = nkx.sampler.MetropolisLocalPt(
             hi,
-            n_replicas=10,
             betas="custom",
-            sweep_size=hib_u.size * 4,
-        )
-
-    with pytest.raises(
-        ValueError,
-        match="""The dimension of the array beta and the number of replicas must match, instead, got 10 replicas but 4 values for beta.""",
-    ):
-        sa = nkx.sampler.MetropolisLocalPt(
-            hi,
-            n_replicas=10,
-            betas=[1.0, 0.9, 0.8, 0.7],
             sweep_size=hib_u.size * 4,
         )
 
@@ -88,19 +75,10 @@ def test_wrong_initialization():
     assert (sa.sorted_betas == 1 - np.arange(32) / 32).all()
 
 
-betas_list = [
-    pytest.param(None, id="None"),
-    pytest.param("lin", id="lin"),
-    pytest.param("log", id="log"),
-    pytest.param(1 - (np.arange(32) / 32) ** 3, id="cubic"),
-    pytest.param(np.linspace(0.1, 1, 32)[::-1], id="shuffled"),
-]
-
-
 # Verify the possibility to initialize in multiple ways
 @pytest.mark.parametrize("n_replicas", [None, 32])
-@pytest.mark.parametrize("betas", betas_list)
-def test_initialization_beta(model_and_weights, n_replicas, betas):
+@pytest.mark.parametrize("betas", ["linear", "logarithmic"])
+def test_initialization_beta_distribution(model_and_weights, n_replicas, betas):
     g = nk.graph.Hypercube(length=4, n_dim=1)
     hi = nk.hilbert.Spin(s=0.5, N=g.n_nodes)
     hib_u = nk.hilbert.Fock(n_max=3, N=g.n_nodes)
@@ -108,6 +86,34 @@ def test_initialization_beta(model_and_weights, n_replicas, betas):
     sa = nkx.sampler.MetropolisLocalPt(
         hi,
         n_replicas=n_replicas,
+        betas=betas,
+        sweep_size=hib_u.size * 4,
+    )
+    assert sa.n_replicas == 32
+    assert sa.sorted_betas.shape == (32,)
+    assert sa.sorted_betas[0] == 1 and sa.sorted_betas[-1] > 0
+
+    ma, w = model_and_weights(hi, sa)
+
+    sampler_state = sa.init_state(ma, w, seed=SAMPLER_SEED)
+    assert sampler_state.beta.shape == (sa.n_batches // sa.n_replicas, sa.n_replicas)
+
+
+betas_list = [
+    pytest.param(1 - (np.arange(32) / 32) ** 3, id="cubic"),
+    pytest.param(np.linspace(0.1, 1, 32)[::-1], id="shuffled"),
+]
+
+
+# Verify the possibility to initialize in multiple ways
+@pytest.mark.parametrize("betas", betas_list)
+def test_initialization_beta_list(model_and_weights, betas):
+    g = nk.graph.Hypercube(length=4, n_dim=1)
+    hi = nk.hilbert.Spin(s=0.5, N=g.n_nodes)
+    hib_u = nk.hilbert.Fock(n_max=3, N=g.n_nodes)
+
+    sa = nkx.sampler.MetropolisLocalPt(
+        hi,
         betas=betas,
         sweep_size=hib_u.size * 4,
     )


### PR DESCRIPTION
As discussed in #1769, this code adds the possibility of instantiating the PT sampler with an explicit list of temperatures. 

For now, the best way I found to be able to `_init_state` correctly is by storing beta as an attribute of the sampler (called `sorted_betas` to not mix this with the tiled array `beta` in `sampler_state`). 
 
Also, I put the argument of the temperatures as optional, where the default temperatures would be a linear distribution of 32 values, as before.
