### PR TITLE
Fix an outdated example

### DIFF
--- a/Examples/DissipativeIsing1d/ising1d.py
+++ b/Examples/DissipativeIsing1d/ising1d.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import jax
 import netket as nk
 
 # 1D Lattice
@@ -63,8 +64,8 @@ sa = nk.sampler.MetropolisLocal(lind.hilbert)
 op = nk.optimizer.Sgd(0.01)
 sr = nk.optimizer.SR(diag_shift=0.01)
 
-vs = nk.vqs.MCMixedState(sa, ma, n_samples=2000, n_samples_diag=500)
-vs.init_parameters(nk.nn.initializers.normal(stddev=0.01))
+vs = nk.vqs.MCMixedState(sa, ma, n_samples=2000, n_samples_diag=512)
+vs.init_parameters(jax.nn.initializers.normal(stddev=0.01))
 
 ss = nk.SteadyState(lind, op, variational_state=vs, preconditioner=sr)
 


### PR DESCRIPTION
Apparently, [this commit](https://github.com/netket/netket/tree/bd23a34ee1684b6ca8666cc672a6c180ba8085ac) missed and example `DissipativeIsing1d/ising1d.py`
- Change initializer to `jax.nn...` from `nk.nn...`
- Fix `n_samples_diag` to 512 from 500 (500 is not divisible with `n_chains=16`)