### PR TITLE
GPU efficient Jastrow Ansatz

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Drivers now call the loggers from all ranks, allowing more advanced logging logic (and checkpointers) to be implemented [#1920](https://github.com/netket/netket/pull/1920).
 * The `netket.experimental.dynamics` module has been greatly refactored, changing all internal logics but exposing a well designed, easier to extend interface. While the interface is not yet documented, it is now reasonably possible to implement new ode integrators on top of our interface to be used with {class}`~netket.experimental.driver.TDVP` or other drivers [#1933](https://github.com/netket/netket/pull/1933).
 * Timing of the run function with `timeit=True` is now more accurate, even on GPUs, but it will decrease performance [#1958](https://github.com/netket/netket/pull/1958).
+* The model {class}`netket.models.Jastrow` now constructs its kernel matrix differently, resulting in faster calculations, especially on GPUs. The usage of the class is unchanged and the internal structure of the parameters does not break from previous versions [#1964](https://github.com/netket/netket/pull/1964). 
 
 ### Breaking Changes
 * Removed support for using Numba-operators under sharding. This has never really worked realiably and lead to uncomprehensible crashes, and was very hard to maintain so it's leaving [#1919](https://github.com/netket/netket/pull/1919).

--- a/netket/models/jastrow.py
+++ b/netket/models/jastrow.py
@@ -43,10 +43,15 @@ class Jastrow(nn.Module):
         )
 
         ## separate real and imaginray part in order to be effificient on GPUs
-        Wr = jnp.zeros((nv, nv), dtype=kernel.real.dtype).at[il].set(kernel.real)
-        Wi = jnp.zeros((nv, nv), dtype=kernel.imag.dtype).at[il].set(kernel.imag)
+        if jnp.issubdtype(self.param_dtype, jnp.complexfloating):
+            Wr = jnp.zeros((nv, nv), dtype=kernel.real.dtype).at[il].set(kernel.real)
+            Wi = jnp.zeros((nv, nv), dtype=kernel.imag.dtype).at[il].set(kernel.imag)
+            W = Wr + 1j * Wi
 
-        W, x_in = promote_dtype(Wr + 1j * Wi, x_in, dtype=None)
+        else:
+            W = jnp.zeros((nv, nv), dtype=self.param_dtype).at[il].set(kernel)
+
+        W, x_in = promote_dtype(W, x_in, dtype=None)
         y = jnp.einsum("...i,ij,...j", x_in, W, x_in)
 
         return y

--- a/netket/models/jastrow.py
+++ b/netket/models/jastrow.py
@@ -42,7 +42,9 @@ class Jastrow(nn.Module):
             "kernel", self.kernel_init, (nv * (nv - 1) // 2,), self.param_dtype
         )
 
-        ## separate real and imaginray part in order to be effificient on GPUs
+        # .at[].set is VERY slow for complex128 numbers in jax.
+        # So we do it on the real-valued real and imaginary parts separately and then join them back
+        # See issue https://github.com/jax-ml/jax/issues/24872
         if jnp.issubdtype(self.param_dtype, jnp.complexfloating):
             Wr = jnp.zeros((nv, nv), dtype=kernel.real.dtype).at[il].set(kernel.real)
             Wi = jnp.zeros((nv, nv), dtype=kernel.imag.dtype).at[il].set(kernel.imag)

--- a/netket/models/jastrow.py
+++ b/netket/models/jastrow.py
@@ -42,9 +42,11 @@ class Jastrow(nn.Module):
             "kernel", self.kernel_init, (nv * (nv - 1) // 2,), self.param_dtype
         )
 
-        W = jnp.zeros((nv, nv), dtype=self.param_dtype).at[il].set(kernel)
+        ## separate real and imaginray part in order to be effificient on GPUs
+        Wr = jnp.zeros((nv, nv), dtype=kernel.real.dtype).at[il].set(kernel.real)
+        Wi = jnp.zeros((nv, nv), dtype=kernel.imag.dtype).at[il].set(kernel.imag)
 
-        W, x_in = promote_dtype(W, x_in, dtype=None)
+        W, x_in = promote_dtype(Wr + 1j * Wi, x_in, dtype=None)
         y = jnp.einsum("...i,ij,...j", x_in, W, x_in)
 
         return y


### PR DESCRIPTION
As indicated, this PR changes the way to initialize the Jastrow parameters so that it is efficient on GPUs. 
To confirm it, I compared the performances (quick test measuring computation time for a random system of 10 spins with 10k samples) on MPI and GPU for this form, the "old" one and a form written in `jax.pallas` code 

|        | Expect | QGT   | Grad   |
| ------ | ------ | ----- | ------ |
| MPI    |        |       |        |
| old    | 1.925  | 2.102 | 8.968  |
| new    | 1.946  | 1.605 | 7.241  |
| GPU    |        |       |        |
| old    | 7.768  | 0.500 | 13.670 |
| pallas | 1.251  | 0.486 | 14.061 |
| new    | 1.420  | 0.495 | 14.077 |


The `pallas` code is slightly faster, but the implementation is in my opinion worse than the one proposed here (in particular, it requires much more effort, takes way more memory and is only compatible with certain GPUs, also it implies a modification in the sharding due to a slight bug still not solved in pallas, which I don't really like). 