### PR TITLE
Better compute the chunk size in forward pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 
 ## NetKet 3.14 (⚙️ In development)
 
+### Changes
+* Jax operators now use the same `chunk_size` as specified by the user when computing the forward pass. Prior to this change, Jax operators would be chunking the sample axis, but if an operator had a lot of connected elements this would end up increasing the effective sample size [#1875](https://github.com/netket/netket/pull/1875).
+
 
 ## NetKet 3.13 (11 July 2024)
 

--- a/netket/vqs/mc/kernels.py
+++ b/netket/vqs/mc/kernels.py
@@ -186,7 +186,7 @@ def local_value_kernel_jax_chunked(
     local_value_kernel = lambda s: local_value_kernel_jax(logpsi, pars, s, O)
 
     local_value_chunked = nkjax.apply_chunked(
-        local_value_kernel, in_axes=0, chunk_size=max(1, chunk_size//O.max_conn_size)
+        local_value_kernel, in_axes=0, chunk_size=max(1, chunk_size // O.max_conn_size)
     )
 
     return local_value_chunked(σ)

--- a/netket/vqs/mc/kernels.py
+++ b/netket/vqs/mc/kernels.py
@@ -186,7 +186,7 @@ def local_value_kernel_jax_chunked(
     local_value_kernel = lambda s: local_value_kernel_jax(logpsi, pars, s, O)
 
     local_value_chunked = nkjax.apply_chunked(
-        local_value_kernel, in_axes=0, chunk_size=chunk_size
+        local_value_kernel, in_axes=0, chunk_size=max(1, chunk_size//O.max_conn_size)
     )
 
     return local_value_chunked(σ)


### PR DESCRIPTION
This PR brings in line the chunk size for jax and numba operators.
Without this PR, jax would be effectively using a Chunk size number of connected elements larger than the one specified by the user.

For the forward pass only.