### PR TITLE
Restructure Permutation

### DIFF
--- a/netket/utils/deprecation.py
+++ b/netket/utils/deprecation.py
@@ -64,7 +64,7 @@ def deprecated_new_name(func_name, reason=""):
     {func.__name__} has been renamed to {func_name}. The old name is
     now deprecated and will be removed in the next minor version.
 
-    Please update your code by chaing occurences of `{func.__name__}` with
+    Please update your code by changing occurences of `{func.__name__}` with
     `{func_name}`.
 
     {dedent(reason)}

--- a/netket/utils/group/_permutation_group.py
+++ b/netket/utils/group/_permutation_group.py
@@ -30,13 +30,14 @@ from ._semigroup import Element
 
 
 class Permutation(Element):
-    def __init__(self,
-                 permutation: Array | None = None,
-                 *,# change one line somewhere
-                 name: str | None = None,
-                 permutation_array: Array | None = None,
-                 inverse_permutation_array: Array | None = None,
-                 ):
+    def __init__(
+        self,
+        permutation: Array | None = None,
+        *,  # change one line somewhere
+        name: str | None = None,
+        permutation_array: Array | None = None,
+        inverse_permutation_array: Array | None = None,
+    ):
         r"""
         Creates a `Permutation` from either the array of images `permutation_array` or preimages `inverse_permutation_array`. Note that the left action of a permutation on an array `a` is `a[inverse_permutation_array]`.
 
@@ -52,16 +53,22 @@ class Permutation(Element):
 
         arg_list = [permutation, permutation_array, inverse_permutation_array]
         if sum([arg is not None for arg in arg_list]) != 1:
-            raise TypeError("Only one among `permutation`, `permutation_array` and `inverse_permutation_array` must be specified.")
+            raise TypeError(
+                "Only one among `permutation`, `permutation_array` and `inverse_permutation_array` must be specified."
+            )
 
         if permutation is not None:
-            warn_deprecation("The argument `permutation` is deprecated. In order to clarify notations, you should either pass the array of images `permutation_array` or preimages `inverse_permutation_array`.")
+            warn_deprecation(
+                "The argument `permutation` is deprecated. In order to clarify notations, you should either pass the array of images `permutation_array` or preimages `inverse_permutation_array`."
+            )
             inverse_permutation_array = permutation
-        
+
         if permutation_array is not None:
             inverse_permutation_array = np.argsort(permutation_array)
-        
-        self._inverse_permutation_array = HashableArray(np.asarray(inverse_permutation_array))
+
+        self._inverse_permutation_array = HashableArray(
+            np.asarray(inverse_permutation_array)
+        )
 
         self.__name = name
 
@@ -73,17 +80,19 @@ class Permutation(Element):
             return np.array_equal(self.permutation_array, other.permutation_array)
         else:
             return False
-    
+
     @property
     def permutation_array(self):
         return np.asarray(np.argsort(self._inverse_permutation_array))
-    
+
     @property
     def inverse_permutation_array(self):
         return np.asarray(self._inverse_permutation_array)
-    
+
     @property
-    @deprecated("Deprecated in favor of `permutation.inverse_permutation_array` or `permutation.permutation_array`")
+    @deprecated(
+        "Deprecated in favor of `permutation.inverse_permutation_array` or `permutation.permutation_array`"
+    )
     def permutation(self):
         return np.asarray(self._inverse_permutation_array)
 

--- a/netket/utils/group/_permutation_group.py
+++ b/netket/utils/group/_permutation_group.py
@@ -70,7 +70,7 @@ class Permutation(Element):
 
     def __eq__(self, other):
         if isinstance(other, Permutation):
-            return self.permutation_array == other.permutation_array
+            return np.array_equal(self.permutation_array, other.permutation_array)
         else:
             return False
     
@@ -112,7 +112,7 @@ def product(p: Permutation, x: Array):
     # direct indexing fails, so we call np.asarray on it to extract the
     # wrapped array
     # TODO make indexing work with HashableArray directly
-    return x[..., np.asarray(p.inverse_permutation_array)]
+    return x[..., p.inverse_permutation_array]
 
 
 @dispatch

--- a/netket/utils/group/_permutation_group.py
+++ b/netket/utils/group/_permutation_group.py
@@ -131,7 +131,7 @@ class Permutation(Element):
 
     def apply_to_id(self, x: Array):
         """Returns the image of indices `x` under the permutation"""
-        return np.argsort(self.permutation)[x]
+        return self.permutation_array[x]
 
 
 @dispatch

--- a/netket/utils/group/_permutation_group.py
+++ b/netket/utils/group/_permutation_group.py
@@ -55,7 +55,7 @@ class Permutation(Element):
             raise TypeError("Only one among `permutation`, `permutation_array` and `inverse_permutation_array` must be specified.")
 
         if permutation is not None:
-            warn_deprecation("The argument `permutation` is deprecated. In order to clarify notations, you should either pass the array of images `permutation_array` or preimages `inverse_permutation_array`")
+            warn_deprecation("The argument `permutation` is deprecated. In order to clarify notations, you should either pass the array of images `permutation_array` or preimages `inverse_permutation_array`.")
             inverse_permutation_array = permutation
         
         if permutation_array is not None:
@@ -83,7 +83,7 @@ class Permutation(Element):
         return np.asarray(self._inverse_permutation_array)
     
     @property
-    @deprecated("Bye bye")
+    @deprecated("Deprecated in favor of `permutation.inverse_permutation_array` or `permutation.permutation_array`")
     def permutation(self):
         return np.asarray(self._inverse_permutation_array)
 
@@ -91,17 +91,16 @@ class Permutation(Element):
     def _name(self):
         return self.__name
 
-    def __repr__(self): # Should it return the permutation or permutation inverse?
+    def __repr__(self):
         if self._name is not None:
             return self._name
         else:
             return f"Permutation({self.permutation_array.tolist()})"
 
-    @deprecated("Bye bye bye")
+    @deprecated("Deprecated in favor of `permutation.inverse_permutation_array`")
     def __array__(self, dtype: DType = None):
         return np.asarray(self._inverse_permutation_array, dtype)
 
-    @deprecated("Bye bye bye")
     def apply_to_id(self, x: Array):
         """Returns the image of indices `x` under the permutation"""
         return np.argsort(self.permutation)[x]
@@ -119,10 +118,8 @@ def product(p: Permutation, x: Array):
 @dispatch
 def product(p: Permutation, q: Permutation):  # noqa: F811
     name = None if p._name is None and q._name is None else f"{p} @ {q}"
-    # I don't like the __call__ here. I don't like that __call__ is a product. It goes all the way back to SemiGroup.
-    #return Permutation(p(np.asarray(q)), name=name)
-    # If it makes any difference, the product can be taken with the inverses as inverse_permutation_array=q.inverse_permutation_array[p.inverse_permutation_array]
-    return Permutation(permutation_array=p.permutation_array[q.permutation_array], name=name)
+    inverse_permutation_array = q.inverse_permutation_array[p.inverse_permutation_array]
+    return Permutation(inverse_permutation_array=inverse_permutation_array, name=name)
 
 
 @struct.dataclass

--- a/netket/utils/group/_permutation_group.py
+++ b/netket/utils/group/_permutation_group.py
@@ -23,7 +23,7 @@ from netket.utils import HashableArray, struct
 from netket.utils.types import Array, DType, Shape
 from netket.utils.dispatch import dispatch
 
-from netket.utils import warn_deprecation, deprecated
+from netket.utils import warn_deprecation, deprecated, deprecated_new_name
 
 from ._group import FiniteGroup
 from ._semigroup import Element
@@ -39,27 +39,42 @@ class Permutation(Element):
         inverse_permutation_array: Array | None = None,
     ):
         r"""
