### PR TITLE
Define and document an interface for publicly defining custom constraint

### DIFF
--- a/docs/api/hilbert.md
+++ b/docs/api/hilbert.md
@@ -75,9 +75,7 @@ Those classes cannot be directly instantiated, but you can inherit from one of t
 
 ```
 
-### Random submodule
-
-When defining a new Hilbert space, you must define how to uniformly sample the basis elements of that Hilbert space by defining some dispatch rules for those functions.
+### Constraints
 
 ```{eval-rst}
 .. currentmodule:: netket.hilbert
@@ -87,7 +85,22 @@ When defining a new Hilbert space, you must define how to uniformly sample the b
    :template: class
    :nosignatures:
 
+   DiscreteHilbertConstraint
+```
+
+### Random submodule
+
+When defining a new Hilbert space, you must define how to uniformly sample the basis elements of that Hilbert space by defining some dispatch rules for those functions.
+
+```{eval-rst}
+.. currentmodule:: netket.hilbert
+
+.. autosummary::
+   :toctree: _generated/hilbert
+   :nosignatures:
+
    random.flip_state
    random.random_state
+   index.optimalConstrainedHilbertindex
 ```
 

--- a/docs/docs/hilbert.md
+++ b/docs/docs/hilbert.md
@@ -15,8 +15,8 @@ Classes whose edge is dashed are abstract classes, while the others are concrete
 
 ```{eval-rst}
 .. inheritance-diagram:: netket.hilbert
