### PR TITLE
Change the name of the flag for fast estimator in `nk.experimental.VarianceObservable`

### DIFF
--- a/netket/experimental/observable/variance/variance_operator.py
+++ b/netket/experimental/observable/variance/variance_operator.py
@@ -49,8 +49,7 @@ class VarianceObservable(AbstractObservable):
 
         Args:
             operator: The operator for which the variance is to be computed.
-            use_Oloc_squared: If False, uses the local estimator of the squared operator `O^2` for variance computation (defaults to False).
-                        If True, uses only the operator `O` for variance computation.
+            use_Oloc_squared: (Defaults False) if True, uses the fast estimator obtained by squaring the local estimator O_loc. If False, uses the straightforward estimator of (O@O)_loc which is quadratically more expensive. The fast estimator can sometimes lead to worse quality results.
 
         Returns:
             Observable computing the variance of `operator`.

--- a/netket/experimental/observable/variance/variance_operator.py
+++ b/netket/experimental/observable/variance/variance_operator.py
@@ -23,7 +23,7 @@ class VarianceObservable(AbstractObservable):
     Observable computing the variance of a quantum operator :math:`O`.
     """
 
-    def __init__(self, operator: AbstractOperator, use_Oloc2: bool = False):
+    def __init__(self, operator: AbstractOperator, use_fast_estimator: bool = False):
         r"""
         Constructs the observable computing the variance of an arbitrary quantum operator :math:`O` as:
 
@@ -49,8 +49,8 @@ class VarianceObservable(AbstractObservable):
 
         Args:
             operator: The operator for which the variance is to be computed.
-            use_Oloc2: If True, uses the local estimator of the squared operator `O^2` for variance computation.
-                        If False, uses only the operator `O` for variance computation (defaults to False).
+            use_fast_estimator: If False, uses the local estimator of the squared operator `O^2` for variance computation (defaults to False).
+                        If True, uses only the operator `O` for variance computation.
 
         Returns:
             Observable computing the variance of `operator`.
@@ -58,7 +58,7 @@ class VarianceObservable(AbstractObservable):
         super().__init__(operator.hilbert)
         self._operator = operator
 
-        if use_Oloc2:
+        if use_fast_estimator:
             self._operator_squared = nk.operator.Squared(operator)
         else:
             self._operator_squared = operator @ operator
@@ -74,9 +74,9 @@ class VarianceObservable(AbstractObservable):
     def operator_squared(self) -> AbstractOperator:
         """
         The squared of the operator for which the variance is to be computed.
-        Depending on the flag `use_Oloc2`, this can be the operator using the local
-        estimator of `O^2` (True), or the one using the square modulus of the
-        local estimator of `O` (False).
+        Depending on the flag `use_fast_estimator`, this can be the operator using the local
+        estimator of `O^2` (False), or the one using the square modulus of the
+        local estimator of `O` (True).
         """
         return self._operator_squared
 

--- a/netket/experimental/observable/variance/variance_operator.py
+++ b/netket/experimental/observable/variance/variance_operator.py
@@ -23,7 +23,7 @@ class VarianceObservable(AbstractObservable):
     Observable computing the variance of a quantum operator :math:`O`.
     """
 
-    def __init__(self, operator: AbstractOperator, use_fast_estimator: bool = False):
+    def __init__(self, operator: AbstractOperator, use_Oloc_squared: bool = False):
         r"""
         Constructs the observable computing the variance of an arbitrary quantum operator :math:`O` as:
 
@@ -49,7 +49,7 @@ class VarianceObservable(AbstractObservable):
 
         Args:
             operator: The operator for which the variance is to be computed.
-            use_fast_estimator: If False, uses the local estimator of the squared operator `O^2` for variance computation (defaults to False).
+            use_Oloc_squared: If False, uses the local estimator of the squared operator `O^2` for variance computation (defaults to False).
                         If True, uses only the operator `O` for variance computation.
 
         Returns:
@@ -58,7 +58,7 @@ class VarianceObservable(AbstractObservable):
         super().__init__(operator.hilbert)
         self._operator = operator
 
-        if use_fast_estimator:
+        if use_Oloc_squared:
             self._operator_squared = nk.operator.Squared(operator)
         else:
             self._operator_squared = operator @ operator
@@ -74,7 +74,7 @@ class VarianceObservable(AbstractObservable):
     def operator_squared(self) -> AbstractOperator:
         """
         The squared of the operator for which the variance is to be computed.
-        Depending on the flag `use_fast_estimator`, this can be the operator using the local
+        Depending on the flag `use_Oloc_squared`, this can be the operator using the local
         estimator of `O^2` (False), or the one using the square modulus of the
         local estimator of `O` (True).
         """

--- a/test/observable/test_variance.py
+++ b/test/observable/test_variance.py
@@ -64,15 +64,15 @@ def var_exact_fun(params, vs, H, H2):
     ],
 )
 @pytest.mark.parametrize(
-    "use_Oloc2",
+    "use_Oloc_squared",
     [
         pytest.param(True, id="UseOloc2"),
         pytest.param(False, id="NotUseOloc2"),
     ],
 )
-def test_MCState(useExactSampler, use_Oloc2):
+def test_MCState(useExactSampler, use_Oloc_squared):
     vs, vs_exact, H, H2 = _setup(useExactSampler)
-    var_op = nkx.observable.VarianceObservable(H, use_Oloc2=use_Oloc2)
+    var_op = nkx.observable.VarianceObservable(H, use_Oloc_squared=use_Oloc_squared)
 
     params, unravel = nk.jax.tree_ravel(vs.parameters)
 
@@ -99,16 +99,16 @@ def test_MCState(useExactSampler, use_Oloc2):
 
 
 @pytest.mark.parametrize(
-    "use_Oloc2",
+    "use_Oloc_squared",
     [
         pytest.param(True, id="UseOloc2"),
         pytest.param(False, id="NotUseOloc2"),
     ],
 )
-def test_FullSumState(use_Oloc2):
+def test_FullSumState(use_Oloc_squared):
     err = 1e-3
     vs, vs_exact, H, H2 = _setup()
-    var_op = nkx.observable.VarianceObservable(H, use_Oloc2=use_Oloc2)
+    var_op = nkx.observable.VarianceObservable(H, use_Oloc_squared=use_Oloc_squared)
 
     params, unravel = nk.jax.tree_ravel(vs_exact.parameters)
 


### PR DESCRIPTION
Modifying the flag for using the faster and biased estimator for computing the quantum variance of an arbitrary operator. 