### PR TITLE
Allow `point_group` as an argument in specific lattice constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,11 @@
 ### Changes
 * Jax operators now use the same `chunk_size` as specified by the user when computing the forward pass. Prior to this change, Jax operators would be chunking the sample axis, but if an operator had a lot of connected elements this would end up increasing the effective sample size [#1875](https://github.com/netket/netket/pull/1875).
 
+### Improvements
+* Specialised lattice constructors like {func}`nk.graph.Grid` now accept a `point_group` argument, overriding the default (usually maximal) point groups [#1879](https://github.com/netket/netket/pull/1879).
+
 ### Bug fixes
-* Fix the function {meth}`nk.graph.SpaceGroupBuilder.space_group_irreps` throwing away the imaginary part of point-group characters, which led to incorrect space-group characters in some rare cases. [#1876](https://github.com/netket/netket/pull/1876).
+* Fix the function {meth}`nk.graph.SpaceGroupBuilder.space_group_irreps` throwing away the imaginary part of point-group characters, which led to incorrect space-group characters in some rare cases [#1876](https://github.com/netket/netket/pull/1876).
 
 
 ## NetKet 3.13 (11 July 2024)

--- a/netket/graph/common_lattices.py
+++ b/netket/graph/common_lattices.py
@@ -14,6 +14,7 @@
 
 from itertools import permutations
 from collections.abc import Sequence
+from typing import Optional
 import numpy as np
 
 from .lattice import Lattice

--- a/netket/graph/common_lattices.py
+++ b/netket/graph/common_lattices.py
@@ -117,7 +117,7 @@ def Grid(
     if color_edges:
         kwargs["custom_edges"] = [(0, 0, vec) for vec in np.eye(ndim)]
     if point_group is None:
-        point_group = _grid_point_group(extent, pbc, color_edges)
+        point_group = lambda: _grid_point_group(extent, pbc, color_edges)
     return Lattice(
         basis_vectors=np.eye(ndim),
         extent=extent,

--- a/netket/graph/common_lattices.py
+++ b/netket/graph/common_lattices.py
@@ -72,6 +72,7 @@ def Grid(
     *,
     pbc: bool | Sequence[bool] = True,
     color_edges: bool = False,
+    point_group: Optional[PointGroup] = None,
     **kwargs,
 ) -> Lattice:
     """
@@ -88,6 +89,8 @@ def Grid(
         color_edges: generates nearest-neighbour edges colored according to direction
                      i.e. edges along Cartesian direction #i have color i
                      cannot be used with `max_neighbor_order` or `custom_edges`
+        point_group: point group object describing the symmetry of the lattice
+            If not specified, uses the full hypercube symmetry group.
         kwargs: Additional keyword arguments are passed on to the constructor of
             :ref:`netket.graph.Lattice`.
 
@@ -112,11 +115,13 @@ def Grid(
         pbc = [pbc] * ndim
     if color_edges:
         kwargs["custom_edges"] = [(0, 0, vec) for vec in np.eye(ndim)]
+    if point_group is None:
+        point_group = _grid_point_group(extent, pbc, color_edges)
     return Lattice(
         basis_vectors=np.eye(ndim),
         extent=extent,
         pbc=pbc,
-        point_group=lambda: _grid_point_group(extent, pbc, color_edges),
+        point_group=point_group,
         **kwargs,
     )
 
@@ -217,7 +222,11 @@ def Chain(length: int, *, pbc: bool = True, **kwargs) -> Lattice:
 
 
 def BCC(
-    extent: Sequence[int], *, pbc: bool | Sequence[bool] = True, **kwargs
+    extent: Sequence[int],
+    *,
+    pbc: bool | Sequence[bool] = True,
+    point_group: Optional[PointGroup] = None,
+    **kwargs,
 ) -> Lattice:
     """Constructs a BCC lattice of a given spatial extent.
     Periodic boundary conditions can also be imposed
@@ -231,6 +240,8 @@ def BCC(
              This parameter can also be a list of booleans with same length as
              the parameter `length`, in which case each dimension will have
              PBC/OBC depending on the corresponding entry of `pbc`.
+        point_group: point group object describing the symmetry of the lattice
+            If not specified, uses the full cubic symmetry group.
         kwargs: Additional keyword arguments are passed on to the constructor of
             :ref:`netket.graph.Lattice`.
 
@@ -244,15 +255,20 @@ def BCC(
         27
     """
     basis = [[-0.5, 0.5, 0.5], [0.5, -0.5, 0.5], [0.5, 0.5, -0.5]]
-    # determine if full point group is realised by the simulation box
-    point_group = cubic.Oh() if np.all(pbc) and len(set(extent)) == 1 else None
+    if point_group is None:
+        # determine if full point group is realised by the simulation box
+        point_group = cubic.Oh() if np.all(pbc) and len(set(extent)) == 1 else None
     return Lattice(
         basis_vectors=basis, extent=extent, pbc=pbc, point_group=point_group, **kwargs
     )
 
 
 def FCC(
-    extent: Sequence[int], *, pbc: bool | Sequence[bool] = True, **kwargs
+    extent: Sequence[int],
+    *,
+    pbc: bool | Sequence[bool] = True,
+    point_group: Optional[PointGroup] = None,
+    **kwargs,
 ) -> Lattice:
     """Constructs an FCC lattice of a given spatial extent.
     Periodic boundary conditions can also be imposed
@@ -266,6 +282,8 @@ def FCC(
              This parameter can also be a list of booleans with same length as
              the parameter `length`, in which case each dimension will have
              PBC/OBC depending on the corresponding entry of `pbc`.
+        point_group: point group object describing the symmetry of the lattice
+            If not specified, uses the full cubic symmetry group.
         kwargs: Additional keyword arguments are passed on to the constructor of
             :ref:`netket.graph.Lattice`.
 
@@ -279,15 +297,20 @@ def FCC(
         27
     """
     basis = [[0, 0.5, 0.5], [0.5, 0, 0.5], [0.5, 0.5, 0]]
-    # determine if full point group is realised by the simulation box
-    point_group = cubic.Oh() if np.all(pbc) and len(set(extent)) == 1 else None
+    if point_group is None:
+        # determine if full point group is realised by the simulation box
+        point_group = cubic.Oh() if np.all(pbc) and len(set(extent)) == 1 else None
     return Lattice(
         basis_vectors=basis, extent=extent, pbc=pbc, point_group=point_group, **kwargs
     )
 
 
 def Diamond(
-    extent: Sequence[int], *, pbc: bool | Sequence[bool] = True, **kwargs
+    extent: Sequence[int],
+    *,
+    pbc: bool | Sequence[bool] = True,
+    point_group: Optional[PointGroup] = None,
+    **kwargs,
 ) -> Lattice:
     """Constructs a diamond lattice of a given spatial extent.
     Periodic boundary conditions can also be imposed.
@@ -303,6 +326,8 @@ def Diamond(
              This parameter can also be a list of booleans with same length as
              the parameter `length`, in which case each dimension will have
              PBC/OBC depending on the corresponding entry of `pbc`.
+        point_group: point group object describing the symmetry of the lattice
+            If not specified, uses the full symmetry group of the diamond lattice.
         kwargs: Additional keyword arguments are passed on to the constructor of
             :ref:`netket.graph.Lattice`.
 
@@ -317,8 +342,9 @@ def Diamond(
     """
     basis = [[0, 0.5, 0.5], [0.5, 0, 0.5], [0.5, 0.5, 0]]
     sites = [[0, 0, 0], [0.25, 0.25, 0.25]]
-    # determine if full point group is realised by the simulation box
-    point_group = cubic.Fd3m() if np.all(pbc) and len(set(extent)) == 1 else None
+    if point_group is None:
+        # determine if full point group is realised by the simulation box
+        point_group = cubic.Fd3m() if np.all(pbc) and len(set(extent)) == 1 else None
     return Lattice(
         basis_vectors=basis,
         site_offsets=sites,
@@ -330,7 +356,11 @@ def Diamond(
 
 
 def Pyrochlore(
-    extent: Sequence[int], *, pbc: bool | Sequence[bool] = True, **kwargs
+    extent: Sequence[int],
+    *,
+    pbc: bool | Sequence[bool] = True,
+    point_group: Optional[PointGroup] = None,
+    **kwargs,
 ) -> Lattice:
     """Constructs a pyrochlore lattice of a given spatial extent.
     Periodic boundary conditions can also be imposed.
@@ -346,6 +376,8 @@ def Pyrochlore(
             This parameter can also be a list of booleans with same length as
             the parameter `length`, in which case each dimension will have
             PBC/OBC depending on the corresponding entry of `pbc`.
+        point_group: point group object describing the symmetry of the lattice
+            If not specified, uses the full symmetry group of the pyrochlore lattice.
         kwargs: Additional keyword arguments are passed on to the constructor of
             :ref:`netket.graph.Lattice`.
 
@@ -360,8 +392,9 @@ def Pyrochlore(
     """
     basis = [[0, 0.5, 0.5], [0.5, 0, 0.5], [0.5, 0.5, 0]]
     sites = np.array([[1, 1, 1], [1, 3, 3], [3, 1, 3], [3, 3, 1]]) / 8
-    # determine if full point group is realised by the simulation box
-    point_group = cubic.Fd3m() if np.all(pbc) and len(set(extent)) == 1 else None
+    if point_group is None:
+        # determine if full point group is realised by the simulation box
+        point_group = cubic.Fd3m() if np.all(pbc) and len(set(extent)) == 1 else None
     return Lattice(
         basis_vectors=basis,
         site_offsets=sites,
@@ -373,11 +406,17 @@ def Pyrochlore(
 
 
 def _hexagonal_general(
-    extent, *, site_offsets=None, pbc: bool | Sequence[bool] = True, **kwargs
+    extent,
+    *,
+    site_offsets=None,
+    pbc: bool | Sequence[bool] = True,
+    point_group: Optional[PointGroup] = None,
+    **kwargs,
 ) -> Lattice:
     basis = [[1, 0], [0.5, 0.75**0.5]]
-    # determine if full point group is realised by the simulation box
-    point_group = planar.D(6) if np.all(pbc) and extent[0] == extent[1] else None
+    if point_group is None:
+        # determine if full point group is realised by the simulation box
+        point_group = planar.D(6) if np.all(pbc) and extent[0] == extent[1] else None
     return Lattice(
         basis_vectors=basis,
         extent=extent,
@@ -401,6 +440,8 @@ def Triangular(extent, *, pbc: bool | Sequence[bool] = True, **kwargs) -> Lattic
              This parameter can also be a list of booleans with same length as
              the parameter `length`, in which case each dimension will have
              PBC/OBC depending on the corresponding entry of `pbc`.
+        point_group: point group object describing the symmetry of the lattice
+            If not specified, uses the full hexagonal symmetry group.
         kwargs: Additional keyword arguments are passed on to the constructor of
             :ref:`netket.graph.Lattice`.
 
@@ -429,6 +470,8 @@ def Honeycomb(extent, *, pbc: bool | Sequence[bool] = True, **kwargs) -> Lattice
              This parameter can also be a list of booleans with same length as
              the parameter `length`, in which case each dimension will have
              PBC/OBC depending on the corresponding entry of `pbc`.
+        point_group: point group object describing the symmetry of the lattice
+            If not specified, uses the full hexagonal symmetry group.
         kwargs: Additional keyword arguments are passed on to the constructor of
             :ref:`netket.graph.Lattice`.
 
@@ -462,6 +505,8 @@ def Kagome(extent, *, pbc: bool | Sequence[bool] = True, **kwargs) -> Lattice:
              This parameter can also be a list of booleans with same length as
              the parameter `length`, in which case each dimension will have
              PBC/OBC depending on the corresponding entry of `pbc`.
+        point_group: point group object describing the symmetry of the lattice
+            If not specified, uses the full hexagonal symmetry group.
         kwargs: Additional keyword arguments are passed on to the constructor of
             :ref:`netket.graph.Lattice`.
 
@@ -482,7 +527,13 @@ def Kagome(extent, *, pbc: bool | Sequence[bool] = True, **kwargs) -> Lattice:
     )
 
 
-def KitaevHoneycomb(extent, *, pbc: bool | Sequence[bool] = True, **kwargs) -> Lattice:
+def KitaevHoneycomb(
+    extent,
+    *,
+    pbc: bool | Sequence[bool] = True,
+    point_group: Optional[PointGroup] = None,
+    **kwargs,
+) -> Lattice:
     r"""Constructs a honeycomb lattice of a given spatial extent.
 
     Nearest-neighbour edges are coloured according to direction
@@ -498,6 +549,8 @@ def KitaevHoneycomb(extent, *, pbc: bool | Sequence[bool] = True, **kwargs) -> L
              This parameter can also be a list of booleans with same length as
              the parameter `length`, in which case each dimension will have
              PBC/OBC depending on the corresponding entry of `pbc`.
+        point_group: point group object describing the symmetry of the lattice
+            If not specified, uses the 180° rotation symmetry of the Kitaev model.
         kwargs: Additional keyword arguments are passed on to the constructor of
             :ref:`netket.graph.Lattice`.
 
@@ -512,12 +565,14 @@ def KitaevHoneycomb(extent, *, pbc: bool | Sequence[bool] = True, **kwargs) -> L
         >>> print(len(g.edges(filter_color=2)))
         9
     """
+    if point_group is None:
+        point_group = planar.C(2) if np.all(pbc) else None
     return Lattice(
         basis_vectors=[[1, 0], [0.5, 0.75**0.5]],
         extent=extent,
         site_offsets=[[0.5, 0.5 / 3**0.5], [1, 1 / 3**0.5]],
         pbc=pbc,
-        point_group=planar.C(2) if np.all(pbc) else None,
+        point_group=point_group,
         custom_edges=[
             (0, 1, [0.5, 0.5 / 3**0.5]),
             (0, 1, [-0.5, 0.5 / 3**0.5]),

--- a/netket/graph/common_lattices.py
+++ b/netket/graph/common_lattices.py
@@ -14,7 +14,6 @@
 
 from itertools import permutations
 from collections.abc import Sequence
-from typing import Optional
 import numpy as np
 
 from .lattice import Lattice
@@ -73,7 +72,7 @@ def Grid(
     *,
     pbc: bool | Sequence[bool] = True,
     color_edges: bool = False,
-    point_group: Optional[PointGroup] = None,
+    point_group: PointGroup | None = None,
     **kwargs,
 ) -> Lattice:
     """
@@ -226,7 +225,7 @@ def BCC(
     extent: Sequence[int],
     *,
     pbc: bool | Sequence[bool] = True,
-    point_group: Optional[PointGroup] = None,
+    point_group: PointGroup | None = None,
     **kwargs,
 ) -> Lattice:
     """Constructs a BCC lattice of a given spatial extent.
@@ -268,7 +267,7 @@ def FCC(
     extent: Sequence[int],
     *,
     pbc: bool | Sequence[bool] = True,
-    point_group: Optional[PointGroup] = None,
+    point_group: PointGroup | None = None,
     **kwargs,
 ) -> Lattice:
     """Constructs an FCC lattice of a given spatial extent.
@@ -310,7 +309,7 @@ def Diamond(
     extent: Sequence[int],
     *,
     pbc: bool | Sequence[bool] = True,
-    point_group: Optional[PointGroup] = None,
+    point_group: PointGroup | None = None,
     **kwargs,
 ) -> Lattice:
     """Constructs a diamond lattice of a given spatial extent.
@@ -360,7 +359,7 @@ def Pyrochlore(
     extent: Sequence[int],
     *,
     pbc: bool | Sequence[bool] = True,
-    point_group: Optional[PointGroup] = None,
+    point_group: PointGroup | None = None,
     **kwargs,
 ) -> Lattice:
     """Constructs a pyrochlore lattice of a given spatial extent.
@@ -411,7 +410,7 @@ def _hexagonal_general(
     *,
     site_offsets=None,
     pbc: bool | Sequence[bool] = True,
-    point_group: Optional[PointGroup] = None,
+    point_group: PointGroup | None = None,
     **kwargs,
 ) -> Lattice:
     basis = [[1, 0], [0.5, 0.75**0.5]]
@@ -532,7 +531,7 @@ def KitaevHoneycomb(
     extent,
     *,
     pbc: bool | Sequence[bool] = True,
-    point_group: Optional[PointGroup] = None,
+    point_group: PointGroup | None = None,
     **kwargs,
 ) -> Lattice:
     r"""Constructs a honeycomb lattice of a given spatial extent.

--- a/test/graph/test_graph.py
+++ b/test/graph/test_graph.py
@@ -92,13 +92,9 @@ symmetric_graph_names = [
     "pyrochlore",
 ]
 
-# TODO allow point groups to be changed in these constructors
-square_rotation_only = nk.graph.Square(3)
-square_rotation_only._point_group = nk.utils.group.planar.C(4)
-
 symmetric_graphs = [
     # Square with rotation group only
-    square_rotation_only,
+    nk.graph.Square(3, point_group=group.planar.C(4)),
     # Square
     nk.graph.Square(3),
     # Triangular
@@ -129,7 +125,7 @@ coordination_number = [4, 4, 6, 3, 4, 3, 6, 8, 12, 4, 6]
 
 dimension = [2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3]
 
-kvec = [(0, 0), (2 * pi / 3, 0)] + [(4 * pi / 3, 0)] * 4 + [(4 * pi / 3, 0, 0)] * 5
+kvec = [(pi, pi), (2 * pi / 3, 0)] + [(4 * pi / 3, 0)] * 4 + [(4 * pi / 3, 0, 0)] * 5
 
 little_group_size = [4, 2] + [6] * 3 + [1] + [8] * 5
 

--- a/test/graph/test_graph.py
+++ b/test/graph/test_graph.py
@@ -94,7 +94,7 @@ symmetric_graph_names = [
 
 symmetric_graphs = [
     # Square with rotation group only
-    nk.graph.Square(3, point_group=group.planar.C(4)),
+    nk.graph.Square(4, point_group=group.planar.C(4)),
     # Square
     nk.graph.Square(3),
     # Triangular

--- a/test/graph/test_graph.py
+++ b/test/graph/test_graph.py
@@ -94,7 +94,7 @@ symmetric_graph_names = [
 
 symmetric_graphs = [
     # Square with rotation group only
-    nk.graph.Square(4, point_group=group.planar.C(4)),
+    nk.graph.Square(3, point_group=group.planar.C(4)),
     # Square
     nk.graph.Square(3),
     # Triangular
@@ -117,7 +117,7 @@ symmetric_graphs = [
     nk.graph.Pyrochlore([3, 3, 3]),
 ]
 
-unit_cells = [16, 9, 9, 9, 9, 9, 27, 27, 27, 27, 27]
+unit_cells = [9, 9, 9, 9, 9, 9, 27, 27, 27, 27, 27]
 
 atoms_per_unit_cell = [1, 1, 1, 2, 3, 2, 1, 1, 1, 2, 4]
 
@@ -125,7 +125,7 @@ coordination_number = [4, 4, 6, 3, 4, 3, 6, 8, 12, 4, 6]
 
 dimension = [2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3]
 
-kvec = [(pi, pi), (2 * pi / 3, 0)] + [(4 * pi / 3, 0)] * 4 + [(4 * pi / 3, 0, 0)] * 5
+kvec = [(0, 0), (2 * pi / 3, 0)] + [(4 * pi / 3, 0)] * 4 + [(4 * pi / 3, 0, 0)] * 5
 
 little_group_size = [4, 2] + [6] * 3 + [1] + [8] * 5
 

--- a/test/graph/test_graph.py
+++ b/test/graph/test_graph.py
@@ -117,7 +117,7 @@ symmetric_graphs = [
     nk.graph.Pyrochlore([3, 3, 3]),
 ]
 
-unit_cells = [9, 9, 9, 9, 9, 9, 27, 27, 27, 27, 27]
+unit_cells = [16, 9, 9, 9, 9, 9, 27, 27, 27, 27, 27]
 
 atoms_per_unit_cell = [1, 1, 1, 2, 3, 2, 1, 1, 1, 2, 4]
 


### PR DESCRIPTION
Specifying `point_group` in constructors like `Grid` has led to an error, since these constructors would always provide the largest symmetry-allowed point group to `Lattice`. This PR fixes this behaviour, and allows the user to override the default point group by providing the `point_group` argument.

I've also changed a hacky-looking test from #1876 to use this machinery - which serves as a test for whether it works in the `Grid` constructor at least.