### PR TITLE
Adding Ising operators with different graphs (fixes #1850) 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@
 * Fix issue with {class}`netket.logging.JsonLog` raising an error at the end of a program because of a wrongly defined `__del__` method [#2dd40cf](https://github.com/netket/netket/commit/2dd40cf99caaa6e4dd43a235c62e2580ac54ded6)
 
 
+## NetKet 3.12.4
+
+* Fix bug [#1850](https://github.com/netket/netket/issues/1850) where adding two {class}`netket.operator.Ising` acting on different graphs would yield a wrong operator [#1851](https://github.com/netket/netket/issues/1851).
+
+
 ## NetKet 3.12.3 (25 June 2024)
 
 * Preliminary support for NumPy 2.0 [70e7801](https://github.com/netket/netket/commit/70e7801976db8c4ac160734d202c40f0834a649c).

--- a/netket/operator/_hamiltonian.py
+++ b/netket/operator/_hamiltonian.py
@@ -29,7 +29,7 @@ class SpecialHamiltonian(DiscreteOperator):
         if type(self) is type(other):
             res = self.copy()
             res = res.__iadd__(other)
-            if res is not NotImplemented:
+            if isinstance(res, SpecialHamiltonian):
                 return res
         if is_scalar(other) or type(other) is LocalOperator:
             return self.to_local_operator().__add__(other)
@@ -39,7 +39,7 @@ class SpecialHamiltonian(DiscreteOperator):
         if type(self) is type(other):
             res = self.copy()
             res = res.__isub__(other)
-            if res is not NotImplemented:
+            if isinstance(res, SpecialHamiltonian):
                 return res
         if is_scalar(other) or type(other) is LocalOperator:
             return self.to_local_operator().__sub__(other)

--- a/netket/operator/_hamiltonian.py
+++ b/netket/operator/_hamiltonian.py
@@ -11,10 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from netket.utils.numbers import is_scalar
 
 from ._discrete_operator import DiscreteOperator
-from ._local_operator import LocalOperator
 
 
 class SpecialHamiltonian(DiscreteOperator):
@@ -30,7 +28,7 @@ class SpecialHamiltonian(DiscreteOperator):
         if type(self) is type(other):
             res = self.copy()
             res = res.__iadd__(other)
-            if isinstance(res, SpecialHamiltonian):
+            if res is not NotImplemented:
                 return res
 
         return self.to_local_operator() + other
@@ -39,7 +37,7 @@ class SpecialHamiltonian(DiscreteOperator):
         if type(self) is type(other):
             res = self.copy()
             res = res.__isub__(other)
-            if isinstance(res, SpecialHamiltonian):
+            if res is not NotImplemented:
                 return res
 
         return self.to_local_operator() - other

--- a/netket/operator/_hamiltonian.py
+++ b/netket/operator/_hamiltonian.py
@@ -41,9 +41,8 @@ class SpecialHamiltonian(DiscreteOperator):
             res = res.__isub__(other)
             if isinstance(res, SpecialHamiltonian):
                 return res
-        if is_scalar(other) or type(other) is LocalOperator:
-            return self.to_local_operator().__sub__(other)
-        return self.to_local_operator().__sub__(other.to_local_operator())
+
+        return self.to_local_operator() - other
 
     def __radd__(self, other):
         return self.to_local_operator().__radd__(other)

--- a/netket/operator/_hamiltonian.py
+++ b/netket/operator/_hamiltonian.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+from netket.utils.numbers import is_scalar
 from ._discrete_operator import DiscreteOperator
 
 
@@ -27,46 +27,40 @@ class SpecialHamiltonian(DiscreteOperator):
     def __add__(self, other):
         if type(self) is type(other):
             res = self.copy()
-            res += other
-            return res
-
-        return self.to_local_operator().__add__(other)
+            res = res.__iadd__(other)
+            if res is not NotImplemented:
+                return res
+        if is_scalar(other):
+            return self.to_local_operator().__add__(other)
+        return self.to_local_operator().__add__(other.to_local_operator())
 
     def __sub__(self, other):
         if type(self) is type(other):
             res = self.copy()
-            res -= other
-            return res
-
-        return self.to_local_operator().__sub__(other)
+            res = res.__isub__(other)
+            if res is not NotImplemented:
+                return res
+        if is_scalar(other):
+            return self.to_local_operator().__sub__(other)
+        return self.to_local_operator().__sub__(other.to_local_operator())
 
     def __radd__(self, other):
-        if type(self) is type(other):
-            res = self.copy()
-            res += other
-            return res
-
         return self.to_local_operator().__radd__(other)
 
     def __rsub__(self, other):
-        if type(self) is type(other):
-            res = self.copy()
-            res -= other
-            return res
-
         return self.to_local_operator().__rsub__(other)
 
     def __iadd__(self, other):
         if type(self) is type(other):
-            self._iadd_same_hamiltonian(other)
-            return self
+            res = self._iadd_same_hamiltonian(other)
+            return res
 
         return NotImplemented
 
     def __isub__(self, other):
         if type(self) is type(other):
-            self._isub_same_hamiltonian(other)
-            return self
+            res = self._isub_same_hamiltonian(other)
+            return res
 
         return NotImplemented
 
@@ -80,6 +74,9 @@ class SpecialHamiltonian(DiscreteOperator):
         if hasattr(other, "to_local_operator"):
             other = other.to_local_operator()
         return self.to_local_operator().__matmul__(other)
+
+    def __neg__(self):
+        return -1 * self.to_local_operator()
 
     def _op__rmatmul__(self, other):
         if hasattr(other, "to_local_operator"):

--- a/netket/operator/_hamiltonian.py
+++ b/netket/operator/_hamiltonian.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from netket.utils.numbers import is_scalar
 from ._discrete_operator import DiscreteOperator
+from ._local_operator import LocalOperator
 
 
 class SpecialHamiltonian(DiscreteOperator):
@@ -30,7 +31,7 @@ class SpecialHamiltonian(DiscreteOperator):
             res = res.__iadd__(other)
             if res is not NotImplemented:
                 return res
-        if is_scalar(other):
+        if is_scalar(other) or type(other) is LocalOperator:
             return self.to_local_operator().__add__(other)
         return self.to_local_operator().__add__(other.to_local_operator())
 
@@ -40,7 +41,7 @@ class SpecialHamiltonian(DiscreteOperator):
             res = res.__isub__(other)
             if res is not NotImplemented:
                 return res
-        if is_scalar(other):
+        if is_scalar(other) or type(other) is LocalOperator:
             return self.to_local_operator().__sub__(other)
         return self.to_local_operator().__sub__(other.to_local_operator())
 

--- a/netket/operator/_hamiltonian.py
+++ b/netket/operator/_hamiltonian.py
@@ -32,9 +32,8 @@ class SpecialHamiltonian(DiscreteOperator):
             res = res.__iadd__(other)
             if isinstance(res, SpecialHamiltonian):
                 return res
-        if is_scalar(other) or type(other) is LocalOperator:
-            return self.to_local_operator().__add__(other)
-        return self.to_local_operator().__add__(other.to_local_operator())
+
+        return self.to_local_operator() + other
 
     def __sub__(self, other):
         if type(self) is type(other):

--- a/netket/operator/_hamiltonian.py
+++ b/netket/operator/_hamiltonian.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from netket.utils.numbers import is_scalar
+
 from ._discrete_operator import DiscreteOperator
 from ._local_operator import LocalOperator
 

--- a/netket/operator/_ising/base.py
+++ b/netket/operator/_ising/base.py
@@ -184,9 +184,17 @@ class IsingBase(SpecialHamiltonian):
             raise NotImplementedError(
                 "Cannot add hamiltonians on different hilbert spaces"
             )
+        if np.any(
+            [
+                edge not in np.sort(other._edges, axis=-1).tolist()
+                for edge in np.sort(self._edges, axis=-1).tolist()
+            ]
+        ):
+            return NotImplemented
 
         self._h += other.h
         self._J += other.J
+        return self
 
     def _isub_same_hamiltonian(self, other):
         if self.hilbert != other.hilbert:
@@ -194,8 +202,17 @@ class IsingBase(SpecialHamiltonian):
                 "Cannot add hamiltonians on different hilbert spaces"
             )
 
+        if np.any(
+            [
+                edge not in np.sort(other._edges, axis=-1).tolist()
+                for edge in np.sort(self._edges, axis=-1).tolist()
+            ]
+        ):
+            return NotImplemented
+
         self._h -= other.h
         self._J -= other.J
+        return self
 
     def __repr__(self):
         return (

--- a/netket/operator/_ising/base.py
+++ b/netket/operator/_ising/base.py
@@ -184,7 +184,7 @@ class IsingBase(SpecialHamiltonian):
             raise NotImplementedError(
                 "Cannot add hamiltonians on different hilbert spaces"
             )
-        if np.any(
+        if self._edges.shape[0] != other.edges.shape[0] or np.any(
             [
                 edge not in np.sort(other._edges, axis=-1).tolist()
                 for edge in np.sort(self._edges, axis=-1).tolist()
@@ -202,7 +202,7 @@ class IsingBase(SpecialHamiltonian):
                 "Cannot add hamiltonians on different hilbert spaces"
             )
 
-        if np.any(
+        if self._edges.shape[0] != other.edges.shape[0] or np.any(
             [
                 edge not in np.sort(other._edges, axis=-1).tolist()
                 for edge in np.sort(self._edges, axis=-1).tolist()

--- a/netket/operator/_ising/base.py
+++ b/netket/operator/_ising/base.py
@@ -197,12 +197,7 @@ class IsingBase(SpecialHamiltonian):
                 "Cannot add hamiltonians on different hilbert spaces"
             )
 
-        if self._edges.shape[0] != other.edges.shape[0] or np.any(
-            [
-                edge not in np.sort(other._edges, axis=-1).tolist()
-                for edge in np.sort(self._edges, axis=-1).tolist()
-            ]
-        ):
+        if not np.allclose(self.edges, other.edges):
             return NotImplemented
 
         self._h -= other.h

--- a/netket/operator/_ising/base.py
+++ b/netket/operator/_ising/base.py
@@ -184,12 +184,7 @@ class IsingBase(SpecialHamiltonian):
             raise NotImplementedError(
                 "Cannot add hamiltonians on different hilbert spaces"
             )
-        if self._edges.shape[0] != other.edges.shape[0] or np.any(
-            [
-                edge not in np.sort(other._edges, axis=-1).tolist()
-                for edge in np.sort(self._edges, axis=-1).tolist()
-            ]
-        ):
+        if not np.allclose(self.edges, other.edges):
             return NotImplemented
 
         self._h += other.h

--- a/netket/operator/_local_operator/base.py
+++ b/netket/operator/_local_operator/base.py
@@ -317,7 +317,6 @@ class LocalOperatorBase(DiscreteOperator):
             self._reset_caches()
             self._constant += other
             return self
-
         return NotImplemented
 
     def __truediv__(self, other):

--- a/test/operator/test_operator.py
+++ b/test/operator/test_operator.py
@@ -361,7 +361,6 @@ def test_add_Ising_different_graphs():
     hi = nk.hilbert.Spin(s=0.5, N=3)
     g = nk.graph.Graph(edges=[[0, 1], [1, 2]], n_nodes=3)
     h1 = nk.operator.Ising(hi, g, h=1)
-    g = nk.graph.Graph(edges=[[2, 1], [0, 1]], n_nodes=3)
     h2 = nk.operator.Ising(hi, g, h=0.5)
     g = nk.graph.Graph(edges=[[2, 1], [0, 2]], n_nodes=3)
     h3 = nk.operator.Ising(hi, g, h=0.5)

--- a/test/operator/test_operator.py
+++ b/test/operator/test_operator.py
@@ -17,6 +17,7 @@ hi = nk.hilbert.Spin(s=0.5, N=g.n_nodes)
 operators["Ising 1D"] = nk.operator.Ising(hi, g, h=1.321)
 operators["Ising 1D Jax"] = nk.operator.IsingJax(hi, g, h=1.321)
 
+
 # Heisenberg 1D
 g = nk.graph.Hypercube(length=10, n_dim=1, pbc=True)
 hi = nk.hilbert.Spin(s=0.5, total_sz=0, N=g.n_nodes)
@@ -354,6 +355,24 @@ def test_enforce_float_Ising():
     assert np.issubdtype(op.dtype, np.floating)
     op = nk.operator.IsingJax(hilbert=hi, graph=g, J=1, h=1)
     assert np.issubdtype(op.dtype, np.floating)
+
+
+def test_add_Ising_different_graphs():
+    hi = nk.hilbert.Spin(s=0.5, N=3)
+    g = nk.graph.Graph(edges=[[0, 1], [1, 2]], n_nodes=3)
+    h1 = nk.operator.Ising(hi, g, h=1)
+    g = nk.graph.Graph(edges=[[2, 1], [0, 1]], n_nodes=3)
+    h2 = nk.operator.Ising(hi, g, h=0.5)
+    g = nk.graph.Graph(edges=[[2, 1], [0, 2]], n_nodes=3)
+    h3 = nk.operator.Ising(hi, g, h=0.5)
+
+    h12 = h1 + h2
+    h13 = h1 + h3
+    assert type(h12) == nk.operator.Ising
+    assert type(h13) == nk.operator.LocalOperator
+    np.testing.assert_allclose(h12.to_dense(), h1.to_dense() + h2.to_dense())
+    np.testing.assert_allclose(h13.to_dense(), h1.to_dense() + h3.to_dense())
+    np.testing.assert_allclose((-h1).to_dense(), -h1.to_dense())
 
 
 def test_enforce_float_BoseHubbard():


### PR DESCRIPTION
Fix of the behaviour described in #1850 

When adding two Ising operators with distinct graphs, the operators are now converted to LocalOperator and added as such.