### PR TITLE
Make doubled spaces more easily indexable

### DIFF
--- a/netket/hilbert/doubled_hilbert.py
+++ b/netket/hilbert/doubled_hilbert.py
@@ -19,6 +19,7 @@ from netket.utils.types import Array, DType
 
 from .abstract_hilbert import AbstractHilbert
 from .discrete_hilbert import DiscreteHilbert
+from .index import is_indexable
 
 
 @parametric
@@ -63,6 +64,12 @@ class DoubledHilbert(DiscreteHilbert):
     @property
     def is_finite(self):
         return self.physical.is_finite
+
+    @property
+    def is_indexable(self) -> bool:
+        """Whether the space can be indexed with an integer"""
+        n = self.physical.n_states
+        return self.physical.is_indexable and is_indexable([n, n])
 
     @property
     def local_size(self):

--- a/test/hilbert/test_hilbert.py
+++ b/test/hilbert/test_hilbert.py
@@ -791,3 +791,11 @@ def test_hilbert_numbers_to_states_jit(hi: DiscreteHilbert):
         states0 = hi.numbers_to_states(numbers0)
         states1 = _numbers_to_states_jit(hi, numbers0)
         np.testing.assert_allclose(states0, states1)
+
+
+def test_doubled_hilbert_indexable():
+    # make an indexable hilbert space
+    hi = nkx.hilbert.SpinOrbitalFermions(16, s=1 / 2, n_fermions=1)
+    hid = DoubledHilbert(hi)
+    assert hi.is_indexable  # just to verify this is indeed still the case
+    assert hid.is_indexable  # then this must hold as well


### PR DESCRIPTION
Minor fix: make doubled spaces more easily indexable for certain low-particle-number fock spaces.