### PR TITLE
Change condition for scientific notation when printing Stats object

### DIFF
--- a/netket/stats/mc_stats.py
+++ b/netket/stats/mc_stats.py
@@ -28,7 +28,7 @@ from ._autocorr import integrated_time
 
 
 def _format_decimal(value, std, var):
-    if math.isfinite(std) and std > 1e-7:
+    if math.isfinite(abs(value)) and value > 1e-3:
         decimals = max(int(np.ceil(-np.log10(std))), 0)
         return (
             "{0:.{1}f}".format(value, decimals + 1),

--- a/netket/stats/mc_stats.py
+++ b/netket/stats/mc_stats.py
@@ -36,10 +36,11 @@ def _format_decimal(value, std, var):
             "{0:.{1}f}".format(var, decimals + 1),
         )
     else:
+        n_digits = max(int(np.ceil(-np.log10(std / abs(value)))), 0) + 1
         return (
-            f"{value:.3e}",
-            f"{std:.3e}",
-            f"{var:.3e}",
+            f"{value:.{n_digits}e}",
+            f"{std:.{n_digits}e}",
+            f"{var:.{n_digits}e}",
         )
 
 

--- a/netket/stats/mc_stats.py
+++ b/netket/stats/mc_stats.py
@@ -28,15 +28,30 @@ from ._autocorr import integrated_time
 
 
 def _format_decimal(value, std, var):
-    if math.isfinite(abs(value)) and value > 1e-3:
-        decimals = max(int(np.ceil(-np.log10(std))), 0)
+
+    if not math.isfinite(abs(value)) or not math.isfinite(std):
         return (
-            "{0:.{1}f}".format(value, decimals + 1),
-            "{0:.{1}f}".format(std, decimals + 1),
-            "{0:.{1}f}".format(var, decimals + 1),
+            f"{value:.3e}",
+            f"{std:.3e}",
+            f"{var:.3e}",
         )
+
+    elif abs(value) > 1e-3:
+        if std < 1e-15:
+            decimals = 15
+        else:
+            decimals = max(int(np.ceil(-np.log10(std))), 0) + 1
+        return (
+            "{0:.{1}f}".format(value, decimals),
+            "{0:.{1}f}".format(std, decimals),
+            "{0:.{1}f}".format(var, decimals),
+        )
+
     else:
-        n_digits = max(int(np.ceil(-np.log10(std / abs(value)))), 0) + 1
+        if abs(value) < 1e-15 or std / abs(value) < 1e-15:
+            n_digits = 15
+        else:
+            n_digits = max(int(np.ceil(-np.log10(std / abs(value)))), 0) + 1
         return (
             f"{value:.{n_digits}e}",
             f"{std:.{n_digits}e}",

--- a/netket/stats/mc_stats.py
+++ b/netket/stats/mc_stats.py
@@ -29,14 +29,14 @@ from ._autocorr import integrated_time
 
 def _format_decimal(value, std, var):
 
-    if not math.isfinite(abs(value)) or not math.isfinite(std):
+    if math.isfinite(abs(value)) or math.isfinite(std) or abs(value) < 1e-3:
         return (
             f"{value:.3e}",
             f"{std:.3e}",
             f"{var:.3e}",
         )
 
-    elif abs(value) > 1e-3:
+    else:
         if std < 1e-15:
             decimals = 15
         else:
@@ -45,17 +45,6 @@ def _format_decimal(value, std, var):
             "{0:.{1}f}".format(value, decimals),
             "{0:.{1}f}".format(std, decimals),
             "{0:.{1}f}".format(var, decimals),
-        )
-
-    else:
-        if abs(value) < 1e-15 or std / abs(value) < 1e-15:
-            n_digits = 15
-        else:
-            n_digits = max(int(np.ceil(-np.log10(std / abs(value)))), 0) + 1
-        return (
-            f"{value:.{n_digits}e}",
-            f"{std:.{n_digits}e}",
-            f"{var:.{n_digits}e}",
         )
 
 

--- a/netket/stats/mc_stats.py
+++ b/netket/stats/mc_stats.py
@@ -30,29 +30,31 @@ from ._autocorr import integrated_time
 def _format_main_string(value, std, var):
 
     if not math.isfinite(abs(value)) or not math.isfinite(std):
-        return f"{value:.2e} ± {std:.2e} [σ²={var:.2e}"
+        return f"{value:.2e} ± {std:.2e} [σ²={var:.1e}"
 
-    elif abs(value) < 1e-3:
+    elif abs(value) + std < 1e-2:
         value_std_str = _format_scientific_notation(value, std)
-        return value_std_str + " [σ²={var:.2e}"
+        return value_std_str + f" [σ²={var:.1e}"
 
     else:
         if std < 1e-15:
             decimals = 15
         else:
             decimals = max(int(np.ceil(-np.log10(std))), 0) + 1
-        return f"{value:.{decimals}e} ± {std:.{decimals}e} [σ²={var:.{decimals}e}"
+        return f"{value:.{decimals}f} ± {std:.{decimals}f} [σ²={var:.1e}"
 
 
 def _format_scientific_notation(value, std):
 
