### PR TITLE
Improve accuracy of timing in `run(..., timeit=True)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * The {meth}`~netket.graph.Lattice.draw` method of {class}`~netket.graph.Lattic` has been overhauled, and now supports 3D lattices and additional keyword arguments. The defaults are now tuned to draw the whole lattice as well as repeated cells due to periodicity, as well as the basis vectors.
 * Drivers now call the loggers from all ranks, allowing more advanced logging logic (and checkpointers) to be implemented [#1920](https://github.com/netket/netket/pull/1920).
 * The `netket.experimental.dynamics` module has been greatly refactored, changing all internal logics but exposing a well designed, easier to extend interface. While the interface is not yet documented, it is now reasonably possible to implement new ode integrators on top of our interface to be used with {class}`~netket.experimental.driver.TDVP` or other drivers [#1933](https://github.com/netket/netket/pull/1933).
+* Timing of the run function with `timeit=True` is now more accurate, even on GPUs, but it will decrease performance [#1958](https://github.com/netket/netket/pull/1958).
 
 ### Breaking Changes
 * Removed support for using Numba-operators under sharding. This has never really worked realiably and lead to uncomprehensible crashes, and was very hard to maintain so it's leaving [#1919](https://github.com/netket/netket/pull/1919).

--- a/netket/driver/abstract_variational_driver.py
+++ b/netket/driver/abstract_variational_driver.py
@@ -345,9 +345,8 @@ class AbstractVariationalDriver(abc.ABC):
                 first_step = True
 
                 for step in self.iter(n_iter, step_size):
-                    with timing.timed_scope(name="observables"):
-                        log_data = self.estimate(obs)
-                        self._log_additional_data(log_data, step)
+                    log_data = self.estimate(obs)
+                    self._log_additional_data(log_data, step)
 
                     # if the cost-function is defined then report it in the progress bar
                     if self._loss_stats is not None:
@@ -393,6 +392,7 @@ class AbstractVariationalDriver(abc.ABC):
 
         return loggers
 
+    @timing.timed(name="estimate observables")
     def estimate(self, observables):
         """
         Return MCMC statistics for the expectation value of observables in the

--- a/netket/driver/vmc.py
+++ b/netket/driver/vmc.py
@@ -15,6 +15,7 @@
 
 from textwrap import dedent
 
+from netket.utils import timing
 from netket.utils.types import PyTree, Optimizer
 from netket.operator import AbstractOperator
 from netket.stats import Stats
@@ -106,6 +107,7 @@ class VMC(AbstractVariationalDriver):
 
         self._preconditioner = val
 
+    @timing.timed
     def _forward_and_backward(self):
         """
         Performs a number of VMC optimization steps.

--- a/netket/experimental/driver/tdvp_common.py
+++ b/netket/experimental/driver/tdvp_common.py
@@ -376,9 +376,8 @@ class TDVPBaseDriver(AbstractVariationalDriver):
 
             with timing.timed_scope(force=timeit) as timer:
                 for step in self._iter(T, tstops=tstops, callback=update_progress_bar):
-                    with timing.timed_scope(name="observables"):
-                        log_data = self.estimate(obs)
-                        self._log_additional_data(log_data, step)
+                    log_data = self.estimate(obs)
+                    self._log_additional_data(log_data, step)
 
                     self._postfix = {"n": self.step_count}
                     # if the cost-function is defined then report it in the progress bar

--- a/netket/experimental/driver/vmc_srt.py
+++ b/netket/experimental/driver/vmc_srt.py
@@ -260,6 +260,7 @@ class VMC_SRt(AbstractVariationalDriver):
             )
         self._jacobian_mode = mode
 
+    @timing.timed
     def _forward_and_backward(self):
         """
         Performs a number of VMC optimization steps.

--- a/netket/utils/timing.py
+++ b/netket/utils/timing.py
@@ -20,6 +20,8 @@ import inspect
 import functools
 import contextlib
 
+import jax
+
 from rich.tree import Tree
 from rich.panel import Panel
 
@@ -122,6 +124,9 @@ class Timer(struct.Pytree, mutable=True):
             self.sub_timers[name] = Timer()
         return self.sub_timers[name]
 
+    def block_until_ready(self, args):
+        return jax.block_until_ready(args)
+
     def __enter__(self):
         global CURRENT_TIMER_STACK
         CURRENT_TIMER_STACK.append(self)
@@ -134,6 +139,29 @@ class Timer(struct.Pytree, mutable=True):
         self.total += current_timer
         _ = CURRENT_TIMER_STACK.pop()
         assert _ is self
+
+
+class NullTimer(struct.Pytree):
+    """
+    A timer-compatible class that does nothing.
+
+    Used to return
+    """
+
+    def get_subtimer(self, name: str):
+        return self
+
+    def block_until_ready(self, args):
+        return args
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        pass
+
+
+_NULLTIMER = NullTimer()
 
 
 @contextlib.contextmanager
@@ -149,21 +177,35 @@ def timed_scope(name: str = None, force: bool = False):
     timer is in use as well. If `force` is specified, the timer
     and nested timers will always run.
 
+    .. note::
+
+        If you are using JAX functions in your code, to get reliable timing
+        results you should block the output of the function with `block_until_ready`.
+        As this can sensibly slow down your code, this is only done when `force=True`
+        or if a top-level timer is in use.
+
+        To block the output on those conditions, simply use `timer.block_until_ready(output)`
+        on the output of the function you want to time.
+
     Example:
 
         Time a section of code
 
         >>> import netket as nk
-        >>> import time
+        >>> import time; import jax
         >>>
-        >>> with nk.utils.timing.timed_scope(force=True) as t:
+        >>> with nk.utils.timing.timed_scope(force=True) as timer:
         ...    time.sleep(1)  # This line and the ones below are indented
         ...    with nk.utils.timing.timed_scope("subfunction 1"):
         ...       time.sleep(0.5)
         ...    with nk.utils.timing.timed_scope("subfunction 2"):
         ...       time.sleep(0.25)
+        ...    a = jax.random.normal(jax.random.key(1), (100,100))
+        ...    # Must block jax functions otherwise the timing is off
+        ...    timer.block_until_ready(timer)
+        ...
         >>>
-        >>> t  # doctest: +SKIP
+        >>> timer  # doctest: +SKIP
         ╭──────────────────────── Timing Information ─────────────────────────╮
         │ Total: 1.763                                                        │
         │ ├── (28.7%) | subfunction 1 : 0.505 s                               │
@@ -197,10 +239,12 @@ def timed_scope(name: str = None, force: bool = False):
         with timer:
             yield timer
     else:  # disabled
-        yield None
+        yield _NULLTIMER
 
 
-def timed(fun: Callable[P, T] = None, name: str | None = None) -> Callable[P, T]:
+def timed(
+    fun: Callable[P, T] = None, name: str | None = None, block_until_ready: bool = True
+) -> Callable[P, T]:
     """
     Marks the decorated function to be timed individually in
     NetKet timing scopes.
@@ -213,6 +257,8 @@ def timed(fun: Callable[P, T] = None, name: str | None = None) -> Callable[P, T]
     Args:
         fun: Function to be decorated
         name: Name to use for the timing of this line.
+        block_until_ready: Calls `jax.block_until_ready` on the output if timing (default True),
+            which slows down the code but gives accurate timing results of JAX functions.
     """
     if fun is None:
         return functools.partial(timed, name=name)
@@ -226,8 +272,12 @@ def timed(fun: Callable[P, T] = None, name: str | None = None) -> Callable[P, T]
     @functools.wraps(fun)
     def timed_function(*args, **kwargs):
         __tracebackhide__ = True
-        with timed_scope(name):
-            return fun(*args, **kwargs)
+        with timed_scope(name) as ts:
+            result = fun(*args, **kwargs)
+            if block_until_ready:
+                return ts.block_until_ready(result)
+            else:
+                return result
 
     return timed_function
 

--- a/netket/utils/timing.py
+++ b/netket/utils/timing.py
@@ -93,7 +93,7 @@ class Timer(struct.Pytree, mutable=True):
     def _rich_walk_tree_(self, tree):
         attributed = 0.0
         for key, sub_timer in self.sub_timers.items():
-            if sub_timer.total / self.total > 0.01:
+            if self.total > 0 and sub_timer.total / self.total > 0.01:
                 percentage = 100 * (sub_timer.total / self.total)
                 attributed += sub_timer.total
 
@@ -203,7 +203,7 @@ def timed_scope(name: str = None, force: bool = False):
         ...    a = jax.random.normal(jax.random.key(1), (100,100))
         ...    # Must block jax functions otherwise the timing is off
         ...    timer.block_until_ready(timer)
-        ...
+        ...    # doctest: +SKIP
         >>>
         >>> timer  # doctest: +SKIP
         ╭──────────────────────── Timing Information ─────────────────────────╮

--- a/netket/vqs/mc/mc_state/state.py
+++ b/netket/vqs/mc/mc_state/state.py
@@ -535,13 +535,16 @@ class MCState(VariationalState):
         )
 
         if self.n_discard_per_chain > 0:
-            with timing.timed_scope("sampling n_discarded samples"):
+            with timing.timed_scope("sampling n_discarded samples") as timer:
                 _, self.sampler_state = self.sampler.sample(
                     self._sampler_model,
                     self.variables,
                     state=self.sampler_state,
                     chain_length=n_discard_per_chain,
                 )
+                # If timer is not None, we are timing, so we should block
+                if timer is not None:
+                    _.block_until_ready()
 
         self._samples, self.sampler_state = self.sampler.sample(
             self._sampler_model,


### PR DESCRIPTION
This will make running with `timeit=True` slower than before, but the timing will be accurate.

Essentially it forces a `jax.block_until_ready` on the output of all timed modules.

Without this, timing on GPUS (and recent jax CPU versions) is completely wrong.