-	:top-classes: netket.hilbert.AbstractHilbert
-	:parts: 1
+    :top-classes: netket.hilbert.AbstractHilbert
+    :parts: 1
 
 ```
 
@@ -282,6 +282,77 @@ You can freely use {class}`~nk.hilbert.AbstractHilbert` objects inside of {func}
 
 All attributes and methods of Hilbert spaces can be freely used inside of a {func}`jax.jit` block.
 In particular the {meth}`~DiscreteHilbert.random_state` method can be used inside of jitted blocks, as it is written in jax, as long as you pass a valid jax {func}`jax.random.PRNGKey` object as the first argument.
+
+## Using custom constraints for Discrete Hilbert spaces
+
+Existing Hilbert spaces such as {class}`~nk.hilbert.Spin` or {class}`~nk.hilbert.Fock` support natively a constraint based on the total magnetization or population. However, at times you might want to work with some custom, more complex constraints.
+
+A constraint effectively declares that the Hilbert space you are working with is smaller than the original {class}`~nk.hilbert.Spin` or {class}`~nk.hilbert.Fock`, for example by only considering configurations with a well defined magnetization. Those are often associated to some simmetries.
+
+To work with a custom constraint, you must do 2 things:
+ - Define a custom constraint class, used to specify whether a configuration is valid or not. This must be a callable class inheriting from {class}`~nk.hilbert.DiscreteHilbertConstraint` that if passed a set of configurations will return an array of boolean flags telling netket whether those configurations are valid or not.
+ - You must define a custom {func}`nk.hilbert.random.random_state` dispatch rule specifying how to generate random configurations directly within the subspace. In principle this should return configurations distributed uniformly, but it is not terribly important (this is used to start the samplers, so even if it's a constant it might lead to worse warmup time but it might still work). 
+
+Both those methods should be implemented in such a way to be {func}`jax.jit`-table. If you can't write them in a jax-friendly way, you should call your function using {func}`jax.pure_callback`, which allows jax to call back into python functions.
+
+### Example
+
+In the following example, we will be implementing our own custom SumConstraint
+
+```python
+
+import netket as nk
+import jax; import jax.numpy as jnp
+
+class SumConstraint(nk.hilbert.DiscreteHilbertConstraint):
+    # A simple constraint checking that the total sum of the elements
+    # in the configuration is equal to a given value.
+
+    def __init__(self, total_sum):
+        self.total_sum = total_sum
+
+    def __call__(self, x):
+        # Makes it jax-compatible
+       return jnp.sum(x, axis=-1) == self.total_sum
+
+    def __hash__(self):
+        return hash(("SumConstraint", self.total_sum))
+
+    def __eq__(self, other):
+        if isinstance(other, SumConstraint):
+            return self.total_sum == other.total_sum
+        return False
+
+
+@nk.hilbert.random.random_state.dispatch
+def random_state_sumconstraint(
+        hilb: nk.hilb.Fock, constraint: SumConstraint, key, batches: int, *, dtype=None
+    ):
+    """
+    This function should return a batch of `batches` samples distributed uniformly.
+    If batches is 3, it should return a matrix of size `(3, hilb.size)`
+
+    As it can be very hard to write those functions in jax, a typical trick is to write them in 
+    Numpy and use a pure callback
+    """
+
+    def random_constraints_py(key):
+        # Create a RNG based on the provided key for reproducibility
+        rng = np.random.default_rng(np.array(key))
+        # generate random configurations...
+        # It should be a numpy matrix with shape (batches, hilb.size) and dtype dtype
+        return ...
+
+    return jax.pure_callback(random_constraints_py,
+        jax.ShapeDtypeStruct(hilb.size, dtype),
+        jax.random.key_data(key),
+        )
+    
+
+hi = nk.hilbert.Fock(0.5, 10, constraint=SumConstraint(0))
+``` 
+
+
 
 ### Adapting Hilbert spaces with numpy `states_to_numbers` / `numbers_to_states`
 

--- a/netket/errors.py
+++ b/netket/errors.py
@@ -693,6 +693,28 @@ class UnoptimalSRtWarning(NetketWarning):
         )
 
 
+class InvalidConstraintInterface(NetketError):
+    """Error thrown when a constraint for an Homogeneous
+    Hilbert space does not conform to the expected interface.
+
+    A custom Constraint must respect the :class:`netket.hilbert.DiscreteHilbertConstraint`
+    interface by inheriting that class and by having a jax-jittable :code:`__call__` method.
+
+    If you see this error, your constraint might just be a function without inheriting from this
+    class, or it does not have a jittable call method.
+
+    See the class documentation of :class:`netket.hilbert.DiscreteHilbertConstraint` for
+    some examples.
+    """
+
+    def __init__(self):
+        super().__init__(
+            """Your custom constraint does not respect the constraint interface.
+            Look at the documentation online to learn more.
+            """
+        )
+
+
 #################################################
 # Functions to throw errors                     #
 #################################################

--- a/netket/hilbert/__init__.py
+++ b/netket/hilbert/__init__.py
@@ -14,7 +14,7 @@
 
 from .abstract_hilbert import AbstractHilbert
 from .discrete_hilbert import DiscreteHilbert
-from .homogeneous import HomogeneousHilbert
+from .homogeneous import HomogeneousHilbert, DiscreteHilbertConstraint
 
 from .continuous_hilbert import ContinuousHilbert
 

--- a/netket/hilbert/custom_hilbert.py
+++ b/netket/hilbert/custom_hilbert.py
@@ -76,7 +76,7 @@ class CustomHilbert(HomogeneousHilbert):
             >>> print(hi.size)
             100
         """
-        super().__init__(local_states, N, constraint_fn)
+        super().__init__(local_states, N, constraint_fn=constraint_fn)
 
     def _mul_sametype_(self, other):
         assert type(self) == type(other)

--- a/netket/hilbert/fock.py
+++ b/netket/hilbert/fock.py
@@ -19,7 +19,7 @@ import numpy as np
 from netket.utils import StaticRange
 
 from .homogeneous import HomogeneousHilbert
-from .index.constraints import SumConstraint
+from .index.constraints import DiscreteHilbertConstraint, SumConstraint
 
 FOCK_MAX = np.iinfo(np.intp).max - 1
 """
@@ -37,6 +37,7 @@ class Fock(HomogeneousHilbert):
         n_max: Optional[int] = None,
         N: int = 1,
         n_particles: Optional[int] = None,
+        constraint: Optional[DiscreteHilbertConstraint] = None,
     ):
         r"""
         Constructs a new ``Boson`` given a maximum occupation number, number of sites
@@ -48,6 +49,9 @@ class Fock(HomogeneousHilbert):
           N: number of bosonic modes (default = 1)
           n_particles: Constraint for the number of particles. If None, no constraint
             is imposed.
+          constraint: A custom constraint on the allowed configurations. This argument
+            cannot be specified at the same time as :code:`n_particles`. The constraint
+            must be a subclass of :class:`~netket.hilbert.DiscreteHilbertConstraint`
 
         Examples:
            Simple boson hilbert space.
@@ -66,6 +70,11 @@ class Fock(HomogeneousHilbert):
                 raise TypeError(
                     f"n_particles must be an integer. Got {n_particles} ({type(n_particles)})"
                 )
+            if constraint is not None:
+                raise ValueError(
+                    "Cannot specify at the same time a total magnetization "
+                    "constraint and a `custom_constraint."
+                )
 
             n_particles = int(n_particles)
             if n_particles < 0:
