### PR TITLE
Chunking in `MetropolisSampler`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### New Features
 * Added the function {func}`netket.jax.tree_norm` to compute the L-p norm of a PyTree, interpreted as a vector of values, without concatenating or ravelling the leaves [#1819](https://github.com/netket/netket/issues/1819).
 * The default value of `n_discard_per_chain` has been changed to 5, which is a more reasonable number in most cases. It might be low for some applications.
+* The sampler {class}`netket.sampler.MetropolisSampler` and all its derivatives now support chunking for the evaluation of the wavefunction at every Metropolis step [#1828](https://github.com/netket/netket/issues/1828).
 
 ### Deprecations
 

--- a/netket/optimizer/qgt/qgt_jacobian_common.py
+++ b/netket/optimizer/qgt/qgt_jacobian_common.py
@@ -67,6 +67,7 @@ def to_shift_offset(diag_shift, diag_scale):
     else:
         return diag_scale, diag_shift / diag_scale
 
+
 @partial(jax.jit, static_argnames="ndims")
 def rescale(centered_oks, offset, *, ndims: int = 1):
     """

--- a/netket/sampler/metropolis.py
+++ b/netket/sampler/metropolis.py
@@ -432,9 +432,12 @@ class MetropolisSampler(Sampler):
         """
 
         if sampler.chunk_size is None:
+
             def apply_machine(σ):
                 return machine.apply(parameters, σ)
+
         else:
+
             def apply_machine(σ):
                 σ = σ.reshape(-1, sampler.chunk_size, σ.shape[-1])
                 f = lambda s: machine.apply(parameters, s)

--- a/netket/sampler/metropolis.py
+++ b/netket/sampler/metropolis.py
@@ -320,10 +320,11 @@ class MetropolisSampler(Sampler):
             device_count(),
             "rank",
         )
+        n_chains_per_rank = n_chains // device_count()
 
         if chunk_size is not None and n_chains_per_rank % chunk_size != 0:
             raise ValueError(
-                f"Chunk size must divide number of chains per rank, {self.n_chains_per_rank}"
+                f"Chunk size must divide number of chains per rank, {n_chains_per_rank}"
             )
         self.chunk_size = chunk_size
 

--- a/netket/sampler/metropolis_numpy.py
+++ b/netket/sampler/metropolis_numpy.py
@@ -89,12 +89,10 @@ class MetropolisNumpySamplerState:
 
 @partial(jax.jit, static_argnums=(0, 3))
 def apply_model(machine, pars, weights, chunk_size):
-    if chunk_size is None:
-        return machine.apply(pars, weights)
-    else:
-        weights = weights.reshape(-1, chunk_size, weights.shape[-1])
-        f = lambda s: machine.apply(pars, s)
-        return jax.lax.map(f, weights).ravel()
+    chunked = nkjax.apply_chunked(
+        machine.apply, in_axes=(None, 0), chunk_size=chunk_size
+    )
+    return chunked(pars, weights)
 
 
 class MetropolisSamplerNumpy(MetropolisSampler):

--- a/test/sampler/test_sampler.py
+++ b/test/sampler/test_sampler.py
@@ -652,8 +652,7 @@ def test_hamiltonian_jax_sampler_isleaf():
 )
 def test_chunking_invariant(model_and_weights, sampler_type):
     sa = samplers[sampler_type]
-    sa_ch = samplers[sampler_type + "-chunked"]
-
+    hi = sa.hilbert
     ma, w = model_and_weights(hi, sa)
 
     sampler_state = sa.init_state(ma, w, seed=SAMPLER_SEED)
@@ -665,11 +664,13 @@ def test_chunking_invariant(model_and_weights, sampler_type):
         chain_length=10,
     )
 
-    ma, w = model_and_weights(hi, sa_ch)
+    sa = samplers[sampler_type + "-chunked"]
+    hi = sa.hilbert
+    ma, w = model_and_weights(hi, sa)
 
-    sampler_state = sa_ch.init_state(ma, w, seed=SAMPLER_SEED)
-    sampler_state = sa_ch.reset(ma, w, state=sampler_state)
-    samples_ch, sampler_state = sa_ch.sample(
+    sampler_state = sa.init_state(ma, w, seed=SAMPLER_SEED)
+    sampler_state = sa.reset(ma, w, state=sampler_state)
+    samples_ch, sampler_state = sa.sample(
         ma,
         w,
         state=sampler_state,


### PR DESCRIPTION
Introduces a `chunk_size` variable in `MetropolisSampler` (and its derivatives) to allow chunking when evaluating the NQS inside the Metropolis loop. This allows us to use more chains, which seems to be the best way of getting reasonably good samples for SR.

Missing:
* implementation for PT
* tests (I have a hard time following the test file, what do we need to check for?)