### PR TITLE
Autogenerate serialisation methods for MetropolisSamplerState (fix #1881)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,17 +11,20 @@
 * Fermionic hilbert spaces {class}`~nk.experimental.hilbert.SpinOrbitalFermions` now support an extra arbitrary constraint that can be specified by passing the keyword argument `constraint=...` [#1832](https://github.com/netket/netket/pull/1832)
 * Support equinox modules as models in Variational states. Note that equinox models by default only work with scalar inputs, while NetKet requires modules that work with batch inputs, so you will have to modify them slightly.
 
-### Changes
+### Breaking Changes
 * Jax operators now use the same `chunk_size` as specified by the user when computing the forward pass. Prior to this change, Jax operators would be chunking the sample axis, but if an operator had a lot of connected elements this would end up increasing the effective sample size [#1875](https://github.com/netket/netket/pull/1875).
 * Metropolis Hamiltonian sampler for numba operators has been greatly simplified in order to remove the dependency on numba4jax. The new implementation will generally be slower than before, so we encourage you to use Jax Operators if possible. In the future, if people ask for it, we may reintroduce this implementation as a separate package [#1747](https://github.com/netket/netket/pull/1747).
 * Previously-internal hilbert space constraint sub-module located at `netket.hilbert.index.constraints` has been moved to `netket.hilbert.constraint` [#1908](https://github.com/netket/netket/pull/1908).
+* Due to improvements to the saving logic, it might no longer be possible to load when using MPI the sampler state saved in previous versions using MPI, as those only contained the sampler state of the rank 0 and it was leading silently to having the same sampler state across all ranks [#1914](https://github.com/netket/netket/pull/1914).
 
 ### Improvements
 * Specialised lattice constructors like {func}`nk.graph.Grid` now accept a `point_group` argument, overriding the default (usually maximal) point groups [#1879](https://github.com/netket/netket/pull/1879).
 * Methods to generate random states are automatically implemented for all {class}`nk.hilbert.HomogeneousHilbert`, constrained or not [#1911](https://github.com/netket/netket/pull/1911).
+* Serialization of metropolis sampler states when using MPI will now serialise the parameters across all MPI ranks, not only rank 0 [#1914](https://github.com/netket/netket/pull/1914).
 
 ### Bug fixes
 * Fix the function {meth}`nk.graph.SpaceGroupBuilder.space_group_irreps` throwing away the imaginary part of point-group characters, which led to incorrect space-group characters in some rare cases [#1876](https://github.com/netket/netket/pull/1876).
+* Fixed bug [#1811](https://github.com/netket/netket/pull/1811), and it is now possible to serialise sampler states that have new-style jax random number generators [#1914](https://github.com/netket/netket/pull/1914).
 
 ### Finalized deprecations
 Some features that have been deprecated for the last ~24 months have been finally removed from NetKet and will now raise errors. If this is a problem for you, you should install an older version of NetKet.

--- a/test/sampler/test_metropolis_serialization.py
+++ b/test/sampler/test_metropolis_serialization.py
@@ -111,3 +111,6 @@ def test_metropolis_serialization(key_type, tmp_path_distributed):
             _σ_all = σ_all[: sa.n_chains].reshape(mpi.n_nodes, -1)
             σ2_all = _allgather(hi.states_to_numbers(sampler_state_2.σ))
             np.testing.assert_allclose(σ2_all, _σ_all)
+
+        # verify that it works
+        sa.samples(ma, pars, state=sampler_state_2)

--- a/test/sampler/test_metropolis_serialization.py
+++ b/test/sampler/test_metropolis_serialization.py
@@ -1,0 +1,113 @@
+# Copyright 2021 The NetKet Authors - All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from jax import numpy as jnp
+from flax import serialization
+from jax.experimental import multihost_utils
+
+import pytest
+import numpy as np
+import jax
+
+import netket as nk
+from netket.utils import mpi
+
+
+nk.config.update("NETKET_EXPERIMENTAL", True)
+np.random.seed(1234)
+
+WEIGHT_SEED = 1234
+SAMPLER_SEED = 15324
+
+
+def _allgather(x):
+    if nk.config.netket_experimental_sharding and jax.process_count() > 1:
+        y = multihost_utils.process_allgather(x)
+    else:
+        y = mpi.mpi_allgather(x)
+    return y
+
+
+@pytest.mark.parametrize("key_type", ["PRNGKey", "key"])
+def test_metropolis_serialization(key_type, tmp_path_distributed):
+    rank = (
+        mpi.rank if not nk.config.netket_experimental_sharding else jax.process_index()
+    )
+    n_nodes = (
+        mpi.n_nodes
+        if not nk.config.netket_experimental_sharding
+        else jax.process_count()
+    )
+    keyT = jax.random.PRNGKey if key_type == "PRNGKey" else jax.random.key
+
+    tmp_file_name = tmp_path_distributed / "data.mpack"
+    print(f"r{rank}/{n_nodes} - saving to: {tmp_file_name}")
+
+    hi = nk.hilbert.Spin(0.5, 10)
+    ma = nk.models.RBM()
+    pars = ma.init(jax.random.key(WEIGHT_SEED), jnp.zeros((5, 10)))
+
+    # 120 = (2**3)* 3 * 5 which are all prime factors reasonable for
+    # a CI test. Doubt anybody using more than 6 nodes in any case...
+    sa = nk.sampler.MetropolisLocal(hi, n_chains=12)
+    sampler_state = sa.init_state(ma, pars, keyT(SAMPLER_SEED))
+    sampler_state = sa.reset(ma, pars, state=sampler_state)
+
+    state_dict = serialization.to_state_dict(sampler_state)
+
+    # if we must do it, we must replicate
+    # if nk.config.netket_experimental_sharding and nk.config.netket_experimental_sharding_fast_serialization:
+    #     def _fun(x):
+    #         if isinstance(x, jax.Array) and not x.is_fully_replicated:
+    #             return jax.lax.with_sharding_constraint(x, x.sharding.replicate())
+    #         return x
+    #     state = jax.tree.map(_fun, state)
+
+    if mpi.rank == 0 and jax.process_index() == 0:
+        bindata = serialization.msgpack_serialize(state_dict)
+        with open(tmp_file_name, "wb") as f:
+            f.write(bindata)
+
+    if mpi.n_nodes > 1:
+        mpi.MPI_py_comm.barrier()
+    elif nk.config.netket_experimental_sharding:
+        multihost_utils.sync_global_devices("ciao")
+
+    # load data
+    with open(tmp_file_name, "rb") as f:
+        bindata = f.read()
+
+    print(_allgather(hi.states_to_numbers(sampler_state.σ)))
+    σ_all = _allgather(hi.states_to_numbers(sampler_state.σ)).reshape(-1)
+
+    # Create another sampler state
+    for n_readout_chains in [12, 8, 6]:
+        print("n_readout_chains: ", n_readout_chains)
+        sa = nk.sampler.MetropolisLocal(hi, n_chains=n_readout_chains)
+        sampler_state_2 = sa.init_state(ma, pars, SAMPLER_SEED + 100)
+
+        state_dict_loaded = serialization.msgpack_restore(bindata)
+        sampler_state_2 = serialization.from_state_dict(
+            sampler_state_2, state_dict_loaded
+        )
+
+        if nk.config.netket_experimental_sharding:
+            assert sampler_state_2.σ.sharding.shape == (len(jax.devices()), 1)
+            assert bool(
+                jnp.all(sampler_state_2.σ == sampler_state.σ[: sa.n_batches, :])
+            )
+        else:
+            _σ_all = σ_all[: sa.n_chains].reshape(mpi.n_nodes, -1)
+            σ2_all = _allgather(hi.states_to_numbers(sampler_state_2.σ))
+            np.testing.assert_allclose(σ2_all, _σ_all)


### PR DESCRIPTION
Fixes #1881 by leveraging the automatic utilities in the Pytree. 

The same should be done for Parallel Tempering, but I will let Linda handle it.

Supersedes #1831 and #1887 

