### PR TITLE
Correcting wrong normalization in PT sampler (diffusion statistics)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,9 @@ This version (as all previous versions) are incompatible with Jax 0.6 . A future
 ### Deprecations
 * Constructing the {class}~`netket.optimizer.SR` object with `SR(qgt=QGTType(...))` is now deprecated. This construction can lead to unexpected results because the keyword arguments specified in the `QGTType` are overwritten by those specified by the SR class and its defaults. To fix this, construct SR as `SR(qgt=QGTType, ...)`. A warning will be raised when using the deprecated syntax, and this will become an error in a future release.
 
+### Bug Fixes
+* Fixed a bug in the default values of the normalization of the Parallel Tempering bug, present in the last few versions [#2041](https://github.com/netket/netket/pull/2041#issuecomment-2882798193)
+
 
 ## NetKet 3.14.4 (7 November 2024)
 * Fix a bug introduced in 3.14.3 when using chunking [#1943](https://github.com/netket/netket/pull/1943).

--- a/netket/sampler/parallel_tempering.py
+++ b/netket/sampler/parallel_tempering.py
@@ -97,8 +97,8 @@ class ParallelTemperingSamplerState(MetropolisSamplerState):
         Average variance of the position of :math:`\\beta = 1`.
         In the ideal case, this quantity should be of order ~[0.2, 1.0]
         """
-        diffusion = jnp.sqrt(
-            self.beta_diffusion / self.exchange_steps / self.beta.shape[-1]
+        diffusion = (
+            jnp.sqrt(self.beta_diffusion / self.exchange_steps) / self.beta.shape[-1]
         )
         out, _ = mpi.mpi_mean_jax(diffusion.mean())
 

--- a/test/sampler/test_pt.py
+++ b/test/sampler/test_pt.py
@@ -124,8 +124,9 @@ def test_initialization_beta_list(model_and_weights, betas):
 
 
 # This test verifies that the acceptance is indeed a float
-# It also verifies that its value is 1 for a state with flat distribution
-def test_acceptance():
+# and that its value is 1 for a state with flat distribution
+# It also verifies that the statistics of the temperatures are normalized
+def test_sampler_statistics():
     g = nk.graph.Hypercube(length=4, n_dim=1)
     hi = nk.hilbert.Spin(s=0.5, N=g.n_nodes)
 
@@ -142,6 +143,10 @@ def test_acceptance():
     vs.sample()
 
     assert jnp.isclose(vs.sampler_state.acceptance, 1.0)
+
+    # check the statistics of beta=1
+    assert jnp.abs(vs.sampler_state.normalized_position) <= 1.0
+    assert vs.sampler_state.normalized_diffusion <= 1.0
 
 
 # The following fixture initialises a model and it's weights


### PR DESCRIPTION
I just saw that the normalization of the diffusion of temperatures in the Parallel Tempering sampler is wrong (I obtained values > 1, while it should be normalized). Comparing to previous code (see [here](https://github.com/netket/netket/blob/87d469aa8c23f71c4838cf09d7ed7b87ff2ea01f/netket/legacy/sampler/numpy/metropolis_hastings_pt.py) for example), I found that a factor was supposed to be outside the square root, in opposition to what is done now. Nothing else was changed. 