### PR TITLE
Improve dtypes StaticRange

### DIFF
--- a/netket/experimental/hilbert/spin_orbital_fermions.py
+++ b/netket/experimental/hilbert/spin_orbital_fermions.py
@@ -181,7 +181,7 @@ class SpinOrbitalFermions(HomogeneousHilbert):
 
         """Internal representation of this Hilbert space (Fock or TensorHilbert)."""
         # local states are the occupation numbers (0, 1)
-        local_states = StaticRange(0.0, 1.0, 2, dtype=np.int8)
+        local_states = StaticRange(0, 1, 2)
 
         # we use the constraints from the Fock spaces, and override `constrained`
         super().__init__(local_states, N=total_size, constraint=constraint)

--- a/netket/hilbert/custom_hilbert.py
+++ b/netket/hilbert/custom_hilbert.py
@@ -68,7 +68,7 @@ class CustomHilbert(HomogeneousHilbert):
             >>> import netket as nk
             >>> n_max = 10
             >>> nk.utils.StaticRange(start=0, step=1, length=n_max)
-            StaticRange(start=0, step=1, length=10, dtype=int64)
+            StaticRange(start=0, step=1, length=10, dtype=int8)
 
         and the range of a Spin-1/2 Hilbert space is constructed as:
 
@@ -77,7 +77,7 @@ class CustomHilbert(HomogeneousHilbert):
             >>> import netket as nk
             >>> n_max = 10
             >>> nk.utils.StaticRange(start=-1, step=2, length=2)
-            StaticRange(start=-1, step=2, length=2, dtype=int64)
+            StaticRange(start=-1, step=2, length=2, dtype=int8)
 
 
         Examples:

--- a/netket/hilbert/fock.py
+++ b/netket/hilbert/fock.py
@@ -101,7 +101,6 @@ class Fock(HomogeneousHilbert):
             0,
             1,
             self._n_max + 1,
-            dtype=np.int8 if self._n_max < 2**6 else int,  # type: ignore[arg-type]
         )
 
         super().__init__(local_states, N, constraint=constraint)

--- a/netket/hilbert/homogeneous.py
+++ b/netket/hilbert/homogeneous.py
@@ -197,7 +197,7 @@ class HomogeneousHilbert(DiscreteHilbert):
         Returns:
             a tensor containing integer indices into the local hilbert
         """
-        return self._local_states.states_to_numbers(x, dtype=np.int32)
+        return self._local_states.states_to_numbers(x)
 
     def local_indices_to_states(self, x: Array, dtype=None):
         r"""

--- a/netket/hilbert/homogeneous.py
+++ b/netket/hilbert/homogeneous.py
@@ -197,7 +197,7 @@ class HomogeneousHilbert(DiscreteHilbert):
         Returns:
             a tensor containing integer indices into the local hilbert
         """
-        return self._local_states.states_to_numbers(x)
+        return self._local_states.states_to_numbers(x, dtype=np.int32)
 
     def local_indices_to_states(self, x: Array, dtype=None):
         r"""

--- a/netket/hilbert/spin.py
+++ b/netket/hilbert/spin.py
@@ -214,7 +214,6 @@ class Spin(HomogeneousHilbert):
                 local_size - 1,  # type: ignore[arg-type]
                 -2,  # type: ignore[arg-type]
                 local_size,
-                dtype=np.int8 if local_size < 2**7 else int,
             )
         else:
             # Old ordering where -1=↑ 1=↓
@@ -222,7 +221,6 @@ class Spin(HomogeneousHilbert):
                 1 - local_size,  # type: ignore[arg-type]
                 2,  # type: ignore[arg-type]
                 local_size,
-                dtype=np.int8 if local_size < 2**7 else int,
             )
 
         _check_total_sz(total_sz, s, N)

--- a/netket/jax/_utils_dtype.py
+++ b/netket/jax/_utils_dtype.py
@@ -108,7 +108,7 @@ def canonicalize_dtypes(*values, dtype=None):
         dtype = jnp.result_type(*[_dtype(x) for x in values])
     # Fallback to x32 when x64 is disabled in JAX
     dtype = jax.dtypes.canonicalize_dtype(dtype)