-        Creates a `Permutation` from either the array of images `permutation_array` or preimages `inverse_permutation_array`. Note that the left action of a permutation on an array `a` is `a[inverse_permutation_array]`.
+        Creates a `Permutation` from either the array of images
+        `permutation_array` or preimages `inverse_permutation_array`.
+        
+        Exactly one argument among `permutation_array` and
+        `inverse_permutation_array` (and the deprecated argument `permutation`)
+        must be specified.
+
+        Note that the left action of a permutation on an array `a` is
+        `a[inverse_permutation_array]`.
 
         Args:
-            permutation: (deprecated) 1D array listing :math:`g^{-1}(x)` for all :math:`0\le x \le N-1`.
+            permutation: (deprecated) 1D array listing
+                :math:`g^{-1}(x)` for all :math:`0\le x \le N-1`.
             name: Optional, custom name for the permutation.
-            permutation_array: 1D array listing :math:`g(x)` for all :math:`0\le x \le N-1`.
-            inverse_permutation_array: 1D array listing :math:`g^{-1}(x)` for all :math:`0\le x \le N-1`.
+            permutation_array: 1D array listing
+                :math:`g(x)` for all :math:`0\le x \le N-1`.
+            inverse_permutation_array: 1D array listing
+                :math:`g^{-1}(x)` for all :math:`0\le x \le N-1`.
 
         Returns:
-            A `Permutation` object encoding the same permutation.
+            A `Permutation` object that encodes the specified permutation.
         """
 
         arg_list = [permutation, permutation_array, inverse_permutation_array]
         if sum([arg is not None for arg in arg_list]) != 1:
-            raise TypeError(
-                "Only one among `permutation`, `permutation_array` and `inverse_permutation_array` must be specified."
+            raise ValueError(
+                "Exactly one argument among `permutation`, `permutation_array` "
+                "and `inverse_permutation_array` must be specified."
             )
 
         if permutation is not None:
             warn_deprecation(
-                "The argument `permutation` is deprecated. In order to clarify notations, you should either pass the array of images `permutation_array` or preimages `inverse_permutation_array`."
+                "The argument `permutation` is deprecated.\n\n"
+                "In order to clarify notations, you should either pass "
+                "the array of images `permutation_array` or "
+                "preimages `inverse_permutation_array`."
             )
             inverse_permutation_array = permutation
 
@@ -91,7 +106,8 @@ class Permutation(Element):
 
     @property
     @deprecated(
-        "Deprecated in favor of `permutation.inverse_permutation_array` or `permutation.permutation_array`"
+        "Deprecated in favor of `permutation.inverse_permutation_array` or "
+        "`permutation.permutation_array`"
     )
     def permutation(self):
         return np.asarray(self._inverse_permutation_array)
@@ -106,7 +122,7 @@ class Permutation(Element):
         else:
             return f"Permutation({self.permutation_array.tolist()})"
 
-    @deprecated("Deprecated in favor of `permutation.inverse_permutation_array`")
+    @deprecated_new_name("permutation.inverse_permutation_array")
     def __array__(self, dtype: DType = None):
         return np.asarray(self._inverse_permutation_array, dtype)
 

--- a/netket/utils/group/_permutation_group.py
+++ b/netket/utils/group/_permutation_group.py
@@ -41,7 +41,7 @@ class Permutation(Element):
         r"""
         Creates a `Permutation` from either the array of images
         `permutation_array` or preimages `inverse_permutation_array`.
-        
+
         Exactly one argument among `permutation_array` and
         `inverse_permutation_array` (and the deprecated argument `permutation`)
         must be specified.

--- a/netket/utils/group/_permutation_group.py
+++ b/netket/utils/group/_permutation_group.py
@@ -46,6 +46,9 @@ class Permutation(Element):
         `inverse_permutation_array` (and the deprecated argument `permutation`)
         must be specified.
 
+        The deprecated argument `permutation` should be substituted for
+        `inverse_permutation_array`.
+
         Note that the left action of a permutation on an array `a` is
         `a[inverse_permutation_array]`.
 

--- a/test/utils/test_group.py
+++ b/test/utils/test_group.py
@@ -391,6 +391,13 @@ def test_permutations():
     cycle_2 = Permutation(permutation=np.argsort(cycle_array))
     cycle_3 = Permutation(inverse_permutation_array=np.argsort(cycle_array))
 
+    # Wrong ways of instantiating a permutation
+    with pytest.raises(ValueError):
+        Permutation()
+    with pytest.raises(ValueError):
+        Permutation(permutation_array=cycle_array,
+                    inverse_permutation_array=np.argsort(cycle_array))
+
     transposition = Permutation(permutation_array=[1, 0, 2])
 
     assert not cycle == transposition

--- a/test/utils/test_group.py
+++ b/test/utils/test_group.py
@@ -381,10 +381,9 @@ def test_call_point(grp):
         assert_allclose(gv, g(v), rtol=1e-15)
 
 
