### PR TITLE
Minor changes to Samplers

### DIFF
--- a/netket/sampler/metropolis.py
+++ b/netket/sampler/metropolis.py
@@ -121,12 +121,15 @@ class MetropolisSamplerState(SamplerState):
         return res
 
     def __repr__(self):
-        if self.n_steps > 0:
-            acc_string = f"# accepted = {self.n_accepted}/{self.n_steps} ({self.acceptance * 100}%), "
-        else:
-            acc_string = ""
+        try:
+            if self.n_steps > 0:
+                acc_string = f"# accepted = {self.n_accepted}/{self.n_steps} ({self.acceptance * 100}%), "
+            else:
+                acc_string = ""
 
-        return f"{type(self).__name__}({acc_string}rng state={self.rng})"
+            return f"{type(self).__name__}({acc_string}rng state={self.rng})"
+        except TypeError:
+            return f"{type(self).__name__}(???, rng state={self.rng})"
 
     def __process_deserialization_updates__(self, updates):
         # In netket 3.15 we changed the default dtype of samples

--- a/netket/sampler/metropolis_numpy.py
+++ b/netket/sampler/metropolis_numpy.py
@@ -191,7 +191,7 @@ class MetropolisSamplerNumpy(MetropolisSampler):
             )
 
         state.rule_state = sampler.rule.reset(sampler, machine, parameters, state)