-    return dtype
+    return jnp.dtype(dtype)
 
 
 def _in_int_dtype_range(num, dtype):
@@ -134,7 +134,7 @@ def bottom_int_dtype(*vals, dtype=None, allow_unsigned: bool = False):
         dtype = canonicalize_dtypes(*vals, dtype=dtype)
 
     if np.issubdtype(dtype, np.floating):
-        return dtype
+        return jnp.dtype(dtype)
 
     # Check if all values are unsigned. If yes, work with uint types,
     # else check int types
@@ -147,7 +147,7 @@ def bottom_int_dtype(*vals, dtype=None, allow_unsigned: bool = False):
 
     for dtyp in dtypes_choice:
         if all(_in_int_dtype_range(v, dtyp) for v in vals):
-            return dtyp
+            return jnp.dtype(dtyp)
     raise ValueError(
         f"Some of the values in {vals} do not fit in any numpy integer dtype."
     )

--- a/netket/jax/_utils_dtype.py
+++ b/netket/jax/_utils_dtype.py
@@ -109,3 +109,45 @@ def canonicalize_dtypes(*values, dtype=None):
     # Fallback to x32 when x64 is disabled in JAX
     dtype = jax.dtypes.canonicalize_dtype(dtype)
     return dtype
+
+
+def _in_int_dtype_range(num, dtype):
+    return np.iinfo(dtype).min <= num <= np.iinfo(dtype).max
+
+
+_int_dtypes = [np.int8, np.int16, np.int32, np.int64]
+_uint_dtypes = [np.uint8, np.uint16, np.uint32, np.uint64]
+
+
+def bottom_int_dtype(*vals, dtype=None, allow_unsigned: bool = False):
+    """
+    Find the smallest integer dtype that contains the values
+
+    If the dtype provided is floating, simply return it.
+
+    Args:
+        values: An arbitrary number of values
+        dtype: default dtype to start from
+        allow_unsigned: whether to allow unsigned dtypes
+    """
+    if dtype is None:
+        dtype = canonicalize_dtypes(*vals, dtype=dtype)
+
+    if np.issubdtype(dtype, np.floating):
+        return dtype
+
+    # Check if all values are unsigned. If yes, work with uint types,
+    # else check int types
+    if any(v < 0 for v in vals) or not allow_unsigned:
+        dtypes_choice = _int_dtypes
+    # elif all(v in (0, 1) for v in vals):
+    #    return np.dtype(bool)
+    else:
+        dtypes_choice = _uint_dtypes
+
+    for dtyp in dtypes_choice:
+        if all(_in_int_dtype_range(v, dtyp) for v in vals):
+            return dtyp
+    raise ValueError(
+        f"Some of the values in {vals} do not fit in any numpy integer dtype."
+    )

--- a/netket/utils/static_range.py
+++ b/netket/utils/static_range.py
@@ -92,7 +92,7 @@ class StaticRange(struct.Pytree):
             >>> import netket as nk
             >>> n_max = 10
             >>> nk.utils.StaticRange(start=0, step=1, length=n_max)
-            StaticRange(start=0, step=1, length=10, dtype=<class 'numpy.int8'>)
+            StaticRange(start=0, step=1, length=10, dtype=int8)
 
         and the range of a Spin-1/2 Hilbert space is constructed as:
 
@@ -101,7 +101,7 @@ class StaticRange(struct.Pytree):
             >>> import netket as nk
             >>> n_max = 10
             >>> nk.utils.StaticRange(start=-1, step=2, length=2)
-            StaticRange(start=-1, step=2, length=2, dtype=<class 'numpy.int8'>)
+            StaticRange(start=-1, step=2, length=2, dtype=int8)
 
         Args:
             start: Value of the first entry

--- a/netket/utils/static_range.py
+++ b/netket/utils/static_range.py
@@ -24,10 +24,6 @@ from netket.utils.types import DType
 from netket.jax import canonicalize_dtypes
 
 