-
 # cycle_1 and cycle_2 are deprecated
 def test_permutations():
-    
+
     cycle_array = [1, 2, 0]
 
     cycle = Permutation(permutation_array=cycle_array)

--- a/test/utils/test_group.py
+++ b/test/utils/test_group.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import pytest
+import warnings
 
 import netket as nk
 import numpy as np
@@ -387,8 +388,10 @@ def test_permutations():
     cycle_array = [1, 2, 0]
 
     cycle = Permutation(permutation_array=cycle_array)
-    cycle_1 = Permutation(np.argsort(cycle_array))
-    cycle_2 = Permutation(permutation=np.argsort(cycle_array))
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", FutureWarning)
+        cycle_1 = Permutation(np.argsort(cycle_array))
+        cycle_2 = Permutation(permutation=np.argsort(cycle_array))
     cycle_3 = Permutation(inverse_permutation_array=np.argsort(cycle_array))
 
     # Wrong ways of instantiating a permutation

--- a/test/utils/test_group.py
+++ b/test/utils/test_group.py
@@ -395,8 +395,10 @@ def test_permutations():
     with pytest.raises(ValueError):
         Permutation()
     with pytest.raises(ValueError):
-        Permutation(permutation_array=cycle_array,
-                    inverse_permutation_array=np.argsort(cycle_array))
+        Permutation(
+            permutation_array=cycle_array,
+            inverse_permutation_array=np.argsort(cycle_array),
+        )
 
     transposition = Permutation(permutation_array=[1, 0, 2])
 

--- a/test/utils/test_group.py
+++ b/test/utils/test_group.py
@@ -19,6 +19,7 @@ import numpy as np
 from numpy.testing import assert_equal
 
 from netket.utils import group
+from netket.utils.group import Permutation
 
 from itertools import product
 
@@ -378,3 +379,26 @@ def test_call_point(grp):
 
     for g, gv in zip(grp, apply_v):
         assert_allclose(gv, g(v), rtol=1e-15)
+
+
+
+# cycle_1 and cycle_2 are deprecated
+def test_permutations():
+    
+    cycle_array = [1, 2, 0]
+
+    cycle = Permutation(permutation_array=cycle_array)
+    cycle_1 = Permutation(np.argsort(cycle_array))
+    cycle_2 = Permutation(permutation=np.argsort(cycle_array))
+    cycle_3 = Permutation(inverse_permutation_array=np.argsort(cycle_array))
+
+    transposition = Permutation(permutation_array=[1, 0, 2])
+
+    assert not cycle == transposition
+    assert cycle == cycle_1 == cycle_2 == cycle_3
+
+    transposition_cycle = Permutation(permutation_array=[0, 2, 1])
+    cycle_transposition = Permutation(permutation_array=[2, 1, 0])
+
+    assert cycle @ transposition == cycle_transposition
+    assert transposition @ cycle == transposition_cycle


### PR DESCRIPTION
The clarification of names in `Permutation` as discussed with @PhilipVinc and @attila-i-szabo. The objective is to solve the confusion that might be caused by the property `permutation` actually encoding the inverse permutation.

**Changes**:
- The constructor of `Permutation` now takes in either the permutation array or its inverse. `name` is now a keyword argument.
- The `Permutation` property `permutation` is deprecated in favor of `permutation_array` and `inverse_permutation_array`.
- `__repr__` now returns the array of the permutation instead of its inverse.
- `__array__` is deprecated and replaced by `Permutation.inverse_permutation_array` for more clarity.

---

As far as I can tell, the PR is functional right now, but I think it's better to wait for Attila's PR to be merged so we can update the usage of the `Permutation` class in `SpaceGroup` and the likes, and avoid an avalanche of deprecation warnings.

Two other points:
- There is the function `apply_to_id` in `Permutation`. From what I can see, it's only used twice inside the tests to obtain the permutation (instead of its inverse). Since it's effectively identical to `p.permutation_array[x]` now, would it make sense to deprecate it?
- There is this `HashableArray` business going on, and I'm not sure what it's for (being able to hash `permutation` I guess?). I think what I wrote in that regard makes sense, but you should probably check.