@@ -82,9 +91,8 @@ class Fock(HomogeneousHilbert):
                         """The required total number of bosons is not compatible
                         with the given n_max."""
                     )
-            constraints = SumConstraint(n_particles)
+            constraint = SumConstraint(n_particles)
         else:
-            constraints = None
             self._n_particles = None
 
         if self._n_max is not None:
@@ -96,7 +104,7 @@ class Fock(HomogeneousHilbert):
             self._n_max = FOCK_MAX
             local_states = None
 
-        super().__init__(local_states, N, constraints)
+        super().__init__(local_states, N, constraint=constraint)
 
     @property
     def n_max(self) -> Optional[int]:

--- a/netket/hilbert/homogeneous.py
+++ b/netket/hilbert/homogeneous.py
@@ -20,7 +20,8 @@ import jax.numpy as jnp
 
 from equinox import error_if
 
-from netket.utils import StaticRange
+from netket.errors import InvalidConstraintInterface
+from netket.utils import StaticRange, warn_deprecation
 from netket.utils.types import Array
 
 from .discrete_hilbert import DiscreteHilbert
@@ -28,7 +29,44 @@ from .index import (
     HilbertIndex,
     UniformTensorProductHilbertIndex,
     optimalConstrainedHilbertindex,
+    DiscreteHilbertConstraint,
 )
+
+
+def check_and_deprecate_constraint(
+    constraint,
+    constraint_fn,
+):
+    __tracebackhide__ = True
+
+    if constraint is not None and constraint_fn is not None:
+        raise ValueError(
+            "Cannot specify at the same time `constraint` and `constraint_fn`, which"
+            "has been deprecated. Please remove the latter."
+        )
+    elif constraint_fn is not None and constraint is None:
+        constraint = constraint_fn
+        warn_deprecation(
+            "The keyword argument `constraint_fn` was renamed to `constraint` and "
+            "deprecated. Moreover, you can no longer pass a function, but must specify a class "
+            "according to the documentation."
+        )
+
+    if constraint is None:
+        return constraint
+
+    # now
+    if not isinstance(constraint, DiscreteHilbertConstraint):
+        raise InvalidConstraintInterface()
+    try:
+        _ = hash(constraint)
+    except TypeError as err:
+        raise TypeError(
+            f"class {type(constraint)} is not hashable. Please define the __hash___ method.\n"
+            "\nThis error was originated from\n"
+        ) from err
+
+    return constraint
 
 
 class HomogeneousHilbert(DiscreteHilbert):
@@ -58,6 +96,8 @@ class HomogeneousHilbert(DiscreteHilbert):
         self,
         local_states: Optional[StaticRange],
         N: int = 1,
+        *,
+        constraint: Optional[DiscreteHilbertConstraint] = None,
         constraint_fn: Optional[Callable] = None,
     ):
         r"""
@@ -72,9 +112,11 @@ class HomogeneousHilbert(DiscreteHilbert):
                 numbers used to encode the local degree of freedom of this Hilbert
                 Space.
             N: Number of modes in this hilbert space (default 1).
-            constraint_fn: A function specifying constraints on the quantum numbers.
+            constraint: A callable class specifying constraints on the quantum numbers.
                 Given a batch of quantum numbers it should return a vector of bools
-                specifying whether those states are valid or not.
+                specifying whether those states are valid or not. It must be an
+                hashable subclass of :class:`netket.hilbert.DiscreteHilbertConstraint`.
+
         """
         assert isinstance(N, int)
 
