### PR TITLE
Fix chunking for Jax operators to also chunk along connected elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 * Removed support for using Numba-operators under sharding. This has never really worked realiably and lead to uncomprehensible crashes, and was very hard to maintain so it's leaving [#1919](https://github.com/netket/netket/pull/1919).
 * Loggers will now be called from all MPI ranks/ Jax processes, and are themselves responsible for only performing expensive I/O operations on a single rank (such as rank 0). The attribute {attr}`netket.logging.AbstractLog._is_master_process` can be used to determine whether the logger is being executed on the master process or not. For examples on how update loggers, refer to {class}`netket.logging.RuntimeLog` or {class}`netket.logging.TensorboardLog` [#1920](https://github.com/netket/netket/pull/1920).
 
+## NetKet 3.14.3 (2 October 2024)
+* Fix an issue in Jax operators, which would not be chunking correctly if they had more connected entries than the chunk size [#1940](https://github.com/netket/netket/pull/1940).
+
 
 ## NetKet 3.14.2 (18 September 2024)
 * Fix an issue in {class}`~netket.experimental.hilbert.SpinOrbitalFermions` where the extra constraint would not work without a fermion number constraint [#1924](https://github.com/netket/netket/pull/1924).

--- a/netket/vqs/mc/kernels.py
+++ b/netket/vqs/mc/kernels.py
@@ -59,8 +59,18 @@ def local_value_kernel(logpsi: Callable, pars: PyTree, σ: Array, args: PyTree):
     σp, mel = args
     return jnp.sum(mel * jnp.exp(logpsi(pars, σp) - logpsi(pars, σ)))
 
-
 def local_value_kernel_jax(
+    logpsi: Callable, pars: PyTree, σ: Array, O: DiscreteJaxOperator
+):
+    """
+    local_value kernel for MCState for jax-compatible operators
+    """
+    σp, mel = O.get_conn_padded(σ)
+    logpsi_σ = logpsi(pars, σ)
+    logpsi_σp = logpsi(pars, σp.reshape(-1, σp.shape[-1])).reshape(σp.shape[:-1])
+    return jnp.sum(mel * jnp.exp(logpsi_σp - jnp.expand_dims(logpsi_σ, -1)), axis=-1)
+
+def local_value_kernel_jax_conn_chunked(
     logpsi: Callable, pars: PyTree, σ: Array, O: DiscreteJaxOperator, chunk_size: int,
 ):
     """
@@ -68,13 +78,9 @@ def local_value_kernel_jax(
     """
 
     σp, mel = O.get_conn_padded(jnp.squeeze(σ))
-   
     logpsi_σ = logpsi(pars, σ)
-
     apply_conn = lambda s: logpsi(pars,s)
-    
     apply_conn = nkjax.apply_chunked(apply_conn,in_axes=0,chunk_size=chunk_size) 
-    
     logpsi_σp = apply_conn(σp)
 
     return jnp.sum(mel * jnp.exp(logpsi_σp - jnp.expand_dims(logpsi_σ, -1)), axis=-1)
@@ -190,9 +196,12 @@ def local_value_kernel_jax_chunked(
     """
     local_value kernel for MCState and jaxcoompatible operators
     """
-   
-    local_value_kernel = lambda s: local_value_kernel_jax(logpsi, pars, s, O, chunk_size=min(O.max_conn_size,chunk_size))
 
+    if chunk_size >= O.max_conn_size:
+        local_value_kernel = lambda s: local_value_kernel_jax(logpsi, pars, s, O)
+    else:
+        local_value_kernel = lambda s: local_value_kernel_jax_conn_chunked(logpsi, pars, s, O, chunk_size)
+    
     local_value_chunked = nkjax.apply_chunked(
         local_value_kernel, in_axes=0, chunk_size=max(1, chunk_size // O.max_conn_size)
     )

--- a/netket/vqs/mc/kernels.py
+++ b/netket/vqs/mc/kernels.py
@@ -61,7 +61,7 @@ def local_value_kernel(logpsi: Callable, pars: PyTree, σ: Array, args: PyTree):
 
 
 def local_value_kernel_jax(
-    logpsi: Callable, pars: PyTree, σ: Array, O: DiscreteJaxOperator, chunk_size: int, max_conn: int
+    logpsi: Callable, pars: PyTree, σ: Array, O: DiscreteJaxOperator, chunk_size: int,
 ):
     """
     local_value kernel for MCState for jax-compatible operators
@@ -69,17 +69,6 @@ def local_value_kernel_jax(
 
     σp, mel = O.get_conn_padded(jnp.squeeze(σ))
    
-    def select_nonzero(xp,mels):
-      k = jnp.argmin(jnp.abs(mels))
-      i = jnp.nonzero(mels,size=max_conn,fill_value=k)
-
-      xp = xp[i]
-      mels = mels[i]
-
-      return xp, mels
-
-    σp, mel = select_nonzero(σp, mel)
-
     logpsi_σ = logpsi(pars, σ)
 
     apply_conn = lambda s: logpsi(pars,s)
@@ -202,7 +191,7 @@ def local_value_kernel_jax_chunked(
     local_value kernel for MCState and jaxcoompatible operators
     """
    
-    local_value_kernel = lambda s: local_value_kernel_jax(logpsi, pars, s, O, chunk_size=min(O.max_conn_size,chunk_size),max_conn=O.max_conn_size)
+    local_value_kernel = lambda s: local_value_kernel_jax(logpsi, pars, s, O, chunk_size=min(O.max_conn_size,chunk_size))
 
     local_value_chunked = nkjax.apply_chunked(
         local_value_kernel, in_axes=0, chunk_size=max(1, chunk_size // O.max_conn_size)


### PR DESCRIPTION
When `chunk_size < max_conn`,  the forward pass is chunked over the connected samples as well. 