### PR TITLE
Samplers: add option to return the probability of samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 ## NetKet 3.17 (In development)
 
 ### Breaking Changes
+* The {meth}`~netket.sampler.Sampler._sample_chain` method of {class}`~netket.sampler.Sampler`, as well as {meth}`~netket.sampler.MetropolisSampler._sample_next` is now passed a new optional keyword argument, `return_log_probabilities`. This means that custom samplers will stop working unless they start accepting this new extra keyword argument. To upgrade, we suggest to simply raise an error if this extra argument is True [#2012](https://github.com/netket/netket/pull/2012).
+
+### New Features
+* The {meth}`~netket.sampler.Sampler.sample` method of {class}`~netket.sampler.Sampler` now accepts a new optional keyword argument, `return_log_probabilities` which, if specified, will make the samplers return both the samples and the corresponding log-probabilities. The default is False, and therefore the default behaviour is unchanged [#2012](https://github.com/netket/netket/pull/2012).
 
 ### Deprecations
 

--- a/netket/sampler/autoreg.py
+++ b/netket/sampler/autoreg.py
@@ -105,8 +105,22 @@ class ARDirectSampler(Sampler):
     def _reset(self, model, variables, state):
         return state
 
-    @partial(jax.jit, static_argnums=(1, 4))
-    def _sample_chain(self, model, variables, state, chain_length):
+    @partial(
+        jax.jit, static_argnames=("model", "chain_length", "return_log_probabilities")
+    )
+    def _sample_chain(
+        self,
+        model,
+        variables,
+        state,
+        chain_length,
+        return_log_probabilities: bool = False,
+    ):
+        if return_log_probabilities:
+            raise NotImplementedError(
+                "return_log_probability is not implemented for ARDirectSampler"
+            )
+
         if "cache" in variables:
             variables, _ = flax.core.pop(variables, "cache")
         variables_no_cache = variables

--- a/netket/sampler/base.py
+++ b/netket/sampler/base.py
@@ -293,10 +293,14 @@ class Sampler(struct.Pytree):
             parameters: The PyTree of parameters of the model.
             state: The current state of the sampler. If not specified, then initialize and reset it.
             chain_length: The length of the chains (default = 1).
+            return_log_probabilities: If `True`, the log-probabilities are also returned.
+                Defaults to False.
 
         Returns:
-            σ: The generated batches of samples.
-            state: The new state of the sampler.
+            Returns a tuple of 'samples' and 'state'. If `return_log_probabilities` is False,
+            the samples are just the 3-rank array of samples. If `return_log_probabilities` is
+            True, the samples are a tuple of the 3-rank array of samples and the 2-rank array of
+            un-normalized log-probabilities corresponding to each sample.
         """
         if state is None:
             state = self.reset(machine, parameters)
@@ -316,7 +320,6 @@ class Sampler(struct.Pytree):
         *,
         state: SamplerState | None = None,
         chain_length: int = 1,
-        return_log_probabilities: bool = False,
     ) -> Iterator[jnp.ndarray]:
         """
         Returns a generator sampling `chain_length` batches of samples along the chains.
@@ -359,10 +362,14 @@ class Sampler(struct.Pytree):
             parameters: The PyTree of parameters of the model.
             state: The current state of the sampler.
             chain_length: The length of the chains.
+            return_log_probabilities: If `True`, the log-probabilities are also returned.
+                Defaults to False.
 
         Returns:
-            σ: The generated batches of samples.
-            state: The new state of the sampler.
+            Returns a tuple of 'samples' and 'state'. If `return_log_probabilities` is False,
+            the samples are just the 3-rank array of samples. If `return_log_probabilities` is
+            True, the samples are a tuple of the 3-rank array of samples and the 2-rank array of
+            un-normalized log-probabilities corresponding to each sample.
         """
 
     @abc.abstractmethod

--- a/netket/sampler/base.py
+++ b/netket/sampler/base.py
@@ -282,7 +282,7 @@ class Sampler(struct.Pytree):
         *,
         state: SamplerState | None = None,
         chain_length: int = 1,
-        return_probabilties: bool = False,
+        return_log_probabilities: bool = False,
     ) -> tuple[jnp.ndarray, SamplerState]:
         """
         Samples `chain_length` batches of samples along the chains.
@@ -306,7 +306,7 @@ class Sampler(struct.Pytree):
             parameters,
             state,
             chain_length,
-            return_probabilties=return_probabilties,
+            return_log_probabilities=return_log_probabilities,
         )
 
     def samples(
@@ -316,7 +316,7 @@ class Sampler(struct.Pytree):
         *,
         state: SamplerState | None = None,
         chain_length: int = 1,
-        return_probabilties: bool = False,
+        return_log_probabilities: bool = False,
     ) -> Iterator[jnp.ndarray]:
         """
         Returns a generator sampling `chain_length` batches of samples along the chains.
@@ -344,7 +344,7 @@ class Sampler(struct.Pytree):
         parameters: PyTree,
         state: SamplerState,
         chain_length: int,
-        return_probabilties: bool = False,
+        return_log_probabilities: bool = False,
     ) -> tuple[jnp.ndarray, SamplerState]:
         """
         Implementation of `sample` for subclasses of `Sampler`.

--- a/netket/sampler/base.py
+++ b/netket/sampler/base.py
@@ -282,6 +282,7 @@ class Sampler(struct.Pytree):
         *,
         state: SamplerState | None = None,
         chain_length: int = 1,
+        return_probabilties: bool = False,
     ) -> tuple[jnp.ndarray, SamplerState]:
         """
         Samples `chain_length` batches of samples along the chains.
@@ -300,7 +301,13 @@ class Sampler(struct.Pytree):
         if state is None:
             state = self.reset(machine, parameters)
 
-        return self._sample_chain(wrap_afun(machine), parameters, state, chain_length)
+        return self._sample_chain(
+            wrap_afun(machine),
+            parameters,
+            state,
+            chain_length,
+            return_probabilties=return_probabilties,
+        )
 
     def samples(
         self,
@@ -309,6 +316,7 @@ class Sampler(struct.Pytree):
         *,
         state: SamplerState | None = None,
         chain_length: int = 1,
+        return_probabilties: bool = False,
     ) -> Iterator[jnp.ndarray]:
         """
         Returns a generator sampling `chain_length` batches of samples along the chains.