-    print(value)
-    print(type(value))
     length = 5
 
-    exponent_val = (
-        int(np.floor(np.log10(max(np.abs(np.real(value)), np.abs(np.imag(value)))))),
+    value_ref = (
+        np.real(value)
+        if np.abs(np.real(value)) > np.abs(np.imag(value))
+        else np.imag(value)
     )
+
+    exponent_val = int(np.floor(np.log10(np.abs(value_ref))))
     exponent_std = int(np.floor(np.log10(std)))
     n_digits = max(exponent_val - exponent_std, 0) + 1
 
@@ -67,7 +69,7 @@ def _format_scientific_notation(value, std):
         + f"{mantissa_std:.{n_digits}f}".rjust(length)
     )
 
-    return mantissa_str + " e" + f"{value:e}".split("e")[1]
+    return mantissa_str + " e" + f"{value_ref:e}".split("e")[1]
 
 
 _NaN = float("NaN")

--- a/netket/stats/mc_stats.py
+++ b/netket/stats/mc_stats.py
@@ -32,7 +32,10 @@ def _format_main_string(value, std, var):
     if not math.isfinite(abs(value)) or not math.isfinite(std):
         return f"{value:.2e} ± {std:.2e} [σ²={var:.1e}"
 
-    elif abs(value) + std < 1e-2:
+    elif std == 0.0:
+        return f"{value:.3e} [σ²={var:.1e}"
+
+    elif (abs(value) + abs(std) < 1e-2) or abs(std) <= 1e-7:
         value_std_str = _format_scientific_notation(value, std)
         return value_std_str + f" [σ²={var:.1e}"
 

--- a/test/stats/test_stats.py
+++ b/test/stats/test_stats.py
@@ -192,16 +192,28 @@ def test_decimal_format():
 
     assert str(Stats(1.0, 1e-3)) == "1.0000 ± 0.0010 [σ²=nan]"
     assert str(Stats(1.0, 1e-6)) == "1.0000000 ± 0.0000010 [σ²=nan]"
-    assert str(Stats(1.0, 1e-7)) == "1.000e+00 ± 1.000e-07 [σ²=nan]"
+    assert str(Stats(1.0, 1e-7)) == "1.00000000 ± 0.00000010 e+00 [σ²=nan]"
 
     assert str(Stats(float("nan"), float("inf"))) == "nan ± inf [σ²=nan]"
-    assert str(Stats(1.0, float("nan"))) == "1.000e+00 ± nan [σ²=nan]"
-    assert str(Stats(1.0, float("inf"))) == "1.000e+00 ± inf [σ²=nan]"
-    assert str(Stats(float("inf"), 0.0)) == "inf ± 0.000e+00 [σ²=nan]"
-    assert str(Stats(1.0, 0.0)) == "1.000e+00 ± 0.000e+00 [σ²=nan]"
+    assert str(Stats(1.0, float("nan"))) == "1.00e+00 ± nan [σ²=nan]"
+    assert str(Stats(1.0, float("inf"))) == "1.00e+00 ± inf [σ²=nan]"
+    assert str(Stats(float("inf"), 0.0)) == "inf ± 0.00e+00 [σ²=nan]"
+    assert str(Stats(1.0, 0.0)) == "1.000e+00 [σ²=nan]"
 
-    assert str(Stats(1.0, 0.12, 0.5)) == "1.00 ± 0.12 [σ²=0.50]"
-    assert str(Stats(1.0, 0.12, 0.5, R_hat=1.01)) == "1.00 ± 0.12 [σ²=0.50, R̂=1.0100]"
+    assert str(Stats(1.0, 0.12, 0.5)) == "1.00 ± 0.12 [σ²=5.0e-01]"
+    assert str(Stats(1.0, 0.12, 0.5, R_hat=1.01)) == "1.00 ± 0.12 [σ²=5.0e-01, R̂=1.010]"
+
+    assert str(Stats(0.0032 + 0.0003j, 0.00673)) == "    3.2+0.3j ±   6.7 e-03 [σ²=nan]"
+    assert (
+        str(Stats(0.0032 + 0.0007j, 0.0000673)) == "3.200+0.700j ± 0.067 e-03 [σ²=nan]"
+    )
+    assert (
+        str(Stats(0.000032 + 0.000003j, 0.00000000673))
+        == "3.20000+0.30000j ± 0.00067 e-05 [σ²=nan]"
+    )
+    assert (
+        str(Stats(0.000032 + 0.003j, 0.0000673)) == "0.032+3.000j ± 0.067 e-03 [σ²=nan]"
+    )
 
 
 @common.skipif_mpi


### PR DESCRIPTION
When printing a `Stats` object, the current condition for it to be displayed in scientific notation is `std<1e-7`. This PR proposes to change the condition to `value<1e-3`. The reason is that when optimising a quantity that should converge to 0, such as the infidelity or a centred energy, it's much more convenient to read and track progress of a number like `1.234e-5` rather than `0.00001234`, especially on a progress bar.