### PR TITLE
Set replicate-sharding for parameters of MCState

### DIFF
--- a/netket/jax/_utils_random.py
+++ b/netket/jax/_utils_random.py
@@ -53,6 +53,10 @@ def PRNGKey(
         key = jax.tree_util.tree_map(
             lambda k: mpi.mpi_bcast_jax(k, root=root, comm=comm)[0], key
         )
+    else:
+        from . import sharding
+
+        key = sharding.replicate(key)
     return key
 
 

--- a/netket/vqs/mc/mc_mixed_state/state.py
+++ b/netket/vqs/mc/mc_mixed_state/state.py
@@ -26,7 +26,7 @@ from netket.stats import Stats
 from netket.utils.types import PyTree
 from netket.operator import AbstractOperator
 
-from netket.jax.sharding import extract_replicated
+from netket.jax.sharding import extract_replicated, replicate
 
 from netket.vqs import VariationalMixedState
 
@@ -270,8 +270,8 @@ def deserialize_MCMixedState(vstate, state_dict):
         vstate._diagonal, state_dict["diagonal"]
     )
 
-    new_vstate.variables = serialization.from_state_dict(
-        vstate.variables, state_dict["variables"]
+    new_vstate.variables = replicate(
+        serialization.from_state_dict(vstate.variables, state_dict["variables"])
     )
     new_vstate.sampler_state = serialization.from_state_dict(
         vstate.sampler_state, state_dict["sampler_state"]


### PR DESCRIPTION
Also sets the replicated sharding on the nkjax.PRNGKey, as this is what the contract says for it.

Part of the reason for this is because recently we realised that when we reload weights of a nn with flax.serialization, the loaded ones where bare numpy arrays without sharding annotations.

Also, this might be related to why we had to put shard map everywhere. Maybe we were not telling jax that our parameters where identical everywhere?