### PR TITLE
Introduce geometry module for particle Hilbert spaces

### DIFF
--- a/docs/api/api.md
+++ b/docs/api/api.md
@@ -21,6 +21,7 @@ drivers
 errors
 exact
 graph
+geometry
 hilbert
 jax
 logging

--- a/docs/api/geometry.md
+++ b/docs/api/geometry.md
@@ -1,0 +1,19 @@
+(netket_geometry_api)=
+# netket.geometry
+
+```{eval-rst}
+.. currentmodule:: netket.geometry
+```
+
+The :mod:`netket.geometry` module contains helper classes to describe the geometry of continuous spaces.
+These objects can be passed to {class}`~netket.hilbert.Particle` and provide utilities such as distance computations.
+
+```{eval-rst}
+.. autosummary::
+   :toctree: _generated/geometry
+   :template: class
+   :nosignatures:
+
+   Cell
+   FreeSpace
+```

--- a/docs/tutorials/gs-continuous-space.ipynb
+++ b/docs/tutorials/gs-continuous-space.ipynb
@@ -128,10 +128,8 @@
     "\n",
     "# 10 particles in 3D space without periodic boundary conditions. \n",
     "# The length of the L-tuple indicates the spatial dimension of space.\n",
-    "hi = nk.hilbert.Particle(N=N, L=(jnp.inf, jnp.inf, jnp.inf), pbc=False)\n",
-    "\n",
-    "# You can also use the shorter notation to build this kind of setups\n",
-    "hi = nk.hilbert.Particle(N=N, D=3)"
+    "geo = nk.geometry.FreeSpace(d=3)\n",
+    "hi = nk.hilbert.Particle(N=N, geometry=geo)"
    ]
   },
   {
@@ -700,7 +698,8 @@
     "L = (N / D)**(1/dim)\n",
     "\n",
     "\n",
-    "hilb = nk.hilbert.Particle(N=N, L=(L,), pbc=True)\n",
+    "geo = nk.geometry.Cell(d=1, L=(L,), pbc=True)\n",
+    "hilb = nk.hilbert.Particle(N=N, geometry=geo)\n",
     "sa = nk.sampler.MetropolisGaussian(hilbert=hilb, sigma=0.4, n_chains=16, sweep_size=10)\n",
     "\n",
     "\n",

--- a/netket/__init__.py
+++ b/netket/__init__.py
@@ -22,6 +22,7 @@ from . import errors
 __all__ = [
     "exact",
     "graph",
+    "geometry",
     "callbacks",
     "hilbert",
     "operator",
@@ -38,6 +39,7 @@ from . import jax
 from . import stats
 
 from . import graph
+from . import geometry
 from . import hilbert
 
 from . import nn

--- a/netket/geometry/__init__.py
+++ b/netket/geometry/__init__.py
@@ -1,0 +1,8 @@
+"""Geometry classes for continuous Hilbert spaces."""
+
+from .cell import Cell, FreeSpace
+
+__all__ = [
+    "Cell",
+    "FreeSpace",
+]

--- a/netket/geometry/cell.py
+++ b/netket/geometry/cell.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+import jax.numpy as jnp
+import numpy as np
+from jax.tree_util import register_pytree_node_class
+
+
+@register_pytree_node_class
+@dataclass(frozen=True)
+class Cell:
+    """A finite region in continuous space."""
+
+    extent: tuple[float, ...]
+    pbc: tuple[bool, ...]
+
+    def __init__(
+        self,
+        d: int,
+        L: float | Sequence[float] = 1.0,
+        pbc: bool | Sequence[bool] = True,
+    ) -> None:
+        if d <= 0:
+            raise ValueError("d must be positive")
+
+        if hasattr(L, "__len__"):
+            if len(L) != d:
+                raise ValueError("Length of L must match d")
+            extent = tuple(float(x) for x in L)
+        else:
+            extent = (float(L),) * d
+
+        if isinstance(pbc, bool):
+            pbc_tuple = (pbc,) * d
+        else:
+            if len(pbc) != d:
+                raise ValueError("Length of pbc must match d")
+            pbc_tuple = tuple(bool(x) for x in pbc)
+
+        for e, b in zip(extent, pbc_tuple):
+            if np.isinf(e) and b:
+                raise ValueError(
+                    "Cannot combine periodic boundary conditions with infinite extent"
+                )
+
+        object.__setattr__(self, "extent", extent)
+        object.__setattr__(self, "pbc", pbc_tuple)
+
+    def tree_flatten(self):
+        data = (jnp.asarray(self.extent), jnp.asarray(self.pbc))
+        return data, None
+
+    @classmethod
+    def tree_unflatten(cls, aux, data):
+        extent, pbc = data
+        return cls(
+            d=len(extent),
+            L=tuple(float(x) for x in extent),
+            pbc=tuple(bool(x) for x in pbc),
+        )
+
+    @property
+    def d(self) -> int:
+        return len(self.extent)
+
+    def distance(
+        self, r1: Sequence[float] | jnp.ndarray, r2: Sequence[float] | jnp.ndarray
+    ) -> jnp.ndarray:
+        """Euclidean distance between ``r1`` and ``r2`` considering boundary conditions."""
+
+        r1 = jnp.asarray(r1)
+        r2 = jnp.asarray(r2)
+        diff = r1 - r2
+        ext = jnp.asarray(self.extent)
+        pbc = jnp.asarray(self.pbc)
+
+        shift = jnp.where(pbc, jnp.round(diff / ext) * ext, 0.0)
+        diff = diff - shift
+        return jnp.linalg.norm(diff, axis=-1)
+
+
+@register_pytree_node_class
+@dataclass(frozen=True)
+class FreeSpace(Cell):
+    """Infinite space without periodic boundary conditions."""
+
+    def __init__(self, d: int) -> None:
+        super().__init__(d=d, L=(np.inf,) * d, pbc=False)

--- a/test/geometry/test_cell.py
+++ b/test/geometry/test_cell.py
@@ -1,0 +1,18 @@
+import jax
+import jax.numpy as jnp
+import netket as nk
+
+
+def test_distance_jit():
+    cell = nk.geometry.Cell(d=1, L=1.0, pbc=True)
+    dist = cell.distance(jnp.array([0.1]), jnp.array([0.9]))
+    assert jnp.isclose(dist, 0.2)
+    dist_jit = jax.jit(cell.distance)(jnp.array([0.1]), jnp.array([0.9]))
+    assert jnp.isclose(dist_jit, 0.2)
+
+
+def test_freespace_distance():
+    fs = nk.geometry.FreeSpace(d=2)
+    r1 = jnp.array([1.0, 0.0])
+    r2 = jnp.array([0.0, 1.0])
+    assert jnp.isclose(fs.distance(r1, r2), jnp.sqrt(2.0))

--- a/test/hilbert/test_hilbert.py
+++ b/test/hilbert/test_hilbert.py
@@ -128,17 +128,16 @@ hilberts["SpinOrbitalFermions (higherspin)"] = nk.hilbert.SpinOrbitalFermions(
 
 # Continuous space
 # no pbc
-hilberts["ContinuousSpaceHilbert"] = nk.hilbert.Particle(
-    N=5, L=(np.inf, 10.0), pbc=(False, True)
-)
+geo_default = nk.geometry.Cell(d=2, L=(np.inf, 10.0), pbc=(False, True))
+hilberts["ContinuousSpaceHilbert"] = nk.hilbert.Particle(N=5, geometry=geo_default)
 hilberts["TensorContinuous"] = nk.hilbert.Particle(
-    N=2, L=(np.inf, 10.0), pbc=(False, True)
-) * nk.hilbert.Particle(N=3, L=(np.inf, 10.0), pbc=(False, True))
+    N=2, geometry=geo_default
+) * nk.hilbert.Particle(N=3, geometry=geo_default)
 
 
 N = 10
 hilberts["ContinuousHelium"] = nk.hilbert.Particle(
-    N=N, L=(N / (0.3 * 2.9673),), pbc=True
+    N=N, geometry=nk.geometry.Cell(d=1, L=(N / (0.3 * 2.9673),), pbc=True)
 )
 
 all_hilbert_params = [pytest.param(hi, id=name) for name, hi in hilberts.items()]
@@ -254,7 +253,10 @@ def test_random_states_particle(hi: Particle):
 
 def test_particle_fail():
     with pytest.raises(ValueError):
-        _ = Particle(N=5, L=(jnp.inf, 2.0), pbc=True)
+        _ = Particle(
+            N=5,
+            geometry=nk.geometry.Cell(d=2, L=(jnp.inf, 2.0), pbc=True),
+        )
 
 
 @pytest.mark.parametrize("hi", discrete_hilbert_params)
@@ -671,7 +673,7 @@ def test_tensor_combination():
     assert len(hit._hilbert_spaces) == 5
     assert isinstance(repr(hit), str)
 
-    hi3 = nk.hilbert.Particle(N=5, L=(np.inf, 10.0), pbc=(False, True))
+    hi3 = nk.hilbert.Particle(N=5, geometry=geo_default)
     hit2 = hi1 * hi3
     assert isinstance(hit2, nk.hilbert.TensorHilbert)
     assert hit2.size == hi1.size + hi3.size
@@ -726,9 +728,7 @@ def test_tensor_combination():
     assert len(hit._hilbert_spaces) == 1
     assert isinstance(repr(hit), str)
 
-    hit = nk.hilbert.TensorHilbert(
-        nk.hilbert.Particle(N=5, L=(np.inf, 10.0), pbc=(False, True))
-    )
+    hit = nk.hilbert.TensorHilbert(nk.hilbert.Particle(N=5, geometry=geo_default))
     assert isinstance(hit, nk.hilbert._tensor_hilbert.TensorGenericHilbert)
     assert len(hit._hilbert_spaces) == 1
     assert isinstance(repr(hit), str)
@@ -741,7 +741,7 @@ def test_errors():
     with pytest.raises(TypeError):
         hi * 1
 
-    hi = nk.hilbert.Particle(N=5, L=(np.inf, 10.0), pbc=(False, True))
+    hi = nk.hilbert.Particle(N=5, geometry=geo_default)
     with pytest.raises(TypeError):
         1 * hi
     with pytest.raises(TypeError):
@@ -774,21 +774,21 @@ def test_constrained_eq_hash():
 
 
 def test_particle_alternative_constructors():
-    hi1 = nk.hilbert.Particle(N=5, L=(np.inf, np.inf), pbc=False)
-    hi2 = nk.hilbert.Particle(N=5, L=(np.inf, np.inf))
+    hi1 = nk.hilbert.Particle(N=5, geometry=nk.geometry.FreeSpace(d=2))
+    hi2 = nk.hilbert.Particle(
+        N=5,
+        geometry=nk.geometry.Cell(d=2, L=(np.inf, np.inf), pbc=False),
+    )
     assert hi1 == hi2
 
-    hi2 = nk.hilbert.Particle(N=5, D=2)
+
+def test_particle_with_geometry():
+    geo = nk.geometry.Cell(d=2, L=(np.inf, 10.0), pbc=(False, True))
+    hi1 = nk.hilbert.Particle(N=5, geometry=geo)
+    hi2 = nk.hilbert.Particle(N=5, geometry=geo_default)
     assert hi1 == hi2
-
-    with pytest.raises(ValueError, match=r"Must specify at least.*"):
-        nk.hilbert.Particle(N=5)
-
-    with pytest.raises(TypeError, match=r"Cannot specify at the same time.*"):
-        nk.hilbert.Particle(N=5, L=np.inf, D=1)
-
-    with pytest.raises(ValueError, match=r".*must be specified.*"):
-        nk.hilbert.Particle(N=5, L=3)
+    geo2 = nk.geometry.Cell(d=1, L=1.0, pbc=True)
+    assert np.isclose(geo2.distance([0.1], [0.9]), 0.2)
 
 
 def test_hilbert_states_outside_range_errors():


### PR DESCRIPTION
## Summary
- add geometry.Cell and FreeSpace as jax-compatible PyTrees
- require geometry object when creating `hilbert.Particle`
- update continuous-space tutorial to use geometry classes
- adjust unit tests and add geometry-specific tests

## Testing
- `pre-commit run --files netket/geometry/cell.py netket/hilbert/particle.py test/hilbert/test_hilbert.py test/geometry/test_cell.py docs/tutorials/gs-continuous-space.ipynb` *(fails: `fatal: unable to access 'https://github.com/astral-sh/ruff-pre-commit/': Couldn't connect to server`)*
- `pytest test/hilbert/test_hilbert.py::test_particle_with_geometry test/geometry/test_cell.py::test_distance_jit -q`