### PR TITLE
Update state within sweeps of ParallelTempering sampler

### DIFF
--- a/netket/sampler/parallel_tempering.py
+++ b/netket/sampler/parallel_tempering.py
@@ -326,26 +326,17 @@ class ParallelTemperingSampler(MetropolisSampler):
     def _sample_next(
         self, machine, parameters: PyTree, state: ParallelTemperingSamplerState
     ):
-        def loop_body(i, s):
+        def loop_body(
+            i, state: ParallelTemperingSamplerState
+        ) -> ParallelTemperingSamplerState:
             # 1 to propagate for next iteration, 1 for uniform rng and n_chains for transition kernel
-            s["key"], key1, key2, key3, key4 = jax.random.split(s["key"], 5)
+            new_rng, key1, key2, key3, key4 = jax.random.split(state.rng, 5)
 
-            # def cbi(data):
-            #    i, beta = data
-            #    print("sweep #", i, " for beta=\n", beta)
-            #    return beta
-            #
-            # beta = hcb.call(
-            #   cbi,
-            #   (i, s["beta"]),
-            #   result_shape=jax.ShapeDtypeStruct(s["beta"].shape, s["beta"].dtype),
-            # )
-
-            beta = s["beta"]
+            beta = state.beta
 
             ## Usual Metropolis sampling
             σp, log_prob_correction = self.rule.transition(
-                self, machine, parameters, state, key1, s["σ"]
+                self, machine, parameters, state, key1, state.σ
             )
             proposal_log_prob = self.machine_pow * machine.apply(parameters, σp).real
 
@@ -353,21 +344,21 @@ class ParallelTemperingSampler(MetropolisSampler):
             if log_prob_correction is not None:
                 do_accept = uniform < jnp.exp(
                     beta.reshape((-1,))
-                    * (proposal_log_prob - s["log_prob"] + log_prob_correction)
+                    * (proposal_log_prob - state.log_prob + log_prob_correction)
                 )
             else:
                 do_accept = uniform < jnp.exp(
-                    beta.reshape((-1,)) * (proposal_log_prob - s["log_prob"])
+                    beta.reshape((-1,)) * (proposal_log_prob - state.log_prob)
                 )
 
             # do_accept must match ndim of proposal and state (which is 2)
