### PR TITLE
nk.jax.jacobian: support sharding of sharded wave functions

### DIFF
--- a/netket/jax/_jacobian/logic.py
+++ b/netket/jax/_jacobian/logic.py
@@ -159,7 +159,7 @@ def jacobian(
 
       samples = samples.reshape(-1, samples.shape[-1])
       parameters = jax.tree_util.tree_map(lambda x: x.real, parameters)
-      O_k = jax.jacrev(lambda pars: logpsi(pars, samples).real, parameters)
+      O_k = jax.jacrev(lambda pars: logpsi(pars, samples).real)(parameters)
 
     The jacobian that is returned is a PyTree with the same shape
     as :code:`parameters`, with real data type.
@@ -199,8 +199,8 @@ def jacobian(
     .. code:: python
 
       samples = samples.reshape(-1, samples.shape[-1])
-      Or_k = jax.jacrev(lambda pars: logpsi(pars, samples).real, parameters)
-      Oi_k = jax.jacrev(lambda pars: logpsi(pars, samples).imag, parameters)
+      Or_k = jax.jacrev(lambda pars: logpsi(pars, samples).real)(parameters)
+      Oi_k = jax.jacrev(lambda pars: logpsi(pars, samples).imag)(parameters)
       O_k = jax.tree_util.tree_map(lambda jr, ji: jnp.concatenate([jr, ji]], axis=1),
                                                         Or_k, Oi_k)
 
@@ -251,9 +251,9 @@ def jacobian(
       # tree_to_real splits the parameters in a tuple like
       # {'real': jax.tree.map(jnp.real, pars), 'imag': jax.tree.map(jnp.imag, pars)}
       pars_real, reconstruct = nk.jax.tree_to_real(parameters)
-      Or_k = jax.jacrev(lambda pars_re: logpsi(reconstruct(pars_re), samples).real,
+      Or_k = jax.jacrev(lambda pars_re: logpsi(reconstruct(pars_re), samples).real)(
                         pars_real)
-      Oi_k = jax.jacrev(lambda pars_re: logpsi(reconstruct(pars_re), samples).imag,
+      Oi_k = jax.jacrev(lambda pars_re: logpsi(reconstruct(pars_re), samples).imag)(
                         pars_real)
       O_k = jax.tree_util.tree_map(lambda jr, ji: jnp.concatenate([jr, ji]], axis=1),
                                                         Or_k, Oi_k)
@@ -278,7 +278,7 @@ def jacobian(
     .. code:: python
 
       samples = samples.reshape(-1, samples.shape[-1])
-      O_k = jax.jacrev(lambda pars: logpsi(pars, samples), parameters, holomorphic=True)
+      O_k = jax.jacrev(lambda pars: logpsi(pars, samples), holomorphic=True)(parameters)
 
     If the function is not holomorphic the result will be numerically wrong.
 

--- a/netket/jax/_vmap_chunked.py
+++ b/netket/jax/_vmap_chunked.py
@@ -62,8 +62,8 @@ def _eval_fun_in_chunks_sharding(vmapped_fun, chunk_size, argnums, *args, **kwar
 def _chunk_vmapped_function(
     vmapped_fun: Callable,
     chunk_size: int | None,
-    argnums=0,
-    axis_0_is_sharded=False,
+    argnums: int | tuple[int, ...] = 0,
+    axis_0_is_sharded: bool = False,
 ) -> Callable:
     """takes a vmapped function and computes it in chunks"""
 
@@ -98,7 +98,7 @@ def apply_chunked(
     in_axes=0,
     *,
     chunk_size: int | None,
-    axis_0_is_sharded=config.netket_experimental_sharding,  # type: ignore[attr-defined]
+    axis_0_is_sharded: bool = config.netket_experimental_sharding,  # type: ignore[attr-defined]
 ) -> Callable:
     """
     Takes an implicitly vmapped function over the axis 0 and uses scan to
@@ -142,7 +142,7 @@ def vmap_chunked(
     in_axes=0,
     *,
     chunk_size: int | None,
-    axis_0_is_sharded=config.netket_experimental_sharding,  # type: ignore[attr-defined]
+    axis_0_is_sharded: bool = config.netket_experimental_sharding,  # type: ignore[attr-defined]
 ) -> Callable:
     """
     Behaves like jax.vmap but uses scan to chunk the computations in smaller chunks.

--- a/netket/jax/_vmap_chunked.py
+++ b/netket/jax/_vmap_chunked.py
@@ -68,6 +68,8 @@ def _chunk_vmapped_function(
     """takes a vmapped function and computes it in chunks"""
 
     if chunk_size is None:
+        # TODO: Here we are not applyign sharding_decorator, while below we are
+        # Maybe we should always apply it for consistency?
         return vmapped_fun
 
     if isinstance(argnums, int):

--- a/test/common.py
+++ b/test/common.py
@@ -85,7 +85,9 @@ xfailif_sharding = pytest.mark.xfail(
 """Use as a decorator to mark a test to be expected to fail only when running with
 Sharding.
 """
-
+onlyif_sharding = pytest.mark.skipif(
+    not nk.config.netket_experimental_sharding, reason="Only run with Sharding"
+)
 
 skipif_distributed = pytest.mark.skipif(
     nk.utils.mpi.n_nodes > 1 or nk.config.netket_experimental_sharding,

--- a/test/jax/test_jacobian.py
+++ b/test/jax/test_jacobian.py
@@ -11,7 +11,7 @@ import netket as nk
 from .. import common
 
 
-@common.skipif_mpi
+@common.skipif_distributed
 def test_real_function_error():
     k = jax.random.key(1)
 
@@ -26,7 +26,7 @@ def test_real_function_error():
         nk.jax.jacobian(afun, parameters, xs, model_state, mode="complex")
 
 
-@common.skipif_mpi
+@common.skipif_distributed
 def test_real_function_output():
     k = jax.random.key(1)
 
@@ -43,5 +43,64 @@ def test_real_function_output():
         return ma.apply(vars, xs)
 
     jac_2 = nk.jax.jacobian(afun, parameters, xs, model_state, mode="real", dense=True)
+
+    np.testing.assert_allclose(jac_re, jac_2)
+
+
+@common.onlyif_sharding
+@pytest.mark.parametrize("sharded", [False, True])
+def test_real_function_sharding(sharded):
+    k = jax.random.key(1)
+
+    ma = nk.models.RBM(param_dtype=jnp.float32)
+
+    if sharded:
+        n_samples = 2 * jax.device_count()
+    else:
+        n_samples = 3
+
+    xs = jax.random.normal(k, (n_samples, 4))
+    if sharded:
+        xs = jax.lax.with_sharding_constraint(
+            xs, jax.sharding.PositionalSharding(jax.devices()).reshape(-1, 1)
+        )
+
+    model_state, parameters = fcore.pop(ma.init(k, xs), "params")
+
+    def afun(vars, xs):
+        return ma.apply(vars, xs) + 0.3j * ma.apply(vars, xs)
+
+    jac_re = nk.jax.jacobian(
+        afun,
+        parameters,
+        xs,
+        model_state,
+        mode="real",
+        dense=True,
+        _axis_0_is_sharded=sharded,
+    )
+
+    def afun(vars, xs):
+        return ma.apply(vars, xs)
+
+    jac_2 = nk.jax.jacobian(
+        afun,
+        parameters,
+        xs,
+        model_state,
+        mode="real",
+        dense=True,
+        _axis_0_is_sharded=sharded,
+    )
+
+    if sharded:
+        assert jac_re.sharding.shape == (jax.device_count(), 1)
+        assert jac_2.sharding.shape == (jax.device_count(), 1)
+        jac_re = jax.lax.with_sharding_constraint(
+            jac_re, jax.sharding.PositionalSharding(jax.devices()).replicate()
+        )
+        jac_2 = jax.lax.with_sharding_constraint(
+            jac_2, jax.sharding.PositionalSharding(jax.devices()).replicate()
+        )
 
     np.testing.assert_allclose(jac_re, jac_2)


### PR DESCRIPTION
[use sharding_decorator inside nk.jax.jacobian to support](https://github.com/netket/netket/commit/f2c7f126fc62c2b654464b28a335940d85e772a5) variational wavefunctions with sharding_decorators inside.
