### PR TITLE
Add warning to QGT argument overwrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
 * Loggers will now be called from all MPI ranks/ Jax processes, and are themselves responsible for only performing expensive I/O operations on a single rank (such as rank 0). The attribute {attr}`netket.logging.AbstractLog._is_master_process` can be used to determine whether the logger is being executed on the master process or not. For examples on how update loggers, refer to {class}`netket.logging.RuntimeLog` or {class}`netket.logging.TensorboardLog` [#1920](https://github.com/netket/netket/pull/1920).
 * The `integrator` argument of the constructors {class}`~netket.experimental.driver.TDVP` and {class}`~netket.experimental.driver.TDVPSchmitt` has been renamed to `ode_solver`, and a deprecation warning will be raised if `integrator is specified`. The attribute `integrator` of the driver is maintained, albeit it has sensibly different internals, but we also have added a new `ode_solver` attribute as well [#1933](https://github.com/netket/netket/pull/1933).
 
+### Deprecations
+* Constructing the {class}~`netket.optimizer.SR` object with `SR(qgt=QGTType(...))` is now deprecated. This construction can lead to unexpected results because the keyword arguments specified in the `QGTType` are overwritten by those specified by the SR class and its defaults. To fix this, construct SR as `SR(qgt=QGTType, ...)`. A warning will be raised when using the deprecated syntax, and this will become an error in a future release.
+
 ## NetKet 3.14.3 (2 October 2024)
 * Fix an issue in Jax operators, which would not be chunking correctly if they had more connected entries than the chunk size [#1940](https://github.com/netket/netket/pull/1940).
 

--- a/netket/optimizer/sr.py
+++ b/netket/optimizer/sr.py
@@ -55,6 +55,7 @@ def check_conflicting_args_in_partial(
                 conflicting, {k: qgt.keywords[k] for k in conflicting}
             ),
             UserWarning,
+            stacklevel=3,
         )
 
 
@@ -159,7 +160,10 @@ class SR(AbstractLinearPreconditioner, mutable=True):
         check_conflicting_args_in_partial(
             qgt,
             ["diag_shift", "diag_scale"],
-            "The QGT arguments {} will be overwritten by the ones specified by SR (including defaults).",
+            "Constructing the SR object with `SR(qgt= MyQGTType({}))` can lead to unexpected results and has been deprecated, "
+            "because the keyword arguments specified in the QGTType are overwritten by those specified by the SR class and its defaults.\n\n"
+            "To fix this, construct SR as  `SR(qgt=MyQGTType, {})` .\n\n"
+            "In the future, this warning will become an error.",
         )
 
         super().__init__(solver, solver_restart=solver_restart)

--- a/netket/optimizer/sr.py
+++ b/netket/optimizer/sr.py
@@ -119,13 +119,11 @@ class SR(AbstractLinearPreconditioner, mutable=True):
         if qgt is None:
             qgt = QGTAuto(solver)
 
-        # Store the provided values
         self.qgt_constructor = qgt
         self.qgt_kwargs = kwargs
         self.diag_shift = diag_shift
         self.diag_scale = diag_scale
 
-        # Check for conflicts in diag_shift and diag_scale
         conflicting_args = set()
         sr_values_map = {"diag_shift": diag_shift, "diag_scale": diag_scale}
 

--- a/test/optimizer/test_sr_api.py
+++ b/test/optimizer/test_sr_api.py
@@ -154,25 +154,29 @@ def test_sr_diag_warnings(qgt):
     vstate.init_parameters()
     vstate.sample()
 
+    warning_message = r"The QGT arguments {(%s)} will be overwritten by the ones specified by SR \(including defaults\)\."
+
     # Case 1: Overwriting diag_shift from SR default
-    with pytest.warns(UserWarning, match=r"Overwriting diag_shift.*"):
+    with pytest.warns(UserWarning, match=warning_message % r"'diag_shift'"):
         nk.optimizer.SR(qgt=qgt(diag_shift=1e-3))
 
     # Case 2: Overwriting diag_scale from SR  default
-    with pytest.warns(UserWarning, match=r"Overwriting diag_scale.*"):
+    with pytest.warns(UserWarning, match=warning_message % r"'diag_scale'"):
         nk.optimizer.SR(qgt=qgt(diag_scale=1e-4))
 
     # Case 3: Overwriting both diag_shift and diag_scale from SR default
     with pytest.warns(
         UserWarning,
-        match=r"Overwriting (diag_shift, diag_scale|diag_scale, diag_shift).*",
+        match=warning_message
+        % r"'diag_shift', 'diag_scale'|'diag_scale', 'diag_shift'",
     ):
         nk.optimizer.SR(qgt=qgt(diag_shift=1e-3, diag_scale=1e-4))
 
     # Case 4: Warning with default diag_shift and diag_scale by specifying them in SR
     with pytest.warns(
         UserWarning,
-        match=r"Overwriting (diag_shift, diag_scale|diag_scale, diag_shift).*",
+        match=warning_message
+        % r"'diag_shift', 'diag_scale'|'diag_scale', 'diag_shift'",
     ):
         nk.optimizer.SR(
             qgt=qgt(diag_shift=1e-3, diag_scale=1e-4), diag_shift=1e-2, diag_scale=1e-3

--- a/test/optimizer/test_sr_api.py
+++ b/test/optimizer/test_sr_api.py
@@ -146,38 +146,22 @@ def test_sr_diag_warnings(qgt):
     """
     Test various scenarios for warnings related to diag_shift and diag_scale in SR.
     """
-    N = 5
-    hi = nk.hilbert.Spin(1 / 2, N)
-    model = nk.models.RBM(alpha=1)
-    sampler = nk.sampler.MetropolisLocal(hi)
-    vstate = nk.vqs.MCState(sampler, model)
-    vstate.init_parameters()
-    vstate.sample()
-
-    warning_message = r"The QGT arguments {(%s)} will be overwritten by the ones specified by SR \(including defaults\)\."
+    warning_message = r"Constructing the SR object with `SR\(qgt= MyQGTType\({.*}\)\)` can lead to unexpected results and has been deprecated, because the keyword arguments specified in the QGTType are overwritten by those specified by the SR class and its defaults\.\n\nTo fix this, construct SR as  `SR\(qgt=MyQGTType, {.*}\)` \.\n\nIn the future, this warning will become an error\."
 
     # Case 1: Overwriting diag_shift from SR default
-    with pytest.warns(UserWarning, match=warning_message % r"'diag_shift'"):
+    with pytest.warns(UserWarning, match=warning_message):
         nk.optimizer.SR(qgt=qgt(diag_shift=1e-3))
 
-    # Case 2: Overwriting diag_scale from SR  default
-    with pytest.warns(UserWarning, match=warning_message % r"'diag_scale'"):
+    # Case 2: Overwriting diag_scale from SR default
+    with pytest.warns(UserWarning, match=warning_message):
         nk.optimizer.SR(qgt=qgt(diag_scale=1e-4))
 
     # Case 3: Overwriting both diag_shift and diag_scale from SR default
-    with pytest.warns(
-        UserWarning,
-        match=warning_message
-        % r"'diag_shift', 'diag_scale'|'diag_scale', 'diag_shift'",
-    ):
+    with pytest.warns(UserWarning, match=warning_message):
         nk.optimizer.SR(qgt=qgt(diag_shift=1e-3, diag_scale=1e-4))
 
     # Case 4: Warning with default diag_shift and diag_scale by specifying them in SR
-    with pytest.warns(
-        UserWarning,
-        match=warning_message
-        % r"'diag_shift', 'diag_scale'|'diag_scale', 'diag_shift'",
-    ):
+    with pytest.warns(UserWarning, match=warning_message):
         nk.optimizer.SR(
             qgt=qgt(diag_shift=1e-3, diag_scale=1e-4), diag_shift=1e-2, diag_scale=1e-3
         )

--- a/test/optimizer/test_sr_api.py
+++ b/test/optimizer/test_sr_api.py
@@ -155,36 +155,31 @@ def test_sr_diag_warnings(qgt):
     vstate.sample()
 
     # Case 1: Overwriting diag_shift from SR default
-    sr1 = nk.optimizer.SR(qgt=qgt(diag_shift=1e-3))
     with pytest.warns(UserWarning, match=r"Overwriting diag_shift.*"):
-        sr1.lhs_constructor(vstate)
+        nk.optimizer.SR(qgt=qgt(diag_shift=1e-3))
 
     # Case 2: Overwriting diag_scale from SR  default
-    sr2 = nk.optimizer.SR(qgt=qgt(diag_scale=1e-4))
     with pytest.warns(UserWarning, match=r"Overwriting diag_scale.*"):
-        sr2.lhs_constructor(vstate)
+        nk.optimizer.SR(qgt=qgt(diag_scale=1e-4))
 
     # Case 3: Overwriting both diag_shift and diag_scale from SR default
-    sr3 = nk.optimizer.SR(qgt=qgt(diag_shift=1e-3, diag_scale=1e-4))
     with pytest.warns(
         UserWarning,
         match=r"Overwriting (diag_shift, diag_scale|diag_scale, diag_shift).*",
     ):
-        sr3.lhs_constructor(vstate)
+        nk.optimizer.SR(qgt=qgt(diag_shift=1e-3, diag_scale=1e-4))
 
     # Case 4: Warning with default diag_shift and diag_scale by specifying them in SR
-    sr4 = nk.optimizer.SR(
-        qgt=qgt(diag_shift=1e-3, diag_scale=1e-4), diag_shift=1e-2, diag_scale=1e-3
-    )
     with pytest.warns(
         UserWarning,
         match=r"Overwriting (diag_shift, diag_scale|diag_scale, diag_shift).*",
     ):
-        sr4.lhs_constructor(vstate)
+        nk.optimizer.SR(
+            qgt=qgt(diag_shift=1e-3, diag_scale=1e-4), diag_shift=1e-2, diag_scale=1e-3
+        )
 
     # Case 5: No warning when diag_shift and diag_scale are specified only in SR
-    sr5 = nk.optimizer.SR(qgt=qgt)
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
-        sr5.lhs_constructor(vstate)
+        nk.optimizer.SR(qgt=qgt)
     assert len(w) == 0, "Unexpected warning(s) raised"


### PR DESCRIPTION
Hi! This is my attempt at addressing #1861. As per the discussion, I have tried to raise warnings instead of errors in the conditions there specified. If my solution is not a good fit, feel free to disregard this PR :)

Points of consideration:
	- Maybe I did not need to test both `QGTJacobianDense` and `QGTJacobianPyTree`
	- I don't think test case 4 needs to warn anything, since the overwrite here is more obvious, but in my approach it is there. If this is inconvenient I can try a workaround. 
	- The use of `warnings.catch_warnings` was necessary to test the case where no warnings are raised, as recommended by `pytest` since `pytest.warns(None)` is deprecated.

-------

Loosely related question: 
I have noted in the process of making this PR that under `qgt_jacobian_common.py`, the returns of

```python3
def to_shift_offset(
    diag_shift: float | None, diag_scale: float | None
) -> tuple[float, float | None]:
    if diag_shift is None:
        diag_shift = 0.0

    if isinstance(diag_scale, jax.Array):
        return diag_scale, diag_shift / diag_scale
    else:
        if diag_scale is None or diag_scale == 0.0:
            return diag_shift, None
        else:
            return diag_scale, diag_shift / diag_scale
```
may have the opposite order as intended. Maybe I am missing something, in which case I do apologize. However, as per the naming of the receiving variables when the function is used (`shift, offset = to_shift_offset(diag_shift, diag_scale)`), there seems to be a sneaky flip in their order.
