### PR TITLE
use BCSR in sparse format of jaxoperators instead of BCOO

### DIFF
--- a/netket/operator/_discrete_operator_jax.py
+++ b/netket/operator/_discrete_operator_jax.py
@@ -18,7 +18,7 @@ import numpy as np
 from scipy import sparse
 
 import jax.numpy as jnp
-from jax.experimental.sparse import JAXSparse, BCOO
+from jax.experimental.sparse import JAXSparse, BCOO, BCSR
 
 from netket.operator import AbstractOperator, DiscreteOperator
 from netket.utils.optional_deps import import_optional_dependency
@@ -207,7 +207,7 @@ class DiscreteJaxOperator(DiscreteOperator):
         i = np.broadcast_to(np.arange(n)[..., None], mels.shape).ravel()
         j = self.hilbert.states_to_numbers(xp).ravel()
         ij = np.concatenate((i[:, None], j[:, None]), axis=1)
-        return BCOO((a, ij), shape=(n, n))
+        return BCSR.from_bcoo(BCOO((a, ij), shape=(n, n)))
 
     def to_dense(self) -> np.ndarray:
         r"""Returns the dense matrix representation of the operator. Note that,

--- a/test/operator/test_operator.py
+++ b/test/operator/test_operator.py
@@ -536,8 +536,9 @@ def test_matmul_sparse_vector(op):
 
     if isinstance(op, DiscreteJaxOperator):
         v = BCOO.fromdense(v)
+        Ov_sparse = op @ v
     else:
         v = scipy.sparse.csr_array(v)
-    Ov_sparse = op @ v
+        Ov_sparse = (op @ v).todense()
 
-    np.testing.assert_array_equal(Ov_dense, Ov_sparse.todense())
+    np.testing.assert_array_equal(Ov_dense, Ov_sparse)

--- a/test_sharding/test_sharding.py
+++ b/test_sharding/test_sharding.py
@@ -351,7 +351,9 @@ def test_serialization():
 @pytest.mark.skipif(
     not nk.config.netket_experimental_sharding, reason="Only run with sharding"
 )
-@pytest.mark.parametrize("ode_jit", [False]) # odejit is broken since jax 0.4.27, True])
+@pytest.mark.parametrize(
+    "ode_jit", [False]
+)  # odejit is broken since jax 0.4.27, True])
 def test_timeevolution(ode_jit):
     nk.config.update("netket_experimental_disable_ode_jit", not ode_jit)
     L = 8


### PR DESCRIPTION
BCOO should just be used to construct it, not to use it for matrix vector multiplications...