### PR TITLE
Pv/sharding ci fixes

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -6,7 +6,6 @@ features = [
   "extra",
 ]
 extra-dependencies = [
-  "jax @ git+https://github.com/google/jax"
 ]
 randomize = false
 parallel = false

--- a/test_sharding/test_sharding_distributed.py
+++ b/test_sharding/test_sharding_distributed.py
@@ -3,4 +3,4 @@ import jax
 jax.config.update("jax_cpu_enable_gloo_collectives", True)
 jax.distributed.initialize()
 
-from test_sharding import *  # noqa
+from test.sharding.test_sharding import *  # noqa


### PR DESCRIPTION
Leftover jax master branch version in hatch automatic testing
Update some over references to the distributed sharding tests