### PR TITLE
tree_map -> tree_util.tree_map in VarianceObservable

### DIFF
--- a/netket/experimental/observable/variance/exact.py
+++ b/netket/experimental/observable/variance/exact.py
@@ -89,6 +89,6 @@ def expect_and_grad_inner_fs(
     var, var_vjp_fun = nkjax.vjp(expect_kernel_var, params, conjugate=True)
 
     var_grad = var_vjp_fun(jnp.ones_like(var))[0]
-    var_grad = jax.tree_map(lambda x: mpi.mpi_mean_jax(x)[0], var_grad)
+    var_grad = jax.tree_util.tree_map(lambda x: mpi.mpi_mean_jax(x)[0], var_grad)
 
     return Stats(mean=var, error_of_mean=0.0, variance=0.0), var_grad

--- a/netket/experimental/observable/variance/expect.py
+++ b/netket/experimental/observable/variance/expect.py
@@ -136,6 +136,6 @@ def expect_and_grad_inner_mc(
     )
 
     var_grad = var_vjp_fun(jnp.ones_like(var))[0]
-    var_grad = jax.tree_map(lambda x: mpi.mpi_sum_jax(x)[0], var_grad)
+    var_grad = jax.tree_util.tree_map(lambda x: mpi.mpi_sum_jax(x)[0], var_grad)
 
     return var_stats, var_grad


### PR DESCRIPTION
Substitute `tree_map` with `tree_util.tree_map ` in `expect.py` and `exact.py` of `VarianceObservable `.