-def _in_int_dtype_range(num, dtype):
-    return np.iinfo(dtype).min <= num <= np.iinfo(dtype).max
-
-
 class StaticRange(struct.Pytree):
     """
     An object representing a range similar to python's range, but that
@@ -74,8 +70,6 @@ class StaticRange(struct.Pytree):
     """The first value in the range."""
     step: float = struct.field(pytree_node=False)
     """The difference between two consecutive values in the range."""
-    end: float = struct.field(pytree_node=False)
-    """The difference between two consecutive values in the range."""
     length: int = struct.field(pytree_node=False)
     """The number of entries in the range."""
     dtype: DType = struct.field(pytree_node=False)
@@ -97,7 +91,7 @@ class StaticRange(struct.Pytree):
             >>> import netket as nk
             >>> n_max = 10
             >>> nk.utils.StaticRange(start=0, step=1, length=n_max)
-            StaticRange(start=0, step=1, end=9, length=10, dtype=int64)
+            StaticRange(start=0, step=1, length=10, dtype=int64)
 
         and the range of a Spin-1/2 Hilbert space is constructed as:
 
@@ -106,7 +100,7 @@ class StaticRange(struct.Pytree):
             >>> import netket as nk
             >>> n_max = 10
             >>> nk.utils.StaticRange(start=-1, step=2, length=2)
-            StaticRange(start=-1, step=2, end=1, length=2, dtype=int64)
+            StaticRange(start=-1, step=2, length=2, dtype=int64)
 
         Args:
             start: Value of the first entry
@@ -114,24 +108,10 @@ class StaticRange(struct.Pytree):
             length: Length of this range
             dtype: The data type
         """
-        end = start + step * (length - 1)
-
-        if dtype is None:
-            dtype = canonicalize_dtypes(start, step, dtype=dtype)
-        else:
-            if np.issubdtype(dtype, np.integer):
-                if not _in_int_dtype_range(start, dtype):
-                    raise TypeError("The start element of dtype range.")
-                if not _in_int_dtype_range(end, dtype):
-                    raise TypeError("The end element is outside of dtype range.")
-                if not _in_int_dtype_range(length * step, dtype):
-                    raise TypeError(
-                        "Dtype has a too limited range for intermediate calculations."
-                    )
+        dtype = canonicalize_dtypes(start, step, dtype=dtype)
 
         self.start = np.array(start, dtype=dtype).item()
         self.step = np.array(step, dtype=dtype).item()
-        self.end = np.array(end, dtype=dtype).item()
         self.length = int(length)
 
         self.dtype = dtype
@@ -158,7 +138,7 @@ class StaticRange(struct.Pytree):
             raise IndexError
         return self.start + self.step * i
 
-    def states_to_numbers(self, x, dtype: DType = None):
+    def states_to_numbers(self, x, dtype: DType = int):
         """Given an element in the range, returns it's index.
 
         Args:
@@ -169,14 +149,12 @@ class StaticRange(struct.Pytree):
         Returns:
             An array of integers, which can be.
         """
-        idx = (x - self.start) // self.step
-        if dtype is None:
-            dtype = self.dtype if np.issubdtype(self.dtype, np.integer) else int
-        if not hasattr(idx, "astype"):
-            npx = jnp if isinstance(x, jax.Array) else np
-            idx = npx.array(idx, dtype=dtype)
-        else:
-            idx = idx.astype(dtype)
+        idx = (x - self.start) / self.step
+        if dtype is not None:
+            if not hasattr(idx, "astype"):
+                idx = np.array(idx, dtype=dtype)
+            else:
+                idx = idx.astype(dtype)
         return idx
 
     def numbers_to_states(self, i, dtype: DType = None):
@@ -204,7 +182,8 @@ class StaticRange(struct.Pytree):
         """Only works if this range has length 2. Given a state, returns the other state."""
         if not len(self) == 2:
             raise ValueError
