### PR TITLE
Do not raise Warning when running under MPI with sharding

### DIFF
--- a/netket/utils/mpi/mpi.py
+++ b/netket/utils/mpi/mpi.py
@@ -75,7 +75,7 @@ except ImportError:
     MPI = FakeMPI()
 
     # Try to detect if we are running under MPI and warn that mpi4py is not installed
-    if config.netket_mpi_warning:
+    if config.netket_mpi_warning and not config.netket_experimental_sharding:
         _MPI_ENV_VARIABLES = [
             "OMPI_COMM_WORLD_SIZE",
             "I_MPI_HYDRA_HOST_FILE",


### PR DESCRIPTION
This is a valid configuration, and its easier to setup, so let's automatically silence netket warnings here...