### PR TITLE
fix: timer is never null only NullTimer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 ## Bug Fixes
 * A bug in the deserialization of variational states, which was not properly restoring the good sharding, has been fixed [1983](https://github.com/netket/netket/pull/1983)
-
+* A performance bug that caused `.block_until_ready()` to be called in every timed function, even when not timing, was addressed [1991](https://github.com/netket/netket/pull/1991)
 
 ## NetKet 3.15 (24 November 2024)
 

--- a/netket/vqs/mc/mc_state/state.py
+++ b/netket/vqs/mc/mc_state/state.py
@@ -563,8 +563,8 @@ class MCState(VariationalState):
                     state=self.sampler_state,
                     chain_length=n_discard_per_chain,
                 )
-                # If timer is not None, we are timing, so we should block
-                if timer is not None:
+                # If timer is not NullTimer, we are timing, so we should block
+                if not (timer is None or isinstance(timer, timing.NullTimer)):
                     _.block_until_ready()
 
         self._samples, self.sampler_state = self.sampler.sample(


### PR DESCRIPTION
this is definitely a bug, but i'm not so sure either whether the:
```
_.block_until_ready()
```
should work as `_` is an ndarray.

but either way w/o this patch the `timeit=False`, will still get into this branch, which is not what it should be happening 