### PR TITLE
fix: BoseHubbardJax precision

### DIFF
--- a/netket/operator/_bose_hubbard/jax.py
+++ b/netket/operator/_bose_hubbard/jax.py
@@ -54,11 +54,15 @@ class BoseHubbardJax(BoseHubbardBase, DiscreteJaxOperator):
     @wraps(BoseHubbardBase.get_conn_padded)
     def get_conn_padded(self, x):
         x_ids = self.hilbert.states_to_local_indices(x)
+
+        # Note that the calculation of the matrix elements will be done
+        # in double precision, and we cast to the dtype of the oeprator
+        # only at the end. Otherwise jnp.sqrt might return 'bad' results.
         xp_ids, mels = _bh_kernel_jax(
             x_ids, self._edges, self.U, self.V, self.J, self.mu, self._n_max
         )
         xp = self.hilbert.local_indices_to_states(xp_ids, dtype=x.dtype)
-        return xp, mels
+        return xp, mels.astype(self.dtype)
 
     def to_numba_operator(self) -> "BoseHubbard":  # noqa: F821
         """
@@ -104,12 +108,6 @@ class BoseHubbardJax(BoseHubbardBase, DiscreteJaxOperator):
 
 @partial(jax.jit, static_argnames="n_max")
 def _bh_kernel_jax(x, edges, U, V, J, mu, n_max):
-    # x is int32, hence when calling jnp.sqrt(2) it'll use float32
-    # so in order to enforce 64 bit precision we need to case it to 64 bits
-    # note jax.config.update("jax_enable_x64", True) does not solve the
-    # above mentioned problem
-    x = jax.lax.convert_element_type(x, jnp.int64)
-
     i = edges[:, 0]
     j = edges[:, 1]
     n_i = jnp.vectorize(lambda x: x[i], signature="(n)->(m)")(x)
@@ -129,16 +127,24 @@ def _bh_kernel_jax(x, edges, U, V, J, mu, n_max):
         lambda x, idx, addend: x.at[..., idx].add(addend), (-2, 0, None), -2
     )
 
+    # x might be stored in lower (int8, int16...) precision, which will
+    # cause jnp.sqrt(n) to be computed in float16, float32 precision, which
+    # we have seen to lead to some numerical precision errors.
+    # so in order to enforce 64 bit precision we need to case it to 64 bits
+    h_dtype = jnp.float64 if jax.config.jax_enable_x64 else jnp.float32
+    n_i_64 = n_i.astype(h_dtype)
+    n_j_64 = n_j.astype(h_dtype)
+
     # destroy on i create on j
     mask1 = (n_i > 0) & (n_j < n_max)
-    mels1 = mask1 * (-J * jnp.sqrt(n_i) * jnp.sqrt(n_j + 1))
+    mels1 = mask1 * (-J * jnp.sqrt(n_i_64) * jnp.sqrt(n_j_64 + 1))
     xp1 = jnp.repeat(_x, mask1.shape[-1], axis=-2)
     xp1 = add_at(xp1, i, -1)
     xp1 = add_at(xp1, j, +1)
 
     # destroy on j create on i
     mask2 = (n_j > 0) & (n_i < n_max)
-    mels2 = mask2 * (-J * jnp.sqrt(n_j) * jnp.sqrt(n_i + 1))
+    mels2 = mask2 * (-J * jnp.sqrt(n_j_64) * jnp.sqrt(n_i_64 + 1))
     xp2 = jnp.repeat(_x, mask2.shape[-1], axis=-2)
     xp2 = add_at(xp2, j, -1)
     xp2 = add_at(xp2, i, +1)

--- a/netket/operator/_bose_hubbard/jax.py
+++ b/netket/operator/_bose_hubbard/jax.py
@@ -104,6 +104,12 @@ class BoseHubbardJax(BoseHubbardBase, DiscreteJaxOperator):
 
 @partial(jax.jit, static_argnames="n_max")
 def _bh_kernel_jax(x, edges, U, V, J, mu, n_max):
+    # x is int32, hence when calling jnp.sqrt(2) it'll use float32
+    # so in order to enforce 64 bit precision we need to case it to 64 bits
+    # note jax.config.update("jax_enable_x64", True) does not solve the
+    # above mentioned problem
+    x = jax.lax.convert_element_type(x, jnp.int64)
+
     i = edges[:, 0]
     j = edges[:, 1]
     n_i = jnp.vectorize(lambda x: x[i], signature="(n)->(m)")(x)

--- a/test/operator/test_operator.py
+++ b/test/operator/test_operator.py
@@ -576,3 +576,22 @@ def test_matmul_sparse_vector(op):
 )
 def test_jax_operator_to_jax_operator(op):
     assert op == op.to_jax_operator()
+
+
+
+def test_bose_hubbard_precision():
+    N=2
+    g = nk.graph.Hypercube(length=2, n_dim=1, pbc=True)
+
+    hi = nk.hilbert.Fock(N=g.n_nodes, n_max=N, n_particles=N)
+    ha = nk.operator.BoseHubbard(hilbert=hi, graph=g, U = 1.0, J = 1.0, V = 0.0)
+    haj = nk.operator.BoseHubbardJax(hilbert=hi, graph=g, U = 1.0, J = 1.0, V = 0.0)
+
+    def gcp(s):
+        xp, mels = ha.get_conn_padded(s)
+        return jnp.asarray(mels).sort(axis=-1)
+    def gcpj(s):
+        return haj.get_conn_padded(s)[1].sort(axis=-1)
+
+    s=hi.all_states()
+    assert jax.numpy.all(gcp(s) == gcpj(s))

--- a/test/operator/test_operator.py
+++ b/test/operator/test_operator.py
@@ -5,6 +5,7 @@ from netket.operator import DiscreteJaxOperator
 
 import pytest
 import jax
+import jax.numpy as jnp
 from jax.experimental.sparse import BCOO
 from netket.jax.sharding import shard_along_axis
 
@@ -578,20 +579,21 @@ def test_jax_operator_to_jax_operator(op):
     assert op == op.to_jax_operator()
 
 
-
 def test_bose_hubbard_precision():
-    N=2
+    # Issue #1994
+    N = 2
     g = nk.graph.Hypercube(length=2, n_dim=1, pbc=True)
 
     hi = nk.hilbert.Fock(N=g.n_nodes, n_max=N, n_particles=N)
-    ha = nk.operator.BoseHubbard(hilbert=hi, graph=g, U = 1.0, J = 1.0, V = 0.0)
-    haj = nk.operator.BoseHubbardJax(hilbert=hi, graph=g, U = 1.0, J = 1.0, V = 0.0)
+    ha = nk.operator.BoseHubbard(hilbert=hi, graph=g, U=1.0, J=1.0, V=0.0)
+    haj = nk.operator.BoseHubbardJax(hilbert=hi, graph=g, U=1.0, J=1.0, V=0.0)
 
     def gcp(s):
         xp, mels = ha.get_conn_padded(s)
         return jnp.asarray(mels).sort(axis=-1)
+
     def gcpj(s):
         return haj.get_conn_padded(s)[1].sort(axis=-1)
 
-    s=hi.all_states()
+    s = hi.all_states()
     assert jax.numpy.all(gcp(s) == gcpj(s))


### PR DESCRIPTION
@PhilipVinc this fixes the immediate error we are observing in the this code:
```
import netket as nk
import netket.nn as nknn
import jax.numpy as jnp
import jax

N=4
g = nk.graph.Hypercube(length=3, n_dim=2, pbc=True)

# Boson Hilbert Space
hi = nk.hilbert.Fock(N=g.n_nodes, n_max=N, n_particles=N)

# Bose Hubbard Hamiltonian
ha = nk.operator.BoseHubbard(hilbert=hi, graph=g, U = 1.0, J = 1.0, V = 0.0)
haj = nk.operator.BoseHubbardJax(hilbert=hi, graph=g, U = 1.0, J = 1.0, V = 0.0)

def gcp(s):
    xp, mels = ha.get_conn_padded(s)
    return jnp.asarray(mels).sort(axis=-1)
def gcpj(s):
    return haj.get_conn_padded(s)[1].sort(axis=-1)

s=hi.all_states()
jnp.sort((gcp(s) - gcpj(s)).reshape(-1))
```