### PR TITLE
Allow `machine_pow` to be any positive number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Improve several aspects of the fermions API when working with systems that have Spin-1 or greater fermions [#1844](https://github.com/netket/netket/pull/1844).
 * Greatly improve the documentation of {func}`netket.jax.expect` and provide examples of how to use it when running with multiple MPI nodes [#1356](https://github.com/netket/netket/pull/1356).
 * Supports Numpy 2.0 [#1852](https://github.com/netket/netket/pull/1852).
+* Supports any positive real power `machine_pow` of the wave function amplitude as probability distribution for Monte Carlo sampling, not just integers [#1854](https://github.com/netket/netket/pull/1854).
 
 
 ### Bug Fixes

--- a/netket/sampler/autoreg.py
+++ b/netket/sampler/autoreg.py
@@ -80,7 +80,9 @@ class ARDirectSampler(Sampler):
                 "touch with us. We are interested!)"
             )
 
-        return super().__init__(hilbert, machine_pow=2, dtype=dtype)
+        super().__init__(hilbert, machine_pow=2, dtype=dtype)
+        # ensure machine_pow is a float, as it can be sometimes used around...
+        self.machine_pow = float(self.machine_pow)
 
     @property
     def is_exact(sampler):

--- a/netket/sampler/base.py
+++ b/netket/sampler/base.py
@@ -57,7 +57,7 @@ class Sampler(struct.Pytree):
     hilbert: AbstractHilbert = struct.field(pytree_node=False)
     """The Hilbert space to sample."""
 
-    machine_pow: int = struct.field(default=2)
+    machine_pow: float = struct.field(default=2.0)
     """The power to which the machine should be exponentiated to generate the pdf."""
 
     dtype: DType = struct.field(pytree_node=False, default=float)
@@ -67,7 +67,7 @@ class Sampler(struct.Pytree):
         self,
         hilbert: AbstractHilbert,
         *,
-        machine_pow: int = 2,
+        machine_pow: float = 2.0,
         dtype: DType = float,
     ):
         """
@@ -92,10 +92,10 @@ class Sampler(struct.Pytree):
                 "\n"
             )
 
-        if not np.issubdtype(numbers.dtype(machine_pow), np.integer):
-            raise ValueError(
-                f"machine_pow ({self.machine_pow}) must be a positive integer"
-            )
+        if machine_pow.imag != 0.0:
+            raise ValueError(f"machine_pow ({machine_pow}) must be real")
+        if not machine_pow > 0.0:
+            raise ValueError(f"machine_pow ({machine_pow}) must be positive")
 
         self.hilbert = hilbert
         self.machine_pow = machine_pow

--- a/netket/sampler/base.py
+++ b/netket/sampler/base.py
@@ -67,7 +67,7 @@ class Sampler(struct.Pytree):
         self,
         hilbert: AbstractHilbert,
         *,
-        machine_pow: float = 2.0,
+        machine_pow: float = 2,
         dtype: DType = float,
     ):
         """

--- a/netket/sampler/metropolis_numpy.py
+++ b/netket/sampler/metropolis_numpy.py
@@ -14,7 +14,7 @@
 
 import math
 from dataclasses import dataclass
-from functools import partial
+from functools import partial, wraps
 
 from typing import Any, Callable
 
@@ -29,7 +29,7 @@ from netket.utils.types import PyTree
 
 import netket.jax as nkjax
 
-from .metropolis import MetropolisSampler
+from .metropolis import MetropolisSampler, MetropolisRule
 
 
 @dataclass
@@ -113,6 +113,12 @@ class MetropolisSamplerNumpy(MetropolisSampler):
 
     See :ref:`netket.sampler.MetropolisSampler` for more information.
     """
+
+    @wraps(MetropolisSampler.__init__)
+    def __init__(self, hilbert: AbstractHilbert, rule: MetropolisRule, **kwargs):
+        super().__init__(hilbert, rule, **kwargs)
+        # standard samplers use jax arrays, this must be a numpy array
+        self.machine_pow = np.array(self.machine_pow)
 
     def _init_state(sampler, machine, parameters, key):
         rgen = np.random.default_rng(np.asarray(key))

--- a/netket/vqs/mc/mc_state/expect_grad.py
+++ b/netket/vqs/mc/mc_state/expect_grad.py
@@ -109,8 +109,8 @@ def expect_and_grad_nonhermitian(
     Ō, Ō_grad, new_model_state = _grad_expect_nonherm_kernel(
         local_estimator_fun,
         vstate._apply_fun,
-        vstate.sampler.machine_pow,
         mutable,
+        vstate.sampler.machine_pow,
         vstate.parameters,
         vstate.model_state,
         σ,
@@ -123,12 +123,12 @@ def expect_and_grad_nonhermitian(
     return Ō, Ō_grad
 
 
-@partial(jax.jit, static_argnums=(0, 1, 2, 3))
+@partial(jax.jit, static_argnums=(0, 1, 2))
 def _grad_expect_nonherm_kernel(
     local_value_kernel: Callable,
     model_apply_fun: Callable,
-    machine_pow: int,
     mutable: CollectionFilter,
+    machine_pow: float,
     parameters: PyTree,
     model_state: PyTree,
     σ: jnp.ndarray,


### PR DESCRIPTION
There doesn't seem to be a good reason to require `machine_pow` in samplers to be an integer. This PR replaces the checks to allow it to be any positive real number.

I don't think this affects any of the tests. Do we need additional ones?