### PR TITLE
expect_forces_chunked statistics minor fix

### DIFF
--- a/netket/vqs/mc/mc_state/expect_forces_chunked.py
+++ b/netket/vqs/mc/mc_state/expect_forces_chunked.py
@@ -120,7 +120,7 @@ def forces_expect_hermitian_chunked(
         chunk_size=chunk_size,
     )
 
-    Ō = statistics(O_loc.reshape(σ_shape[:-1]).T)
+    Ō = statistics(O_loc.reshape(σ_shape[:-1]))
 
     O_loc -= Ō.mean
 

--- a/test/variational/test_variational.py
+++ b/test/variational/test_variational.py
@@ -511,9 +511,9 @@ def test_expect_chunking(vstate, operator, n_chunks):
     )
 
     vstate.chunk_size = None
-    grad_nochunk = vstate.grad(operator)
+    grad_nochunk = vstate.expect_and_grad(operator)
     vstate.chunk_size = chunk_size
-    grad_chunk = vstate.grad(operator)
+    grad_chunk = vstate.expect_and_grad(operator)
 
     jax.tree_util.tree_map(
         partial(np.testing.assert_allclose, atol=1e-13), grad_nochunk, grad_chunk


### PR DESCRIPTION
Based on the issue #2010, I fixed the transpose operation in the expect_forces_chunked statistics.
I verified the correct statistics from the previously reported code. 