### PR TITLE
Fix tutorial imports

### DIFF
--- a/docs/tutorials/lattice-fermions.ipynb
+++ b/docs/tutorials/lattice-fermions.ipynb
@@ -37,8 +37,7 @@
    "id": "e179b60d-6f21-4c79-9d7d-9eded189200e",
    "metadata": {},
    "source": [
-    "Fermionic operators are fundamental to describing quantum systems with fermions (e.g., electrons). NetKet provides tools to work with these operators efficiently. Let's start by setting up the necessary environment and defining our quantum system. \n",
-    "We start by importing the main netket library, as well as the experimental part of it. The latter is where fermionic operators are currently contained. In the next major release of netket this will change. "
+    "Fermionic operators are fundamental to describing quantum systems with fermions (e.g., electrons). NetKet provides these operators directly via the `netket.operator.fermion` module. Let's start by setting up the necessary environment and defining our quantum system."
    ]
   },
   {
@@ -50,8 +49,7 @@
    },
    "outputs": [],
    "source": [
-    "import netket as nk\n",
-    "import netket.experimental as nkx"
+    "import netket as nk\n"
    ]
   },
   {
@@ -294,7 +292,7 @@
     "import jax.numpy as jnp\n",
     "\n",
     "# Note: This function can also be found inside of netket, in `nk.jax.logdet_cmplx`, but we implement it here\n",
-    "# for pedagogical purposes.\n",
+    "#\u00a0for pedagogical purposes.\n",
     "def _logdet_cmplx(A):\n",
     "    sign, logabsdet = jnp.linalg.slogdet(A)\n",
     "    return logabsdet.astype(complex) + jnp.log(sign.astype(complex))"
@@ -625,7 +623,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Optimized energy : -5.037-0.000j ± 0.035 [σ²=4.412, R̂=1.0018]\n",
+      "Optimized energy : -5.037-0.000j \u00b1 0.035 [\u03c3\u00b2=4.412, R\u0302=1.0018]\n",
       "Relative error   : 0.26558582788878166\n"
      ]
     }
@@ -806,7 +804,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Optimized energy : -6.823-0.000j ± 0.011 [σ²=0.451, R̂=1.0025]\n",
+      "Optimized energy : -6.823-0.000j \u00b1 0.011 [\u03c3\u00b2=0.451, R\u0302=1.0025]\n",
       "Relative error   : 0.005247299660359021\n"
      ]
     }
@@ -973,7 +971,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Optimized energy : -6.821-0.000j ± 0.012 [σ²=0.651, R̂=1.0015]\n",
+      "Optimized energy : -6.821-0.000j \u00b1 0.012 [\u03c3\u00b2=0.651, R\u0302=1.0015]\n",
       "Relative error   : 0.005498504723083019\n"
      ]
     }


### PR DESCRIPTION
## Summary
- update text in `lattice-fermions.ipynb`
- remove `netket.experimental` import
- clarify operators come from `netket.operator.fermion`

## Testing
- `pre-commit run --files docs/tutorials/lattice-fermions.ipynb` *(fails: couldn't connect to github.com)*