@@ -336,6 +344,7 @@ class Sampler(struct.Pytree):
         parameters: PyTree,
         state: SamplerState,
         chain_length: int,
+        return_probabilties: bool = False,
     ) -> tuple[jnp.ndarray, SamplerState]:
         """
         Implementation of `sample` for subclasses of `Sampler`.

--- a/netket/sampler/base.py
+++ b/netket/sampler/base.py
@@ -199,7 +199,7 @@ class Sampler(struct.Pytree):
 
         Args:
             model: A Flax module or callable with the forward pass of the log-pdf.
-                If it is a callable, it should have the signature :code:`f(parameters, σ) -> jnp.ndarray`.
+                If it is a callable, it should have the signature :code:`f(parameters, σ) -> jax.Array`.
 
         Returns:
             The log-probability density function.
@@ -238,7 +238,7 @@ class Sampler(struct.Pytree):
 
         Args:
             machine: A Flax module or callable with the forward pass of the log-pdf.
-                If it is a callable, it should have the signature :code:`f(parameters, σ) -> jnp.ndarray`.
+                If it is a callable, it should have the signature :code:`f(parameters, σ) -> jax.Array`.
             parameters: The PyTree of parameters of the model.
             seed: An optional seed or jax PRNGKey. If not specified, a random seed will be used.
 
@@ -262,7 +262,7 @@ class Sampler(struct.Pytree):
 
         Args:
             machine: A Flax module or callable with the forward pass of the log-pdf.
-                If it is a callable, it should have the signature :code:`f(parameters, σ) -> jnp.ndarray`.
+                If it is a callable, it should have the signature :code:`f(parameters, σ) -> jax.Array`.
             parameters: The PyTree of parameters of the model.
             state: The current state of the sampler. If not specified, it will be constructed
                 by calling :code:`sampler.init_state(machine, parameters)` with a random seed.
@@ -283,7 +283,7 @@ class Sampler(struct.Pytree):
         state: SamplerState | None = None,
         chain_length: int = 1,
         return_log_probabilities: bool = False,
-    ) -> tuple[jnp.ndarray, SamplerState]:
+    ) -> tuple[jax.Array, SamplerState] | tuple[tuple[jax.Array, jax.Array], SamplerState]:
         """
         Samples `chain_length` batches of samples along the chains.
 

--- a/netket/sampler/base.py
+++ b/netket/sampler/base.py
@@ -319,8 +319,8 @@ class Sampler(struct.Pytree):
             parameters: The PyTree of parameters of the model.
             state: The current state of the sampler. If not specified, then initialize and reset it.
             chain_length: The length of the chains (default = 1).
-            return_log_probabilities: If `True`, the log-probabilities are also returned.
-                Defaults to False.
+            return_log_probabilities: If `True`, the log-probabilities are also returned, which is sometimes
+                useful to avoid re-evaluating the log-pdf when doing importance sampling. Defaults to False.
 
         Returns:
             Returns a tuple of 'samples' and 'state'. If `return_log_probabilities` is False,

