### PR TITLE
Allow custom constraints on SpinOrbitalFermions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### New features
 * Hilbert spaces such as {class}`nk.hilbert.Spin` and {class}`nk.hilbert.Fock`, as well as their base class {class}`nk.hilbert.HomogeneousHilbert`, now support arbitrary custom constraints [#1908](https://github.com/netket/netket/pull/1908).
 * The constraint interface has been stabilised, documented, and made compatible with several utilities. It is now possible to generate random states from arbitrary constrained hilbert spaces automatically, and it is possible to index into those spaces efficiently. Look at the hilbert space documentation for more information [#1908](https://github.com/netket/netket/pull/1908).
+* Fermionic hilbert spaces {class}`~nk.experimental.hilbert.SpinOrbitalFermions` now support an extra arbitrary constraint that can be specified by passing the keyword argument `constraint=...` [#1832](https://github.com/netket/netket/pull/1832)
 
 ### Changes
 * Jax operators now use the same `chunk_size` as specified by the user when computing the forward pass. Prior to this change, Jax operators would be chunking the sample axis, but if an operator had a lot of connected elements this would end up increasing the effective sample size [#1875](https://github.com/netket/netket/pull/1875).

--- a/netket/experimental/hilbert/spin_orbital_fermions.py
+++ b/netket/experimental/hilbert/spin_orbital_fermions.py
@@ -77,7 +77,8 @@ class SpinOrbitalFermions(HomogeneousHilbert):
                 between **n_fermions** and **n_fermions_per_spin** can be specified. The length
                 of the iterable should be :math:`2S+1`.
             constraint: An extra constraint for the Hilbert space, defined according to the
-                constraint API.
+                constraint API (see :class:`netket.hilbert.constraint.DiscreteHilbertConstraint`
+                for more details).
 
         Returns:
             A SpinOrbitalFermions object

--- a/netket/hilbert/constraint/__init__.py
+++ b/netket/hilbert/constraint/__init__.py
@@ -15,6 +15,7 @@
 from .base import DiscreteHilbertConstraint
 from .sum import SumConstraint
 from .multiple import ExtraConstraint
+from .sum_partition import SumOnPartitionConstraint
 
 
 from netket.utils import _hide_submodules

--- a/netket/hilbert/constraint/sum_partition.py
+++ b/netket/hilbert/constraint/sum_partition.py
@@ -1,0 +1,71 @@
+# Copyright 2024 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import jax
+import jax.numpy as jnp
+
+from netket.utils import struct
+from netket.utils.types import Scalar, Array
+
+from .base import (
+    DiscreteHilbertConstraint,
+)
+
+
+class SumOnPartitionConstraint(DiscreteHilbertConstraint):
+    """
+    Constraint of an Hilbert space enforcing a total sum of all the values
+    in partitions of different sizes.
+
+    Constructed by specifying the tuples of sums on every partition and the length
+    of every partition.
+
+    This can be used to represent tensor products of Spin subsystems with
+    different total magnetizations, or constraint on the number of fermions
+    on different parts.
+    """
+
+    sum_values: tuple[Scalar, ...] = struct.field(pytree_node=False)
+    sizes: tuple[int, ...] = struct.field(pytree_node=False, default=None)
+
+    def __init__(self, sum_values, sizes):
+        if not (isinstance(sum_values, tuple) and isinstance(sizes, tuple)):
+            raise ValueError("sum_values and sizes must be tuples.")
+        if not len(sum_values) == len(sizes):
+            raise ValueError("Length mismatch between sum values and sizes")
+        if any(v is None for v in sum_values):
+            raise TypeError("None not supported as a sum constraint.")
+
+        self.sum_values = sum_values
+        self.sizes = sizes
+
+    @jax.jit
+    def __call__(self, x: Array) -> Array:
+        s0 = 0
+        conditions = []
+        for N, sv in zip(self.sizes, self.sum_values):
+            conditions.append(x[..., s0 : s0 + N].sum(axis=-1) == sv)
+            s0 = s0 + N
+        return jax.tree_util.tree_reduce(jnp.logical_and, conditions)
+
+    def __hash__(self):
+        return hash(("SumOnPartitionConstraint", self.sum_values, self.sizes))
+
+    def __eq__(self, other):
+        if isinstance(other, SumOnPartitionConstraint):
+            return self.sum_values == other.sum_values and self.sizes == other.sizes
+        return False
+
+    def __repr__(self):
+        return f"SumOnPartitionConstraint(sum_values={self.sum_values}, sizes={self.sizes})"

--- a/netket/hilbert/constraint/sum_partition.py
+++ b/netket/hilbert/constraint/sum_partition.py
@@ -41,7 +41,7 @@ class SumOnPartitionConstraint(DiscreteHilbertConstraint):
 
     def __init__(self, sum_values, sizes):
         if not (isinstance(sum_values, tuple) and isinstance(sizes, tuple)):
-            raise ValueError("sum_values and sizes must be tuples.")
+            raise TypeError("sum_values and sizes must be tuples.")
         if not len(sum_values) == len(sizes):
             raise ValueError("Length mismatch between sum values and sizes")
         if any(v is None for v in sum_values):

--- a/netket/hilbert/homogeneous.py
+++ b/netket/hilbert/homogeneous.py
@@ -164,7 +164,13 @@ class HomogeneousHilbert(DiscreteHilbert):
         return self.local_states
 
     @property
-    def constraint(self):
+    def constraint(self) -> DiscreteHilbertConstraint:
+        """
+        The constraint inflicted upon this poor Hilbert space.
+
+        Instead of all possible combinations of local states, only those satisfying
+        the constraint are part of this Hilbert space.
+        """
         return self._constraint
 
     @property

--- a/netket/hilbert/index/__init__.py
+++ b/netket/hilbert/index/__init__.py
@@ -34,6 +34,7 @@ from .unconstrained import LookupTableHilbertIndex
 from .uniform_tensor import UniformTensorProductHilbertIndex
 from .constrained_generic import ConstrainedHilbertIndex, optimalConstrainedHilbertindex
 from .constrained_sum import SumConstrainedHilbertIndex
+from .constrained_sum_partitions import SumOnPartitionConstrainedHilbertIndex
 
 
 from netket.utils import _hide_submodules

--- a/netket/hilbert/index/constrained_sum_partitions.py
+++ b/netket/hilbert/index/constrained_sum_partitions.py
@@ -1,0 +1,117 @@
+import math
+
+import jax
+import jax.numpy as jnp
+
+from netket.utils import struct
+from netket.utils.types import Array
+
+from netket.hilbert.constraint import SumOnPartitionConstraint
+
+from .base import HilbertIndex, is_indexable
+from .unconstrained import LookupTableHilbertIndex
+from .constrained_sum import SumConstrainedHilbertIndex
+from .constrained_generic import optimalConstrainedHilbertindex
+
+
+@optimalConstrainedHilbertindex.dispatch
+def optimalConstrainedHilbertindex(
+    local_states, size, constraint: SumOnPartitionConstraint
+):
+    if size != sum(constraint.sizes):
+        raise ValueError(
+            f"The size {size} does not match the total size of the constraint"
+            f"partitions {sum(constraint.sizes)}."
+        )
+    specialized_index = SumOnPartitionConstrainedHilbertIndex(
+        sub_indices=tuple(
+            SumConstrainedHilbertIndex(local_states, N, sv)
+            for (N, sv) in zip(constraint.sizes, constraint.sum_values)
+        )
+    )
+    return specialized_index
+
+
+@struct.dataclass
+class SumOnPartitionConstrainedHilbertIndex(HilbertIndex):
+    """
+    Specialized implementation for a constrained space with a SumConstraint.
+    Does not require the unconstrained space to be indexable.
+    """
+
+    sub_indices: list[SumConstrainedHilbertIndex] = struct.field(pytree_node=False)
+
+    @property
+    def size(self) -> int:
+        return sum(s.size for s in self.sub_indices)
+
+    @property
+    def shape(self):
+        return sum((s.shape for s in self.sub_indices), start=())
+
+    @property
+    def n_states(self):
+        return math.prod(s.n_states for s in self.sub_indices)
+
+    def states_to_numbers(self, states: Array) -> Array:
+        return self._lookup_table.states_to_numbers(states)
+
+    def numbers_to_states(self, numbers: Array):
+        return self._lookup_table.numbers_to_states(numbers)
+
+    def all_states(self):
+        return self._lookup_table.all_states()
+
+    @jax.jit
+    def _compute_all_states(self):
+        states = []
+        for index in self.sub_indices:
+            states.append(index.all_states())
+        return combine_configurations(*states)
+
+    @struct.property_cached(pytree_node=True)
+    def _lookup_table(self) -> LookupTableHilbertIndex:
+        with jax.ensure_compile_time_eval():
+            all_states = self._compute_all_states()
+        return LookupTableHilbertIndex(all_states)
+
+    @property
+    def n_states_bound(self):
+        # upper bound on n_states, exact if n_max == 1
+        # number of combinations to check in _compute_all_states
+        return math.prod(s.n_states_bound for s in self.sub_indices)
+
+    @property
+    def is_indexable(self):
+        # make sure we have less than than max_states to check in _compute_all_states
+        return is_indexable(self.n_states_bound)
+
+
+def combine_configurations(*matrices):
+    """
+    Concatenate a list of configurations, generating all possible combinations.
+    """
+    if len(matrices) == 1:
+        return matrices[0]
+
+    # Initialize with the first matrix
+    result = matrices[0]
+
+    for matrix in matrices[1:]:
+        M1, N1 = result.shape
+        M2, N2 = matrix.shape
+
+        # Reshape matrices to make use of broadcasting
+        result_reshaped = result[:, jnp.newaxis, :]
+        matrix_reshaped = matrix[jnp.newaxis, :, :]
+
+        # Create the resulting matrix by concatenating along the last axis
+        result = jnp.concatenate(
+            (result_reshaped.repeat(M2, axis=1), matrix_reshaped.repeat(M1, axis=0)),
+            axis=-1,
+        )
+
+        # Reshape to the new form
+        result = result.reshape(M1 * M2, N1 + N2)
+
+    return result


### PR DESCRIPTION
This PR makes use of the interface defined in #1805 to implement the constraint of the population on subsections of SpinOrbitalFermions, removing the internal Fock Hilbert space.

While this change is not very useful per se, this allows us to add an additional constraint to the fermionic (and potentially any other Hilbert space) space.