### PR TITLE
Modify finite/infinite Fock spaces

### DIFF
--- a/netket/hilbert/fock.py
+++ b/netket/hilbert/fock.py
@@ -87,14 +87,11 @@ class Fock(HomogeneousHilbert):
             constraints = None
             self._n_particles = None
 
-        if self._n_max is not None:
-            # assert self._n_max > 0
-            local_states = StaticRange(
-                0, 1, self._n_max + 1, dtype=np.int8 if self._n_max < 2**6 else int
-            )
-        else:
+        if self._n_max is None:
             self._n_max = FOCK_MAX
-            local_states = None
+        local_states = StaticRange(
+            0, 1, self._n_max + 1, dtype=np.int8 if self._n_max < 2**6 else int
+        )
 
         super().__init__(local_states, N, constraints)
 

--- a/netket/hilbert/homogeneous.py
+++ b/netket/hilbert/homogeneous.py
@@ -81,14 +81,9 @@ class HomogeneousHilbert(DiscreteHilbert):
         if not (isinstance(local_states, StaticRange) or local_states is None):
             raise TypeError("local_states must be a StaticRange.")
 
-        self._is_finite = local_states is not None
-
-        if self._is_finite:
-            self._local_states = local_states
-            self._local_size = len(local_states)
-        else:
-            self._local_states = None
-            self._local_size = np.iinfo(np.intp).max
+        self._local_states = local_states
+        self._local_size = len(local_states)
+        self._is_finite = self._local_size < np.iinfo(np.intp).max
 
         self._constraint_fn = constraint_fn
 
@@ -176,6 +171,11 @@ class HomogeneousHilbert(DiscreteHilbert):
     @property
     def is_finite(self) -> bool:
         r"""Whether the local hilbert space is finite."""
+        # De-facto, all Homogeneous Hilbert spaces, as they have internally
+        # a StaticRange, are factually finite. So, even when we say this is
+        # False we are lying because it's technically always Finite...
+        # 
+        # Do we still need this flag?
         return self._is_finite
 
     @property

--- a/netket/hilbert/homogeneous.py
+++ b/netket/hilbert/homogeneous.py
@@ -174,7 +174,7 @@ class HomogeneousHilbert(DiscreteHilbert):
         # De-facto, all Homogeneous Hilbert spaces, as they have internally
         # a StaticRange, are factually finite. So, even when we say this is
         # False we are lying because it's technically always Finite...
-        # 
+        #
         # Do we still need this flag?
         return self._is_finite
 


### PR DESCRIPTION
We always want to have a local_states around. So we create it also for non finite Fock spaces. Now all HomogeneousHilbert are de-facto finite (which was already the case)

Do we still need this flag? I think it's a bit useless...