### PR TITLE
Added warning when attempting to initialize a periodic lattice on a small lattice

### DIFF
--- a/netket/errors.py
+++ b/netket/errors.py
@@ -1128,3 +1128,38 @@ def concrete_or_error(force, value, error_class, *args, **kwargs):
         )
     except ConcretizationTypeError as err:
         raise error_class(*args, **kwargs) from err
+
+
+#################################################
+# Graph errors                                  #
+#################################################
+
+
+class InitializePeriodicLatticeOnSmallLatticeWarning(NetketWarning):
+    """
+    Warning thrown when attempting to create a periodic lattice on a lattice with less than two sites in one direction.
+
+    In a periodic lattice with two sites (a, b) in one direction,
+    the expected behavior is to have an edge connecting both a->b and b->a
+
+    However, as the lattice uses an undirected graph to represent the lattice, it does not support this behavior.
+    Hence, only one edge a->b is created, which makes the behavior equivalent to an open boundary condition in this direction.
+
+    This may cause unexpected behavior if you intend to loop over the edges to create a Hamiltonian, for example.
+
+    To avoid this warning, consider either using a lattice with more than two sites in the direction you want to be periodic,
+    or define the graph using :class:`~netket.graph.Graph` by adding the edges manually.
+    """
+
+    def __init__(self, extent, dimension):
+        super().__init__(
+            f"""
+            You are attempting to define a lattice with length {extent} in dimension {dimension} using periodic boundary condition.
+
+            Lattice with less than two sites in one direction does not support periodic boundary condition.
+            The behavior of the lattice is equivalent to an open boundary condition in this direction.
+
+            To avoid this warning, consider either using a lattice with more than two sites in the direction you want to be periodic,
+            or define the graph using :class:`~netket.graph.Graph` by adding the edges manually.
+            """
+        )

--- a/netket/graph/common_lattices.py
+++ b/netket/graph/common_lattices.py
@@ -16,10 +16,12 @@ from itertools import permutations
 from functools import partial
 from collections.abc import Sequence
 import numpy as np
+import warnings
 
 from .lattice import Lattice
 
 from netket.utils.group import PointGroup, PGSymmetry, planar, cubic, Identity
+from netket.errors import InitializePeriodicLatticeOnSmallLatticeWarning
 
 
 def _perm_symm(perm: tuple) -> PGSymmetry:
@@ -110,10 +112,21 @@ def Grid(
         12
     """
     extent = np.asarray(extent, dtype=int)
-
     ndim = len(extent)
     if isinstance(pbc, bool):
         pbc = [pbc] * ndim
+    raised_periodic_lattice_on_small_lattice_warning = False
+    for i in range(ndim):
+        if (
+            extent[i] <= 2
+            and pbc[i]
+            and not raised_periodic_lattice_on_small_lattice_warning
+        ):
+            raised_periodic_lattice_on_small_lattice_warning = True
+            warnings.warn(
+                InitializePeriodicLatticeOnSmallLatticeWarning(extent[i], i),
+                UserWarning,
+            )
     if color_edges:
         kwargs["custom_edges"] = [(0, 0, vec) for vec in np.eye(ndim)]
     if point_group is None:
@@ -455,6 +468,21 @@ def Triangular(extent, *, pbc: bool | Sequence[bool] = True, **kwargs) -> Lattic
         >>> print(g.n_nodes)
         9
     """
+    ndim = len(extent)
+    raised_periodic_lattice_on_small_lattice_warning = False
+    if isinstance(pbc, bool):
+        pbc = [pbc] * ndim
+    for i in range(ndim):
+        if (
+            extent[i] <= 2
+            and pbc[i]
+            and not raised_periodic_lattice_on_small_lattice_warning
+        ):
+            raised_periodic_lattice_on_small_lattice_warning = True
+            warnings.warn(
+                InitializePeriodicLatticeOnSmallLatticeWarning(extent[i], i),
+                UserWarning,
+            )
     return _hexagonal_general(extent, site_offsets=None, pbc=pbc, **kwargs)
 
 


### PR DESCRIPTION
This is a follow-up on the issue [here](https://github.com/netket/netket/issues/1989).

I added a warning class InitializePeriodicLatticeOnSmallLatticeWarning in netket.errors.py and used it in the Grid and Triangular Class in common_lattices.py. I think these two lattice classes are the only ones where the periodic lattice problem would happen; in more complicated lattices like diamond or Kagome the periodic looped edge is not equivalent to one of the edges in the open boundary case.

Please advise if the wording in the warning class is appropriate or if I should edit something.

