### PR TITLE
QGTOnTheFly: use chunking only if n_samples_per_rank is smaller thank chunking

### DIFF
--- a/netket/jax/__init__.py
+++ b/netket/jax/__init__.py
@@ -66,4 +66,4 @@ from . import sharding
 
 from netket.utils import _hide_submodules
 
-_hide_submodules(__name__)
+_hide_submodules(__name__, ignore="sharding")

--- a/netket/optimizer/qgt/qgt_onthefly.py
+++ b/netket/optimizer/qgt/qgt_onthefly.py
@@ -86,9 +86,9 @@ def QGTOnTheFly(
     if chunk_size is None and hasattr(vstate, "chunk_size"):
         chunk_size = vstate.chunk_size
 
-    n_samples = samples.shape[0]
+    n_samples_per_rank = samples.shape[0] // nkjax.sharding.device_count_per_rank()
 
-    if chunk_size is None or chunk_size >= n_samples:
+    if chunk_size is None or chunk_size >= n_samples_per_rank:
         mv_factory = mat_vec_factory
         chunking = False
     else:


### PR DESCRIPTION
previously we were switching to chunked logic if `n_samples` was smaller than chunking.