@@ -90,7 +132,7 @@ class HomogeneousHilbert(DiscreteHilbert):
             self._local_states = None
             self._local_size = np.iinfo(np.intp).max
 
-        self._constraint_fn = constraint_fn
+        self._constraint = check_and_deprecate_constraint(constraint, constraint_fn)
 
         self._hilbert_index_ = None
 
@@ -120,6 +162,10 @@ class HomogeneousHilbert(DiscreteHilbert):
 
     def states_at_index(self, i: int):
         return self.local_states
+
+    @property
+    def constraint(self):
+        return self._constraint
 
     @property
     def n_states(self) -> int:
@@ -165,7 +211,7 @@ class HomogeneousHilbert(DiscreteHilbert):
         Typically, objects defined in the constrained space cannot be
         converted to QuTiP or other formats.
         """
-        return self._constraint_fn is not None
+        return self.constraint is not None
 
     def _numbers_to_states(self, numbers: np.ndarray) -> np.ndarray:
         return self._hilbert_index.numbers_to_states(numbers)
@@ -185,7 +231,7 @@ class HomogeneousHilbert(DiscreteHilbert):
         if self.constrained:
             states = error_if(
                 states,
-                ~self._constraint_fn(states).all(),
+                ~self.constraint(states).all(),
                 "States do not fulfill constraint.",
             )
 
@@ -218,7 +264,7 @@ class HomogeneousHilbert(DiscreteHilbert):
                 index = UniformTensorProductHilbertIndex(self._local_states, self.size)
             else:
                 index = optimalConstrainedHilbertindex(
-                    self._local_states, self.size, self._constraint_fn
+                    self._local_states, self.size, self.constraint
                 )
             self._hilbert_index_ = index
         return self._hilbert_index_
@@ -243,5 +289,5 @@ class HomogeneousHilbert(DiscreteHilbert):
             self.local_size,
             self._local_states,
             self.constrained,
-            self._constraint_fn,
+            self._constraint,
         )

--- a/netket/hilbert/index/__init__.py
+++ b/netket/hilbert/index/__init__.py
@@ -30,6 +30,10 @@ defined in the file `base.py`.
 """
 
 from .base import HilbertIndex, is_indexable, max_states
-from .constraints import ConstrainedHilbertIndex, optimalConstrainedHilbertindex
+from .constraints import (
+    ConstrainedHilbertIndex,
+    optimalConstrainedHilbertindex,
+    DiscreteHilbertConstraint,
+)
 from .unconstrained import LookupTableHilbertIndex
 from .uniform_tensor import UniformTensorProductHilbertIndex

--- a/netket/hilbert/index/constraints/__init__.py
+++ b/netket/hilbert/index/constraints/__init__.py
@@ -1,2 +1,6 @@
-from .base import optimalConstrainedHilbertindex, ConstrainedHilbertIndex
+from .base import (
+    optimalConstrainedHilbertindex,
+    ConstrainedHilbertIndex,
+    DiscreteHilbertConstraint,
+)
 from .sum import SumConstraint

--- a/netket/hilbert/index/constraints/sum.py
+++ b/netket/hilbert/index/constraints/sum.py
@@ -11,12 +11,15 @@ from netket.utils.types import Scalar, Array
 from ..base import HilbertIndex, is_indexable
 from ..unconstrained import LookupTableHilbertIndex
 from ..uniform_tensor import UniformTensorProductHilbertIndex
-
-from .base import optimalConstrainedHilbertindex, ConstrainedHilbertIndex
+from .base import (
+    optimalConstrainedHilbertindex,
+    ConstrainedHilbertIndex,
+    DiscreteHilbertConstraint,
+)
 
 
 @struct.dataclass