-            s["σ"] = jnp.where(do_accept.reshape(-1, 1), σp, s["σ"])
-            n_accepted_per_beta = s["n_accepted_per_beta"] + do_accept.reshape(
+            new_σ = jnp.where(do_accept.reshape(-1, 1), σp, state.σ)
+            n_accepted_per_beta = state.n_accepted_per_beta + do_accept.reshape(
                 (self.n_batches // self.n_replicas, self.n_replicas)
             )
 
-            s["log_prob"] = jax.numpy.where(
-                do_accept.reshape(-1), proposal_log_prob, s["log_prob"]
+            new_log_prob = jax.numpy.where(
+                do_accept.reshape(-1), proposal_log_prob, state.log_prob
             )
 
             ## exchange betas
@@ -409,7 +400,7 @@ class ParallelTemperingSampler(MetropolisSampler):
                 return prob_rescaled
 
             # compute the probability of the swaps
-            log_prob = (proposed_beta - s["beta"]) * s["log_prob"].reshape(
+            log_prob = (proposed_beta - state.beta) * new_log_prob.reshape(
                 (self.n_batches // self.n_replicas, self.n_replicas)
             )
 
@@ -437,27 +428,26 @@ class ParallelTemperingSampler(MetropolisSampler):
 
             # Do the swap where it has to be done
             new_beta = jax.numpy.where(do_swap, proposed_beta, beta)
-            s["beta"] = new_beta
 
             swap_order = swap_order.reshape(-1)
 
             beta_0_moved = jax.vmap(jnp.take)(
-                do_swap, s["beta_0_index"]
+                do_swap, state.beta_0_index
             )  # flag saying if beta_0 should move
             proposed_beta_0_index = jnp.mod(
-                s["beta_0_index"]
+                state.beta_0_index
                 + (-2 * jnp.mod(swap_order, 2) + 1)
-                * (-2 * jnp.mod(s["beta_0_index"], 2) + 1),
+                * (-2 * jnp.mod(state.beta_0_index, 2) + 1),
                 self.n_replicas,
             )
 
-            s["beta_0_index"] = jnp.where(
-                beta_0_moved, proposed_beta_0_index, s["beta_0_index"]
+            new_beta_0_index = jnp.where(
+                beta_0_moved, proposed_beta_0_index, state.beta_0_index
             )
 
             # swap acceptances
             swapped_n_accepted_per_beta = swap_rows(n_accepted_per_beta, idxs, inn)
-            s["n_accepted_per_beta"] = jax.numpy.where(
+            new_n_accepted_per_beta = jax.numpy.where(
                 do_swap,
                 swapped_n_accepted_per_beta,
                 n_accepted_per_beta,
@@ -465,55 +455,39 @@ class ParallelTemperingSampler(MetropolisSampler):
 
             # Update statistics to compute diffusion coefficient of replicas
             # Total exchange steps performed
-            s["exchange_steps"] += 1
-            delta = s["beta_0_index"] - s["beta_position"]
-            s["beta_position"] = s["beta_position"] + delta / s["exchange_steps"]
-            delta2 = s["beta_0_index"] - s["beta_position"]
-            s["beta_diffusion"] = s["beta_diffusion"] + delta * delta2
+            new_exchange_steps = state.exchange_steps + 1
+            delta = new_beta_0_index - state.beta_position
+            new_beta_position = state.beta_position + delta / new_exchange_steps
+            delta2 = new_beta_0_index - new_beta_position
+            new_beta_diffusion = state.beta_diffusion + delta * delta2
 
-            return s
+            return state.replace(
+                rng=new_rng,
+                σ=new_σ,
+                log_prob=new_log_prob,
+                beta=new_beta,
+                beta_0_index=new_beta_0_index,
+                n_accepted_per_beta=new_n_accepted_per_beta,
+                beta_position=new_beta_position,
+                beta_diffusion=new_beta_diffusion,
+                exchange_steps=new_exchange_steps,
+                n_steps_proc=state.n_steps_proc + self.n_batches // self.n_replicas,
+                n_accepted_proc=jax.vmap(jnp.take)(
+                    new_n_accepted_per_beta, new_beta_0_index
+                ),
+            )
 
-        s = {
-            "key": state.rng,
-            "σ": state.σ,
-            # Log prob is already computed in reset, so don't recompute it.
-            # "log_prob": self.machine_pow * apply_machine(parameters, state.σ).real,
-            "log_prob": state.log_prob,
-            "beta": state.beta,
-            # for logging
-            "beta_0_index": state.beta_0_index,
-            "n_accepted_per_beta": state.n_accepted_per_beta,
-            "beta_position": state.beta_position,
-            "beta_diffusion": state.beta_diffusion,
-            "exchange_steps": state.exchange_steps,
-        }
-        s = jax.lax.fori_loop(0, self.sweep_size, loop_body, s)
+        new_state = jax.lax.fori_loop(0, self.sweep_size, loop_body, state)
 
-        n_accepted_proc = jax.vmap(jnp.take)(
-            s["n_accepted_per_beta"], s["beta_0_index"]
-        )
-
-        new_state = state.replace(
-            rng=s["key"],
-            σ=s["σ"],
-            log_prob=s["log_prob"],
-            n_steps_proc=state.n_steps_proc
-            + self.sweep_size * self.n_batches // self.n_replicas,
-            beta=s["beta"],
-            beta_0_index=s["beta_0_index"],
-            beta_position=s["beta_position"],
-            beta_diffusion=s["beta_diffusion"],
-            exchange_steps=s["exchange_steps"],
-            n_accepted_per_beta=s["n_accepted_per_beta"],
-            n_accepted_proc=n_accepted_proc,
-        )
         σ_flat = new_state.σ
         σ = σ_flat.reshape((-1, self.n_replicas, σ_flat.shape[-1]))
-        σ_new = jnp.take_along_axis(σ, s["beta_0_index"][:, None, None], axis=1)
+        σ_new = jnp.take_along_axis(σ, new_state.beta_0_index[:, None, None], axis=1)
         σ_new = jax.lax.collapse(σ_new, 0, 2)  # remove dummy replica dim
 
         log_prob = new_state.log_prob.reshape((-1, self.n_replicas))
-        log_prob_new = jnp.take_along_axis(log_prob, s["beta_0_index"][:, None], axis=1)
+        log_prob_new = jnp.take_along_axis(
+            log_prob, new_state.beta_0_index[:, None], axis=1
+        )
         log_prob_new = jax.lax.collapse(log_prob_new, 0, 2)  # remove dummy replica dim
 
         return new_state, (σ_new, log_prob_new)


### PR DESCRIPTION
Modifies the state of the sampler during the sweep, as done for the standard `MetropolisSampler`. 