### PR TITLE
Use Flax's `Module.is_initializing()` to detect initialization

### DIFF
--- a/netket/experimental/nn/rnn/layers_fast.py
+++ b/netket/experimental/nn/rnn/layers_fast.py
@@ -75,8 +75,7 @@ class FastRNNLayer(RNNLayer):
         hidden = self._extract_hidden(outputs, index, prev_neighbors)
         cell_mem, hidden = self.cell(inputs, cell_mem, hidden)
 
-        initializing = self.is_mutable_collection("params")
-        if not initializing:
+        if not self.is_initializing():
             _cell_mem.value = cell_mem
             _outputs.value = outputs.at[:, index, :].set(hidden)
 

--- a/netket/nn/fast_masked_linear.py
+++ b/netket/nn/fast_masked_linear.py
@@ -114,8 +114,7 @@ class FastMaskedDense1D(nn.Module):
             "cache", "inputs", zeros, None, (batch, size, in_features), inputs.dtype
         )
 
-        initializing = self.is_mutable_collection("params")
-        if not initializing:
+        if not self.is_initializing():
             # Add the input site into the cache
             # To write the cache, use `_cache.value` as the left value of the assignment
             _cache.value = jnp.where(
@@ -123,6 +122,7 @@ class FastMaskedDense1D(nn.Module):
                 _cache.value.at[:, index - self.exclusive, :].set(inputs),
                 _cache.value,
             )
+
         cache = _cache.value
 
         cache_i = cache[:, :size_i, :]
@@ -241,8 +241,7 @@ class FastMaskedConv1D(nn.Module):
             inputs.dtype,
         )
 
-        initializing = self.is_mutable_collection("params")
-        if not initializing:
+        if not self.is_initializing():
             # Add the input site into the cache
             # To write the cache, use `_cache.value` as the left value of the assignment
             _cache.value = jnp.where(
@@ -389,8 +388,7 @@ class FastMaskedConv2D(nn.Module):
             inputs.dtype,
         )
 
-        initializing = self.is_mutable_collection("params")
-        if not initializing:
+        if not self.is_initializing():
             # Add the input site into the cache
             # To write the cache, use `_cache.value` as the left value of the assignment
 


### PR DESCRIPTION
See https://github.com/google/flax/pull/2234 . Previously we used an idiom from Flax `initializing = self.is_mutable_collection("params")` to do this, but it's not reliable when the method is called in some unconventional ways, and now they have a more reliable way to do this

After merging this, we can discuss again #1656