-        state.log_prob = np.copy(
+        state.log_prob = np.array(
             sampler.machine_pow
             * apply_model(machine, parameters, state.σ, sampler.chunk_size).real
         )
@@ -228,22 +228,22 @@ class MetropolisSamplerNumpy(MetropolisSampler):
                 pspecs = jax.sharding.PartitionSpec("x")
 
                 all_samples = host_local_array_to_global_array(σ1, global_mesh, pspecs)
-                log_prob = (
+                _log_prob = (
                     mpow
                     * apply_model(
                         machine, parameters, all_samples, sampler.chunk_size
                     ).real
                 )
-                assert len(log_prob.addressable_shards) == 1
-                log_prob = global_array_to_host_local_array(
+                assert len(_log_prob.addressable_shards) == 1
+                _log_prob = global_array_to_host_local_array(
                     log_prob, global_mesh, pspecs
                 )
             else:
-                log_prob = (
+                _log_prob = (
                     mpow * apply_model(machine, parameters, σ1, sampler.chunk_size).real
                 )
 
-            log_prob_1 = np.asarray(log_prob)
+            log_prob_1 = np.copy(_log_prob)
             assert log_prob_1.shape == σ1.shape[:-1]
 
             random_uniform = rgen.uniform(0, 1, size=σ.shape[0])

--- a/netket/sampler/metropolis_numpy.py
+++ b/netket/sampler/metropolis_numpy.py
@@ -243,8 +243,8 @@ class MetropolisSamplerNumpy(MetropolisSampler):
                     mpow * apply_model(machine, parameters, σ1, sampler.chunk_size).real
                 )
 
-            log_values_1 = np.asarray(log_psi)
-            assert log_values_1.shape == σ1.shape[:-1]
+            log_prob_1 = np.asarray(log_prob)
+            assert log_prob_1.shape == σ1.shape[:-1]
 
             random_uniform = rgen.uniform(0, 1, size=σ.shape[0])
 

--- a/netket/sampler/metropolis_numpy.py
+++ b/netket/sampler/metropolis_numpy.py
@@ -41,9 +41,9 @@ class MetropolisNumpySamplerState:
     σ1: np.ndarray
     """Holds a proposed configuration (preallocation)."""
 
-    log_values: np.ndarray
+    log_prob: np.ndarray
     """Holds model(pars, σ) for the current σ (preallocation)."""
-    log_values_1: np.ndarray
+    log_prob_1: np.ndarray
     """Holds model(pars, σ1) for the last σ1 (preallocation)."""
     log_prob_corr: np.ndarray
     """Holds optional acceptance correction (preallocation)."""
@@ -160,8 +160,8 @@ class MetropolisSamplerNumpy(MetropolisSampler):
         state = MetropolisNumpySamplerState(
             σ=σ,
             σ1=np.copy(σ),
-            log_values=np.zeros(sampler.n_batches, dtype=ma_out.dtype),
-            log_values_1=np.zeros(sampler.n_batches, dtype=ma_out.dtype),
+            log_prob=np.zeros(sampler.n_batches, dtype=ma_out.dtype),
+            log_prob_1=np.zeros(sampler.n_batches, dtype=ma_out.dtype),
             log_prob_corr=np.zeros(
                 sampler.n_batches, dtype=nkjax.dtype_real(ma_out.dtype)
             ),
@@ -191,8 +191,9 @@ class MetropolisSamplerNumpy(MetropolisSampler):
             )
 
         state.rule_state = sampler.rule.reset(sampler, machine, parameters, state)
-        state.log_values = np.copy(
-            apply_model(machine, parameters, state.σ, sampler.chunk_size)
+        state.log_prob = np.copy(
+            sampler.machine_pow
+            * apply_model(machine, parameters, state.σ, sampler.chunk_size).real
         )
 
         state._accepted_samples = 0
@@ -203,8 +204,8 @@ class MetropolisSamplerNumpy(MetropolisSampler):
     def _sample_next(sampler, machine, parameters, state):
         σ = state.σ
         σ1 = state.σ1
-        log_values = state.log_values
-        log_values_1 = state.log_values_1
+        log_prob = state.log_prob
+        log_prob_1 = state.log_prob_1
         log_prob_corr = state.log_prob_corr
         mpow = sampler.machine_pow
 
@@ -227,13 +228,20 @@ class MetropolisSamplerNumpy(MetropolisSampler):
                 pspecs = jax.sharding.PartitionSpec("x")
 
                 all_samples = host_local_array_to_global_array(σ1, global_mesh, pspecs)
-                log_psi = apply_model(
-                    machine, parameters, all_samples, sampler.chunk_size
+                log_prob = (
+                    mpow
+                    * apply_model(
+                        machine, parameters, all_samples, sampler.chunk_size
+                    ).real
                 )
-                assert len(log_psi.addressable_shards) == 1
-                log_psi = global_array_to_host_local_array(log_psi, global_mesh, pspecs)
+                assert len(log_prob.addressable_shards) == 1
+                log_prob = global_array_to_host_local_array(
+                    log_prob, global_mesh, pspecs
+                )
             else:
-                log_psi = apply_model(machine, parameters, σ1, sampler.chunk_size)
+                log_prob = (
+                    mpow * apply_model(machine, parameters, σ1, sampler.chunk_size).real
+                )
 
             log_values_1 = np.asarray(log_psi)
             assert log_values_1.shape == σ1.shape[:-1]
@@ -244,8 +252,8 @@ class MetropolisSamplerNumpy(MetropolisSampler):
             accepted += acceptance_kernel(
                 σ,
                 σ1,
-                log_values,
-                log_values_1,
+                log_prob,
+                log_prob_1,
                 log_prob_corr,
                 mpow,
                 random_uniform,
@@ -254,7 +262,7 @@ class MetropolisSamplerNumpy(MetropolisSampler):
         state.n_steps_proc += sampler.sweep_size * sampler.n_chains_per_rank
         state.n_accepted_proc += accepted
 
-        return state, state.σ
+        return state, (state.σ, state.log_prob)
 
     def _sample_chain(
         sampler,
@@ -262,20 +270,27 @@ class MetropolisSamplerNumpy(MetropolisSampler):
         parameters: PyTree,
         state: MetropolisNumpySamplerState,
         chain_length: int,
+        return_probabilties: bool = False,
     ) -> tuple[jnp.ndarray, MetropolisNumpySamplerState]:
         samples = np.empty(
             (chain_length, sampler.n_chains_per_rank, sampler.hilbert.size),
             dtype=sampler.dtype,
         )
+        log_probs = np.empty((chain_length, sampler.n_chains_per_rank), dtype=float)
 
         for i in range(chain_length):
-            state, σ = sampler.sample_next(machine, parameters, state)
+            state, (σ, log_prob) = sampler.sample_next(machine, parameters, state)
             samples[i] = σ
+            log_probs[i] = log_prob
 
         # make it (n_chains_per_rank, n_samples_per_chain, hi.size) as expected by netket.stats.statistics
         samples = np.swapaxes(samples, 0, 1)
+        log_probs = np.swapaxes(log_probs, 0, 1)
 
-        return samples, state
+        if return_probabilties:
+            return samples, log_probs, state
+        else:
+            return samples, state
 
     def __repr__(sampler):
         return (
@@ -303,18 +318,16 @@ class MetropolisSamplerNumpy(MetropolisSampler):
 
 @jit(nopython=True)
 def acceptance_kernel(
-    σ, σ1, log_values, log_values_1, log_prob_corr, machine_pow, random_uniform
+    σ, σ1, log_prob, log_prob_1, log_prob_corr, machine_pow, random_uniform
 ):
     accepted = 0
 
     for i in range(σ.shape[0]):
-        prob = np.exp(
-            machine_pow * (log_values_1[i] - log_values[i]).real + log_prob_corr[i]
-        )
+        prob = np.exp(log_prob_1[i] - log_prob[i] + log_prob_corr[i])
         assert not math.isnan(prob)
 
         if prob > random_uniform[i]:
-            log_values[i] = log_values_1[i]
+            log_prob[i] = log_prob_1[i]
             σ[i] = σ1[i]
             accepted += 1
 

--- a/netket/sampler/metropolis_numpy.py
+++ b/netket/sampler/metropolis_numpy.py
@@ -43,8 +43,6 @@ class MetropolisNumpySamplerState:
 
     log_prob: np.ndarray
     """Holds model(pars, σ) for the current σ (preallocation)."""
-    log_prob_1: np.ndarray
-    """Holds model(pars, σ1) for the last σ1 (preallocation)."""
     log_prob_corr: np.ndarray
     """Holds optional acceptance correction (preallocation)."""
 
@@ -161,7 +159,6 @@ class MetropolisSamplerNumpy(MetropolisSampler):
             σ=σ,
             σ1=np.copy(σ),
             log_prob=np.zeros(sampler.n_batches, dtype=ma_out.dtype),
-            log_prob_1=np.zeros(sampler.n_batches, dtype=ma_out.dtype),
             log_prob_corr=np.zeros(
                 sampler.n_batches, dtype=nkjax.dtype_real(ma_out.dtype)
             ),
@@ -205,7 +202,6 @@ class MetropolisSamplerNumpy(MetropolisSampler):
         σ = state.σ
         σ1 = state.σ1
         log_prob = state.log_prob
-        log_prob_1 = state.log_prob_1
         log_prob_corr = state.log_prob_corr
         mpow = sampler.machine_pow
 


### PR DESCRIPTION
MetropolisNumpy: adopt the same convention of storing the log-probabilities as Jax Mtropolis sampler

Also add a try/catch to the __repr__ of MetropolisState to avoid seeing errors raised from errors when jax compilation failes.