### PR TITLE
Fix type mismatch in autocorrelation with  sharding

### DIFF
--- a/netket/stats/_autocorr.py
+++ b/netket/stats/_autocorr.py
@@ -83,4 +83,4 @@ def integrated_time(x, c=5):
     f = autocorr_1d(x)
     taus = 2.0 * jnp.cumsum(f) - 1.0
     window = auto_window(taus, c)
-    return taus[window]
+    return taus[window.astype(jnp.int32)]


### PR DESCRIPTION
This shows up when using shading with new style autocorrelation:

```
Traceback (most recent call last):
  File "/mnt/beegfs/home/CPHT/antoine.misery/importance_sampling_nqs/main.py", line 49, in main
    task()
  File "/mnt/beegfs/home/CPHT/antoine.misery/importance_sampling_nqs/packages/grad_sample/tasks/vmc_gs.py", line 148, in __call__
    self.gs.run(n_iter=self.n_iter, out=self.out_log, callback=self.callbacks)
  File "/mnt/beegfs/home/CPHT/antoine.misery/importance_sampling_nqs/packages/advanced_drivers/_src/driver/abstract_variational_driver.py", line 377, in run
    raise error
  File "/mnt/beegfs/home/CPHT/antoine.misery/importance_sampling_nqs/packages/advanced_drivers/_src/driver/abstract_variational_driver.py", line 338, in run
    self._loss_stats, self._dp = self.compute_loss_and_update()
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/beegfs/workdir/antoine.misery/mambaforge/envs/is_paper_env/lib/python3.11/site-packages/netket/utils/timing.py", line 276, in timed_function
    result = fun(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^
  File "/mnt/beegfs/home/CPHT/antoine.misery/importance_sampling_nqs/packages/advanced_drivers/_src/driver/ngd/driver_abstract_ngd.py", line 325, in compute_loss_and_update
    self._loss_stats = statistics(local_loss, weights)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/beegfs/home/CPHT/antoine.misery/importance_sampling_nqs/packages/advanced_drivers/_src/driver/ngd/is_stats.py", line 313, in statistics
    return _statistics(data, weights)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/beegfs/home/CPHT/antoine.misery/importance_sampling_nqs/packages/advanced_drivers/_src/driver/ngd/is_stats.py", line 471, in _statistics
    taus = jax.vmap(integrated_time)(data*weights)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/beegfs/home/CPHT/antoine.misery/importance_sampling_nqs/packages/advanced_drivers/_src/driver/ngd/is_stats.py", line 59, in integrated_time
    return taus[window]
           ~~~~^^^^^^^^
  File "/mnt/beegfs/workdir/antoine.misery/mambaforge/envs/is_paper_env/lib/python3.11/site-packages/jax/_src/numpy/array_methods.py", line 1060, in op
    return getattr(self.aval, f"_{name}")(self, *args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/beegfs/workdir/antoine.misery/mambaforge/envs/is_paper_env/lib/python3.11/site-packages/jax/_src/numpy/array_methods.py", line 652, in _getitem
    return indexing.rewriting_take(self, item)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/beegfs/workdir/antoine.misery/mambaforge/envs/is_paper_env/lib/python3.11/site-packages/jax/_src/numpy/indexing.py", line 618, in rewriting_take
    if (result := _attempt_rewriting_take_via_slice(arr, idx, mode)) is not None:
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/beegfs/workdir/antoine.misery/mambaforge/envs/is_paper_env/lib/python3.11/site-packages/jax/_src/numpy/indexing.py", line 601, in _attempt_rewriting_take_via_slice
    arr = lax.dynamic_slice(
          ^^^^^^^^^^^^^^^^^^
jaxlib.xla_extension.XlaRuntimeError: INVALID_ARGUMENT: Cannot concatenate arrays with different element types: S32 vs S64.
--------------------
For simplicity, JAX has removed its internal frames from the traceback of the following exception. Set JAX_TRACEBACK_FILTERING=off to include these.
```