-        return (self.start - state) + self.end
+        constant_sum = 2 * self.start + self.step
+        return constant_sum - state
 
     def all_states(self, dtype: DType = None):
         """Return all elements in the range. Equal to __array__
@@ -246,12 +225,12 @@ class StaticRange(struct.Pytree):
             )
         elif hasattr(o, "shape"):
             if self.shape == o.shape:
-                return np.all(self.__array__() == o)
+                return self.__array__() == o
         elif hasattr(o, "__array__"):
             if hasattr(o, "shape") and self.shape == o.shape:
-                return np.all(self.__array__() == o.__array__())
+                return self.__array__() == o
 
         return False
 
     def __repr__(self):
-        return f"StaticRange(start={self.start}, step={self.step}, end={self.end}, length={self.length}, dtype={self.dtype})"
+        return f"StaticRange(start={self.start}, step={self.step}, length={self.length}, dtype={self.dtype})"

--- a/netket/utils/static_range.py
+++ b/netket/utils/static_range.py
@@ -43,7 +43,7 @@ class StaticRange(struct.Pytree):
         >>> n_max = 10
         >>> ran = nk.utils.StaticRange(start=0, step=1, length=n_max)
         >>> np.array(ran)
-        array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], dtype=int8)
 
     And it can be used to convert between integer values starting at 0
     and the values in the range.
@@ -53,11 +53,11 @@ class StaticRange(struct.Pytree):
         >>> import netket as nk; import numpy as np
         >>> ran = nk.utils.StaticRange(start=-2, step=2, length=3)
         >>> np.array(ran)
-        array([-2,  0,  2])
+        array([-2,  0,  2], dtype=int8)
         >>> len(ran)
         3
         >>> ran.states_to_numbers(0)
-        array(1)
+        array(1, dtype=int8)
         >>> ran.numbers_to_states(0)
         -2
         >>> ran.numbers_to_states(1)
@@ -92,7 +92,7 @@ class StaticRange(struct.Pytree):
             >>> import netket as nk
             >>> n_max = 10
             >>> nk.utils.StaticRange(start=0, step=1, length=n_max)
-            StaticRange(start=0, step=1, length=10, dtype=int64)
+            StaticRange(start=0, step=1, length=10, dtype=<class 'numpy.int8'>)
 
         and the range of a Spin-1/2 Hilbert space is constructed as:
 
@@ -101,7 +101,7 @@ class StaticRange(struct.Pytree):
             >>> import netket as nk
             >>> n_max = 10
             >>> nk.utils.StaticRange(start=-1, step=2, length=2)
-            StaticRange(start=-1, step=2, length=2, dtype=int64)
+            StaticRange(start=-1, step=2, length=2, dtype=<class 'numpy.int8'>)
 
         Args:
             start: Value of the first entry

--- a/netket/utils/static_range.py
+++ b/netket/utils/static_range.py
@@ -246,10 +246,10 @@ class StaticRange(struct.Pytree):
             )
         elif hasattr(o, "shape"):
             if self.shape == o.shape:
-                return self.__array__() == o
+                return np.all(self.__array__() == o)
         elif hasattr(o, "__array__"):
             if hasattr(o, "shape") and self.shape == o.shape:
-                return self.__array__() == o
+                return np.all(self.__array__() == o.__array__())
 
         return False
 

--- a/test/utils/test_range.py
+++ b/test/utils/test_range.py
@@ -79,6 +79,9 @@ def test_staticrange_array_interface():
         np.array(StaticRange(0, 10, 100, dtype=float).astype(int)),
     )
 
+    ran = StaticRange(0, 10, 100)
+    assert ran == np.arange(0, 1000, 10)  # start, *end*, step
+
 
 def test_staticrange_flip():
     ran = StaticRange(0, 10, 100, dtype=float)

--- a/test/utils/test_range.py
+++ b/test/utils/test_range.py
@@ -37,7 +37,7 @@ def test_staticrange_eq():
 
 
 def test_staticrange_array_interface():
-    ran = StaticRange(0, 10, 100)
+    ran = StaticRange(0, 10, 100, dtype=int)
 
     assert ran.dtype == int
     assert ran.ndim == 1
@@ -54,7 +54,8 @@ def test_staticrange_array_interface():
     np.testing.assert_allclose(
         ran.states_to_numbers(np.array([0, 10, 100])), np.array([0, 1, 10])
     )
-    assert ran.states_to_numbers(10).dtype == int
+    assert ran.states_to_numbers(10).dtype == np.int8
+    assert ran.states_to_numbers(10, dtype=int).dtype == int
     assert ran.states_to_numbers(10, dtype=float).dtype == float
     assert isinstance(ran.states_to_numbers(10), np.ndarray)
     assert isinstance(ran.states_to_numbers(np.array([10, 20])), np.ndarray)
@@ -70,7 +71,7 @@ def test_staticrange_array_interface():
 
     ran = StaticRange(0, 10, 100, dtype=float)
     assert ran.dtype == float
-    assert ran.states_to_numbers(1).dtype == int
+    assert ran.states_to_numbers(1).dtype == np.int8
     assert ran.numbers_to_states(1).dtype == float
     assert isinstance(ran.numbers_to_states(1), float)
     assert np.array(ran).dtype == float
@@ -88,3 +89,13 @@ def test_staticrange_flip():
 
     ran = StaticRange(0, 1, 2)
     ran.flip_state(0) == 1
+
+
+def test_staticrange_auto_default_dtype():
+    ran = StaticRange(0, 10, 100)
+    assert ran.dtype == np.int16
+    assert np.asarray(ran).dtype == np.int16
+
+    ran = StaticRange(0, 1, 2)
+    assert ran.dtype == np.int8
+    assert np.asarray(ran).dtype == np.int8

--- a/test/utils/test_range.py
+++ b/test/utils/test_range.py
@@ -79,9 +79,6 @@ def test_staticrange_array_interface():
         np.array(StaticRange(0, 10, 100, dtype=float).astype(int)),
     )
 
-    ran = StaticRange(0, 10, 100)
-    assert ran == np.arange(0, 1000, 10)  # start, *end*, step
-
 
 def test_staticrange_flip():
     ran = StaticRange(0, 10, 100, dtype=float)


### PR DESCRIPTION
Concerning the issue: Improve dtypes in StaticRange (#1956)
  
This fixes changing of dtype to float in `states_to_numbers`. Code now runs for `N=20` (see issue).
  
It is necessary not only that `start`, `end`, `step` and `length` lie inside the dtype but also `length * step` so that in `states_to_numbers` the intermediate result `(x - self.start)` does not fall outside dtype range.¹
  
For similar reason, `flip_state` is rewritten.

Furthermore, I fixed what _seemed_ like a bug in `__eq__`. It was never tested, so I added a test.

¹ Even if `start`, `step` and `length` are inside dtype range, we can have a problem if we limit ourselves to `np.int8`.

```python
sr = nk.utils.StaticRange(start=-127, step=1, length=255, dtype=np.int8)
assert sr.__array__()[-1] == list(sr)[-1]
end = list(sr)[-1]
print(f"Max local state: {end}. Is it in range? {end <= np.iinfo(np.int8).max}")
# Max local state: 127. Is it in range? True

number = sr.states_to_numbers(np.array([end]))
print(number, number.dtype, sr.numbers_to_states(number))  # default dtype=int (=np.int64)
# [254] int64 [127]

number = sr.states_to_numbers(np.array([end], dtype=sr.dtype))
print(number, number.dtype, sr.numbers_to_states(number))
# [-2] int64 [127]
```

The problem is more severe in highly artificial case `nk.utils.StaticRange(start=-113, step=7, length=35, dtype=np.int8)` where `sr.numbers_to_states(sr.states_to_numbers(states)) != states` for some states.
In `state_to_numbers`: `x - self.start` calculates `np.array([125], dtype=np.int8) + 113` in `int8` arithmetic and returns a negative number, which then may not be divisible with `step` (it appears only for `step >= 3`).

A proper solution would be to calculate (beside all params inside dtype):
```python
x // sr.step - sr.start//sr.step + (x % sr.step - sr.start % sr.step) // sr.step
```
but we have 8 instead of 3 operations previously.
Rather, I suggest, to check that `length * step` lies inside dtype range.