### PR TITLE
Support proper serialisation of variational states when running under MPI

### DIFF
--- a/netket/sampler/metropolis.py
+++ b/netket/sampler/metropolis.py
@@ -15,6 +15,7 @@
 from functools import partial
 from typing import Any, Callable, Optional, Union
 from textwrap import dedent
+import warnings
 
 import numpy as np
 
@@ -108,45 +109,121 @@ class MetropolisSamplerState(SamplerState):
         return f"{type(self).__name__}({acc_string}rng state={self.rng})"
 
 
-# serialization when sharded
-def serialize_MetropolisSamplerState_sharding(sampler_state):
+# We must support serialization of the sampler state, which is a bit tricky
+# because we must support multi-GPU, sharding or MPI.
+def serialize_MetropolisSamplerState(sampler_state):
+    # First serialize the local data with the default scheme
     state_dict = MetropolisSamplerState._to_flax_state_dict(
         MetropolisSamplerState._pytree__static_fields, sampler_state
     )
 
-    for prop in ["σ", "n_accepted_proc"]:
-        x = state_dict.get(prop, None)
-        if x is not None and isinstance(x, jax.Array) and len(x.devices()) > 1:
-            state_dict[prop] = gather(x)
-    state_dict = extract_replicated(state_dict)
+    # then post-process the data to gather the data to all devices
+    if config.netket_experimental_sharding:
+        # For sharding, we simply gather and unreplicate the data
+        for prop in ["σ", "n_accepted_proc"]:
+            x = state_dict.get(prop, None)
+            if x is not None and isinstance(x, jax.Array) and len(x.devices()) > 1:
+                state_dict[prop] = gather(x)
+        state_dict = extract_replicated(state_dict)
+        # distributed == -1 means sharding
+        state_dict["distributed"] = -1
+    else:
+        # For MPI, we gather the data to all processes
+        # here the rng is not global, so we must gather it as well.
+        for prop in ["σ", "n_accepted_proc", "rng"]:
+            x = state_dict.get(prop, None)
+            if x is not None:
+                x = mpi.mpi_allgather(x)
+                y = x.reshape(-1, *x.shape[2:])
+                state_dict[prop] = y
+
+        rng = state_dict.get("rng", None)
+        if rng is not None:
+            if rng.ndim > 1:
+                rng
+
+        state_dict["distributed"] = mpi.n_nodes
     return state_dict
 
 
-def deserialize_MetropolisSamplerState_sharding(sampler_state, state_dict):
-    for prop in ["σ", "n_accepted_proc"]:
-        x = state_dict[prop]
-        if x is not None:
-            state_dict[prop] = distribute_to_devices_along_axis(x)
+def deserialize_MetropolisSamplerState(sampler_state, state_dict):
+    # backward compatibility
+    if "distributed" not in state_dict:
+        state_dict["distributed"] = 1
+
+    if config.netket_experimental_sharding:
+        if state_dict["distributed"] != -1:
+            warnings.warn(
+                "Deserializing a MetropolisSamplerState with sharding, but the current setup is not sharded. This might lead to unexpected behavior.",
+                category=UserWarning,
+                stacklevel=2,
+            )
+        del state_dict["distributed"]
+
+        for prop in ["σ", "n_accepted_proc"]:
+            x = state_dict[prop]
+            if x is not None:
+                state_dict[prop] = distribute_to_devices_along_axis(x)
+    else:
+        n_chains = sampler_state.σ.shape[0] * mpi.n_nodes
+        if state_dict["distributed"] != mpi.n_nodes:
+            n_chains_serialized = state_dict["σ"].shape[0]
+            if n_chains_serialized == n_chains:
+                warnings.warn(
+                    f"Deserializing a MetropolisSamplerState saved with {state_dict['distributed']} MPI nodes."
+                    "Same number of chains detected: using same samples but different seed.",
+                    category=UserWarning,
+                    stacklevel=2,
+                )
+            else:
+                warnings.warn(
+                    "Deserializing a MetropolisSamplerState saved with a different number of MPI nodes and different number"
+                    f"of chains. This is impossible. Use n_chains={n_chains_serialized} to load this file correctly."
+                    "\nInstead of hard erroring, we will skip loading the sampler state.",
+                    category=UserWarning,
+                    stacklevel=2,
+                )
+
+            rank_mismatch = True
+        else:
+            rank_mismatch = False
+            n_chains_serialized = n_chains
+
+        del state_dict["distributed"]
+        if not rank_mismatch:
+            for prop in ["σ", "n_accepted_proc", "rng"]:
+                x = state_dict[prop]
+                y = x.reshape(mpi.n_nodes, *getattr(sampler_state, prop).shape)
+                state_dict[prop] = y[mpi.rank]
+        elif n_chains_serialized == n_chains:
+            x = state_dict["σ"]
+            y = x.reshape(mpi.n_nodes, n_chains_serialized, *x.shape[1:])
+            state_dict["σ"] = y[mpi.rank]
+            state_dict["n_accepted_proc"] = sampler_state.n_accepted_proc
+            state_dict["rng"] = sampler_state.rng
+        else:
+            state_dict["σ"] = sampler_state.σ
+            state_dict["n_accepted_proc"] = sampler_state.n_accepted_proc
+            state_dict["rng"] = sampler_state.rng
 
     return MetropolisSamplerState._from_flax_state_dict(
         MetropolisSamplerState._pytree__static_fields, sampler_state, state_dict
     )
 
 
-if config.netket_experimental_sharding:
-    # when running on multiple jax processes the σ and n_accepted_proc are not fully addressable
-    # however, when serializing they need to be so here we register custom handlers which
-    # gather all the data to every process.
-    # when deserializing we distribute the samples again to all availale devices
-    # this way it is enough to serialize on process 0, and we can restart the simulation
-    # also  on a different number of devices, provided the number of samples is still
-    # divisible by the new number of devices
-    serialization.register_serialization_state(
-        MetropolisSamplerState,
-        serialize_MetropolisSamplerState_sharding,
-        deserialize_MetropolisSamplerState_sharding,
-        override=True,
-    )
+# when running on multiple jax processes the σ and n_accepted_proc are not fully addressable
+# however, when serializing they need to be so here we register custom handlers which
+# gather all the data to every process.
+# when deserializing we distribute the samples again to all availale devices
+# this way it is enough to serialize on process 0, and we can restart the simulation
+# also  on a different number of devices, provided the number of samples is still
+# divisible by the new number of devices
+serialization.register_serialization_state(
+    MetropolisSamplerState,
+    serialize_MetropolisSamplerState,
+    deserialize_MetropolisSamplerState,
+    override=True,
+)
 
 
 def _assert_good_sample_shape(samples, shape, dtype, obj=""):


### PR DESCRIPTION
When running under MPI we serialise only the sampler_state on the first rank, and ignore the one on the other ranks.
This is wrong.
When you load it, you get the same seed and chains on every rank (which is wrong!)

I want to get netket working with proper checkpointing, so getting serialisation to work correctly is necessary.

This seems to be what needs to be done to support proper full serialisation of variational states and the stream of samples they generate.

To avoid raising errors, if you attempt to load a saved state there are three cases:
 - If you have same number of ranks and of chains, then just load it and all is good
 - If you have different number of ranks , but same number of total chains, then just load the chains and use some random seed (we cannot restore perfectly, but at least the chains are already thermalised)
 - If you have different number of chains, then simply load the weights and throw a warning.

I'd like some opinions..