### PR TITLE
Fix jitting in _step_adaptive

### DIFF
--- a/netket/experimental/dynamics/_utils.py
+++ b/netket/experimental/dynamics/_utils.py
@@ -58,12 +58,10 @@ def set_flag_jax(condition, flags, flag):
         if condition:
             flags |= flag
     """
-    return jax.lax.cond(
-        condition,
-        lambda x: x | flag,
-        lambda x: x,
-        flags,
-    )
+    if condition:
+        return flags | flag
+    else:
+        return flags
 
 
 def scaled_error(y, y_err, atol, rtol, *, last_norm_y=None, norm_fn) -> float:


### PR DESCRIPTION
In the past, _step_adaptive was jitted, which was later removed. However, calls to jax.lax.cond remained, which, because it used lambdas, was recompiled at each call. This leads to excessive memory usage, see #2043
These are now replaced with native Python if clauses.

A similar problem was with the call to mpi_all_jax, which also led to excessive memory usage. It is now replaced with mpi_all with calls to numpy instead of jax.numpy.