### PR TITLE
Change `states_to_numbers` array from Jax to NumPy in `_reorder_kronecker_product`

### DIFF
--- a/netket/operator/_local_operator/helpers.py
+++ b/netket/operator/_local_operator/helpers.py
@@ -195,7 +195,7 @@ def _reorder_kronecker_product(hi, mat, acting_on) -> tuple[Array, tuple]:
     # convert them to origin (unordered) ordering
     v_unsorted = v[:, acting_on_unsorted_ids]
     # convert the unordered bit-strings to numbers in the target space.
-    n_unsorted = hi_unsorted_subspace.states_to_numbers(v_unsorted)
+    n_unsorted = np.asarray(hi_unsorted_subspace.states_to_numbers(v_unsorted))
 
     # reorder the matrix
     if sparse.issparse(mat):


### PR DESCRIPTION
This PR in-place changes the [`n_unsorted`](https://github.com/netket/netket/blob/c6424cc9c540ffb9e3f1380b23d2be82abf3534a/netket/operator/_local_operator/helpers.py#L198) in the [`_reorder_kronecker_product`](https://github.com/netket/netket/blob/c6424cc9c540ffb9e3f1380b23d2be82abf3534a/netket/operator/_local_operator/helpers.py#L149) from a Jax to a NumPy array. 

It is only used internally in that function, and leaving it as a Jax array causes the [`np.argsort()`](https://github.com/netket/netket/blob/c6424cc9c540ffb9e3f1380b23d2be82abf3534a/netket/operator/_local_operator/helpers.py#L203) to become comparatively slow. 

Quick benchmark of constructing an operator with a rather large number of products of LocalOperators shows runtime went from approx. 10 minutes to approx. 3 minutes after the change.