### PR TITLE
Allow specifying `characters` directly in `SymmSumExp`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ## New features
 
+* `SymmSumExp` supports specifying group characters as an array in addition to their index in the full character table. [#2075](https://github.com/netket/netket/pull/2075).
+
 ## Deprecations and Removals
 
 

--- a/netket/nn/blocks/symmetry_sum.py
+++ b/netket/nn/blocks/symmetry_sum.py
@@ -96,7 +96,7 @@ class SymmExpSum(nn.Module):
 
     chi: HashableArray | None = None
     """Character of the space group to project onto.
-    
+
     Only one of `chi` and `character_id` may be specified.
     If neither is specified, the character is taken to be all 1,
     yielding a trivially symmetric state.

--- a/netket/nn/blocks/symmetry_sum.py
+++ b/netket/nn/blocks/symmetry_sum.py
@@ -146,7 +146,7 @@ class SymmExpSum(nn.Module):
         # Compute the log-wavefunction obtaining (-1,) and reshape to (N_symm, ...)
         psi_symm = self.module(x_symm).reshape(*x_symm_shape[:-1])
 
-        characters = self._chi.reshape((-1,) + tuple(1 for _ in range(x.ndim - 1)))
+        characters = np.expand_dims(self._chi, range(1, x.ndim))
 
         # If those are all positive, then use standard logsumexp that returns a
         # real-valued, positive logsumexp

--- a/netket/nn/blocks/symmetry_sum.py
+++ b/netket/nn/blocks/symmetry_sum.py
@@ -146,7 +146,7 @@ class SymmExpSum(nn.Module):
         # Compute the log-wavefunction obtaining (-1,) and reshape to (N_symm, ...)
         psi_symm = self.module(x_symm).reshape(*x_symm_shape[:-1])
 
-        characters = np.expand_dims(self._chi, range(1, x.ndim))
+        characters = np.expand_dims(self._chi, tuple(range(1, x.ndim)))
 
         # If those are all positive, then use standard logsumexp that returns a
         # real-valued, positive logsumexp

--- a/netket/nn/blocks/symmetry_sum.py
+++ b/netket/nn/blocks/symmetry_sum.py
@@ -95,7 +95,7 @@ class SymmExpSum(nn.Module):
     """
 
     characters: HashableArray | None = None
-    """Characters :math:`\chi_g` of the space group to project onto.
+    r"""Characters :math:`\chi_g` of the space group to project onto.
 
     Only one of `characters` and `character_id` may be specified.
     If neither is specified, the character is taken to be all 1,

--- a/netket/nn/blocks/symmetry_sum.py
+++ b/netket/nn/blocks/symmetry_sum.py
@@ -94,10 +94,10 @@ class SymmExpSum(nn.Module):
 
     """
 
-    chi: HashableArray | None = None
-    """Character of the space group to project onto.
+    characters: HashableArray | None = None
+    """Characters :math:`\chi_g` of the space group to project onto.
 
-    Only one of `chi` and `character_id` may be specified.
+    Only one of `characters` and `character_id` may be specified.
     If neither is specified, the character is taken to be all 1,
     yielding a trivially symmetric state.
     """
@@ -112,22 +112,24 @@ class SymmExpSum(nn.Module):
 
         symm_group.character_table()[character_id]
 
-    Only one of `chi` and `character_id` may be specified.
+    Only one of `characters` and `character_id` may be specified.
     If neither is specified, the character is taken to be all 1,
     yielding a trivially symmetric state.
     """
 
     def setup(self):
-        if self.chi is None:
+        if self.characters is None:
             if self.character_id is None:
                 self._chi = np.ones(len(np.asarray(self.symm_group)))
             else:
                 self._chi = self.symm_group.character_table()[self.character_id]
         else:
             if self.character_id is None:
-                self._chi = self.chi.wrapped
+                self._chi = self.characters.wrapped
             else:
-                raise AttributeError("Must not specify both `chi` and `character_id`")
+                raise AttributeError(
+                    "Must not specify both `characters` and `character_id`"
+                )
 
     @nn.compact
     def __call__(self, x: jax.Array) -> jax.Array:

--- a/netket/nn/blocks/symmetry_sum.py
+++ b/netket/nn/blocks/symmetry_sum.py
@@ -25,56 +25,65 @@ from netket.utils import HashableArray
 
 class SymmExpSum(nn.Module):
     r"""
-    A flax module symmetrizing the log-wavefunction :math:`\log\psi_\theta(\sigma)`
-    encoded into another flax module (:class:`flax.linen.Module`) by summing over
-    all possible symmetries :math:`g` in a certain discrete permutation
-    group :math:`G`.
+    A wrapper module to symmetrise a variational wave function with respect
+    to a permutation group :math:`G` by summing over all permuted inputs.
+
+    Given the characters :math:`\chi_g` of an irreducible representation
+    (irrep) of :math:`G`, a variational state that transforms according
+    to this irrep is given by the projection formula
 
     .. math::
 
-        \log\psi_\theta(\sigma) = \frac{1}{|G|}\log\sum_{g\in G}
-            \chi_g\exp[\log\psi_\theta(T_{g}\sigma)]
+        \psi_\theta(\sigma) = \frac{1}{|G|}\sum_{g\in G}
+            \chi_g \psi_\theta(T_{g}\sigma).
 
-    For the ground-state, it is usually found that :math:`\chi_g=1 \forall g\in G`.
-
-    To construct this network, one has to specify the module, the symmetry group
-    and (optionally)the id of the character to consider.
-
-    The module's :code:`.__call__` will be called.
-    The :code:`symm_group` attribute
+    Ground states usually transform according to the trivial irrep
+    :math:`\chi_g=1 \forall g\in G`.
 
     Examples:
 
-       Constructs a :ref:`netket.nn.blocks.SymmExpSum` for a bare
-       :ref:`netket.models.RBM`, summing over all translations of a
-       2D Square lattice
+        Symmetrise an :ref:`netket.models.RBM` with respect to the space
+        group of a 2D :ref:`netket.graph.Square` lattice:
 
-       >>> import netket as nk
-       >>> graph = nk.graph.Square(3)
-       >>> print("number of translational symmetries: ", len(graph.translation_group()))
-       number of translational symmetries:  9
-       >>> # Construct the bare unsymmetrized machine
-       >>> machine_no_symm = nk.models.RBM(alpha=2)
-       >>> # Symmetrize the RBM over all translations
-       >>> ma = nk.nn.blocks.SymmExpSum(module = machine_no_symm, symm_group=graph.translation_group())
+        >>> import netket as nk
+        >>> graph = nk.graph.Square(4)
+        >>> group = graph.space_group()
+        >>> print("Size of space group:", len(group))
+        Size of space group: 128
+        >>> # Construct the bare unsymmetrized machine
+        >>> machine_no_symm = nk.models.RBM(alpha=2)
+        >>> # Symmetrize the RBM over the space group
+        >>> ma = nk.nn.blocks.SymmExpSum(module = machine_no_symm, symm_group=group)
 
-       If you have a Convolutional NN that is already invariant under translations, you might
-       want to only symmetrize over the point-group (mirror symmetry and rotations).
+        Nontrivial irreps can be specified using momentum and point-group
+        quantum numbers:
 
-       >>> import netket as nk
-       >>> graph = nk.graph.Square(3)
-       >>> print("number of point-group symmetries: ", len(graph.point_group()))
-       number of point-group symmetries:  8
-       >>> # Construct the bare unsymmetrized machine
-       >>> machine_no_symm = nk.models.RBM(alpha=2)
-       >>> # Symmetrize the RBM over all translations
-       >>> ma = nk.nn.blocks.SymmExpSum(module = machine_no_symm, symm_group=graph.point_group())
+        >>> from math import pi
+        >>> print(group.little_group(pi, 0).character_table_readable())
+        (['1xId()', '1xRefl(0°)', '1xRefl(90°)', '1xRot(180°)'],
+        array([[ 1.,  1.,  1.,  1.],
+               [ 1.,  1., -1., -1.],
+               [ 1., -1.,  1., -1.],
+               [ 1., -1., -1.,  1.]]))
+        >>> chi = group.space_group_irreps(pi, 0)[1]
+        >>> ma = nk.nn.blocks.SymmExpSum(module = machine_no_symm, symm_group=group, characters=chi)
 
+        Convolutional networks are already invariant under translations,
+        so they only need to be symmetrised with respect to the point group
+        (e.g., mirrors and rotations).
+
+        >>> import netket as nk
+        >>> graph = nk.graph.Square(4)
+        >>> print("Size of the point group:", len(graph.point_group()))
+        Size of the point group: 8
+        >>> # Construct a translation-invariant RBM
+        >>> machine_trans = nk.models.RBMSymm(alpha=2, symmetries=graph.translation_group())
+        >>> # Symmetrize the RBM over the point group
+        >>> ma = nk.nn.blocks.SymmExpSum(module = machine_trans, symm_group=graph.point_group())
     """
 
     module: nn.Module
-    """The neural network architecture encoding the log-wavefunction
-    to symmetrize in the :code:`.__call__` function."""
+    """The unsymmetrised neural-network ansatz."""
 
     symm_group: PermutationGroup
     """The symmetry group to use. It should be a valid

--- a/test/nn/test_symmsum.py
+++ b/test/nn/test_symmsum.py
@@ -26,12 +26,6 @@ bare_modules = {}
 bare_modules["RBM(real)"] = nk.models.RBM(alpha=1, param_dtype=float)
 bare_modules["RBM(complex)"] = nk.models.RBM(alpha=1, param_dtype=complex)
 
-character_ids = {}
-character_ids["Char=None"] = (None, None)
-character_ids["Idx=0"] = (0, None)
-character_ids["Idx=1"] = (1, None)
-character_ids["Char=0"] = ()
-
 ones = HashableArray(np.ones(9))
 
 

--- a/test/nn/test_symmsum.py
+++ b/test/nn/test_symmsum.py
@@ -33,7 +33,7 @@ ones = HashableArray(np.ones(9))
     "bare_module", [pytest.param(v, id=k) for k, v in bare_modules.items()]
 )
 @pytest.mark.parametrize(
-    "character_id,chi,trivial",
+    "character_id,characters,trivial",
     [
         pytest.param(None, None, True, id="Char=None"),
         pytest.param(0, None, True, id="Id=0"),
@@ -44,12 +44,12 @@ ones = HashableArray(np.ones(9))
         ),
     ],
 )
-def test_symmexpsum(bare_module, character_id, chi, trivial):
+def test_symmexpsum(bare_module, character_id, characters, trivial):
     graph = nk.graph.Square(3)
     g = graph.translation_group()
 
     ma = nknn.blocks.SymmExpSum(
-        bare_module, symm_group=g, character_id=character_id, chi=chi
+        bare_module, symm_group=g, character_id=character_id, characters=characters
     )
 
     hi = nk.hilbert.Spin(0.5, graph.n_nodes)


### PR DESCRIPTION
Given that space group irreps can be generated much more conveniently than by looking at the (gigantic) full character table, we should allow specifying characters as arrays. This PR does that for `SymmSumExp`.