### PR TITLE
fix: the return type of the samples should be the same as the input

### DIFF
--- a/netket/sampler/metropolis.py
+++ b/netket/sampler/metropolis.py
@@ -702,9 +702,6 @@ def MetropolisHamiltonian(hilbert, hamiltonian, **kwargs) -> MetropolisSampler:
     Notice that this sampler preserves by construction all the symmetries
     of the Hamiltonian. This is in generally not true for the local samplers instead.
 
-    This sampler only works on the CPU. To use the Hamiltonian sampler with GPUs,
-    you should use :class:`netket.sampler.MetropolisHamiltonianNumpy`
-
     Args:
         hilbert: The Hilbert space to sample.
         hamiltonian: The operator used to perform off-diagonal transition.

--- a/netket/sampler/metropolis_numpy.py
+++ b/netket/sampler/metropolis_numpy.py
@@ -114,6 +114,15 @@ class MetropolisSamplerNumpy(MetropolisSampler):
     very poorly on jax so this is a good workaround.
 
     See :ref:`netket.sampler.MetropolisSampler` for more information.
+
+    .. warning::
+       This sampler only works on the CPU. To use the Hamiltonian sampler with GPUs, you
+       should use :class:`netket.sampler.MetropolisHamiltonian`.
+
+       This sampler is largely outdated, and we recommend not to use them. Little effort has
+       been put into improving performance in those samplers after 2021.
+
+       If you have a complicated transitions rule, consider instead using a `jax.pure_callback`.
     """
 
     @wraps(MetropolisSampler.__init__)

--- a/netket/sampler/rules/hamiltonian.py
+++ b/netket/sampler/rules/hamiltonian.py
@@ -190,7 +190,7 @@ class HamiltonianRuleJax(HamiltonianRuleBase):
         nonzero_i_plus1 = (jnp.cumsum(nonzeros, axis=-1)) * nonzeros
         rand_i_mask = nonzero_i_plus1 == jnp.expand_dims(rand_i + 1, -1)
         # .sum promotes the dtype, so we must convert it to xp dtype
-        x_proposed = (xp * jnp.expand_dims(rand_i_mask, -1)).sum(axis=1).astype(x.dtype)
+        x_proposed = (xp * jnp.expand_dims(rand_i_mask, -1)).sum(axis=1, dtype=xp.dtype)
         n_conn_proposed = self.operator.n_conn(x_proposed)
 
         # _, mels_proposed = self.operator.get_conn_padded(x_proposed)
@@ -210,7 +210,7 @@ class HamiltonianRuleJax(HamiltonianRuleBase):
 
         log_prob_corr = jnp.log(n_conn) - jnp.log(n_conn_proposed)
 
-        return x_proposed, log_prob_corr
+        return x_proposed.astype(x.dtype), log_prob_corr
 
 
 def HamiltonianRule(operator):


### PR DESCRIPTION
based on @PhilipVinc suggestion