### PR TITLE
Discard states that are not in the constraint Hilbert space for the FermionOperator2nd operator

### DIFF
--- a/docs/docs/hilbert.md
+++ b/docs/docs/hilbert.md
@@ -204,6 +204,14 @@ of particles is conserved, and therefore respects the constraint if it is correc
 In short: when working with constrained Hilbert spaces you have to take extra care when choosing your sampler. And if you have exotic constraints you will most likely need to define your own transition kernel. But don't worry: it is very easy! (however nobody has yet written documentation for it. In the meantime, have a look at [this discussion](https://github.com/netket/netket/discussions/755#discussioncomment-858719))
 ```
 
+```{admonition} Warning: Common error
+:class: warning
+
+When you define a constrained Hilbert space and use operators in matrix representation, e.g. if you do exact diagonalization:
+
+The states the operator generates, which are not in the constraint Hilbert space, are discarded!
+```
+
 The constraints supported on the built-in hilbert spaces are:
 
  - {class}`Spin` supports an optional keyword argument `total_sz` which can be used to impose a fixed total magnetization. 

--- a/netket/operator/_discrete_operator.py
+++ b/netket/operator/_discrete_operator.py
@@ -217,11 +217,11 @@ class DiscreteOperator(AbstractOperator):
                     x_prime_must_keep_per_row = {}
                     at_section = section_of_next
             
-            mustkeep_test = np.array([x_prime_must_keep[tuple(x_prime[i])]==True for i in range(x_prime.shape[0])])
+            mustkeep_test = np.array([x_prime_must_keep[tuple(x_prime[i])] for i in range(x_prime.shape[0])])
 
-            removed_indices = np.where(mustkeep_test == False)[0]
+            removed_indices = np.where(not mustkeep_test)[0]
             return removed_indices
-            
+
 
         # if check_out_of_hilbert is True, it only removes states, which sum up to 0, 
         # the operator is responsible not to generate out of Hilbert space states
@@ -229,7 +229,7 @@ class DiscreteOperator(AbstractOperator):
         if check_out_of_hilbert:
             removed_indices = check_ooHS(x_prime, mels, sections1)
         else:
-            removed_indices = np.where(self.hilbert.constraint(x_prime) == False)[0]
+            removed_indices = np.where(self.hilbert.constraint(x_prime) == False)[0]  # pylint: disable=E712    as pylint is wrong here
 
         # Apply the mask to all arrays at once
         x_prime = np.delete(x_prime, removed_indices, axis=0)
@@ -268,7 +268,6 @@ class DiscreteOperator(AbstractOperator):
         if hilb.constrained:
             x_prime, mels, sections1 = self.check_out_of_hilbert(x_prime, mels, sections1)
         numbers = hilb.states_to_numbers(x_prime)
-        
 
         return _csr_matrix(
             (mels, numbers, sections1),

--- a/netket/operator/_discrete_operator.py
+++ b/netket/operator/_discrete_operator.py
@@ -198,7 +198,7 @@ class DiscreteOperator(AbstractOperator):
         mels = np.delete(mels, removed_indices)
         
         # Adjust sections1 based on removed indices
-        adjustment = np.searchsorted(removed_indices, sections1, side='left')
+        adjustment = np.searchsorted(removed_indices, sections1, side="left")
         sections1 -= adjustment
         return x_prime, mels, sections1
     
@@ -228,7 +228,9 @@ class DiscreteOperator(AbstractOperator):
         sections1[0] = 0
         
         if hilb.constrained:
-            x_prime, mels, sections1 = self.check_out_of_hilbert(x_prime, mels, sections1)
+            x_prime, mels, sections1 = self.check_out_of_hilbert(
+                x_prime, mels, sections1
+            )
         
         numbers = hilb.states_to_numbers(x_prime)
 

--- a/netket/operator/_discrete_operator.py
+++ b/netket/operator/_discrete_operator.py
@@ -219,7 +219,7 @@ class DiscreteOperator(AbstractOperator):
             
             mustkeep_test = np.array([x_prime_must_keep[tuple(x_prime[i])] for i in range(x_prime.shape[0])])
 
-            removed_indices = np.where(not mustkeep_test)[0]
+            removed_indices = np.where(~mustkeep_test)[0]
             return removed_indices
 
 
@@ -229,7 +229,7 @@ class DiscreteOperator(AbstractOperator):
         if check_out_of_hilbert:
             removed_indices = check_ooHS(x_prime, mels, sections1)
         else:
-            removed_indices = np.where(self.hilbert.constraint(x_prime) == False)[0]  # pylint: disable=E712    as pylint is wrong here
+            removed_indices = np.where(~self.hilbert.constraint(x_prime))[0]
 
         # Apply the mask to all arrays at once
         x_prime = np.delete(x_prime, removed_indices, axis=0)

--- a/netket/operator/_discrete_operator.py
+++ b/netket/operator/_discrete_operator.py
@@ -265,7 +265,8 @@ class DiscreteOperator(AbstractOperator):
         sections1[1:] = sections
         sections1[0] = 0
         # numbers = hilb.states_to_numbers(x_prime)
-        x_prime, mels, sections1 = self.check_out_of_hilbert(x_prime, mels, sections1)
+        if hilb.constrained:
+            x_prime, mels, sections1 = self.check_out_of_hilbert(x_prime, mels, sections1)
         numbers = hilb.states_to_numbers(x_prime)
         
 

--- a/netket/operator/_discrete_operator.py
+++ b/netket/operator/_discrete_operator.py
@@ -259,7 +259,7 @@ class DiscreteOperator(AbstractOperator):
         sections = np.empty(x.shape[0], dtype=np.int32)
         x_prime, mels = concrete_op.get_conn_flattened(x, sections)
 
-        numbers = hilb.states_to_numbers(x_prime)
+        # numbers = hilb.states_to_numbers(x_prime)
 
         sections1 = np.empty(sections.size + 1, dtype=np.int32)
         sections1[1:] = sections

--- a/netket/operator/_discrete_operator.py
+++ b/netket/operator/_discrete_operator.py
@@ -188,7 +188,7 @@ class DiscreteOperator(AbstractOperator):
             low = old_out
 
         return out
-    
+
     def check_out_of_hilbert(self, x_prime, mels, sections1):
         # This function is used to remove the states that are not in the Hilbert space
         removed_indices = np.where(~self.hilbert.constraint(x_prime))[0]
@@ -196,12 +196,12 @@ class DiscreteOperator(AbstractOperator):
         # Apply the mask to all arrays at once
         x_prime = np.delete(x_prime, removed_indices, axis=0)
         mels = np.delete(mels, removed_indices)
-        
+
         # Adjust sections1 based on removed indices
         adjustment = np.searchsorted(removed_indices, sections1, side="left")
         sections1 -= adjustment
         return x_prime, mels, sections1
-    
+
     def to_sparse(self) -> _csr_matrix:
         r"""Returns the sparse matrix representation of the operator. Note that,
         in general, the size of the matrix is exponential in the number of quantum
@@ -226,12 +226,12 @@ class DiscreteOperator(AbstractOperator):
         sections1 = np.empty(sections.size + 1, dtype=np.int32)
         sections1[1:] = sections
         sections1[0] = 0
-        
+
         if hilb.constrained:
             x_prime, mels, sections1 = self.check_out_of_hilbert(
                 x_prime, mels, sections1
             )
-        
+
         numbers = hilb.states_to_numbers(x_prime)
 
         return _csr_matrix(

--- a/netket/operator/_discrete_operator.py
+++ b/netket/operator/_discrete_operator.py
@@ -188,7 +188,58 @@ class DiscreteOperator(AbstractOperator):
             low = old_out
 
         return out
+    
+    def check_out_of_hilbert(self, x_prime, mels, sections1):
+        # This function is used to remove the states that are not in the Hilbert space
+        
+        # @jit(nopython=True) # tuple is not supported by numba
+        def check_ooHS(x_prime, mels, sections1):
+            x_prime_dict = {} # dictionary to store the sum of mels for each x_prime, is checked by row
+            at_section = 0
+            x_prime_must_keep_per_row = {} # in each row, the sum for each x_prime has to be zero, to remove the x_prime
+            x_prime_must_keep = {}  # dictionary of x_prime with non zero matrix elements
+            for i in range(x_prime.shape[0]):
+                key = tuple(x_prime[i])
+                if key in x_prime_dict:
+                    x_prime_dict[key] += mels[i]
+                else:
+                    x_prime_dict[key] = mels[i]
+                x_prime_must_keep_per_row[key] = (x_prime_dict[key] != 0)
+                section_of_next = np.searchsorted(sections1, i+1, side="right") - 1
+                if section_of_next > at_section:
+                    # last in section
+                    for key in x_prime_must_keep_per_row:
+                        if not (key in x_prime_must_keep):
+                            x_prime_must_keep[key] = x_prime_must_keep_per_row[key]
+                        else:
+                            if x_prime_must_keep_per_row[key]:
+                                x_prime_must_keep[key] = True
+                    x_prime_must_keep_per_row = {}
+                    at_section = section_of_next
+            
+            mustkeep_test = np.array([x_prime_must_keep[tuple(x_prime[i])]==True for i in range(x_prime.shape[0])])
 
+            removed_indices = np.where(mustkeep_test == False)[0]
+            return removed_indices
+            
+
+        # if check_out_of_hilbert is True, it only removes states, which sum up to 0, 
+        # the operator is responsible not to generate out of Hilbert space states
+        check_out_of_hilbert = False
+        if check_out_of_hilbert:
+            removed_indices = check_ooHS(x_prime, mels, sections1)
+        else:
+            removed_indices = np.where(self.hilbert.constraint(x_prime) == False)[0]
+
+        # Apply the mask to all arrays at once
+        x_prime = np.delete(x_prime, removed_indices, axis=0)
+        mels = np.delete(mels, removed_indices)
+        
+        # Adjust sections1 based on removed indices
+        adjustment = np.searchsorted(removed_indices, sections1, side='left')
+        sections1 -= adjustment
+        return x_prime, mels, sections1
+    
     def to_sparse(self) -> _csr_matrix:
         r"""Returns the sparse matrix representation of the operator. Note that,
         in general, the size of the matrix is exponential in the number of quantum
@@ -213,9 +264,10 @@ class DiscreteOperator(AbstractOperator):
         sections1 = np.empty(sections.size + 1, dtype=np.int32)
         sections1[1:] = sections
         sections1[0] = 0
-
-        ## eliminate duplicates from numbers
-        # rows_indices = compute_row_indices(hilb.states_to_numbers(x), sections1)
+        # numbers = hilb.states_to_numbers(x_prime)
+        x_prime, mels, sections1 = self.check_out_of_hilbert(x_prime, mels, sections1)
+        numbers = hilb.states_to_numbers(x_prime)
+        
 
         return _csr_matrix(
             (mels, numbers, sections1),

--- a/netket/operator/_discrete_operator_jax.py
+++ b/netket/operator/_discrete_operator_jax.py
@@ -222,6 +222,13 @@ class DiscreteJaxOperator(DiscreteOperator):
         n = x.shape[0]
         xp, mels = self.get_conn_padded(x)
         a = mels.ravel()
+        if self.hilbert.constrained:
+            # drop out of Hilbert space states
+            xp_flat = xp.reshape(-1, xp.shape[2])
+            valid_xp = self.hilbert.constraint(xp_flat)
+            a = a * valid_xp.ravel()
+            xp_flat = np.where(valid_xp[:, None], xp_flat, x[0])
+            xp = xp_flat.reshape(xp.shape)
         i = np.broadcast_to(np.arange(n)[..., None], mels.shape).ravel()
         j = self.hilbert.states_to_numbers(xp).ravel()
         ij = np.concatenate((i[:, None], j[:, None]), axis=1)

--- a/netket/operator/_discrete_operator_jax.py
+++ b/netket/operator/_discrete_operator_jax.py
@@ -226,6 +226,8 @@ class DiscreteJaxOperator(DiscreteOperator):
             # drop out of Hilbert space states
             xp_flat = xp.reshape(-1, xp.shape[2])
             valid_xp = self.hilbert.constraint(xp_flat)
+            # the mels of the invalid x' are set to 0
+            # the xp are set to a valid state
             a = a * valid_xp.ravel()
             xp_flat = np.where(valid_xp[:, None], xp_flat, x[0])
             xp = xp_flat.reshape(xp.shape)

--- a/netket/operator/_fermion2nd/numba.py
+++ b/netket/operator/_fermion2nd/numba.py
@@ -130,7 +130,6 @@ class FermionOperator2nd(FermionOperator2ndBase):
             self._term_split_idxs,
             self._cutoff,
             pad,
-            self.hilbert.constraint is not None,
         )
 
     @staticmethod
@@ -147,15 +146,7 @@ class FermionOperator2nd(FermionOperator2ndBase):
         term_split_idxs,
         cutoff,
         pad=False,
-        constraint=False,
     ):
-        def hash_raw(x):
-            """Numba can not hash arrays, so we hash them manually"""
-            r = np.uint64(0)
-            for u in x:
-                r = (r * np.uint64(7) + np.uint64(u)) % np.uint64(576460752303423619)  # NextPrime[2^59]  (numba seems to be picky with the types)
-            return r
-        
         x_prime = np.empty((x.shape[0] * max_conn, x.shape[1]), dtype=x.dtype)
         mels = np.zeros((x.shape[0] * max_conn), dtype=weights.dtype)
 
@@ -164,11 +155,6 @@ class FermionOperator2nd(FermionOperator2ndBase):
         orb_idxs_list = np.split(orb_idxs, term_split_idxs)
         daggers_list = np.split(daggers, term_split_idxs)
 
-        
-        if constraint:
-            x_set = set() # set of all states in the hilbert space for quick lookup
-            for raw in x:
-                x_set.add(hash_raw(raw))
         # loop over the batch dimension
         n_c = 0
         for b in range(x.shape[0]):
@@ -193,7 +179,7 @@ class FermionOperator2nd(FermionOperator2ndBase):
                     if not op_has_xp:
                         has_xp = False
                         continue
-                if has_xp and (not constraint or hash_raw(xb) in x_set): # check if in the hilbert space
+                if has_xp:
                     x_prime[n_c, :] = np.copy(xb)  # should be untouched
                     mels[n_c] += mel
 
@@ -217,7 +203,7 @@ class FermionOperator2nd(FermionOperator2ndBase):
                     if not op_has_xp:  # detect zeros
                         has_xp = False
                         continue
-                if has_xp and (not constraint or hash_raw(xt) in x_set):  # check if in the hilbert space
+                if has_xp:
                     x_prime[n_c, :] = np.copy(xt)  # should be different
                     mels[n_c] += mel
                     n_c += 1

--- a/netket/operator/_fermion2nd/numba.py
+++ b/netket/operator/_fermion2nd/numba.py
@@ -153,7 +153,7 @@ class FermionOperator2nd(FermionOperator2ndBase):
             """Numba can not hash arrays, so we hash them manually"""
             r = np.uint64(0)
             for u in x:
-                r = (r * 7 + u) % 576460752303423619  # NextPrime[2^59]
+                r = (r * np.uint64(7) + np.uint64(u)) % np.uint64(576460752303423619)  # NextPrime[2^59]  (numba seems to be picky with the types)
             return r
         
         x_prime = np.empty((x.shape[0] * max_conn, x.shape[1]), dtype=x.dtype)

--- a/netket/operator/_fermion2nd/numba.py
+++ b/netket/operator/_fermion2nd/numba.py
@@ -151,9 +151,9 @@ class FermionOperator2nd(FermionOperator2ndBase):
     ):
         def hash_raw(x):
             """Numba can not hash arrays, so we hash them manually"""
-            r = 0
+            r = np.uint64(0)
             for u in x:
-                r = r * 7 + u
+                r = (r * 7 + u) % 576460752303423619  # NextPrime[2^59]
             return r
         
         x_prime = np.empty((x.shape[0] * max_conn, x.shape[1]), dtype=x.dtype)

--- a/test/operator/test_operator.py
+++ b/test/operator/test_operator.py
@@ -15,12 +15,18 @@ operators = {}
 
 # Operator on constraint Hilbert space
 def c(hi, site, spin):
-    return nk.operator.fermion.destroy(hi, site, spin) * (1 - nk.operator.fermion.number(hi, site, -spin))
+    return nk.operator.fermion.destroy(hi, site, spin) * (
+        1 - nk.operator.fermion.number(hi, site, -spin)
+        )
 
 def cdag(hi, site, spin):
-    return nk.operator.fermion.create(hi, site, spin) * (1 - nk.operator.fermion.number(hi, site, -spin))
+    return nk.operator.fermion.create(hi, site, spin) * (
+        1 - nk.operator.fermion.number(hi, site, -spin)
+        )
 
-g = nk.graph.Grid(extent=(1, 2), pbc=False)  # 2D square lattice with periodic boundary conditions
+g = nk.graph.Grid(
+    extent=(1, 2), pbc=False
+    )  # 2D square lattice with periodic boundary conditions
 
 class AvoidDoubleOccupancy(nk.hilbert.constraint.DiscreteHilbertConstraint):
     def __call__(self, x):
@@ -33,14 +39,12 @@ class AvoidDoubleOccupancy(nk.hilbert.constraint.DiscreteHilbertConstraint):
     def __eq__(self, other):
         return isinstance(other, AvoidDoubleOccupancy)
     
-hi = nk.hilbert.SpinOrbitalFermions(2, 
-                                     s = 1/2, 
-                                     n_fermions_per_spin = (1, 1), 
-                                     constraint=AvoidDoubleOccupancy()
-                                     )
+hi = nk.hilbert.SpinOrbitalFermions(
+    2, s=1 / 2, n_fermions_per_spin=(1, 1), constraint=AvoidDoubleOccupancy()
+)
 
 u, v = g.edges()[0]
-ha = (cdag(hi, u, 1) * c(hi, v, 1) + cdag(hi, v, 1) * c(hi, u, 1))
+ha = cdag(hi, u, 1) * c(hi, v, 1) + cdag(hi, v, 1) * c(hi, u, 1)
 operators["Out of constraint space"] = ha
 
 # Ising 1D

--- a/test/operator/test_operator.py
+++ b/test/operator/test_operator.py
@@ -13,20 +13,24 @@ from .. import common
 
 operators = {}
 
+
 # Operator on constraint Hilbert space
 def c(hi, site, spin):
     return nk.operator.fermion.destroy(hi, site, spin) * (
         1 - nk.operator.fermion.number(hi, site, -spin)
-        )
+    )
+
 
 def cdag(hi, site, spin):
     return nk.operator.fermion.create(hi, site, spin) * (
         1 - nk.operator.fermion.number(hi, site, -spin)
-        )
+    )
+
 
 g = nk.graph.Grid(
     extent=(1, 2), pbc=False
-    )  # 2D square lattice with periodic boundary conditions
+)  # 2D square lattice with periodic boundary conditions
+
 
 class AvoidDoubleOccupancy(nk.hilbert.constraint.DiscreteHilbertConstraint):
     def __call__(self, x):
@@ -34,11 +38,14 @@ class AvoidDoubleOccupancy(nk.hilbert.constraint.DiscreteHilbertConstraint):
         x_sum = jnp.sum(x, axis=1)  # Shape: (batch, L1*L2)
         valid = jnp.all(x_sum <= 1, axis=-1)  # Shape: (batch,)
         return valid.reshape(-1)
+    
     def __hash__(self):
         return hash(("AvoidDoubleOccupancy",))
+    
     def __eq__(self, other):
         return isinstance(other, AvoidDoubleOccupancy)
-    
+
+
 hi = nk.hilbert.SpinOrbitalFermions(
     2, s=1 / 2, n_fermions_per_spin=(1, 1), constraint=AvoidDoubleOccupancy()
 )
@@ -554,6 +561,7 @@ def test_operator_jax_getconn(op):
 def test_operator_numba_throws(op):
     """Check that get conn throws an error"""
     from netket.errors import NumbaOperatorGetConnDuringTracingError
+
     if op.hilbert.constrained:
         pytest.skip("Hilbert space is constrained")
     state = op.hilbert.random_state(jax.random.PRNGKey(1))

--- a/test/operator/test_operator.py
+++ b/test/operator/test_operator.py
@@ -38,10 +38,10 @@ class AvoidDoubleOccupancy(nk.hilbert.constraint.DiscreteHilbertConstraint):
         x_sum = jnp.sum(x, axis=1)  # Shape: (batch, L1*L2)
         valid = jnp.all(x_sum <= 1, axis=-1)  # Shape: (batch,)
         return valid.reshape(-1)
-    
+
     def __hash__(self):
         return hash(("AvoidDoubleOccupancy",))
-    
+
     def __eq__(self, other):
         return isinstance(other, AvoidDoubleOccupancy)
 

--- a/test/operator/test_operator.py
+++ b/test/operator/test_operator.py
@@ -40,7 +40,7 @@ hi = nk.hilbert.SpinOrbitalFermions(2,
                                      )
 
 u, v = g.edges()[0]
-ha = (cdag(hi, u, 1) * c(hi, v, 1))
+ha = (cdag(hi, u, 1) * c(hi, v, 1) + cdag(hi, v, 1) * c(hi, u, 1))
 operators["Out of constraint space"] = ha
 
 # Ising 1D
@@ -207,6 +207,8 @@ for name, op in op_finite_size.items():
 def test_produce_elements_in_hilbert(op, attr):
     rng = nk.jax.PRNGSeq(0)
     hi = op.hilbert
+    if hi.constrained:
+        pytest.skip("Hilbert space is constrained")
     get_conn_fun = getattr(op, attr)
 
     if nk.config.netket_experimental_sharding:
@@ -236,6 +238,8 @@ def test_is_hermitian(op):
     rng = nk.jax.PRNGSeq(20)
 
     hi = op.hilbert
+    if hi.constrained:
+        pytest.skip("Hilbert space is constrained")
     assert len(hi.local_states) == hi.local_size
 
     def _get_nonzero_conn(op, s):
@@ -323,7 +327,8 @@ def test_repr(op):
 )
 def test_get_conn_padded(op, shape, dtype):
     hi = op.hilbert
-
+    if hi.constrained:
+        pytest.skip("Hilbert space is constrained")
     v = hi.random_state(jax.random.PRNGKey(0), shape, dtype=dtype)
 
     vp, mels = op.get_conn_padded(v)
@@ -459,6 +464,8 @@ def test_operator_on_subspace():
 )
 @common.skipif_sharding
 def test_operator_jax_conversion(op):
+    if op.hilbert.constrained:
+        pytest.skip("Hilbert space is constrained")
     op_jax = op.to_jax_operator()
     op_numba = op_jax.to_numba_operator()
 
@@ -488,6 +495,8 @@ def test_operator_jax_conversion(op):
 )
 def test_operator_jax_getconn(op):
     """Check that get_conn returns the same result for jax and numba operators"""
+    if op.hilbert.constrained:
+        pytest.skip("Hilbert space is constrained")
     op_jax = op.to_jax_operator()
 
     states = op.hilbert.all_states()
@@ -541,7 +550,8 @@ def test_operator_jax_getconn(op):
 def test_operator_numba_throws(op):
     """Check that get conn throws an error"""
     from netket.errors import NumbaOperatorGetConnDuringTracingError
-
+    if op.hilbert.constrained:
+        pytest.skip("Hilbert space is constrained")
     state = op.hilbert.random_state(jax.random.PRNGKey(1))
 
     @jax.jit


### PR DESCRIPTION
We had a discussion in #1997.

(Fixes #1973)

The idea is to discard all states, which leave the constraint Hilbert space, effectively projecting on the constraint Hilbert space. I checked with the operator below, which projects, and if I use the "discard all states approach" I get the same result without a projection in the defined operator.

Thanks all for the discussion! Very helpful, Detlef


Cite: 
But maybe the discarding all states, which leave the constraint Hilbert space is the better idea anyway?! And it can be good documented, as you just have to say, we project it on the constraint Hilbert space...

If intermediate results are not allowed to leave the constraint Hilbert space you break a lot of calculation rules e.g.:
cdag_o(hi, site, spin) * (1 - nc(hi, site, -spin)) == cdag_o(hi, site, spin) * 1 - cdag_o(hi, site, spin) * nc(hi, site, -spin))

would not be a valid transformation.

Additionally you break anyway, that it does not matter if you apply the operator to the left or to the right:
<psi|op|psi>

if op is destruction operator, it never leaves the hilbert space applied to the right, but can leave it if applied to the left.