-class SumConstraint:
+class SumConstraint(DiscreteHilbertConstraint):
     """
     Constraint of an Hilbert space enforcing a total sum of all the values in the degrees of freedom.
 

--- a/netket/hilbert/random/__init__.py
+++ b/netket/hilbert/random/__init__.py
@@ -69,7 +69,7 @@ def flip_state_batch(hilb: Fock, key, σ, idx):
 
 from netket.utils import _hide_submodules
 
-from . import custom, doubled, fock, qubit, spin, tensor_hilbert, particle
+from . import custom, doubled, homogeneous, fock, qubit, spin, tensor_hilbert, particle
 from .base import flip_state, random_state
 
 _hide_submodules(__name__)

--- a/netket/hilbert/random/fock.py
+++ b/netket/hilbert/random/fock.py
@@ -13,32 +13,41 @@
 # limitations under the License.
 
 import jax
-import numpy as np
 from jax import numpy as jnp
 
 from netket.hilbert import Fock
+from netket.hilbert.spin import SumConstraint
+
 from netket.utils.dispatch import dispatch
 
 from functools import partial
 
 
 @dispatch
-def random_state(hilb: Fock, key, batches: int, *, dtype=np.float32):
-    shape = (batches,)
-
-    # If unconstrained space, use fast sampling
-    if hilb.n_particles is None:
-        return _random_states_unconstrained(hilb, key, shape, dtype)
-    else:
-        return _random_states_with_constraint(hilb, key, shape, dtype)
-
-
-@partial(jax.jit, static_argnames=("hilb", "shape", "dtype"))
-def _random_states_unconstrained(hilb, key, shape, dtype):
+@partial(jax.jit, static_argnames=("hilb", "batches", "dtype"))
+def random_state(  # noqa: F811
+    hilb: Fock, constraint: None, key, batches: int, *, dtype=None
+):
     assert hilb.n_particles is None
     return jax.random.randint(
-        key, shape=shape + (hilb.size,), minval=0, maxval=hilb.n_max + 1
+        key,
+        shape=(
+            batches,
+            hilb.size,
+        ),
+        minval=0,
+        maxval=hilb.n_max + 1,
     ).astype(dtype)
+
+
+@dispatch
+@partial(jax.jit, static_argnames=("hilb", "batches", "dtype"))
+def random_state(  # noqa: F811
+    hilb: Fock, constraint: SumConstraint, key, batches: int, *, dtype=None
+):
+    return _random_states_with_constraint_fock(
+        hilb.n_particles, hilb.shape, key, (batches,), dtype
+    )
 
 
 def _choice(key, p):
@@ -118,15 +127,8 @@ def _random_states_with_constraint_fock(n_particles, hilb_shape, key, shape, dty
     return jax.lax.scan(body_fun, init, keys)[0]
 
 
-@partial(jax.jit, static_argnames=("hilb", "shape", "dtype"))
-def _random_states_with_constraint(hilb, key, shape, dtype):
-    return _random_states_with_constraint_fock(
-        hilb.n_particles, hilb.shape, key, shape, dtype
-    )
-
-
 @dispatch
-def flip_state_scalar(hilb: Fock, key, σ, idx):
+def flip_state_scalar(hilb: Fock, key, σ, idx):  # noqa: F811
     if hilb._n_max == 0:
         return σ, σ[idx]
 

--- a/netket/hilbert/random/homogeneous.py
+++ b/netket/hilbert/random/homogeneous.py
@@ -1,0 +1,59 @@
+# Copyright 2021 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from netket.hilbert import HomogeneousHilbert
+from netket.utils.dispatch import dispatch
+
+
+@dispatch
+def random_state(hilb: HomogeneousHilbert, key, batches: int, *, dtype=None):
+    return random_state(hilb, hilb.constraint, key, batches, dtype=dtype)
+
+
+# TODO: add a hilb.local_indices_to_states to have a generic
+# implementation
+#
+# @dispatch
+# @partial(jax.jit, static_argnames=("hilb", "batches", "dtype"))
+# def random_state(  # noqa: F811
+#     hilb: HomogeneousHilbert, constraint: None, key, batches: int, *, dtype=None
+# ):
+#     if dtype is None:
+#         dtype = hilb._local_states.dtype
+#
+#     x_ids = jax.random.randint(
+#         key, shape=(batches, hilb.size), minval=0, maxval=len(hilb._local_states)
+#    )
+#    return hilb.local_indices_to_states(x_ids)
+
+
+@dispatch
+def random_state(  # noqa: F811
+    hilb: HomogeneousHilbert, constraint, key, batches: int, *, dtype=None
+):
+    raise NotImplementedError(
+        f"""
+        You are using a custom constraint. You must define how to generate random states
+        for this particular state.
+
+        To do this, define
+
+        @nk.hilbert.random.random_state.dispatch
+        def random_state(hilb: MyHilbType, key, batches: int, constraint: MyConstraintType, *, dtype=None):
+            return ...
+
+        where MyHilbType is {type(hilb)} and MyConstraintType is the type of the constraint you are using.
+        """
+    )

--- a/netket/hilbert/random/spin.py
+++ b/netket/hilbert/random/spin.py
@@ -13,42 +13,39 @@
 # limitations under the License.
 
 import jax
-import numpy as np
 from functools import partial
 
 from netket.hilbert import Spin
+from netket.hilbert.spin import SumConstraint
 from netket.utils.dispatch import dispatch
 
 from .fock import _random_states_with_constraint_fock
 
 
 @dispatch
-def random_state(hilb: Spin, key, batches: int, *, dtype=np.float32):
-    shape = (batches,)
-    if hilb._total_sz is None:
-        return _random_states_unconstrained(hilb, key, shape, dtype)
-    else:
-        return _random_states_with_constraint(hilb, key, shape, dtype)
-
-
-# For the implementations of constrained spaces, we use those found inside of
-# fock.py, and simply convert the spin values (-1, 1) to fock values (0,1, ...).
-
-_spin_to_fock = lambda two_times_s, x: (two_times_s + x) // 2
-_fock_to_spin = lambda two_times_s, x: 2 * x - two_times_s
-
-
-@partial(jax.jit, static_argnames=("hilb", "shape", "dtype"))
-def _random_states_unconstrained(hilb, key, shape, dtype):
+@partial(jax.jit, static_argnames=("hilb", "batches", "dtype"))
+def random_state(  # noqa: F811
+    hilb: Spin, constraint: None, key, batches: int, *, dtype=None
+):
+    if dtype is None:
+        dtype = hilb._local_states.dtype
     two_times_s = round(2 * hilb._s)
     x_fock = jax.random.randint(
-        key, shape=shape + (hilb.size,), minval=0, maxval=two_times_s + 1
+        key, shape=(batches, hilb.size), minval=0, maxval=two_times_s + 1
     )
     return _fock_to_spin(two_times_s, x_fock).astype(dtype)
 
 
-@partial(jax.jit, static_argnames=("hilb", "shape", "dtype"))
-def _random_states_with_constraint(hilb, key, shape, dtype):
+@dispatch
+@partial(jax.jit, static_argnames=("hilb", "batches", "dtype"))
+def random_state(  # noqa: F811
+    hilb: Spin,
+    constraint: SumConstraint,
+    key,
+    batches: int,
+    *,
+    dtype=None,
+):
     # Generate random spin states with a given hilb._total_sz.
     # Note that this is NOT a uniform distribution over the
     # basis states of the constrained hilbert space.
@@ -56,9 +53,16 @@ def _random_states_with_constraint(hilb, key, shape, dtype):
     two_times_total_sz = round(2 * hilb._total_sz)
     n_particles = _spin_to_fock(two_times_s * hilb.size, two_times_total_sz)
     x_fock = _random_states_with_constraint_fock(
-        n_particles, hilb.shape, key, shape, dtype
+        n_particles, hilb.shape, key, (batches,), dtype
     )
     return _fock_to_spin(two_times_s, x_fock).astype(dtype)
+
+
+# For the implementations of constrained spaces, we use those found inside of
+# fock.py, and simply convert the spin values (-1, 1) to fock values (0,1, ...).
+
+_spin_to_fock = lambda two_times_s, x: (two_times_s + x) // 2
+_fock_to_spin = lambda two_times_s, x: 2 * x - two_times_s
 
 
 @dispatch


### PR DESCRIPTION
As some people have been asking this over time, and we have finally a much cleaner interface thanks to the work of @inailuig , I feel safer formalising this partially.

In particular, this PR:
 - defines the interface that discrete Hilbert constraint must follow
 - Adds a keyword argument to `Spin` and `Fock` to define a custom constraint 
 - Formalises how to define `random_state` for general constraints (using dispatch rules)

If this works well, in the future we might start throwing warnings when we have some combinations of Hilbert space/constraints/samplers that we know do not work together...

