### PR TITLE
Fix qutip conversion tests

### DIFF
--- a/test/variational/test_exact_state.py
+++ b/test/variational/test_exact_state.py
@@ -141,7 +141,7 @@ def test_qutip_conversion(vstate):
     assert q_obj.type == "ket"
     assert len(q_obj.dims) == 2
     assert q_obj.dims[0] == list(vstate.hilbert.shape)
-    assert q_obj.dims[1] == [1 for i in range(vstate.hilbert.size)]
+    assert q_obj.dims[1] == [1]
 
     assert q_obj.shape == (vstate.hilbert.n_states, 1)
     np.testing.assert_allclose(q_obj.data.to_array(), ket.reshape(q_obj.shape))

--- a/test/variational/test_variational.py
+++ b/test/variational/test_variational.py
@@ -339,7 +339,7 @@ def test_qutip_conversion(vstate):
     assert q_obj.type == "ket"
     assert len(q_obj.dims) == 2
     assert q_obj.dims[0] == list(vstate.hilbert.shape)
-    assert q_obj.dims[1] == [1 for i in range(vstate.hilbert.size)]
+    assert q_obj.dims[1] == [1]
 
     assert q_obj.shape == (vstate.hilbert.n_states, 1)
     np.testing.assert_allclose(q_obj.data.to_array(), ket.reshape(q_obj.shape))


### PR DESCRIPTION
`QuTiP` now automatically converts trivial `Qobj` dims like `[1, 1, 1, 1]` to `[1]`. This PR fixes the tests to account for this change of behaviour.