### PR TITLE
Extensible constraint interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,14 @@
 
 ## NetKet 3.14 (⚙️ In development)
 
+### New features
+* Hilbert spaces such as {class}`nk.hilbert.Spin` and {class}`nk.hilbert.Fock`, as well as their base class {class}`nk.hilbert.HomogeneousHilbert`, now support arbitrary custom constraints [#1908](https://github.com/netket/netket/pull/1908).
+* The constraint interface has been stabilised, documented, and made compatible with several utilities. It is now possible to generate random states from arbitrary constrained hilbert spaces automatically, and it is possible to index into those spaces efficiently. Look at the hilbert space documentation for more information [#1908](https://github.com/netket/netket/pull/1908).
+
 ### Changes
 * Jax operators now use the same `chunk_size` as specified by the user when computing the forward pass. Prior to this change, Jax operators would be chunking the sample axis, but if an operator had a lot of connected elements this would end up increasing the effective sample size [#1875](https://github.com/netket/netket/pull/1875).
 * Metropolis Hamiltonian sampler for numba operators has been greatly simplified in order to remove the dependency on numba4jax. The new implementation will generally be slower than before, so we encourage you to use Jax Operators if possible. In the future, if people ask for it, we may reintroduce this implementation as a separate package [#1747](https://github.com/netket/netket/pull/1747).
+* Previously-internal hilbert space constraint sub-module located at `netket.hilbert.index.constraints` has been moved to `netket.hilbert.constraint` [#1908](https://github.com/netket/netket/pull/1908).
 
 ### Improvements
 * Specialised lattice constructors like {func}`nk.graph.Grid` now accept a `point_group` argument, overriding the default (usually maximal) point groups [#1879](https://github.com/netket/netket/pull/1879).

--- a/docs/api/errors.md
+++ b/docs/api/errors.md
@@ -26,3 +26,14 @@ Netket has the following classes of errors.
   UnoptimalSRtWarning
   SymmModuleInvalidInputShape
 ```
+
+## Hilbert space errors
+
+```{eval-rst}
+.. autosummary::
+  :toctree: _generated/errors
+  :nosignatures:
+
+  UnoptimisedCustomConstraintRandomStateMethodWarning
+  UnhashableConstraintError
+  InvalidConstraintInterface

--- a/docs/api/errors.md
+++ b/docs/api/errors.md
@@ -37,3 +37,4 @@ Netket has the following classes of errors.
   UnoptimisedCustomConstraintRandomStateMethodWarning
   UnhashableConstraintError
   InvalidConstraintInterface
+```

--- a/docs/api/hilbert.md
+++ b/docs/api/hilbert.md
@@ -85,7 +85,7 @@ Those classes cannot be directly instantiated, but you can inherit from one of t
    :template: class
    :nosignatures:
 
-   DiscreteHilbertConstraint
+   constraint.DiscreteHilbertConstraint
 ```
 
 ### Random submodule

--- a/docs/api/hilbert.md
+++ b/docs/api/hilbert.md
@@ -33,7 +33,6 @@ Below you find a list of all concrete Hilbert spaces that you can use.
    :template: class
    :nosignatures:
 
-   CustomHilbert
    TensorHilbert
    DoubledHilbert
    Spin

--- a/docs/api/hilbert.md
+++ b/docs/api/hilbert.md
@@ -75,9 +75,7 @@ Those classes cannot be directly instantiated, but you can inherit from one of t
 
 ```
 
-### Random submodule
-
-When defining a new Hilbert space, you must define how to uniformly sample the basis elements of that Hilbert space by defining some dispatch rules for those functions.
+### Constraints
 
 ```{eval-rst}
 .. currentmodule:: netket.hilbert
@@ -87,7 +85,22 @@ When defining a new Hilbert space, you must define how to uniformly sample the b
    :template: class
    :nosignatures:
 
+   DiscreteHilbertConstraint
+```
+
+### Random submodule
+
+When defining a new Hilbert space, you must define how to uniformly sample the basis elements of that Hilbert space by defining some dispatch rules for those functions.
+
+```{eval-rst}
+.. currentmodule:: netket.hilbert
+
+.. autosummary::
+   :toctree: _generated/hilbert
+   :nosignatures:
+
    random.flip_state
    random.random_state
+   index.optimalConstrainedHilbertindex
 ```
 

--- a/docs/docs/hilbert.md
+++ b/docs/docs/hilbert.md
@@ -290,7 +290,7 @@ Existing Hilbert spaces such as {class}`~nk.hilbert.Spin` or {class}`~nk.hilbert
 A constraint effectively declares that the Hilbert space you are working with is smaller than the original {class}`~nk.hilbert.Spin` or {class}`~nk.hilbert.Fock`, for example by only considering configurations with a well defined magnetization. Those are often associated to some simmetries.
 
 To work with a custom constraint, you must do 2 things:
- - Define a custom constraint class, used to specify whether a configuration is valid or not. This must be a callable class inheriting from {class}`~nk.hilbert.DiscreteHilbertConstraint` that if passed a set of configurations will return an array of boolean flags telling netket whether those configurations are valid or not.
+ - Define a custom constraint class, used to specify whether a configuration is valid or not. This must be a callable class inheriting from {class}`~nk.hilbert.constraint.DiscreteHilbertConstraint` that if passed a set of configurations will return an array of boolean flags telling netket whether those configurations are valid or not.
  - You must define a custom {func}`nk.hilbert.random.random_state` dispatch rule specifying how to generate random configurations directly within the subspace. In principle this should return configurations distributed uniformly, but it is not terribly important (this is used to start the samplers, so even if it's a constant it might lead to worse warmup time but it might still work). 
 
 Both those methods should be implemented in such a way to be {func}`jax.jit`-table. If you can't write them in a jax-friendly way, you should call your function using {func}`jax.pure_callback`, which allows jax to call back into python functions.
@@ -304,7 +304,7 @@ In the following example, we will be implementing our own custom SumConstraint
 import netket as nk
 import jax; import jax.numpy as jnp
 
-class SumConstraint(nk.hilbert.DiscreteHilbertConstraint):
+class SumConstraint(nk.hilbert.constraint.DiscreteHilbertConstraint):
     # A simple constraint checking that the total sum of the elements
     # in the configuration is equal to a given value.
 

--- a/docs/docs/hilbert.md
+++ b/docs/docs/hilbert.md
@@ -15,8 +15,8 @@ Classes whose edge is dashed are abstract classes, while the others are concrete
 
 ```{eval-rst}
 .. inheritance-diagram:: netket.hilbert
-	:top-classes: netket.hilbert.AbstractHilbert
-	:parts: 1
+    :top-classes: netket.hilbert.AbstractHilbert
+    :parts: 1
 
 ```
 
@@ -282,6 +282,77 @@ You can freely use {class}`~nk.hilbert.AbstractHilbert` objects inside of {func}
 
 All attributes and methods of Hilbert spaces can be freely used inside of a {func}`jax.jit` block.
 In particular the {meth}`~DiscreteHilbert.random_state` method can be used inside of jitted blocks, as it is written in jax, as long as you pass a valid jax {func}`jax.random.PRNGKey` object as the first argument.
+
+## Using custom constraints for Discrete Hilbert spaces
+
+Existing Hilbert spaces such as {class}`~nk.hilbert.Spin` or {class}`~nk.hilbert.Fock` support natively a constraint based on the total magnetization or population. However, at times you might want to work with some custom, more complex constraints.
+
+A constraint effectively declares that the Hilbert space you are working with is smaller than the original {class}`~nk.hilbert.Spin` or {class}`~nk.hilbert.Fock`, for example by only considering configurations with a well defined magnetization. Those are often associated to some simmetries.
+
+To work with a custom constraint, you must do 2 things:
+ - Define a custom constraint class, used to specify whether a configuration is valid or not. This must be a callable class inheriting from {class}`~nk.hilbert.DiscreteHilbertConstraint` that if passed a set of configurations will return an array of boolean flags telling netket whether those configurations are valid or not.
+ - You must define a custom {func}`nk.hilbert.random.random_state` dispatch rule specifying how to generate random configurations directly within the subspace. In principle this should return configurations distributed uniformly, but it is not terribly important (this is used to start the samplers, so even if it's a constant it might lead to worse warmup time but it might still work). 
+
+Both those methods should be implemented in such a way to be {func}`jax.jit`-table. If you can't write them in a jax-friendly way, you should call your function using {func}`jax.pure_callback`, which allows jax to call back into python functions.
+
+### Example
+
+In the following example, we will be implementing our own custom SumConstraint
+
+```python
+
+import netket as nk
+import jax; import jax.numpy as jnp
+
+class SumConstraint(nk.hilbert.DiscreteHilbertConstraint):
+    # A simple constraint checking that the total sum of the elements
+    # in the configuration is equal to a given value.
+
+    def __init__(self, total_sum):
+        self.total_sum = total_sum
+
+    def __call__(self, x):
+        # Makes it jax-compatible
+       return jnp.sum(x, axis=-1) == self.total_sum
+
+    def __hash__(self):
+        return hash(("SumConstraint", self.total_sum))
+
+    def __eq__(self, other):
+        if isinstance(other, SumConstraint):
+            return self.total_sum == other.total_sum
+        return False
+
+
+@nk.hilbert.random.random_state.dispatch
+def random_state_sumconstraint(
+        hilb: nk.hilb.Fock, constraint: SumConstraint, key, batches: int, *, dtype=None
+    ):
+    """
+    This function should return a batch of `batches` samples distributed uniformly.
+    If batches is 3, it should return a matrix of size `(3, hilb.size)`
+
+    As it can be very hard to write those functions in jax, a typical trick is to write them in 
+    Numpy and use a pure callback
+    """
+
+    def random_constraints_py(key):
+        # Create a RNG based on the provided key for reproducibility
+        rng = np.random.default_rng(np.array(key))
+        # generate random configurations...
+        # It should be a numpy matrix with shape (batches, hilb.size) and dtype dtype
+        return ...
+
+    return jax.pure_callback(random_constraints_py,
+        jax.ShapeDtypeStruct(hilb.size, dtype),
+        jax.random.key_data(key),
+        )
+    
+
+hi = nk.hilbert.Fock(0.5, 10, constraint=SumConstraint(0))
+``` 
+
+
 
 ### Adapting Hilbert spaces with numpy `states_to_numbers` / `numbers_to_states`
 

--- a/netket/errors.py
+++ b/netket/errors.py
@@ -697,20 +697,20 @@ class InvalidConstraintInterface(NetketError):
     """Error thrown when a constraint for an Homogeneous
     Hilbert space does not conform to the expected interface.
 
-    A custom Constraint must respect the :class:`netket.hilbert.DiscreteHilbertConstraint`
+    A custom Constraint must respect the :class:`netket.hilbert.constraint.DiscreteHilbertConstraint`
     interface by inheriting that class and by having a jax-jittable :code:`__call__` method.
 
     If you see this error, your constraint might just be a function without inheriting from this
     class, or it does not have a jittable call method.
 
-    See the class documentation of :class:`netket.hilbert.DiscreteHilbertConstraint` for
+    See the class documentation of :class:`netket.hilbert.constraint.DiscreteHilbertConstraint` for
     some examples.
     """
 
     def __init__(self):
         super().__init__(
             """Your custom constraint does not respect the constraint interface, probably because
-            it does not inherit from `netket.hilbert.DiscreteHilbertConstraint`, because it does not
+            it does not inherit from `netket.hilbert.constraint.DiscreteHilbertConstraint`, because it does not
             have a jittable `__call__` method.
 
             Look at the documentation online to learn more.

--- a/netket/errors.py
+++ b/netket/errors.py
@@ -726,7 +726,7 @@ class UnhashableConstraintError(NetketError):
     This usually happens because you did not mark all the pytree fields in your constraint
     as `struct.field(pytree_node=False)`.
 
-    For a good example, see the documentation of :class:`netket.hilbert.index.constraints.DiscreteHilbertConstraint`.
+    For a good example, see the documentation of :class:`netket.hilbert.constraint.DiscreteHilbertConstraint`.
     Below, you find a coincise example of how to fix this error:
 
     .. code-block:: python
@@ -769,7 +769,7 @@ class UnhashableConstraintError(NetketError):
                 from typing import Any
                 from netket.utils import struct
 
-                class MyCustomConstraint(nk.hilbert.index.constraints.DiscreteHilbertConstraint):
+                class MyCustomConstraint(nk.hilbert.constraint.DiscreteHilbertConstraint):
                     fieldA: Any = struct.field(pytree_node=False)
                     fieldB: Any = struct.field(pytree_node=False)
                     def __init__(self, fieldA, fieldB):

--- a/netket/errors.py
+++ b/netket/errors.py
@@ -745,6 +745,14 @@ class UnhashableConstraintError(NetketError):
             def __call__(self, x):
                 ....
 
+            def __hash__(self):
+                return hash(("MyCustomConstraint", self.fieldA, self.fieldB))
+
+            def __eq__(self, other):
+                if isinstance(other, UnhashableConstraintError):
+                    return self.fieldA == other.fieldA and self.fieldB == other.fieldB
+                return False
+
     """
 
     def __init__(self, constraint):
@@ -770,6 +778,14 @@ class UnhashableConstraintError(NetketError):
 
                     def __call__(self, x):
                         ....
+
+                    def __hash__(self):
+                        return hash(("MyCustomConstraint", self.fieldA, self.fieldB))
+
+                    def __eq__(self, other):
+                        if isinstance(other, UnhashableConstraintError):
+                            return self.fieldA == other.fieldA and self.fieldB == other.fieldB
+                        return False
 
             """
         )

--- a/netket/errors.py
+++ b/netket/errors.py
@@ -878,6 +878,7 @@ class UnoptimisedCustomConstraintRandomStateMethodWarning(NetketWarning):
             """
         )
 
+
 class NetKetPyTreeUndeclaredAttributeAssignmentError(AttributeError, NetketError):
     """
     Error thrown when trying to assign an undeclared attribute to a NetKet-style Pytree.

--- a/netket/errors.py
+++ b/netket/errors.py
@@ -693,6 +693,176 @@ class UnoptimalSRtWarning(NetketWarning):
         )
 
 
+class InvalidConstraintInterface(NetketError):
+    """Error thrown when a constraint for an Homogeneous
+    Hilbert space does not conform to the expected interface.
+
+    A custom Constraint must respect the :class:`netket.hilbert.DiscreteHilbertConstraint`
+    interface by inheriting that class and by having a jax-jittable :code:`__call__` method.
+
+    If you see this error, your constraint might just be a function without inheriting from this
+    class, or it does not have a jittable call method.
+
+    See the class documentation of :class:`netket.hilbert.DiscreteHilbertConstraint` for
+    some examples.
+    """
+
+    def __init__(self):
+        super().__init__(
+            """Your custom constraint does not respect the constraint interface, probably because
+            it does not inherit from `netket.hilbert.DiscreteHilbertConstraint`, because it does not
+            have a jittable `__call__` method.
+
+            Look at the documentation online to learn more.
+            """
+        )
+
+
+class UnhashableConstraintError(NetketError):
+    """
+    Error thrown when a constraint is not a fully static pytree, and it cannot be hashed.
+
+    This error is thrown when a constraint is a PyTree with some leaf nodes.
+    This usually happens because you did not mark all the pytree fields in your constraint
+    as `struct.field(pytree_node=False)`.
+
+    For a good example, see the documentation of :class:`netket.hilbert.index.constraints.DiscreteHilbertConstraint`.
+    Below, you find a coincise example of how to fix this error:
+
+    .. code-block:: python
+
+        from typing import Any
+        from netket.utils import struct
+        from netket.hilbert.index.constraints import DiscreteHilbertConstraint
+
+        class MyCustomConstraint(DiscreteHilbertConstraint):
+            fieldA: Any = struct.field(pytree_node=False)
+            fieldB: Any = struct.field(pytree_node=False)
+            def __init__(self, fieldA, fieldB):
+                self.fieldA = fieldA
+                self.fieldB = fieldB
+
+            def __call__(self, x):
+                ....
+
+    """
+
+    def __init__(self, constraint):
+        constraintT = type(constraint)
+        super().__init__(
+            f"""
+            The custom constraint type {constraintT} is a pytree with some nodes, meaning that it cannot be
+            safely passed to jax as a static argument.
+
+            This probably happened because some of the fields in your constraint are not marked as
+            `nk.utils.struct.field(pytree_node=False)`.
+
+            To fix this error, you should mark all fields in your constraint as per the example below:
+                from typing import Any
+                from netket.utils import struct
+
+                class MyCustomConstraint(nk.hilbert.index.constraints.DiscreteHilbertConstraint):
+                    fieldA: Any = struct.field(pytree_node=False)
+                    fieldB: Any = struct.field(pytree_node=False)
+                    def __init__(self, fieldA, fieldB):
+                        self.fieldA = fieldA
+                        self.fieldB = fieldB
+
+                    def __call__(self, x):
+                        ....
+
+            """
+        )
+
+
+class UnoptimisedCustomConstraintRandomStateMethodWarning(NetketWarning):
+    """
+    Warning thrown when calling `random_state` on a Hilbert space with a custom constraint.
+
+    This warning is thrown when the custom Hilbert space constraint does not have a custom
+    `random_state` method implemented. This will default to a slow, possibly infinitely-looping
+    method to generate random states.
+
+    The default fallback works by generating random states in the unconstrained Hilbert space
+    until one is found that satisfies the constraint. This can be very slow, and even never
+    terminate if the constraint is too restrictive.
+
+    .. note::
+
+        Generating random states is only required when initializing a Markov Chain Monte Carlo
+        sampler, but is generally not needed during on. Therefore, even if this warning is thrown,
+        it might not be a problem if you do not reset your chains very often.
+
+        In general, if your constraint is not overly (exponentially) restrictive, you may not
+        need to worry about this warning.
+
+    .. note::
+
+        The fallback implementation is not optimised, especially on GPUs. It will generate 1 random
+        state at a time until it finds one that satisfies the constraint, and will repeat this for
+        every different chain.
+
+        We welcome contributions to improve this method to perform the loop in batches.
+
+    .. note::
+
+        You can silence this warning by setting the environment variable `NETKET_NO_RANDOM_STATE_WARNING=1`.
+
+
+    Example implementation of a custom `random_state` method:
+    ---------------------------------------------------------
+
+    Implementations of :func:`netket.hilbert.random_state` are dispatched based on the Hilbert space and
+    constraint type using Plum's multiple dispatch (see the link <https://beartype.github.io/plum/intro.html>_
+
+    See an example here
+
+    .. code-block:: python
+
+        @dispatch.dispatch
+        def random_state(hilb: HilbertType, constraint: ConstraintType, key, batches: int, *, dtype=None):
+            # your custom implementation here
+            # You should return a batch of `batches` random states, with the given dtype.
+            # return jax.Array with shape (batches, hilb.size) and dtype dtype.
+
+
+    .. note::
+
+        We welcome contributions to improve the documentation here.
+
+    """
+
+    def __init__(self, hilbert_space, constraint):
+        hilb_typ = f"{type(hilbert_space).__module__}.{type(hilbert_space).__name__}"
+        constraint_typ = f"{type(constraint).__module__}.{type(constraint).__name__}"
+        super().__init__(
+            f"""
+            Defaulting to a slow, possibly infinitely-looping method to generate random state of
+            the current Hilbert space with a custom constraint. Consider implementing a
+            custom `random_state` method for your constraint if this method takes a long time to
+            generate a random state.
+
+            To generate a custom random_state dispatched method, you should use multiple dispatch
+            following the following syntax:
+
+            >>> import netket as nk
+            >>> from netket.utils import dispatch
+            >>>
+            >>> @dispatch.dispatch
+            >>> def random_state(hilb: {hilb_typ},
+                                constraint: {constraint_typ},
+                                key,
+                                batches: int,
+                                *,
+                                dtype=None):
+            >>>    # your custom implementation here
+            >>>    # You should return a batch of `batches` random states, with the given dtype.
+            >>>    # return jax.Array with shape (batches, hilb.size) and dtype dtype.
+
+            """
+        )
+
+
 #################################################
 # Functions to throw errors                     #
 #################################################

--- a/netket/errors.py
+++ b/netket/errors.py
@@ -822,7 +822,8 @@ class UnoptimisedCustomConstraintRandomStateMethodWarning(NetketWarning):
 
     .. note::
 
-        You can silence this warning by setting the environment variable `NETKET_NO_RANDOM_STATE_WARNING=1`.
+        You can silence this warning by setting the environment variable ``NETKET_RANDOM_STATE_FALLBACK_WARNING=0``
+        or by setting ``nk.config.netket_random_state_fallback_warning = 0`` in your code.
 
 
     Example implementation of a custom `random_state` method:
@@ -857,6 +858,13 @@ class UnoptimisedCustomConstraintRandomStateMethodWarning(NetketWarning):
             the current Hilbert space with a custom constraint. Consider implementing a
             custom `random_state` method for your constraint if this method takes a long time to
             generate a random state.
+
+            ================================================================
+            You can silence this warning by setting the environment variable
+            ``NETKET_RANDOM_STATE_FALLBACK_WARNING=0``
+            or by setting ``nk.config.netket_random_state_fallback_warning = False``
+            in your code.
+            ================================================================
 
             To generate a custom random_state dispatched method, you should use multiple dispatch
             following the following syntax:

--- a/netket/experimental/observable/variance/exact.py
+++ b/netket/experimental/observable/variance/exact.py
@@ -89,6 +89,6 @@ def expect_and_grad_inner_fs(
     var, var_vjp_fun = nkjax.vjp(expect_kernel_var, params, conjugate=True)
 
     var_grad = var_vjp_fun(jnp.ones_like(var))[0]
-    var_grad = jax.tree_map(lambda x: mpi.mpi_mean_jax(x)[0], var_grad)
+    var_grad = jax.tree_util.tree_map(lambda x: mpi.mpi_mean_jax(x)[0], var_grad)
 
     return Stats(mean=var, error_of_mean=0.0, variance=0.0), var_grad

--- a/netket/experimental/observable/variance/expect.py
+++ b/netket/experimental/observable/variance/expect.py
@@ -136,6 +136,6 @@ def expect_and_grad_inner_mc(
     )
 
     var_grad = var_vjp_fun(jnp.ones_like(var))[0]
-    var_grad = jax.tree_map(lambda x: mpi.mpi_sum_jax(x)[0], var_grad)
+    var_grad = jax.tree_util.tree_map(lambda x: mpi.mpi_sum_jax(x)[0], var_grad)
 
     return var_stats, var_grad

--- a/netket/hilbert/__init__.py
+++ b/netket/hilbert/__init__.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from . import constraint
+from . import index
+
 from .abstract_hilbert import AbstractHilbert
 from .discrete_hilbert import DiscreteHilbert
 from .homogeneous import HomogeneousHilbert
@@ -27,6 +30,8 @@ from .particle import Particle
 
 from .tensor_hilbert import TensorHilbert
 from . import tensor_hilbert_discrete
+
+from . import random
 
 from netket.utils import _hide_submodules
 

--- a/netket/hilbert/__init__.py
+++ b/netket/hilbert/__init__.py
@@ -21,7 +21,6 @@ from .homogeneous import HomogeneousHilbert
 
 from .continuous_hilbert import ContinuousHilbert
 
-from .custom_hilbert import CustomHilbert
 from .doubled_hilbert import DoubledHilbert
 from .spin import Spin
 from .fock import Fock
@@ -35,4 +34,21 @@ from . import random
 
 from netket.utils import _hide_submodules
 
+# Deprecated bindings
+from .custom_hilbert import CustomHilbert as _deprecated_CustomHilbert
+
+_deprecations = {
+    # September 2024, NetKet 3.14
+    "CustomHilbert": (
+        "netket.hilbert.CustomHilbert is deprecated: use custom constraints with "
+        "existing hilbert spaces instead, or define your own hilbert space class.",
+        _deprecated_CustomHilbert,
+    ),
+}
+
+from netket.utils.deprecation import deprecation_getattr as _deprecation_getattr
+
+__getattr__ = _deprecation_getattr(__name__, _deprecations)
 _hide_submodules(__name__)
+
+del _deprecation_getattr

--- a/netket/hilbert/__init__.py
+++ b/netket/hilbert/__init__.py
@@ -32,7 +32,6 @@ from . import tensor_hilbert_discrete
 
 from . import random
 
-from netket.utils import _hide_submodules
 
 # Deprecated bindings
 from .custom_hilbert import CustomHilbert as _deprecated_CustomHilbert
@@ -47,6 +46,7 @@ _deprecations = {
 }
 
 from netket.utils.deprecation import deprecation_getattr as _deprecation_getattr
+from netket.utils import _hide_submodules
 
 __getattr__ = _deprecation_getattr(__name__, _deprecations)
 _hide_submodules(__name__)

--- a/netket/hilbert/constraint/__init__.py
+++ b/netket/hilbert/constraint/__init__.py
@@ -15,3 +15,8 @@
 from .base import DiscreteHilbertConstraint
 from .sum import SumConstraint
 from .multiple import ExtraConstraint
+
+
+from netket.utils import _hide_submodules
+
+_hide_submodules(__name__)

--- a/netket/hilbert/constraint/__init__.py
+++ b/netket/hilbert/constraint/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2024 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .base import DiscreteHilbertConstraint
+from .sum import SumConstraint
+from .multiple import ExtraConstraint

--- a/netket/hilbert/constraint/base.py
+++ b/netket/hilbert/constraint/base.py
@@ -1,0 +1,128 @@
+# Copyright 2023-2024 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import abc
+
+
+import jax
+
+from netket.utils import struct
+
+
+class DiscreteHilbertConstraint(struct.Pytree):
+    r"""
+    Protocol to define an Abstract Constraint for a discete Hilbert space.
+
+    To define a customized constraint, you must subclass this class and at least implement the
+    :code:`__call__` method. The :code:`__call__` method should take as input a matrix encoding a batch of
+    configurations, and return a vector of booleans specifying whether they are valid configurations
+    or not.
+
+    The :code:`__call__` method must be :code:`jax.jit`-able. If you cannot make it jax-jittable, you can implement
+    it in numba/python and wrap it into a :func:`jax.pure_callback` to make it compatible with jax.
+
+    The callback should be hashable and comparable with itself, which means it must implement :code:`__hash__` and :code:`__eq__`.
+    By default, the :code:`__hash__` method is implemented by the `id` of the object, which is unique for each object,
+    which will work but might lead to more recompilations in jax. If you can, you should implement a custom :code:`__hash__`
+
+    Example:
+
+        The following example shows a class that implements a simple constraint checking that the total sum of the
+        elements in the configuration is equal to a given value. The example shows how to implement the :code:`__call__` method
+        and the :code:`__hash__` and :code:`__eq__` methods.
+
+        .. code-block:: python
+
+            import netket as nk
+            from netket.utils import struct
+
+            import jax; import jax.numpy as jnp
+
+            class SumConstraint(nk.hilbert.DiscreteHilbertConstraint):
+                # A simple constraint checking that the total sum of the elements
+                # in the configuration is equal to a given value.
+
+                # The value must be set as a pytree_node=False field, meaning
+                # that it is a constant and changes to this value represent different
+                # constraints.
+                total_sum : float = struct.field(pytree_node=False)
+
+                def __init__(self, total_sum):
+                    self.total_sum = total_sum
+
+                def __call__(self, x):
+                    # Makes it jax-compatible
+                    return jnp.sum(x, axis=-1) == self.total_sum
+
+                def __hash__(self):
+                    return hash(("SumConstraint", self.total_sum))
+
+                def __eq__(self, other):
+                    if isinstance(other, SumConstraint):
+                        return self.total_sum == other.total_sum
+                    return False
+
+    Example:
+
+        The following example shows how to implement the same function as above, but using a pure python function and
+        a :func:`jax.pure_callback` to make it compatible with jax.
+
+        .. code-block:: python
+
+            import jax
+            import jax.numpy as jnp
+            import numpy as np
+
+            import netket as nk
+            from netket.utils import struct
+
+            class SumConstraintPy(nk.hilbert.DiscreteHilbertConstraint):
+                # A simple constraint checking that the total sum of the elements
+                # in the configuration is equal to a given value.
+
+                total_sum : float = struct.field(pytree_node=False)
+
+                def __init__(self, total_sum):
+                    self.total_sum = total_sum
+
+                def __call__(self, x):
+                    return jax.pure_callback(self._call_py,
+                                            result_shape_dtypes=(jax.ShapeDtypeStruct(x.shape[:-1], bool)),
+                                            x,
+                                            vectorized=True)
+
+                def _call_py(self, x):
+                    # Not Jax compatible
+                    return np.sum(x, axis=-1) == self.total_sum
+
+                def __hash__(self):
+                    return hash(("SumConstraintPy", self.total_sum))
+
+                def __eq__(self, other):
+                    if isinstance(other, SumConstraintPy):
+                        return self.total_sum == other.total_sum
+                    return False
+
+    """
+
+    @abc.abstractmethod
+    def __call__(self, x: jax.Array) -> jax.Array:
+        """
+        This function should take as input a matrix encoding a batch of configurations,
+        and return a vector of booleans specifying whether they are valid configurations of
+        the Hilbert space or not.
+
+        Args:
+            x: 2D matrix.
+        """

--- a/netket/hilbert/constraint/base.py
+++ b/netket/hilbert/constraint/base.py
@@ -49,7 +49,7 @@ class DiscreteHilbertConstraint(struct.Pytree):
 
             import jax; import jax.numpy as jnp
 
-            class SumConstraint(nk.hilbert.DiscreteHilbertConstraint):
+            class SumConstraint(nk.hilbert.constraint.DiscreteHilbertConstraint):
                 # A simple constraint checking that the total sum of the elements
                 # in the configuration is equal to a given value.
 
@@ -87,7 +87,7 @@ class DiscreteHilbertConstraint(struct.Pytree):
             import netket as nk
             from netket.utils import struct
 
-            class SumConstraintPy(nk.hilbert.DiscreteHilbertConstraint):
+            class SumConstraintPy(nk.hilbert.constraint.DiscreteHilbertConstraint):
                 # A simple constraint checking that the total sum of the elements
                 # in the configuration is equal to a given value.
 

--- a/netket/hilbert/constraint/multiple.py
+++ b/netket/hilbert/constraint/multiple.py
@@ -55,6 +55,9 @@ class ExtraConstraint(DiscreteHilbertConstraint):
             )
         return False
 
+    def __repr__(self):
+        return f"ExtraConstraint({self.base_constraint}, {self.extra_constraint})"
+
     # ----- Parametric class definition
     # Definitions to make the @dispatch.parametric class give informative errors
     # Look at https://beartype.github.io/plum/parametric.html for more information

--- a/netket/hilbert/constraint/multiple.py
+++ b/netket/hilbert/constraint/multiple.py
@@ -44,6 +44,14 @@ class ExtraConstraint(DiscreteHilbertConstraint):
         )
         return jnp.all(conditions, axis=0)
 
+    def __hash__(self):
+        return hash(("ExtraConstraint", self.base_constraint, self.extra_constraint))
+
+    def __eq__(self, other):
+        if isinstance(other, ExtraConstraint):
+            return self.base_constraint == other.base_constraint and self.extra_constraint == other.extra_constraint
+        return False
+
     # ----- Parametric class definition
     # Definitions to make the @dispatch.parametric class give informative errors
     # Look at https://beartype.github.io/plum/parametric.html for more information

--- a/netket/hilbert/constraint/multiple.py
+++ b/netket/hilbert/constraint/multiple.py
@@ -49,7 +49,10 @@ class ExtraConstraint(DiscreteHilbertConstraint):
 
     def __eq__(self, other):
         if isinstance(other, ExtraConstraint):
-            return self.base_constraint == other.base_constraint and self.extra_constraint == other.extra_constraint
+            return (
+                self.base_constraint == other.base_constraint
+                and self.extra_constraint == other.extra_constraint
+            )
         return False
 
     # ----- Parametric class definition

--- a/netket/hilbert/constraint/multiple.py
+++ b/netket/hilbert/constraint/multiple.py
@@ -1,0 +1,103 @@
+# Copyright 2024 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from textwrap import dedent
+
+import jax.numpy as jnp
+
+from netket.utils.types import Array
+from netket.utils import struct, dispatch
+
+from .base import (
+    DiscreteHilbertConstraint,
+)
+
+
+@dispatch.parametric
+@struct.dataclass
+class ExtraConstraint(DiscreteHilbertConstraint):
+    """
+    Wraps a Constraint and its HilbertIndex into a second constraint (with a
+    default lookup-based hilbert index).
+
+    The first argument is the base constraint while the second is the wrapping
+    one.
+    """
+
+    base_constraint: DiscreteHilbertConstraint = struct.field(pytree_node=False)
+    extra_constraint: DiscreteHilbertConstraint = struct.field(pytree_node=False)
+
+    def __call__(self, x: Array) -> Array:
+        conditions = jnp.stack(
+            [self.base_constraint(x), self.extra_constraint(x)], axis=0
+        )
+        return jnp.all(conditions, axis=0)
+
+    # ----- Parametric class definition
+    # Definitions to make the @dispatch.parametric class give informative errors
+    # Look at https://beartype.github.io/plum/parametric.html for more information
+
+    @classmethod
+    def __init_type_parameter__(self, baseT: type, extraT: type):
+        """Check whether the type parameters are valid."""
+        # In this case, we use `@dispatch` to check the validity of the type parameter.
+        if not (
+            issubclass(baseT, DiscreteHilbertConstraint)
+            and issubclass(extraT, DiscreteHilbertConstraint)
+        ):
+            raise TypeError(
+                dedent(
+                    """The type parameters T1, T2 of ExtraConstraint[T1, T2] must be subtypes of
+                    nk.hilbert.index.constraints.DiscreteHilbertConstraint, but one or more are not.
+
+                    To verify if those are valid type parameters you can check it with
+                    issubclass(T1, nk.hilbert.index.constraints.DiscreteHilbertConstraint).
+
+                    For more information, look at the documentation of parametric classes in
+                    https://beartype.github.io/plum/parametric.html or open an issue on NetKet's
+                    GitHub discussion session.
+                    """
+                )
+            )
+        return baseT, extraT
+
+    @classmethod
+    def __infer_type_parameter__(
+        self,
+        base_constraint: DiscreteHilbertConstraint,
+        extra_constraint: DiscreteHilbertConstraint,
+    ):
+        """Inter the type parameter from the arguments."""
+        if not (
+            isinstance(base_constraint, DiscreteHilbertConstraint)
+            and isinstance(extra_constraint, DiscreteHilbertConstraint)
+        ):
+            raise TypeError(
+                dedent(
+                    """The type parameters T1, T2 of ExtraConstraint[T1, T2] must be subtypes of
+                    nk.hilbert.index.constraints.DiscreteHilbertConstraint, but one or more are not.
+
+                    To verify if those are valid type parameters you can check it with
+                    issubclass(T1, nk.hilbert.index.constraints.DiscreteHilbertConstraint).
+
+                    For more information, look at the documentation of parametric classes in
+                    https://beartype.github.io/plum/parametric.html or open an issue on NetKet's
+                    GitHub discussion session.
+                    """
+                )
+            )
+
+        return type(base_constraint), type(extra_constraint)
+
+    # ------ End of Parametric class definition

--- a/netket/hilbert/constraint/multiple.py
+++ b/netket/hilbert/constraint/multiple.py
@@ -70,10 +70,10 @@ class ExtraConstraint(DiscreteHilbertConstraint):
             raise TypeError(
                 dedent(
                     """The type parameters T1, T2 of ExtraConstraint[T1, T2] must be subtypes of
-                    nk.hilbert.index.constraints.DiscreteHilbertConstraint, but one or more are not.
+                    nk.hilbert.constraint.DiscreteHilbertConstraint, but one or more are not.
 
                     To verify if those are valid type parameters you can check it with
-                    issubclass(T1, nk.hilbert.index.constraints.DiscreteHilbertConstraint).
+                    issubclass(T1, nk.hilbert.constraint.DiscreteHilbertConstraint).
 
                     For more information, look at the documentation of parametric classes in
                     https://beartype.github.io/plum/parametric.html or open an issue on NetKet's
@@ -97,10 +97,10 @@ class ExtraConstraint(DiscreteHilbertConstraint):
             raise TypeError(
                 dedent(
                     """The type parameters T1, T2 of ExtraConstraint[T1, T2] must be subtypes of
-                    nk.hilbert.index.constraints.DiscreteHilbertConstraint, but one or more are not.
+                    nk.hilbert.constraint.DiscreteHilbertConstraint, but one or more are not.
 
                     To verify if those are valid type parameters you can check it with
-                    issubclass(T1, nk.hilbert.index.constraints.DiscreteHilbertConstraint).
+                    issubclass(T1, nk.hilbert.constraint.DiscreteHilbertConstraint).
 
                     For more information, look at the documentation of parametric classes in
                     https://beartype.github.io/plum/parametric.html or open an issue on NetKet's

--- a/netket/hilbert/constraint/sum.py
+++ b/netket/hilbert/constraint/sum.py
@@ -30,7 +30,7 @@ class SumConstraint(DiscreteHilbertConstraint):
 
     sum_value: Scalar = struct.field(pytree_node=False)
 
-    def __init__(self, sum_value : Scalar):
+    def __init__(self, sum_value: Scalar):
         self.sum_value = sum_value
 
     @jax.jit
@@ -44,4 +44,3 @@ class SumConstraint(DiscreteHilbertConstraint):
         if isinstance(other, SumConstraint):
             return self.total_sum == other.total_sum
         return False
-

--- a/netket/hilbert/constraint/sum.py
+++ b/netket/hilbert/constraint/sum.py
@@ -1,0 +1,36 @@
+# Copyright 2024 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import jax
+
+from netket.utils import struct
+from netket.utils.types import Scalar, Array
+
+from .base import DiscreteHilbertConstraint
+
+
+@struct.dataclass
+class SumConstraint(DiscreteHilbertConstraint):
+    """
+    Constraint of an Hilbert space enforcing a total sum of all the values in the degrees of freedom.
+
+    Constructed by specifying the total sum. For Fock-like spaces this is the total population,
+    while for Spin-like spaces this is the magnetisation.
+    """
+
+    sum_value: Scalar = struct.field(pytree_node=False)
+
+    @jax.jit
+    def __call__(self, x: Array) -> Array:
+        return x.sum(axis=-1) == self.sum_value

--- a/netket/hilbert/constraint/sum.py
+++ b/netket/hilbert/constraint/sum.py
@@ -44,3 +44,6 @@ class SumConstraint(DiscreteHilbertConstraint):
         if isinstance(other, SumConstraint):
             return self.sum_value == other.sum_value
         return False
+
+    def __repr__(self):
+        return f"SumConstraint({self.sum_value})"

--- a/netket/hilbert/constraint/sum.py
+++ b/netket/hilbert/constraint/sum.py
@@ -42,5 +42,5 @@ class SumConstraint(DiscreteHilbertConstraint):
 
     def __eq__(self, other):
         if isinstance(other, SumConstraint):
-            return self.total_sum == other.total_sum
+            return self.sum_value == other.sum_value
         return False

--- a/netket/hilbert/constraint/sum.py
+++ b/netket/hilbert/constraint/sum.py
@@ -20,7 +20,6 @@ from netket.utils.types import Scalar, Array
 from .base import DiscreteHilbertConstraint
 
 
-@struct.dataclass
 class SumConstraint(DiscreteHilbertConstraint):
     """
     Constraint of an Hilbert space enforcing a total sum of all the values in the degrees of freedom.
@@ -31,6 +30,18 @@ class SumConstraint(DiscreteHilbertConstraint):
 
     sum_value: Scalar = struct.field(pytree_node=False)
 
+    def __init__(self, sum_value : Scalar):
+        self.sum_value = sum_value
+
     @jax.jit
     def __call__(self, x: Array) -> Array:
         return x.sum(axis=-1) == self.sum_value
+
+    def __hash__(self):
+        return hash(("SumConstraint", self.sum_value))
+
+    def __eq__(self, other):
+        if isinstance(other, SumConstraint):
+            return self.total_sum == other.total_sum
+        return False
+

--- a/netket/hilbert/custom_hilbert.py
+++ b/netket/hilbert/custom_hilbert.py
@@ -21,7 +21,16 @@ from .homogeneous import HomogeneousHilbert
 
 
 class CustomHilbert(HomogeneousHilbert):
-    r"""A custom hilbert space with discrete local quantum numbers."""
+    r"""A custom hilbert space with discrete local quantum numbers.
+
+    .. warning::
+
+        This class is deprecated in version 3.14. Use custom constraints with
+        existing classes instead, or define your own hilbert space class.
+
+        Do contact us on GitHub if you have any questions or need assistance.
+
+    """
 
     def __init__(
         self,
@@ -32,6 +41,11 @@ class CustomHilbert(HomogeneousHilbert):
         r"""
         Constructs a new ``CustomHilbert`` given a list of eigenvalues of the states and
         a number of sites, or modes, within this hilbert space.
+
+        .. warning::
+
+            This class is deprecated in version 3.14. Use custom constraints with
+            existing classes instead, or define your own hilbert space class.
 
         Args:
             local_states: :class:`~netket.utils.StaticRange` object describing the

--- a/netket/hilbert/custom_hilbert.py
+++ b/netket/hilbert/custom_hilbert.py
@@ -76,7 +76,7 @@ class CustomHilbert(HomogeneousHilbert):
             >>> print(hi.size)
             100
         """
-        super().__init__(local_states, N, constraint_fn)
+        super().__init__(local_states, N, constraint_fn=constraint_fn)
 
     def _mul_sametype_(self, other):
         assert type(self) == type(other)

--- a/netket/hilbert/fock.py
+++ b/netket/hilbert/fock.py
@@ -51,7 +51,7 @@ class Fock(HomogeneousHilbert):
             is imposed.
           constraint: A custom constraint on the allowed configurations. This argument
             cannot be specified at the same time as :code:`n_particles`. The constraint
-            must be a subclass of :class:`~netket.hilbert.DiscreteHilbertConstraint`
+            must be a subclass of :class:`~netket.hilbert.constraint.DiscreteHilbertConstraint`
 
         Examples:
            Simple boson hilbert space.

--- a/netket/hilbert/fock.py
+++ b/netket/hilbert/fock.py
@@ -95,14 +95,11 @@ class Fock(HomogeneousHilbert):
         else:
             self._n_particles = None
 
-        if self._n_max is not None:
-            # assert self._n_max > 0
-            local_states = StaticRange(
-                0, 1, self._n_max + 1, dtype=np.int8 if self._n_max < 2**6 else int
-            )
-        else:
+        if self._n_max is None:
             self._n_max = FOCK_MAX
-            local_states = None
+        local_states = StaticRange(
+            0, 1, self._n_max + 1, dtype=np.int8 if self._n_max < 2**6 else int
+        )
 
         super().__init__(local_states, N, constraint=constraint)
 

--- a/netket/hilbert/fock.py
+++ b/netket/hilbert/fock.py
@@ -167,4 +167,4 @@ class Fock(HomogeneousHilbert):
 
     @property
     def _attrs(self):
-        return (self.size, self._n_max, self.n_particles)
+        return (self.size, self._n_max, self.constraint)

--- a/netket/hilbert/fock.py
+++ b/netket/hilbert/fock.py
@@ -119,7 +119,7 @@ class Fock(HomogeneousHilbert):
         return self._n_particles
 
     def __pow__(self, n) -> "Fock":
-        if self.n_particles is None:
+        if not self.constrained:
             return Fock(self.n_max, self.size * n)
 
         return NotImplemented
@@ -127,7 +127,7 @@ class Fock(HomogeneousHilbert):
     def _mul_sametype_(self, other: "Fock") -> "Fock":
         assert type(self) == type(other)
         if self.n_max == other.n_max:
-            if self._n_particles is None and other._n_particles is None:
+            if not self.constrained and not other.constrained:
                 return Fock(self.n_max, N=self.size + other.size)
 
         return NotImplemented
@@ -142,7 +142,7 @@ class Fock(HomogeneousHilbert):
                     f"Site {site} not in this hilbert space of site {self.size}"
                 )
 
-        if self.n_particles is not None:
+        if self.constrained:
             raise TypeError(
                 "Cannot take the partial trace with a total particles constraint."
             )
@@ -155,14 +155,16 @@ class Fock(HomogeneousHilbert):
             return Fock(self.n_max, N=self.size - Nsites)
 
     def __repr__(self):
-        n_particles = (
-            f", n_particles={self._n_particles}"
-            if self._n_particles is not None
-            else ""
-        )
+        if self.n_particles is not None:
+            constraint = f", n_particles={self.n_particles}"
+        elif self.constrained:
+            constraint = f", {self._constraint}"
+        else:
+            constraint = ""
+
         nmax = self._n_max if self._n_max < FOCK_MAX else "FOCK_MAX"
-        return f"Fock(n_max={nmax}{n_particles}, N={self.size})"
+        return f"Fock(n_max={nmax}{constraint}, N={self.size})"
 
     @property
     def _attrs(self):
-        return (self.size, self._n_max, self._n_particles)
+        return (self.size, self._n_max, self.n_particles)

--- a/netket/hilbert/fock.py
+++ b/netket/hilbert/fock.py
@@ -19,7 +19,7 @@ import numpy as np
 from netket.utils import StaticRange
 
 from .homogeneous import HomogeneousHilbert
-from .index.constraints import SumConstraint
+from .constraint import DiscreteHilbertConstraint, SumConstraint
 
 FOCK_MAX = np.iinfo(np.intp).max - 1
 """
@@ -37,6 +37,7 @@ class Fock(HomogeneousHilbert):
         n_max: int | None = None,
         N: int = 1,
         n_particles: int | None = None,
+        constraint: DiscreteHilbertConstraint | None = None,
     ):
         r"""
         Constructs a new ``Boson`` given a maximum occupation number, number of sites
@@ -48,6 +49,9 @@ class Fock(HomogeneousHilbert):
           N: number of bosonic modes (default = 1)
           n_particles: Constraint for the number of particles. If None, no constraint
             is imposed.
+          constraint: A custom constraint on the allowed configurations. This argument
+            cannot be specified at the same time as :code:`n_particles`. The constraint
+            must be a subclass of :class:`~netket.hilbert.DiscreteHilbertConstraint`
 
         Examples:
            Simple boson hilbert space.
@@ -66,6 +70,11 @@ class Fock(HomogeneousHilbert):
                 raise TypeError(
                     f"n_particles must be an integer. Got {n_particles} ({type(n_particles)})"
                 )
+            if constraint is not None:
+                raise ValueError(
+                    "Cannot specify at the same time a total magnetization "
+                    "constraint and a `custom_constraint."
+                )
 
             n_particles = int(n_particles)
             if n_particles < 0:
@@ -82,9 +91,8 @@ class Fock(HomogeneousHilbert):
                         """The required total number of bosons is not compatible
                         with the given n_max."""
                     )
-            constraints = SumConstraint(n_particles)
+            constraint = SumConstraint(n_particles)
         else:
-            constraints = None
             self._n_particles = None
 
         if self._n_max is not None:
@@ -96,7 +104,7 @@ class Fock(HomogeneousHilbert):
             self._n_max = FOCK_MAX
             local_states = None
 
-        super().__init__(local_states, N, constraints)
+        super().__init__(local_states, N, constraint=constraint)
 
     @property
     def n_max(self) -> int | None:

--- a/netket/hilbert/homogeneous.py
+++ b/netket/hilbert/homogeneous.py
@@ -68,7 +68,7 @@ def check_and_deprecate_constraint(
         hash(constraint)
         constraint == constraint
 
-    except RuntimeError as err:
+    except Exception as err:
         raise UnhashableConstraintError(constraint) from err
 
     return constraint

--- a/netket/hilbert/homogeneous.py
+++ b/netket/hilbert/homogeneous.py
@@ -128,14 +128,9 @@ class HomogeneousHilbert(DiscreteHilbert):
         if not (isinstance(local_states, StaticRange) or local_states is None):
             raise TypeError("local_states must be a StaticRange.")
 
-        self._is_finite = local_states is not None
-
-        if self._is_finite:
-            self._local_states = local_states
-            self._local_size = len(local_states)
-        else:
-            self._local_states = None
-            self._local_size = np.iinfo(np.intp).max
+        self._local_states = local_states
+        self._local_size = len(local_states)
+        self._is_finite = self._local_size < np.iinfo(np.intp).max
 
         self._constraint = check_and_deprecate_constraint(constraint, constraint_fn)
 

--- a/netket/hilbert/homogeneous.py
+++ b/netket/hilbert/homogeneous.py
@@ -16,19 +16,62 @@ from collections.abc import Callable
 
 import numpy as np
 
+import jax
 import jax.numpy as jnp
 
 from equinox import error_if
 
-from netket.utils import StaticRange
+from netket.errors import InvalidConstraintInterface
+from netket.utils import StaticRange, warn_deprecation
 from netket.utils.types import Array
 
 from .discrete_hilbert import DiscreteHilbert
+from .constraint import DiscreteHilbertConstraint
 from .index import (
     HilbertIndex,
     UniformTensorProductHilbertIndex,
     optimalConstrainedHilbertindex,
 )
+
+
+def check_and_deprecate_constraint(
+    constraint,
+    constraint_fn,
+):
+    __tracebackhide__ = True
+
+    if constraint is not None and constraint_fn is not None:
+        raise ValueError(
+            "Cannot specify at the same time `constraint` and `constraint_fn`, which"
+            "has been deprecated. Please remove the latter."
+        )
+    elif constraint_fn is not None and constraint is None:
+        constraint = constraint_fn
+        warn_deprecation(
+            "The keyword argument `constraint_fn` was renamed to `constraint` and "
+            "deprecated. Moreover, you can no longer pass a function, but must specify a class "
+            "according to the documentation."
+        )
+
+    if constraint is None:
+        return constraint
+
+    # now
+    if not isinstance(constraint, DiscreteHilbertConstraint):
+        raise InvalidConstraintInterface()
+
+    # Check that the constraint is well behaved and is jax-friendly hashable
+    try:
+        leaves, struct = jax.tree_util.tree_flatten(constraint)
+        assert len(leaves) == 0
+
+    except TypeError as err:
+        raise TypeError(
+            f"class {type(constraint)} is not hashable. Please define the __hash___ method.\n"
+            "\nThis error was originated from\n"
+        ) from err
+
+    return constraint
 
 
 class HomogeneousHilbert(DiscreteHilbert):
@@ -58,6 +101,8 @@ class HomogeneousHilbert(DiscreteHilbert):
         self,
         local_states: StaticRange | None,
         N: int = 1,
+        *,
+        constraint: DiscreteHilbertConstraint | None = None,
         constraint_fn: Callable | None = None,
     ):
         r"""
@@ -72,9 +117,11 @@ class HomogeneousHilbert(DiscreteHilbert):
                 numbers used to encode the local degree of freedom of this Hilbert
                 Space.
             N: Number of modes in this hilbert space (default 1).
-            constraint_fn: A function specifying constraints on the quantum numbers.
+            constraint: A callable class specifying constraints on the quantum numbers.
                 Given a batch of quantum numbers it should return a vector of bools
-                specifying whether those states are valid or not.
+                specifying whether those states are valid or not. It must be an
+                hashable subclass of :class:`netket.hilbert.DiscreteHilbertConstraint`.
+
         """
         assert isinstance(N, int)
 
@@ -90,7 +137,7 @@ class HomogeneousHilbert(DiscreteHilbert):
             self._local_states = None
             self._local_size = np.iinfo(np.intp).max
 
-        self._constraint_fn = constraint_fn
+        self._constraint = check_and_deprecate_constraint(constraint, constraint_fn)
 
         self._hilbert_index_ = None
 
@@ -120,6 +167,10 @@ class HomogeneousHilbert(DiscreteHilbert):
 
     def states_at_index(self, i: int):
         return self.local_states
+
+    @property
+    def constraint(self):
+        return self._constraint
 
     @property
     def n_states(self) -> int:
@@ -190,7 +241,7 @@ class HomogeneousHilbert(DiscreteHilbert):
         Typically, objects defined in the constrained space cannot be
         converted to QuTiP or other formats.
         """
-        return self._constraint_fn is not None
+        return self.constraint is not None
 
     def _numbers_to_states(self, numbers: np.ndarray) -> np.ndarray:
         return self._hilbert_index.numbers_to_states(numbers)
@@ -215,7 +266,7 @@ class HomogeneousHilbert(DiscreteHilbert):
         if self.constrained:
             states = error_if(
                 states,
-                ~self._constraint_fn(states).all(),
+                ~self.constraint(states).all(),
                 "States do not fulfill constraint.",
             )
 
@@ -248,7 +299,7 @@ class HomogeneousHilbert(DiscreteHilbert):
                 index = UniformTensorProductHilbertIndex(self._local_states, self.size)
             else:
                 index = optimalConstrainedHilbertindex(
-                    self._local_states, self.size, self._constraint_fn
+                    self._local_states, self.size, self.constraint
                 )
             self._hilbert_index_ = index
         return self._hilbert_index_
@@ -273,5 +324,5 @@ class HomogeneousHilbert(DiscreteHilbert):
             self.local_size,
             self._local_states,
             self.constrained,
-            self._constraint_fn,
+            self._constraint,
         )

--- a/netket/hilbert/homogeneous.py
+++ b/netket/hilbert/homogeneous.py
@@ -21,7 +21,7 @@ import jax.numpy as jnp
 
 from equinox import error_if
 
-from netket.errors import InvalidConstraintInterface
+from netket.errors import InvalidConstraintInterface, UnhashableConstraintError
 from netket.utils import StaticRange, warn_deprecation
 from netket.utils.types import Array
 
@@ -64,12 +64,11 @@ def check_and_deprecate_constraint(
     try:
         leaves, struct = jax.tree_util.tree_flatten(constraint)
         assert len(leaves) == 0
+        hash(constraint)
+        constraint == constraint
 
     except TypeError as err:
-        raise TypeError(
-            f"class {type(constraint)} is not hashable. Please define the __hash___ method.\n"
-            "\nThis error was originated from\n"
-        ) from err
+        raise UnhashableConstraintError(constraint) from err
 
     return constraint
 
@@ -120,7 +119,7 @@ class HomogeneousHilbert(DiscreteHilbert):
             constraint: A callable class specifying constraints on the quantum numbers.
                 Given a batch of quantum numbers it should return a vector of bools
                 specifying whether those states are valid or not. It must be an
-                hashable subclass of :class:`netket.hilbert.DiscreteHilbertConstraint`.
+                hashable subclass of :class:`netket.hilbert.constraint.DiscreteHilbertConstraint`.
 
         """
         assert isinstance(N, int)

--- a/netket/hilbert/homogeneous.py
+++ b/netket/hilbert/homogeneous.py
@@ -63,11 +63,12 @@ def check_and_deprecate_constraint(
     # Check that the constraint is well behaved and is jax-friendly hashable
     try:
         leaves, struct = jax.tree_util.tree_flatten(constraint)
-        assert len(leaves) == 0
+        if not len(leaves) == 0:
+            raise TypeError
         hash(constraint)
         constraint == constraint
 
-    except TypeError as err:
+    except RuntimeError as err:
         raise UnhashableConstraintError(constraint) from err
 
     return constraint

--- a/netket/hilbert/index/__init__.py
+++ b/netket/hilbert/index/__init__.py
@@ -30,6 +30,6 @@ defined in the file `base.py`.
 """
 
 from .base import HilbertIndex, is_indexable, max_states
-from .constraints import ConstrainedHilbertIndex, optimalConstrainedHilbertindex
+from .constrained_generic import ConstrainedHilbertIndex, optimalConstrainedHilbertindex
 from .unconstrained import LookupTableHilbertIndex
 from .uniform_tensor import UniformTensorProductHilbertIndex

--- a/netket/hilbert/index/__init__.py
+++ b/netket/hilbert/index/__init__.py
@@ -34,3 +34,8 @@ from .unconstrained import LookupTableHilbertIndex
 from .uniform_tensor import UniformTensorProductHilbertIndex
 from .constrained_generic import ConstrainedHilbertIndex, optimalConstrainedHilbertindex
 from .constrained_sum import SumConstrainedHilbertIndex
+
+
+from netket.utils import _hide_submodules
+
+_hide_submodules(__name__)

--- a/netket/hilbert/index/__init__.py
+++ b/netket/hilbert/index/__init__.py
@@ -30,6 +30,7 @@ defined in the file `base.py`.
 """
 
 from .base import HilbertIndex, is_indexable, max_states
-from .constrained_generic import ConstrainedHilbertIndex, optimalConstrainedHilbertindex
 from .unconstrained import LookupTableHilbertIndex
 from .uniform_tensor import UniformTensorProductHilbertIndex
+from .constrained_generic import ConstrainedHilbertIndex, optimalConstrainedHilbertindex
+from .constrained_sum import SumConstrainedHilbertIndex

--- a/netket/hilbert/index/constrained_sum.py
+++ b/netket/hilbert/index/constrained_sum.py
@@ -8,15 +8,12 @@ import jax.numpy as jnp
 from netket.utils import struct, StaticRange
 from netket.utils.types import Array
 
-from netket.hilbert.constraint import (
-    optimalConstrainedHilbertindex,
-    ConstrainedHilbertIndex,
-    SumConstraint,
-)
+from netket.hilbert.constraint import SumConstraint
 
 from .base import HilbertIndex, is_indexable
 from .uniform_tensor import UniformTensorProductHilbertIndex
 from .unconstrained import LookupTableHilbertIndex
+from .constrained_generic import ConstrainedHilbertIndex, optimalConstrainedHilbertindex
 
 
 @optimalConstrainedHilbertindex.dispatch

--- a/netket/hilbert/index/constrained_sum.py
+++ b/netket/hilbert/index/constrained_sum.py
@@ -6,29 +6,17 @@ import jax
 import jax.numpy as jnp
 
 from netket.utils import struct, StaticRange
-from netket.utils.types import Scalar, Array
+from netket.utils.types import Array
 
-from ..base import HilbertIndex, is_indexable
-from ..unconstrained import LookupTableHilbertIndex
-from ..uniform_tensor import UniformTensorProductHilbertIndex
+from netket.hilbert.constraint import (
+    optimalConstrainedHilbertindex,
+    ConstrainedHilbertIndex,
+    SumConstraint,
+)
 
-from .base import optimalConstrainedHilbertindex, ConstrainedHilbertIndex
-
-
-@struct.dataclass
-class SumConstraint:
-    """
-    Constraint of an Hilbert space enforcing a total sum of all the values in the degrees of freedom.
-
-    Constructed by specifying the total sum. For Fock-like spaces this is the total population,
-    while for Spin-like spaces this is the magnetisation.
-    """
-
-    sum_value: Scalar = struct.field(pytree_node=False)
-
-    @jax.jit
-    def __call__(self, x: Array) -> Array:
-        return x.sum(axis=1) == self.sum_value
+from .base import HilbertIndex, is_indexable
+from .uniform_tensor import UniformTensorProductHilbertIndex
+from .unconstrained import LookupTableHilbertIndex
 
 
 @optimalConstrainedHilbertindex.dispatch

--- a/netket/hilbert/index/constraints/__init__.py
+++ b/netket/hilbert/index/constraints/__init__.py
@@ -1,2 +1,0 @@
-from .base import optimalConstrainedHilbertindex, ConstrainedHilbertIndex
-from .sum import SumConstraint

--- a/netket/hilbert/random/__init__.py
+++ b/netket/hilbert/random/__init__.py
@@ -69,7 +69,7 @@ def flip_state_batch(hilb: Fock, key, σ, idx):
 
 from netket.utils import _hide_submodules
 
-from . import custom, doubled, fock, qubit, spin, tensor_hilbert, particle
+from . import custom, doubled, homogeneous, fock, qubit, spin, tensor_hilbert, particle
 from .base import flip_state, random_state
 
 _hide_submodules(__name__)

--- a/netket/hilbert/random/fock.py
+++ b/netket/hilbert/random/fock.py
@@ -16,21 +16,23 @@ import jax
 from jax import numpy as jnp
 
 from netket.hilbert import Fock
-from netket.hilbert.spin import SumConstraint
 
 from netket.utils.dispatch import dispatch
 
 from functools import partial
 
 
-@dispatch
-@partial(jax.jit, static_argnames=("hilb", "batches", "dtype"))
-def random_state(  # noqa: F811
-    hilb: Fock, constraint: SumConstraint, key, batches: int, *, dtype=None
-):
-    return _random_states_with_constraint_fock(
-        hilb.n_particles, hilb.shape, key, (batches,), dtype
-    )
+# No longer implemented. See the generic implementation in
+# homogeneous.py
+#
+# @dispatch
+# @partial(jax.jit, static_argnames=("hilb", "batches", "dtype"))
+# def random_state(  # noqa: F811
+#    hilb: Fock, constraint: SumConstraint, key, batches: int, *, dtype=None
+# ):
+#    return _random_states_with_constraint_fock(
+#        hilb.n_particles, hilb.shape, key, (batches,), dtype
+#    )
 
 
 def _choice(key, p):

--- a/netket/hilbert/random/fock.py
+++ b/netket/hilbert/random/fock.py
@@ -13,32 +13,41 @@
 # limitations under the License.
 
 import jax
-import numpy as np
 from jax import numpy as jnp
 
 from netket.hilbert import Fock
+from netket.hilbert.spin import SumConstraint
+
 from netket.utils.dispatch import dispatch
 
 from functools import partial
 
 
 @dispatch
-def random_state(hilb: Fock, key, batches: int, *, dtype=np.float32):
-    shape = (batches,)
-
-    # If unconstrained space, use fast sampling
-    if hilb.n_particles is None:
-        return _random_states_unconstrained(hilb, key, shape, dtype)
-    else:
-        return _random_states_with_constraint(hilb, key, shape, dtype)
-
-
-@partial(jax.jit, static_argnames=("hilb", "shape", "dtype"))
-def _random_states_unconstrained(hilb, key, shape, dtype):
+@partial(jax.jit, static_argnames=("hilb", "batches", "dtype"))
+def random_state(  # noqa: F811
+    hilb: Fock, constraint: None, key, batches: int, *, dtype=None
+):
     assert hilb.n_particles is None
     return jax.random.randint(
-        key, shape=shape + (hilb.size,), minval=0, maxval=hilb.n_max + 1
+        key,
+        shape=(
+            batches,
+            hilb.size,
+        ),
+        minval=0,
+        maxval=hilb.n_max + 1,
     ).astype(dtype)
+
+
+@dispatch
+@partial(jax.jit, static_argnames=("hilb", "batches", "dtype"))
+def random_state(  # noqa: F811
+    hilb: Fock, constraint: SumConstraint, key, batches: int, *, dtype=None
+):
+    return _random_states_with_constraint_fock(
+        hilb.n_particles, hilb.shape, key, (batches,), dtype
+    )
 
 
 def _choice(key, p):
@@ -118,15 +127,8 @@ def _random_states_with_constraint_fock(n_particles, hilb_shape, key, shape, dty
     return jax.lax.scan(body_fun, init, keys)[0]
 
 
-@partial(jax.jit, static_argnames=("hilb", "shape", "dtype"))
-def _random_states_with_constraint(hilb, key, shape, dtype):
-    return _random_states_with_constraint_fock(
-        hilb.n_particles, hilb.shape, key, shape, dtype
-    )
-
-
 @dispatch
-def flip_state_scalar(hilb: Fock, key, σ, idx):
+def flip_state_scalar(hilb: Fock, key, σ, idx):  # noqa: F811
     if hilb._n_max == 0:
         return σ, σ[idx]
 

--- a/netket/hilbert/random/fock.py
+++ b/netket/hilbert/random/fock.py
@@ -26,23 +26,6 @@ from functools import partial
 @dispatch
 @partial(jax.jit, static_argnames=("hilb", "batches", "dtype"))
 def random_state(  # noqa: F811
-    hilb: Fock, constraint: None, key, batches: int, *, dtype=None
-):
-    assert hilb.n_particles is None
-    return jax.random.randint(
-        key,
-        shape=(
-            batches,
-            hilb.size,
-        ),
-        minval=0,
-        maxval=hilb.n_max + 1,
-    ).astype(dtype)
-
-
-@dispatch
-@partial(jax.jit, static_argnames=("hilb", "batches", "dtype"))
-def random_state(  # noqa: F811
     hilb: Fock, constraint: SumConstraint, key, batches: int, *, dtype=None
 ):
     return _random_states_with_constraint_fock(

--- a/netket/hilbert/random/homogeneous.py
+++ b/netket/hilbert/random/homogeneous.py
@@ -42,8 +42,8 @@ def random_state(  # noqa: F811
     x_ids = jax.random.randint(
         key, shape=(batches, hilb.size), minval=0, maxval=len(hilb._local_states)
     )
-    return hilb.local_indices_to_states(x_ids).astype(dtype)
-
+    res = hilb.local_indices_to_states(x_ids, dtype=dtype)
+    return res
 
 
 @dispatch
@@ -59,7 +59,6 @@ def random_state(  # noqa: F811
     local_states = hilb._local_states
     if dtype is None:
         dtype = hilb._local_states.dtype
-    print("here")
 
     # Convert total constraint to Fock-like total number of excitations
     n_excitations = (
@@ -69,7 +68,7 @@ def random_state(  # noqa: F811
     samples_indx = _random_states_with_constraint_fock(
         n_excitations, hilb.shape, key, (batches,), dtype
     )
-    return hilb.local_indices_to_states(samples_indx)
+    return hilb.local_indices_to_states(samples_indx, dtype=dtype)
 
 
 @dispatch

--- a/netket/hilbert/random/homogeneous.py
+++ b/netket/hilbert/random/homogeneous.py
@@ -43,6 +43,7 @@ def random_state(  # noqa: F811
 
 
 @dispatch
+@partial(jax.jit, static_argnames=("hilb", "batches", "dtype"))
 def random_state(  # noqa: F811
     hilb: HomogeneousHilbert, constraint, key, batches: int, *, dtype=None
 ):

--- a/netket/hilbert/random/homogeneous.py
+++ b/netket/hilbert/random/homogeneous.py
@@ -18,6 +18,7 @@ import warnings
 import jax
 import jax.numpy as jnp
 
+from netket import config
 from netket.errors import UnoptimisedCustomConstraintRandomStateMethodWarning
 from netket.hilbert import HomogeneousHilbert
 from netket.utils.dispatch import dispatch
@@ -76,7 +77,10 @@ def random_state(  # noqa: F811
 def random_state(  # noqa: F811
     hilb: HomogeneousHilbert, constraint, key, batches: int, *, dtype=None
 ):
-    warnings.warn(UnoptimisedCustomConstraintRandomStateMethodWarning(hilb, constraint))
+    if config.netket_random_state_fallback_warning:
+        warnings.warn(
+            UnoptimisedCustomConstraintRandomStateMethodWarning(hilb, constraint)
+        )
 
     keys = jax.random.split(key, batches + 1)
     states = random_state(hilb, None, keys[0], batches, dtype=dtype)

--- a/netket/hilbert/random/homogeneous.py
+++ b/netket/hilbert/random/homogeneous.py
@@ -1,0 +1,67 @@
+# Copyright 2021 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import partial
+import warnings
+
+import jax
+import jax.numpy as jnp
+
+from netket.errors import UnoptimisedCustomConstraintRandomStateMethodWarning
+from netket.hilbert import HomogeneousHilbert
+from netket.utils.dispatch import dispatch
+
+
+@dispatch
+def random_state(hilb: HomogeneousHilbert, key, batches: int, *, dtype=None):
+    return random_state(hilb, hilb.constraint, key, batches, dtype=dtype)
+
+
+@dispatch
+@partial(jax.jit, static_argnames=("hilb", "batches", "dtype"))
+def random_state(  # noqa: F811
+    hilb: HomogeneousHilbert, constraint: None, key, batches: int, *, dtype=None
+):
+    if dtype is None:
+        dtype = hilb._local_states.dtype
+
+    x_ids = jax.random.randint(
+        key, shape=(batches, hilb.size), minval=0, maxval=len(hilb._local_states)
+    )
+    return hilb.local_indices_to_states(x_ids)
+
+
+@dispatch
+def random_state(  # noqa: F811
+    hilb: HomogeneousHilbert, constraint, key, batches: int, *, dtype=None
+):
+    warnings.warn(UnoptimisedCustomConstraintRandomStateMethodWarning(hilb, constraint))
+
+    keys = jax.random.split(key, batches + 1)
+    states = random_state(hilb, None, keys[0], batches, dtype=dtype)
+
+    def _loop_until_ok(state, key):
+        def __body(args):
+            state, _key = args
+            _key, subkey = jax.random.split(_key)
+            new_state = random_state(hilb, None, subkey, 1, dtype=dtype)[0]
+            return (new_state, _key)
+
+        def __cond(args):
+            state, _ = args
+            return jnp.logical_not(constraint(state))
+
+        return jax.lax.while_loop(__cond, __body, (state, key))[0]
+
+    return jax.vmap(_loop_until_ok, in_axes=(0, 0))(states, keys[1:])

--- a/netket/hilbert/random/homogeneous.py
+++ b/netket/hilbert/random/homogeneous.py
@@ -39,7 +39,8 @@ def random_state(  # noqa: F811
     x_ids = jax.random.randint(
         key, shape=(batches, hilb.size), minval=0, maxval=len(hilb._local_states)
     )
-    return hilb.local_indices_to_states(x_ids)
+    return hilb.local_indices_to_states(x_ids).astype(dtype)
+
 
 
 @dispatch

--- a/netket/hilbert/random/spin.py
+++ b/netket/hilbert/random/spin.py
@@ -13,42 +13,9 @@
 # limitations under the License.
 
 import jax
-from functools import partial
 
 from netket.hilbert import Spin
-from netket.hilbert.spin import SumConstraint
 from netket.utils.dispatch import dispatch
-
-from .fock import _random_states_with_constraint_fock
-
-
-@dispatch
-@partial(jax.jit, static_argnames=("hilb", "batches", "dtype"))
-def random_state(  # noqa: F811
-    hilb: Spin,
-    constraint: SumConstraint,
-    key,
-    batches: int,
-    *,
-    dtype=None,
-):
-    # Generate random spin states with a given hilb._total_sz.
-    # Note that this is NOT a uniform distribution over the
-    # basis states of the constrained hilbert space.
-    two_times_s = round(2 * hilb._s)
-    two_times_total_sz = round(2 * hilb._total_sz)
-    n_particles = _spin_to_fock(two_times_s * hilb.size, two_times_total_sz)
-    x_fock = _random_states_with_constraint_fock(
-        n_particles, hilb.shape, key, (batches,), dtype
-    )
-    return _fock_to_spin(two_times_s, x_fock).astype(dtype)
-
-
-# For the implementations of constrained spaces, we use those found inside of
-# fock.py, and simply convert the spin values (-1, 1) to fock values (0,1, ...).
-
-_spin_to_fock = lambda two_times_s, x: (two_times_s + x) // 2
-_fock_to_spin = lambda two_times_s, x: 2 * x - two_times_s
 
 
 @dispatch

--- a/netket/hilbert/random/spin.py
+++ b/netket/hilbert/random/spin.py
@@ -13,42 +13,39 @@
 # limitations under the License.
 
 import jax
-import numpy as np
 from functools import partial
 
 from netket.hilbert import Spin
+from netket.hilbert.spin import SumConstraint
 from netket.utils.dispatch import dispatch
 
 from .fock import _random_states_with_constraint_fock
 
 
 @dispatch
-def random_state(hilb: Spin, key, batches: int, *, dtype=np.float32):
-    shape = (batches,)
-    if hilb._total_sz is None:
-        return _random_states_unconstrained(hilb, key, shape, dtype)
-    else:
-        return _random_states_with_constraint(hilb, key, shape, dtype)
-
-
-# For the implementations of constrained spaces, we use those found inside of
-# fock.py, and simply convert the spin values (-1, 1) to fock values (0,1, ...).
-
-_spin_to_fock = lambda two_times_s, x: (two_times_s + x) // 2
-_fock_to_spin = lambda two_times_s, x: 2 * x - two_times_s
-
-
-@partial(jax.jit, static_argnames=("hilb", "shape", "dtype"))
-def _random_states_unconstrained(hilb, key, shape, dtype):
+@partial(jax.jit, static_argnames=("hilb", "batches", "dtype"))
+def random_state(  # noqa: F811
+    hilb: Spin, constraint: None, key, batches: int, *, dtype=None
+):
+    if dtype is None:
+        dtype = hilb._local_states.dtype
     two_times_s = round(2 * hilb._s)
     x_fock = jax.random.randint(
-        key, shape=shape + (hilb.size,), minval=0, maxval=two_times_s + 1
+        key, shape=(batches, hilb.size), minval=0, maxval=two_times_s + 1
     )
     return _fock_to_spin(two_times_s, x_fock).astype(dtype)
 
 
-@partial(jax.jit, static_argnames=("hilb", "shape", "dtype"))
-def _random_states_with_constraint(hilb, key, shape, dtype):
+@dispatch
+@partial(jax.jit, static_argnames=("hilb", "batches", "dtype"))
+def random_state(  # noqa: F811
+    hilb: Spin,
+    constraint: SumConstraint,
+    key,
+    batches: int,
+    *,
+    dtype=None,
+):
     # Generate random spin states with a given hilb._total_sz.
     # Note that this is NOT a uniform distribution over the
     # basis states of the constrained hilbert space.
@@ -56,9 +53,16 @@ def _random_states_with_constraint(hilb, key, shape, dtype):
     two_times_total_sz = round(2 * hilb._total_sz)
     n_particles = _spin_to_fock(two_times_s * hilb.size, two_times_total_sz)
     x_fock = _random_states_with_constraint_fock(
-        n_particles, hilb.shape, key, shape, dtype
+        n_particles, hilb.shape, key, (batches,), dtype
     )
     return _fock_to_spin(two_times_s, x_fock).astype(dtype)
+
+
+# For the implementations of constrained spaces, we use those found inside of
+# fock.py, and simply convert the spin values (-1, 1) to fock values (0,1, ...).
+
+_spin_to_fock = lambda two_times_s, x: (two_times_s + x) // 2
+_fock_to_spin = lambda two_times_s, x: 2 * x - two_times_s
 
 
 @dispatch

--- a/netket/hilbert/random/spin.py
+++ b/netket/hilbert/random/spin.py
@@ -25,20 +25,6 @@ from .fock import _random_states_with_constraint_fock
 @dispatch
 @partial(jax.jit, static_argnames=("hilb", "batches", "dtype"))
 def random_state(  # noqa: F811
-    hilb: Spin, constraint: None, key, batches: int, *, dtype=None
-):
-    if dtype is None:
-        dtype = hilb._local_states.dtype
-    two_times_s = round(2 * hilb._s)
-    x_fock = jax.random.randint(
-        key, shape=(batches, hilb.size), minval=0, maxval=two_times_s + 1
-    )
-    return _fock_to_spin(two_times_s, x_fock).astype(dtype)
-
-
-@dispatch
-@partial(jax.jit, static_argnames=("hilb", "batches", "dtype"))
-def random_state(  # noqa: F811
     hilb: Spin,
     constraint: SumConstraint,
     key,

--- a/netket/hilbert/spin.py
+++ b/netket/hilbert/spin.py
@@ -148,4 +148,4 @@ class Spin(HomogeneousHilbert):
 
     @property
     def _attrs(self):
-        return (self.size, self._s, self._total_sz)
+        return (self.size, self._s, self.constraint)

--- a/netket/hilbert/spin.py
+++ b/netket/hilbert/spin.py
@@ -20,8 +20,7 @@ import numpy as np
 from netket.utils import StaticRange
 
 from .homogeneous import HomogeneousHilbert
-
-from .index.constraints import SumConstraint
+from .constraint import DiscreteHilbertConstraint, SumConstraint
 
 
 def _check_total_sz(total_sz, S, size):
@@ -59,7 +58,9 @@ class Spin(HomogeneousHilbert):
         self,
         s: float,
         N: int = 1,
+        *,
         total_sz: float | None = None,
+        constraint: DiscreteHilbertConstraint | None = None,
     ):
         r"""Hilbert space obtained as tensor product of local spin states.
 
@@ -68,6 +69,9 @@ class Spin(HomogeneousHilbert):
            N: Number of sites (default=1)
            total_sz: If given, constrains the total spin of system to a particular
                 value.
+          constraint: A custom constraint on the allowed configurations. This argument
+                cannot be specified at the same time as :code:`total_sz`. The constraint
+                must be a subclass of :class:`~netket.hilbert.DiscreteHilbertConstraint`.
 
         Examples:
            Simple spin hilbert space.
@@ -87,14 +91,17 @@ class Spin(HomogeneousHilbert):
 
         _check_total_sz(total_sz, s, N)
         if total_sz is not None:
-            constraints = SumConstraint(round(2 * total_sz))
-        else:
-            constraints = None
+            if constraint is not None:
+                raise ValueError(
+                    "Cannot specify at the same time a total magnetization "
+                    "constraint and a `custom_constraint."
+                )
+            constraint = SumConstraint(round(2 * total_sz))
 
         self._total_sz = total_sz
         self._s = s
 
-        super().__init__(local_states, N, constraints)
+        super().__init__(local_states, N, constraint=constraint)
 
     def __pow__(self, n):
         if not self.constrained:
@@ -120,10 +127,8 @@ class Spin(HomogeneousHilbert):
                     f"Site {site} not in this hilbert space of site {self.size}"
                 )
 
-        if self._total_sz is not None:
-            raise TypeError(
-                "Cannot take the partial trace with a total magnetization constraint."
-            )
+        if self.constrained:
+            raise TypeError("Cannot take the partial trace with a constraint.")
 
         Nsites = len(sites)
 
@@ -133,8 +138,13 @@ class Spin(HomogeneousHilbert):
             return Spin(s=self._s, N=self.size - Nsites)
 
     def __repr__(self):
-        total_sz = f", total_sz={self._total_sz}" if self._total_sz is not None else ""
-        return f"Spin(s={Fraction(self._s)}{total_sz}, N={self.size})"
+        if self._total_sz is not None:
+            constraint = f", total_sz={self._total_sz}"
+        elif self.constrained:
+            constraint = f", {self._constraint}"
+        else:
+            constraint = ""
+        return f"Spin(s={Fraction(self._s)}, N={self.size}{constraint})"
 
     @property
     def _attrs(self):

--- a/netket/utils/config_flags.py
+++ b/netket/utils/config_flags.py
@@ -391,3 +391,18 @@ config.define(
         """
     ),
 )
+
+
+config.define(
+    "NETKET_RANDOM_STATE_FALLBACK_WARNING",
+    bool,
+    default=True,
+    runtime=True,
+    help=dedent(
+        """
+        Print a warning every time you use a fallback that could never stop running
+        when using random_state of constrained hilbert spaces with custom
+        constraints.
+        """
+    ),
+)

--- a/test/hilbert/test_custom_constraint.py
+++ b/test/hilbert/test_custom_constraint.py
@@ -106,11 +106,16 @@ def test_hilbert_extra_constraint():
     assert isinstance(hi * hi, nk.hilbert.TensorHilbert)
     with pytest.raises(TypeError):
         _ = hi**2
+    assert hi == nk.hilbert.Spin(0.5, 4, total_sz=0.0)
+    assert isinstance(repr(hi), str)
 
+    c = nk.hilbert.constraint.SumConstraint(1)
     hi = nk.hilbert.Fock(2, 4, constraint=c)
     assert isinstance(hi * hi, nk.hilbert.TensorHilbert)
     with pytest.raises(TypeError):
         _ = hi**2
+    assert hi == nk.hilbert.Fock(2, 4, n_particles=1)
+    assert isinstance(repr(hi), str)
 
     with pytest.raises(ValueError):
         nk.hilbert.Spin(0.5, 4, total_sz=0.0, constraint=c)

--- a/test/hilbert/test_custom_constraint.py
+++ b/test/hilbert/test_custom_constraint.py
@@ -54,7 +54,7 @@ def test_extra_constraint():
     assert isinstance(repr(c1), str)
 
 
-def test_extra_constraint_integration():
+def test_extra_constraint_integration(recwarn):
     # Constraint checking that first value is 1
     class CustomConstraintPy(nk.hilbert.constraint.DiscreteHilbertConstraint):
         def __call__(self, x):
@@ -96,8 +96,12 @@ def test_extra_constraint_integration():
 
     with pytest.warns(nk.errors.UnoptimisedCustomConstraintRandomStateMethodWarning):
         ran_states = hi.random_state(jax.random.key(1), 100)
-
     assert np.all(joint_constraint(ran_states))
+
+    nk.config.netket_random_state_fallback_warning = False
+    _ = hi.random_state(jax.random.key(1), 2)
+    assert len(recwarn) == 0, "Warnings were raised during the test"
+    nk.config.netket_random_state_fallback_warning = True
 
 
 def test_hilbert_extra_constraint():

--- a/test/hilbert/test_custom_constraint.py
+++ b/test/hilbert/test_custom_constraint.py
@@ -1,0 +1,68 @@
+# Copyright 2024 The Netket Authors. - All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import netket as nk
+import numpy as np
+
+import jax
+
+from .. import common
+
+pytestmark = common.skipif_distributed
+
+
+def test_extra_constraint():
+
+    # Constraint checking that first value is 1
+    class CustomConstraintPy(nk.hilbert.constraint.DiscreteHilbertConstraint):
+
+        def __call__(self, x):
+            return jax.pure_callback(
+                self._call_py,
+                (jax.ShapeDtypeStruct(x.shape[:-1], bool)),
+                x,
+                vectorized=True,
+            )
+
+        def _call_py(self, x):
+            # Not Jax compatible
+            return x[..., 0] == 1
+
+        def __hash__(self):
+            return hash("CustomConstraintPy")
+
+        def __eq__(self, other):
+            if isinstance(other, CustomConstraintPy):
+                return True
+            return False
+
+        def __repr__(self):
+            return "CustomConstraintPy()"
+
+    base_constraint = nk.hilbert.constraint.SumConstraint(0.0)
+    extra_constraint = CustomConstraintPy()
+    joint_constraint = nk.hilbert.constraint.ExtraConstraint(
+        base_constraint, extra_constraint
+    )
+
+    hi = nk.hilbert.Spin(0.5, 4, constraint=joint_constraint)
+    bare_hi = nk.hilbert.Spin(0.5, 4)
+
+    assert hi.n_states == np.sum(joint_constraint(bare_hi.all_states()))
+    assert np.all(base_constraint(hi.all_states()))
+    assert np.all(extra_constraint(hi.all_states()))
+    assert np.all(joint_constraint(hi.all_states()))
+
+    ran_states = hi.random_state(jax.random.key(1), 100)
+    assert np.all(joint_constraint(ran_states))


### PR DESCRIPTION
This PR greatly simplifies the usage of custom constraints with our Hilbert spaces, and solves some usability issues with them.
See the example:

```python
import jax
import jax.numpy as jnp

import netket as nk
from netket.utils import struct

class SumConstraint(nk.hilbert.constraint.DiscreteHilbertConstraint):
    # A simple constraint checking that the total sum of the elements
    # in the configuration is equal to a given value.

    total_sum : float = struct.field(pytree_node=False)

    def __init__(self, total_sum):
        self.total_sum = total_sum

    def __call__(self, x):
        # Makes it jax-compatible
       return jnp.sum(x, axis=-1) == self.total_sum

    def __hash__(self):
        return hash(("SumConstraint", self.total_sum))

    def __eq__(self, other):
        if isinstance(other, SumConstraint):
            return self.total_sum == other.total_sum
        return False

hi = nk.hilbert.Fock(n_max=2, N=5, constraint=SumConstraint(3))
hi.random_state(jax.random.key(3), 10)
```

Admittedly, the syntax to define a custom constraint is not terse. In the future we might be able to autogenerate the hash and eq methods, but for the moment I would keep it as this. 

A lot of examples and informative errors with examples are added everywhere, so it should be clear how to define those constraints. 

The old constraints will not be supported anymore. They were already unsupported, and did not work with random state generation...

 - A big add of this PR is a method to automatically generate random state within the constrained space. Previously we were always asking users to do it. Instead, in this PR there is an automatic fallback that generates random states from the unconstrained space until he gets one that satisfies the constraint. While inefficient, this is not a problem because in general we just need it to seed the sampler. To be safe, we throw a warning telling users to define their own random state logic because this one might be slow.

 - I also added a special constraint to merge two constraints. This can be used to combine multiple constraints.

The PR also refactors a bit the internal methods defined by @inailuig to make it more accessible to external users. 

I also deprecated `CustomHilbert`. It was not really playing out nicely with everything else we have, and it's time we kill it. There's not really any need for it anymore now. Fock + custom constraints should be enough for every use case.