--- a/netket/sampler/exact.py
+++ b/netket/sampler/exact.py
@@ -107,7 +107,10 @@ class ExactSampler(Sampler):
         state: SamplerState,
         chain_length: int,
         return_log_probabilities: bool = False,
-    ) -> tuple[jnp.ndarray, SamplerState]:
+    ) -> (
+        tuple[jax.Array, SamplerState]
+        | tuple[tuple[jax.Array, jax.Array], SamplerState]
+    ):
         # Reimplement sample_chain because we can sample the whole 'chain' in one
         # go, since it's not really a chain anyway. This will be much faster because
         # we call into python only once.

--- a/netket/sampler/metropolis.py
+++ b/netket/sampler/metropolis.py
@@ -497,7 +497,7 @@ class MetropolisSampler(Sampler):
         return new_state, (new_state.σ, new_state.log_prob)
 
     @partial(
-        jax.jit, static_argnames=("machine", "chain_length", "return_probabilties")
+        jax.jit, static_argnames=("machine", "chain_length", "return_log_probabilities")
     )
     def _sample_chain(
         self,
@@ -505,7 +505,7 @@ class MetropolisSampler(Sampler):
         parameters,
         state,
         chain_length,
-        return_probabilties: bool = False,
+        return_log_probabilities: bool = False,
     ):
         """
         Samples `chain_length` batches of samples along the chains.
@@ -532,7 +532,7 @@ class MetropolisSampler(Sampler):
         samples = jnp.swapaxes(samples, 0, 1)
         log_probabilities = jnp.swapaxes(log_probabilities, 0, 1)
 
-        if return_probabilties:
+        if return_log_probabilities:
             return samples, state, log_probabilities
         else:
             return samples, state

--- a/netket/sampler/metropolis.py
+++ b/netket/sampler/metropolis.py
@@ -533,7 +533,7 @@ class MetropolisSampler(Sampler):
         log_probabilities = jnp.swapaxes(log_probabilities, 0, 1)
 
         if return_log_probabilities:
-            return samples, state, log_probabilities
+            return (samples, log_probabilities), state
         else:
             return samples, state
 

--- a/netket/sampler/metropolis_numpy.py
+++ b/netket/sampler/metropolis_numpy.py
@@ -198,7 +198,9 @@ class MetropolisSamplerNumpy(MetropolisSampler):
 
         return state
 
-    def _sample_next(self, machine, parameters, state):
+    def _sample_next(
+        self, machine, parameters, state
+    ) -> tuple[MetropolisNumpySamplerState, tuple[np.ndarray, np.ndarray]]:
         σ = state.σ
         σ1 = state.σ1
         log_prob = state.log_prob

--- a/netket/sampler/metropolis_numpy.py
+++ b/netket/sampler/metropolis_numpy.py
@@ -284,7 +284,7 @@ class MetropolisSamplerNumpy(MetropolisSampler):
         log_probs = np.swapaxes(log_probs, 0, 1)
 
         if return_log_probabilities:
-            return samples, log_probs, state
+            return (samples, log_probs), state
         else:
             return samples, state
 

--- a/netket/sampler/metropolis_numpy.py
+++ b/netket/sampler/metropolis_numpy.py
@@ -266,7 +266,7 @@ class MetropolisSamplerNumpy(MetropolisSampler):
         parameters: PyTree,
         state: MetropolisNumpySamplerState,
         chain_length: int,
-        return_probabilties: bool = False,
+        return_log_probabilities: bool = False,
     ) -> tuple[jnp.ndarray, MetropolisNumpySamplerState]:
         samples = np.empty(
             (chain_length, self.n_chains_per_rank, self.hilbert.size),
@@ -283,7 +283,7 @@ class MetropolisSamplerNumpy(MetropolisSampler):
         samples = np.swapaxes(samples, 0, 1)
         log_probs = np.swapaxes(log_probs, 0, 1)
 
-        if return_probabilties:
+        if return_log_probabilities:
             return samples, log_probs, state
         else:
             return samples, state

--- a/netket/sampler/parallel_tempering.py
+++ b/netket/sampler/parallel_tempering.py
@@ -530,7 +530,15 @@ class ParallelTemperingSampler(MetropolisSampler):
             σ, s["beta_0_index"][:, None, None]
         )
         σ_new = jax.lax.collapse(σ_new, 0, 2)  # remove dummy replica dim
-        return new_state, σ_new
+
+        log_prob = new_state.log_prob.reshape((-1, sampler.n_replicas))
+        # we use shard_map to avoid the all-gather emitted by the batched jnp.take / indexing
+        log_prob_new = sharding_decorator(
+            partial(jnp.take_along_axis, axis=1), (True, True)
+        )(log_prob, s["beta_0_index"][:, None])
+        log_prob_new = jax.lax.collapse(log_prob_new, 0, 2)  # remove dummy replica dim
+
+        return new_state, (σ_new, log_prob_new)
 
 
 def ParallelTemperingLocal(hilbert, *args, **kwargs):

--- a/netket/sampler/parallel_tempering.py
+++ b/netket/sampler/parallel_tempering.py
@@ -531,7 +531,7 @@ class ParallelTemperingSampler(MetropolisSampler):
         )
         σ_new = jax.lax.collapse(σ_new, 0, 2)  # remove dummy replica dim
 
-        log_prob = new_state.log_prob.reshape((-1, sampler.n_replicas))
+        log_prob = new_state.log_prob.reshape((-1, self.n_replicas))
         # we use shard_map to avoid the all-gather emitted by the batched jnp.take / indexing
         log_prob_new = sharding_decorator(
             partial(jnp.take_along_axis, axis=1), (True, True)

--- a/test/sampler/test_sampler.py
+++ b/test/sampler/test_sampler.py
@@ -287,6 +287,24 @@ def test_states_in_hilbert(sampler, model_and_weights):
     #    assert np.min(sampler.acceptance) >= 0 and np.max(sampler.acceptance) <= 1.0
 
 
+def test_return_log_probabilities(sampler, model_and_weights):
+    if isinstance(sampler, nk.sampler.ARDirectSampler):
+        pytest.skip("ARDirectSampler does not support return_log_probabilities")
+
+    hi = sampler.hilbert
+    chain_length = 2
+
+    ma, w = model_and_weights(hi, sampler)
+    (samples, log_probs), _ = sampler.sample(
+        ma, w, chain_length=chain_length, return_log_probabilities=True
+    )
+    log_probs_computed = sampler.machine_pow * ma.apply(w, samples).real
+
+    assert log_probs.shape == samples.shape[:-1]
+    print(log_probs / log_probs_computed)
+    np.testing.assert_allclose(log_probs, log_probs_computed)
+
+
 def findrng(rng):
     if hasattr(rng, "_bit_generator"):
         return rng._bit_generator.state["state"]

--- a/test/sampler/test_sampler.py
+++ b/test/sampler/test_sampler.py
@@ -289,12 +289,12 @@ def test_states_in_hilbert(sampler, model_and_weights):
 
 def test_return_log_probabilities(sampler, model_and_weights):
     if isinstance(sampler, nk.sampler.ARDirectSampler):
-        pytest.skip("ARDirectSampler does not support return_log_probabilities")
+        pytest.skip("ARDirectSampler does not support return_log_probabilities.")
     if (
         isinstance(sampler, nk.sampler.MetropolisNumpy)
         and nk.config.netket_experimental_sharding
     ):
-        pytest.skip("MetropolisNumpy does not support return_log_probabilities")
+        pytest.skip("MetropolisNumpy does not work under sharding.")
 
     hi = sampler.hilbert
     chain_length = 2

--- a/test/sampler/test_sampler.py
+++ b/test/sampler/test_sampler.py
@@ -290,12 +290,17 @@ def test_states_in_hilbert(sampler, model_and_weights):
 def test_return_log_probabilities(sampler, model_and_weights):
     if isinstance(sampler, nk.sampler.ARDirectSampler):
         pytest.skip("ARDirectSampler does not support return_log_probabilities")
+    if (
+        isinstance(sampler, nk.sampler.MetropolisNumpy)
+        and nk.config.netket_experimental_sharding
+    ):
+        pytest.skip("MetropolisNumpy does not support return_log_probabilities")
 
     hi = sampler.hilbert
     chain_length = 2
 
     ma, w = model_and_weights(hi, sampler)
-    (samples, log_probs), _ = sampler.sample(
+    (samples, log_probs), ss = sampler.sample(
         ma, w, chain_length=chain_length, return_log_probabilities=True
     )
     log_probs_computed = sampler.machine_pow * ma.apply(w, samples).real


### PR DESCRIPTION
This adds an option `sampler.sample(..., return_probabilities=True/False)` to also get the **unnormalized** probability `p(sigma)` of a sample  `sigma`.

We already compute it, so it's just a cheap trick to make it available for free.

Only question is: should we return the unnormalised probability or the unnormalised log-probability?
(I personally would be more in favour of log-probability)

your thought @lgravina1997 and @inailuig ?