### PR TITLE
Fix PauliStrings weights type annotation

### DIFF
--- a/netket/operator/_pauli_strings/base.py
+++ b/netket/operator/_pauli_strings/base.py
@@ -194,7 +194,7 @@ class PauliStringsBase(DiscreteOperator):
         return self._operators
 
     @property
-    def weights(self) -> Iterable[str]:
+    def weights(self) -> Array:
         return self._weights
 
     @classmethod


### PR DESCRIPTION
## Summary
- correct the return type of `PauliStringsBase.weights`

## Testing
- `pytest -q test/operator/test_pauli.py`