### PR TITLE
fix chunking of jax operators after #1940

### DIFF
--- a/netket/vqs/mc/kernels.py
+++ b/netket/vqs/mc/kernels.py
@@ -82,12 +82,13 @@ def local_value_kernel_jax_conn_chunked(
     """
     local_value kernel for MCState for jax-compatible operators
     """
-
-    σp, mel = O.get_conn_padded(jnp.squeeze(σ))
-    logpsi_σ = logpsi(pars, σ)
     apply_conn = lambda s: logpsi(pars, s)
     apply_conn = nkjax.apply_chunked(apply_conn, in_axes=0, chunk_size=chunk_size)
-    logpsi_σp = apply_conn(σp)
+
+    σp, mel = O.get_conn_padded(σ)
+
+    logpsi_σ = apply_conn(σ)
+    logpsi_σp = apply_conn(σp.reshape(-1, σ.shape[-1])).reshape(σp.shape[:-1])
 
     return jnp.sum(mel * jnp.exp(logpsi_σp - jnp.expand_dims(logpsi_σ, -1)), axis=-1)
 
@@ -203,16 +204,16 @@ def local_value_kernel_jax_chunked(
     """
     local_value kernel for MCState and jaxcoompatible operators
     """
-
     if chunk_size >= O.max_conn_size:
         local_value_kernel = lambda s: local_value_kernel_jax(logpsi, pars, s, O)
+        local_value_chunked = nkjax.apply_chunked(
+            local_value_kernel,
+            in_axes=0,
+            chunk_size=max(1, chunk_size // O.max_conn_size),
+        )
     else:
-        local_value_kernel = lambda s: local_value_kernel_jax_conn_chunked(
+        local_value_chunked = lambda s: local_value_kernel_jax_conn_chunked(
             logpsi, pars, s, O, chunk_size
         )
-
-    local_value_chunked = nkjax.apply_chunked(
-        local_value_kernel, in_axes=0, chunk_size=max(1, chunk_size // O.max_conn_size)
-    )
 
     return local_value_chunked(σ)


### PR DESCRIPTION
#1940 did a nested chunking that was largely suboptimal for small chunk sizes.
This PR fixes the problem by rewriting the code to be essentially identical to what we do for standard operators.

cc @chrisrothUT