### PR TITLE
Support our netket's linear solvers in VMC_SRt

### DIFF
--- a/netket/experimental/driver/vmc_srt.py
+++ b/netket/experimental/driver/vmc_srt.py
@@ -90,6 +90,11 @@ def SRt(
             matrix_side
         )  # * shift diagonal regularization
         aus_vector = solver_fn(matrix, dv)
+        # some solvers return a tuple, some others do not.
+        # We check and try to support both
+        if isinstance(aus_vector, tuple):
+            aus_vector, _ = aus_vector
+
         aus_vector = aus_vector.reshape(mpi.n_nodes, -1)
         aus_vector, token = mpi.mpi_scatter_jax(aus_vector, token=token)
     else:

--- a/test/driver/test_srt.py
+++ b/test/driver/test_srt.py
@@ -241,3 +241,18 @@ def test_SRt_schedules():
         diag_shift=optax.linear_schedule(0.1, 0.001, 100),
     )
     gs.run(5)
+
+
+def test_SRt_supports_netket_solvers():
+    """
+    nk.driver.VMC_kernelSR must give **exactly** the same dynamics as nk.driver.VMC with nk.optimizer.SR
+    """
+    H, opt, vstate_srt = _setup()
+    gs = VMC_SRt(
+        H,
+        opt,
+        variational_state=vstate_srt,
+        diag_shift=optax.linear_schedule(0.1, 0.001, 100),
+        linear_solver_fn=nk.optimizer.solver.pinv_smooth,
+    )
+    gs.run(5)


### PR DESCRIPTION
A recent PR made our solvers work with dense matrices, but VMC_SRt still assumed that the solver returned a single dense array, while our solver respect the SciPy.sparse interface that returns a tuple (with solver information).

We simply check if the returned result is a tuple, in which case we take only the result.