### PR TITLE
Fix exotic history logging bug (+a sharding one)

### DIFF
--- a/netket/hilbert/discrete_hilbert.py
+++ b/netket/hilbert/discrete_hilbert.py
@@ -161,7 +161,7 @@ class DiscreteHilbert(AbstractHilbert):
 
         # equinox.error_if is broken under shard_map.
         # If we are using shard map, we skip this check
-        if sharding.SHARD_MAP_STACK_LEVEL == 0:
+        if sharding.SHARD_MAP_STACK_LEVEL == 0 and jax.device_count() == 1:
             numbers = error_if(
                 numbers,
                 (numbers >= self.n_states).any() | (numbers < 0).any(),

--- a/netket/hilbert/homogeneous.py
+++ b/netket/hilbert/homogeneous.py
@@ -266,7 +266,7 @@ class HomogeneousHilbert(DiscreteHilbert):
 
             # equinox.error_if is broken under shard_map.
             # If we are using shard map, we skip this check
-            if sharding.SHARD_MAP_STACK_LEVEL == 0:
+            if sharding.SHARD_MAP_STACK_LEVEL == 0 and jax.device_count() == 1:
                 states = error_if(
                     states,
                     (states < start).any() | (states >= end).any(),
@@ -274,7 +274,7 @@ class HomogeneousHilbert(DiscreteHilbert):
                 )
 
         if self.constrained:
-            if sharding.SHARD_MAP_STACK_LEVEL == 0:
+            if sharding.SHARD_MAP_STACK_LEVEL == 0 and jax.device_count() == 1:
                 states = error_if(
                     states,
                     ~self.constraint(states).all(),

--- a/netket/sampler/metropolis.py
+++ b/netket/sampler/metropolis.py
@@ -611,7 +611,7 @@ def MetropolisExchange(
         If you are working with systems where the number of nodes in the physical lattice
         does not match the number of degrees of freedom, you must be careful!
 
-        A typical example is a system of Spin-1/2 fermions on a lattice with N sites, where the 
+        A typical example is a system of Spin-1/2 fermions on a lattice with N sites, where the
         first N degrees of freedom correspond to the spin down degrees of freedom and the
         next N degrees of freedom correspond to the spin up degrees of freedom.
 

--- a/netket/sampler/rules/exchange.py
+++ b/netket/sampler/rules/exchange.py
@@ -56,7 +56,7 @@ class ExchangeRule(MetropolisRule):
         If you are working with systems where the number of nodes in the physical lattice
         does not match the number of degrees of freedom, you must be careful!
 
-        A typical example is a system of Spin-1/2 fermions on a lattice with N sites, where the 
+        A typical example is a system of Spin-1/2 fermions on a lattice with N sites, where the
         first N degrees of freedom correspond to the spin down degrees of freedom and the
         next N degrees of freedom correspond to the spin up degrees of freedom.
 

--- a/netket/utils/history/history.py
+++ b/netket/utils/history/history.py
@@ -154,7 +154,7 @@ class History:
 
             elif hasattr(val, "__array__"):
                 val = np.asarray(val, dtype=dtype)
-                if n_elements == 1 and len(val) != 1:
+                if n_elements == 1 and val.ndim > 0:
                     val = np.reshape(val, (1, *val.shape))
 
                 raise_if_len_not_match(len(val), n_elements, key)

--- a/netket/utils/struct/pytree_serialization_sharding.py
+++ b/netket/utils/struct/pytree_serialization_sharding.py
@@ -44,10 +44,10 @@ class ShardedFieldSpec:
     deserialization_function: ShardedDeserializationFunction | str | None = "relaxed"
     """
     Function to use to deserialize the data. Can be a callable with the signature:
-    
-    ```python
-    def f(value_target: jax.Array, value_state: jax.Array, *, name: str = ".") -> jax.Array
-    ```
+
+    .. code-block:: python
+
+        def f(value_target: jax.Array, value_state: jax.Array, *, name: str = ".") -> jax.Array
 
     or one of the following strings:
 

--- a/test/utils/test_history.py
+++ b/test/utils/test_history.py
@@ -54,7 +54,9 @@ def create_mock_data_iter(iter):
         "int": iter,
         "complex": iter + 1j * iter,
         "npint": np.array(iter),
+        "jax-1d": jnp.full((1,), iter), # tests logging a 1D, 1 element vector
         "jaxcomplex": jnp.array(iter + 1j * iter),
+        "jaxcomple-1d": jnp.full((1,), iter + 1j * iter),
         "dict": {"int": iter},
         "frozendict": flax.core.freeze({"sub": {"int": iter}}),
         "compound": MockCompoundType(iter, iter * 10),

--- a/test/utils/test_history.py
+++ b/test/utils/test_history.py
@@ -54,7 +54,7 @@ def create_mock_data_iter(iter):
         "int": iter,
         "complex": iter + 1j * iter,
         "npint": np.array(iter),
-        "jax-1d": jnp.full((1,), iter), # tests logging a 1D, 1 element vector
+        "jax-1d": jnp.full((1,), iter),  # tests logging a 1D, 1 element vector
         "jaxcomplex": jnp.array(iter + 1j * iter),
         "jaxcomple-1d": jnp.full((1,), iter + 1j * iter),
         "dict": {"int": iter},


### PR DESCRIPTION
Fix a minor bug where if we log a scalar value stored as a 1d array, it would break the logger.
Also stops checking the numbers passed to `hilbert.numbers_to_state` when using more than 1 GPU, as the code cannot be sharded and gives rise to unreadable sharding errors.