### PR TITLE
Make constraints more flexible for SpinOrbitalFermions

### DIFF
--- a/netket/experimental/hilbert/spin_orbital_fermions.py
+++ b/netket/experimental/hilbert/spin_orbital_fermions.py
@@ -168,15 +168,16 @@ class SpinOrbitalFermions(HomogeneousHilbert):
                 if n_fermions is not None:
                     occupation_constraint = SumConstraint(n_fermions)
 
-        # Wrap the extra user provided cosntraint around our
-        # occupation constraint of the populations.
-        if constraint is not None:
-            constraint = ExtraConstraint(
-                base_constraint=occupation_constraint,
-                extra_constraint=constraint,
-            )
-        else:
-            constraint = occupation_constraint
+        if occupation_constraint is not None:
+            # Wrap the extra user provided cosntraint around our
+            # occupation constraint of the populations.
+            if constraint is not None:
+                constraint = ExtraConstraint(
+                    base_constraint=occupation_constraint,
+                    extra_constraint=constraint,
+                )
+            else:
+                constraint = occupation_constraint
 
         """Internal representation of this Hilbert space (Fock or TensorHilbert)."""
         # local states are the occupation numbers (0, 1)

--- a/netket/hilbert/constraint/multiple.py
+++ b/netket/hilbert/constraint/multiple.py
@@ -72,15 +72,11 @@ class ExtraConstraint(DiscreteHilbertConstraint):
         ):
             raise TypeError(
                 dedent(
-                    """The type parameters T1, T2 of ExtraConstraint[T1, T2] must be subtypes of
+                    """The arguments of ExtraConstraint must both be subtypes of
                     nk.hilbert.constraint.DiscreteHilbertConstraint, but one or more are not.
 
                     To verify if those are valid type parameters you can check it with
-                    issubclass(T1, nk.hilbert.constraint.DiscreteHilbertConstraint).
-
-                    For more information, look at the documentation of parametric classes in
-                    https://beartype.github.io/plum/parametric.html or open an issue on NetKet's
-                    GitHub discussion session.
+                    issubclass(arg, nk.hilbert.constraint.DiscreteHilbertConstraint).
                     """
                 )
             )
@@ -99,15 +95,11 @@ class ExtraConstraint(DiscreteHilbertConstraint):
         ):
             raise TypeError(
                 dedent(
-                    """The type parameters T1, T2 of ExtraConstraint[T1, T2] must be subtypes of
+                    """The arguments of ExtraConstraint must both be subtypes of
                     nk.hilbert.constraint.DiscreteHilbertConstraint, but one or more are not.
 
-                    To verify if those are valid type parameters you can check it with
-                    issubclass(T1, nk.hilbert.constraint.DiscreteHilbertConstraint).
-
-                    For more information, look at the documentation of parametric classes in
-                    https://beartype.github.io/plum/parametric.html or open an issue on NetKet's
-                    GitHub discussion session.
+                    To verify if those are valid arguments you can check it with
+                    isinstance(arg, nk.hilbert.constraint.DiscreteHilbertConstraint).
                     """
                 )
             )

--- a/test/hilbert/test_custom_constraint.py
+++ b/test/hilbert/test_custom_constraint.py
@@ -180,10 +180,17 @@ def test_constraint_interface_errors():
 
 
 def test_extra_constraint_spin_orbital_fermion():
+    hi = nkx.hilbert.SpinOrbitalFermions(4, s=1 / 2, n_fermions_per_spin=(1, 2))
+    assert isinstance(hi.constraint, nk.hilbert.constraint.SumOnPartitionConstraint)
+    assert np.all(hi.constraint(hi.all_states()))
+
+    hi = nkx.hilbert.SpinOrbitalFermions(4, s=1 / 2, constraint=CustomConstraintPy())
+    assert isinstance(hi.constraint, CustomConstraintPy)
+    assert np.all(hi.constraint(hi.all_states()))
+
     hi = nkx.hilbert.SpinOrbitalFermions(
         4, s=1 / 2, n_fermions_per_spin=(1, 2), constraint=CustomConstraintPy()
     )
-
     assert isinstance(hi.constraint, nk.hilbert.constraint.ExtraConstraint)
     assert isinstance(
         hi.constraint,
@@ -191,5 +198,4 @@ def test_extra_constraint_spin_orbital_fermion():
             nk.hilbert.constraint.SumOnPartitionConstraint, CustomConstraintPy
         ],
     )
-
     assert np.all(hi.constraint(hi.all_states()))


### PR DESCRIPTION
This lifts the requirement for a fermion-number constraint whenever a custom constraint is specified by the user. Previously, while a priori supported, this would trigger an error. This also makes that exception print a slightly clearer error message.