### PR TITLE
Swap ordering of spin hilbert space

### DIFF
--- a/netket/hilbert/tensor_hilbert_discrete.py
+++ b/netket/hilbert/tensor_hilbert_discrete.py
@@ -38,7 +38,7 @@ class TensorDiscreteHilbert(TensorHilbert, DiscreteHilbert):
         >>> from netket.hilbert import Spin, Fock
         >>> hi = Fock(3)*Spin(0.5, 5)
         >>> print(hi)
-        Fock(n_max=3, N=1)⊗Spin(s=1/2, N=5, ordering=inverted)
+        Fock(n_max=3, N=1)⊗Spin(s=1/2, N=5, ordering=new)
         >>> isinstance(hi, nk.hilbert.TensorHilbert)
         True
         >>> type(hi)

--- a/netket/operator/_pauli_strings/base.py
+++ b/netket/operator/_pauli_strings/base.py
@@ -162,7 +162,7 @@ class PauliStringsBase(DiscreteOperator):
            >>> hilbert = nk.hilbert.Spin(1/2, 2)
            >>> op = nk.operator.PauliStrings(hilbert, operators, weights)
            >>> op.hilbert
-           Spin(s=1/2, N=2, ordering=inverted)
+           Spin(s=1/2, N=2, ordering=new)
         """
         if hilbert is None:
             raise ValueError("None-valued hilbert passed.")


### PR DESCRIPTION
Complete the change initiated in September. With this, Spin Hilbert Spaces will finally have the reasonable ordering of spin up = 1 and spin down = -1