### PR TITLE
Deprecated `rcond` in solvers

### DIFF
--- a/Examples/Ising1d/ising1d_sr_pinv.py
+++ b/Examples/Ising1d/ising1d_sr_pinv.py
@@ -37,7 +37,7 @@ op = nk.optimizer.Sgd(learning_rate=optax.linear_schedule(0.1, 0.0001, 500))
 
 # SR
 sr = nk.optimizer.SR(
-    solver=partial(nk.optimizer.solver.pinv, rcond=1.0e-6), diag_shift=0.01
+    solver=partial(nk.optimizer.solver.pinv, rtol=1.0e-6), diag_shift=0.01
 )
 
 # Variational state

--- a/netket/optimizer/solver/solvers.py
+++ b/netket/optimizer/solver/solvers.py
@@ -79,6 +79,8 @@ def pinv_smooth(
         rtol_smooth : Regularization parameter used with a similar effect to `rtol`
             but with a softer curve. See :math:`\epsilon` in the formula
             above.
+        rcond: (deprecated) Alias for `rtol`. Will be removed in a future release.
+        rcond_smooth: (deprecated) Alias for `rtol_smooth`. Will be removed in a future release.
     """
     del x0
 
@@ -151,6 +153,7 @@ def pinv(A, b, *, rtol: float = 1e-12, x0=None, rcond: float = None):
         A: the matrix A in Ax=b
         b: the vector b in Ax=b
         rtol: Cut-off ratio for small singular values of :code:`A`.
+        rcond: (deprecated) Alias for `rtol`. Will be removed in a future release.
     """
     del x0
 

--- a/netket/optimizer/solver/solvers.py
+++ b/netket/optimizer/solver/solvers.py
@@ -18,6 +18,7 @@ import jax.numpy as jnp
 import jax.scipy as jsp
 
 from netket.jax import tree_ravel
+from netket.utils import module_version
 from netket.utils.api_utils import partial_from_kwargs
 from netket.utils.deprecation import warn_deprecation
 
@@ -168,7 +169,12 @@ def pinv(A, b, *, rtol: float = 1e-12, x0=None, rcond: float = None):
         A = A.to_dense()
     b, unravel = tree_ravel(b)
 
-    A_inv = jnp.linalg.pinv(A, rtol=rtol, hermitian=True)
+    # TODO: Cleanup when we support only jax 0.4.29 or later
+    if module_version(jax) >= (0, 4, 29):
+        A_inv = jnp.linalg.pinv(A, rtol=rtol, hermitian=True)
+    else:
+        A_inv = jnp.linalg.pinv(A, rcond=rtol, hermitian=True)
+
     x = jnp.dot(A_inv, b)
 
     return unravel(x), None

--- a/netket/optimizer/solver/solvers.py
+++ b/netket/optimizer/solver/solvers.py
@@ -19,10 +19,20 @@ import jax.scipy as jsp
 
 from netket.jax import tree_ravel
 from netket.utils.api_utils import partial_from_kwargs
+from netket.utils.deprecation import warn_deprecation
 
 
 @partial_from_kwargs
-def pinv_smooth(A, b, *, rcond: float = 1e-14, rcond_smooth: float = 1e-14, x0=None):
+def pinv_smooth(
+    A,
+    b,
+    *,
+    rtol: float = 1e-14,
+    rtol_smooth: float = 1e-14,
+    x0=None,
+    rcond: float = None,
+    rcond_smooth: float = None,
+):
     r"""
     Solve the linear system by building a pseudo-inverse from the
     eigendecomposition obtained from :func:`jax.numpy.linalg.eigh`.
@@ -62,15 +72,29 @@ def pinv_smooth(A, b, *, rcond: float = 1e-14, rcond_smooth: float = 1e-14, x0=N
     Args:
         A: LinearOperator (matrix)
         b: vector or Pytree
-        rcond : Cut-off ratio for small singular values of :code:`A`. For
+        rtol : Relative tolerance for small singular values of :code:`A`. For
             the purposes of rank determination, singular values are treated
-            as zero if they are smaller than rcond times the largest
+            as zero if they are smaller than `rtol` times the largest
             singular value of :code:`A`.
-        rcond_smooth : regularization parameter used with a similar effect to `rcond`
+        rtol_smooth : Regularization parameter used with a similar effect to `rtol`
             but with a softer curve. See :math:`\epsilon` in the formula
             above.
     """
     del x0
+
+    if rcond is not None:
+        warn_deprecation(
+            "The 'rcond' argument is deprecated and will be removed in a future release. "
+            "Please use 'rtol' instead."
+        )
+        rtol = rcond
+
+    if rcond_smooth is not None:
+        warn_deprecation(
+            "The 'rcond_smooth' argument is deprecated and will be removed in a future release. "
+            "Please use 'rtol_smooth' instead."
+        )
+        rtol_smooth = rcond
 
     if not isinstance(A, jax.Array):
         A = A.to_dense()
@@ -79,10 +103,10 @@ def pinv_smooth(A, b, *, rcond: float = 1e-14, rcond_smooth: float = 1e-14, x0=N
     Σ, U = jnp.linalg.eigh(A)
 
     # Discard eigenvalues below numerical precision
-    Σ_inv = jnp.where(jnp.abs(Σ / Σ[-1]) > rcond, jnp.reciprocal(Σ), 0.0)
+    Σ_inv = jnp.where(jnp.abs(Σ / Σ[-1]) > rtol, jnp.reciprocal(Σ), 0.0)
 
     # Set regularizer for singular value cutoff
-    regularizer = 1.0 / (1.0 + (rcond_smooth / jnp.abs(Σ / Σ[-1])) ** 6)
+    regularizer = 1.0 / (1.0 + (rtol_smooth / jnp.abs(Σ / Σ[-1])) ** 6)
 
     Σ_inv = Σ_inv * regularizer
 
@@ -92,14 +116,14 @@ def pinv_smooth(A, b, *, rcond: float = 1e-14, rcond_smooth: float = 1e-14, x0=N
 
 
 @partial_from_kwargs
-def pinv(A, b, *, rcond: float = 1e-12, x0=None):
+def pinv(A, b, *, rtol: float = 1e-12, x0=None, rcond: float = None):
     """
     Solve the linear system using jax's implementation of the
     pseudo-inverse.
 
     Internally it calls :func:`~jax.numpy.linalg.pinv` which
     uses a :func:`~jax.numpy.linalg.svd` decomposition with
-    the same value of **rcond**.
+    the same value of **rtol**.
 
     .. note::
 
@@ -120,21 +144,28 @@ def pinv(A, b, *, rcond: float = 1e-12, x0=None):
         a partial capturing them.
 
     The diagonal shift on the matrix can be 0 and the
-    **rcond** variable can be used to truncate small
+    **rtol** variable can be used to truncate small
     eigenvalues.
 
     Args:
         A: the matrix A in Ax=b
         b: the vector b in Ax=b
-        rcond: The condition number
+        rtol: Cut-off ratio for small singular values of :code:`A`.
     """
     del x0
+
+    if rcond is not None:
+        warn_deprecation(
+            "The 'rcond' argument is deprecated and will be removed in a future release. "
+            "Please use 'rtol' instead."
+        )
+        rtol = rcond
 
     if not isinstance(A, jax.Array):
         A = A.to_dense()
     b, unravel = tree_ravel(b)
 
-    A_inv = jnp.linalg.pinv(A, rcond=rcond, hermitian=True)
+    A_inv = jnp.linalg.pinv(A, rtol=rtol, hermitian=True)
     x = jnp.dot(A_inv, b)
 
     return unravel(x), None

--- a/test/optimizer/test_qgt_solvers.py
+++ b/test/optimizer/test_qgt_solvers.py
@@ -174,3 +174,24 @@ def test_solver_dense_api(solver):
 
     x, _ = solver(A, b)
     np.testing.assert_allclose(A @ x, b)
+
+
+# Not all solvers had 'rcond' deprecated, so we test only for pinv and pinv_smooth.
+@pytest.mark.parametrize("solver_func", [solvers["pinv"], solvers["pinv_smooth"]])
+def test_solver_rcond_deprecation(solver_func):
+    key = jax.random.PRNGKey(0)
+    A = jax.random.normal(key, (10, 10))
+    A = A @ A.T  # Make PSD
+    b = jax.random.normal(key, (10,))
+
+    # Test with new argument (rtol)
+    x_new, _ = solver_func(A, b, rtol=1e-6)
+
+    with pytest.warns(FutureWarning, match="'rcond' argument is deprecated"):
+        x_old, _ = solver_func(A, b, rcond=1e-6)
+
+    # Check that results are identical
+    np.testing.assert_allclose(x_new, x_old, rtol=1e-10)
+
+    # Check that the solution is correct
+    np.testing.assert_allclose(A @ x_new, b, rtol=1e-6)


### PR DESCRIPTION
First PR here, so please let me know if anything needs adjustment. The idea was to address #1871. I've followed the contribution guidelines, and all tests are passing.

**Comments:**
- `linalg.lstsq` still utilizes `rcond`, so `solvers.svd` was not changed.
- In alignment with other deprecated examples in the project, I did not include the deprecated argument in the docstrings.
- I made an adjustment to the ising1d_sr_pinv example to prevent any warnings from being generated.

----------------
**Edit:** decided to disregard item 2 above since upon checking, the documentation page would load without any explanation of the deprecated arguments.