### PR TITLE
Make ExchangeSampler only propose different configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,13 @@
 
 ## NetKet 3.13 (⚙️ In development)
 
-### New Features
-* {class}`netket.sampler.rules.ExchangeRule` now only proposes exchanges where the local degrees of freedom changes [#18XX](https://github.com/netket/netket/issues/18XX).
 
 ### Deprecations
 
 * Following the discovery and fix of the Parallel Tempering bugs, {class}`netket.experimental.sampler.MetropolisPt` and related samplers have been stabilised, so they should be constructed with {class}`netket.sampler.ParallelTemperingSampler` [#1803](https://github.com/netket/netket/issues/1803).
+
+### Improvements
+* {class}`netket.sampler.rules.ExchangeRule` now only proposes exchanges where the local degrees of freedom changes [#1815](https://github.com/netket/netket/issues/1815).
 
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,9 @@
 * Following the discovery and fix of the Parallel Tempering bugs, {class}`netket.experimental.sampler.MetropolisPt` and related samplers have been stabilised, so they should be constructed with {class}`netket.sampler.ParallelTemperingSampler` [#1803](https://github.com/netket/netket/issues/1803).
 
 ### Improvements
-* {class}`netket.sampler.rules.ExchangeRule` now only proposes exchanges where the local degrees of freedom changes [#1815](https://github.com/netket/netket/issues/1815).
-
-
-### Improvements
 
 * Drivers now always log Monte Carlo acceptance if you are using a Monte Carlo sampler [#1816](https://github.com/netket/netket/issues/1816).
-
+* {class}`netket.sampler.rules.ExchangeRule` now only proposes exchanges where the local degrees of freedom changes [#1815](https://github.com/netket/netket/issues/1815).
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 
 ## NetKet 3.13 (⚙️ In development)
 
+### New Features
+* {class}`netket.sampler.rules.ExchangeRule` now only proposes exchanges where the local degrees of freedom changes [#18XX](https://github.com/netket/netket/issues/18XX).
+
 ### Deprecations
 
 * Following the discovery and fix of the Parallel Tempering bugs, {class}`netket.experimental.sampler.MetropolisPt` and related samplers have been stabilised, so they should be constructed with {class}`netket.sampler.ParallelTemperingSampler` [#1803](https://github.com/netket/netket/issues/1803).

--- a/netket/sampler/rules/exchange.py
+++ b/netket/sampler/rules/exchange.py
@@ -41,8 +41,9 @@ class ExchangeRule(MetropolisRule):
 
     1. A pair of indices :math:`i,j = 1\dots N`, and such
        that :math:`\mathrm{dist}(i,j) \leq d_{\mathrm{max}}`,
-       is chosen with uniform probability.
-    2. The sites are exchanged, i.e. :math:`s^\prime_i = s_j` and :math:`s^\prime_j = s_i`.
+       is chosen with uniform probability, excluding all the sites where
+       :math:`s_i = s_j`;
+    2. The sites are exchanged, i.e. :math:`s^\prime_i = s_j` and :math:`s^\prime_j = s_i`;
 
     Notice that this sampling method generates random permutations of the quantum
     numbers, thus global quantities such as the sum of the local quantum numbers
@@ -97,23 +98,40 @@ class ExchangeRule(MetropolisRule):
     def transition(rule, sampler, machine, parameters, state, key, σ):
         n_chains = σ.shape[0]
 
-        # pick a random cluster
-        cluster_id = jax.random.randint(
-            key, shape=(n_chains,), minval=0, maxval=rule.clusters.shape[0]
-        )
+        # compute a mask for the clusters that can be hopped
+        hoppable_clusters = _compute_different_clusters_mask(rule.clusters, σ)
 
-        # we use shard_map to avoid the all-gather emitted by the batched jnp.take / indexing
-        @partial(sharding_decorator, sharded_args_tree=(True, True))
+        keys = jnp.asarray(jax.random.split(key, n_chains))
+
+        # we use shard_map to avoid the all-gather coming from the batched jnp.take / indexing
+        @partial(sharding_decorator, sharded_args_tree=(True, True, True))
         @jax.vmap
-        def update_fun(σ, cluster):
-            # sites to be exchanged,
+        def _update_samples(key, σ, hoppable_clusters):
+            # pick a random cluster, taking into account the mask
+            n_conn = hoppable_clusters.sum(axis=-1)
+            cluster = jax.random.choice(
+                key,
+                a=jnp.arange(rule.clusters.shape[0]),
+                p=hoppable_clusters,
+                replace=True,
+            )
+
+            # sites to be exchanged
             si = rule.clusters[cluster, 0]
             sj = rule.clusters[cluster, 1]
 
             σp = σ.at[si].set(σ[sj])
-            return σp.at[sj].set(σ[si])
+            σp = σp.at[sj].set(σ[si])
 
-        return (update_fun(σ, cluster_id), None)
+            # compute the number of connected sites
+            hoppable_clusters_proposed = _compute_different_clusters_mask(
+                rule.clusters, σp
+            )
+            n_conn_proposed = hoppable_clusters_proposed.sum(axis=-1)
+            log_prob_corr = jnp.log(n_conn) - jnp.log(n_conn_proposed)
+            return σp, log_prob_corr
+
+        return _update_samples(keys, σ, hoppable_clusters)
 
     def __repr__(self):
         return f"ExchangeRule(# of clusters: {len(self.clusters)})"
@@ -139,3 +157,12 @@ def compute_clusters(graph: AbstractGraph, d_max: int):
         res_clusters[i] = np.asarray(cluster)
 
     return res_clusters
+
+
+@jax.jit
+def _compute_different_clusters_mask(clusters, σ):
+    # mask the clusters to include only feasible moves (occ -> unocc, or the inverse)
+    hoppable_clusters_mask = ~jnp.isclose(
+        σ[..., clusters[:, 0]], σ[..., clusters[:, 1]]
+    )
+    return hoppable_clusters_mask

--- a/netket/sampler/rules/exchange.py
+++ b/netket/sampler/rules/exchange.py
@@ -161,8 +161,12 @@ def compute_clusters(graph: AbstractGraph, d_max: int):
 
 @jax.jit
 def _compute_different_clusters_mask(clusters, σ):
-    # mask the clusters to include only feasible moves (occ -> unocc, or the inverse)
-    hoppable_clusters_mask = ~jnp.isclose(
-        σ[..., clusters[:, 0]], σ[..., clusters[:, 1]]
-    )
+    # mask the clusters to include only moves
+    # where the dof changes
+    if jnp.issubdtype(σ, jnp.bool) or jnp.issubdtype(σ, jnp.integer):
+        hoppable_clusters_mask = σ[..., clusters[:, 0]] != σ[..., clusters[:, 1]]
+    else:
+        hoppable_clusters_mask = ~jnp.isclose(
+            σ[..., clusters[:, 0]], σ[..., clusters[:, 1]]
+        )
     return hoppable_clusters_mask


### PR DESCRIPTION
This was implemented by @jwnys for Fermionic states, but makes sense in general for the ExchangeRule in general.

