### PR TITLE
Ensure that random seeds are synced across sharding ranks

### DIFF
--- a/netket/jax/_utils_random.py
+++ b/netket/jax/_utils_random.py
@@ -30,23 +30,26 @@ def PRNGKey(
     The same seed will be distributed to all processes.
     """
     if seed is None:
-        key = jax.random.PRNGKey(random_seed())
-    elif isinstance(seed, int):
+        seed = random_seed()
+
+    if isinstance(seed, int):
+        # We can't sync the PRNGKey, so we can only sinc integer seeds
+        # see https://github.com/google/jax/pull/16511
+        if config.netket_experimental_sharding:
+            # TODO: use stable jax function
+            from jax.experimental import multihost_utils
+
+            seed = int(
+                multihost_utils.broadcast_one_to_all(
+                    seed, is_source=jax.process_index() == root
+                ).item()
+            )
+
         key = jax.random.PRNGKey(seed)
     else:
         key = seed
 
-    if config.netket_experimental_sharding:
-        # TODO: use stable jax function
-        from jax.experimental import multihost_utils
-
-        dtype = key.dtype
-        key = multihost_utils.broadcast_one_to_all(
-            key, is_source=jax.process_index() == root
-        )
-        # TODO :Return PRNGKey as well?
-        key = jax.random.wrap_key_data(key.astype(dtype))
-    else:
+    if not config.netket_experimental_sharding:
         key = jax.tree_util.tree_map(
             lambda k: mpi.mpi_bcast_jax(k, root=root, comm=comm)[0], key
         )
@@ -97,19 +100,14 @@ def mpi_split(key, *, root=0, comm=MPI_jax_comm) -> PRNGKeyT:
     Returns:
         A PRNGKey depending on rank number and key.
     """
-    if not config.netket_experimental_sharding:
-        # Maybe add error/warning if in_key is not the same
-        # on all MPI nodes?
-        keys = jax.random.split(key, mpi.n_nodes)
 
-        keys = jax.tree_util.tree_map(
-            lambda k: mpi.mpi_bcast_jax(k, root=root)[0], keys
-        )
+    # Maybe add error/warning if in_key is not the same
+    # on all MPI nodes?
+    keys = jax.random.split(key, mpi.n_nodes)
 
-        return keys[mpi.rank]
-    else:
-        # TODO: is this what we want?
-        return key
+    keys = jax.tree_util.tree_map(lambda k: mpi.mpi_bcast_jax(k, root=root)[0], keys)
+
+    return keys[mpi.rank]
 
 
 def batch_choice(key, a, p):

--- a/netket/jax/_utils_random.py
+++ b/netket/jax/_utils_random.py
@@ -35,7 +35,7 @@ def PRNGKey(
     if isinstance(seed, int):
         # We can't sync the PRNGKey, so we can only sinc integer seeds
         # see https://github.com/google/jax/pull/16511
-        if config.netket_experimental_sharding:
+        if config.netket_experimental_sharding and jax.process_count() > 1:
             # TODO: use stable jax function
             from jax.experimental import multihost_utils
 

--- a/netket/utils/api_utils.py
+++ b/netket/utils/api_utils.py
@@ -76,7 +76,6 @@ def partial_from_kwargs(
                 kwargs_exclusion_list[arg] = kwargs_exclusion_list.get(
                     arg, set()
                 ).union(exclusion_set - {arg})
-        print(kwargs_exclusion_list)
 
     @functools.wraps(func)
     def wrapper(*args, **kwargs):

--- a/netket/utils/seed.py
+++ b/netket/utils/seed.py
@@ -19,4 +19,4 @@ def random_seed():
     """
     generates a random seed
     """
-    return np.random.default_rng().integers(0, 1 << 32)
+    return int(np.random.default_rng().integers(0, 1 << 32))


### PR DESCRIPTION
@lgravina1997 has recently noticed that we do not generate the same RNG seeds across hosts when running with multi-process  sharding.

(how come you never noticed @inailuig ?)

Anyhow, this PR fixes it.

Unsure how to test..
