### PR TITLE
Experiment with Pytrees as samples

### DIFF
--- a/netket/optimizer/qgt/qgt_jacobian.py
+++ b/netket/optimizer/qgt/qgt_jacobian.py
@@ -86,8 +86,7 @@ def QGTJacobian_DefaultConstructor(
             pdf = jax.jit(jax.lax.collapse, static_argnums=(1, 2))(pdf, 0, 2)
 
     if samples.ndim >= 3:
-        # use jit so that we can do it on global shared array
-        samples = jax.jit(jax.lax.collapse, static_argnums=(1, 2))(samples, 0, 2)
+        samples = samples.reshape(-1, samples.shape[-1])
 
     jac_mode = mode
     if mode == "imag":

--- a/netket/optimizer/qgt/qgt_onthefly.py
+++ b/netket/optimizer/qgt/qgt_onthefly.py
@@ -113,8 +113,7 @@ def QGTOnTheFly_DefaultConstructor(
 
     # The code does not support an extra batch dimension
     if samples.ndim >= 3:
-        # use jit so that we can do it on global shared array
-        samples = jax.jit(jax.lax.collapse, static_argnums=(1, 2))(samples, 0, 2)
+        samples = samples.reshape(-1, samples.shape[-1])
 
     n_samples_per_rank = samples.shape[0] // jax.device_count()
     if chunk_size is None or chunk_size >= n_samples_per_rank:

--- a/netket/utils/jax.py
+++ b/netket/utils/jax.py
@@ -16,8 +16,6 @@ from collections.abc import Callable
 
 from flax.linen import Module
 
-import jax.numpy as jnp
-
 
 from netket.utils.partial import HashablePartial
 from netket.utils.types import ModuleOrApplyFun, PyTree, Array
@@ -77,7 +75,10 @@ def wrap_to_support_scalar(fun):
     """
 
     def maybe_scalar_fun(apply_fun, pars, x, *args, **kwargs):
-        xb = jnp.atleast_2d(x)
+        if x.ndim < 2:
+            xb = x.reshape(1, -1)
+        else:
+            xb = x
         res = apply_fun(pars, xb, *args, **kwargs)
         # support models with mutable state
         if isinstance(res, tuple):

--- a/netket/utils/samples_pytree.py
+++ b/netket/utils/samples_pytree.py
@@ -1,0 +1,88 @@
+import abc
+import numpy as np
+
+import jax
+
+from flax import struct
+
+
+class SampleWrapper(abc.ABC):
+
+    @property
+    @abc.abstractmethod
+    def _n_batch_dim(self):
+        # static number of batch dimensions of the samples
+        # subclasses are expected to implement this
+        # should be calculated dynacmially as a function of the number of dimension of the data
+        # since we want it to increase automatically if samples are e.g. generated inside a vmap
+        return NotImplemented
+
+    @property
+    def dtype(self):
+        # TODO we could return a tree of dtypes here
+        return None
+
+    @property
+    def ndim(self):
+        return self._n_batch_dim + 1
+
+    @property
+    def _batch_shape(self):
+        # shape of the batch dims; assume the same for all leaves
+        return jax.tree.leaves(self)[0].shape[: self._n_batch_dim]
+
+    @property
+    def _samp_size(self):
+        # sum of all sizes
+        return sum(
+            int(np.prod(x.shape[self._n_batch_dim :])) for x in jax.tree.leaves(self)
+        )
+
+    @property
+    def shape(self):
+        return self._batch_shape + (self._samp_size,)
+
+    def reshape(self, *shape):
+        if len(shape) == 1 and hasattr(shape[0], "len"):
+            (shape,) = shape
+        # only support reshape of the batch dims
+        assert len(shape) >= 1
+        if shape[-1] == -1:
+            assert np.prod(shape[:-1]) == np.prod(self.shape[:-1])
+            shape = shape[:-1] + (self._samp_size,)
+        else:
+            assert shape[-1] == self._samp_size
+        return jax.tree.map(
+            lambda x: x.reshape(shape[:-1] + x.shape[self._n_batch_dim :]), self
+        )
+
+    def swapaxes(self, axis1, axis2):
+        assert axis1 < self._n_batch_dim
+        assert axis2 < self._n_batch_dim
+        return jax.tree.map(lambda x: x.swapaxes(axis1, axis2), self)
+
+    def __getitem__(self, *idx):
+        # only supports indexing of the batch dims
+        dummy_leaf = jax.tree.leaves(self)[0]
+        n_dim_removed = (
+            dummy_leaf.ndim - jax.eval_shape(lambda x: x[*idx], dummy_leaf).ndim
+        )
+        assert n_dim_removed <= self._n_batch_dim
+        return jax.tree.map(lambda x: x[*idx], self)
+
+
+# example implementation using a tuple of sub states for TensorHilbert
+# (would work for any pytree of sub_states)
+@struct.dataclass
+class SampleWrapperExample(SampleWrapper):
+    sub_states: tuple[jax.Array]  # pytree of substates
+    # ShapeDtypeStruct's of the sub states without batch dims; in principle we would only need ndim of one of them
+    _structure: tuple[jax.ShapeDtypeStruct] = struct.field(pytree_node=False)
+
+    @property
+    def _n_batch_dim(self):
+        # assume all are consitent
+        # TODO could check
+        return jax.tree.leaves(
+            jax.tree.map(lambda a, b: a.ndim - b.ndim, self.sub_states, self._structure)
+        )[0]

--- a/netket/vqs/mc/mc_state/state.py
+++ b/netket/vqs/mc/mc_state/state.py
@@ -314,7 +314,7 @@ class MCState(VariationalState):
                 "because you did not supply a valid init_function."
             )
 
-        if dtype is None:
+        if dtype is None and hasattr(self, "_sampler"):
             dtype = self.sampler.dtype
 
         key = nkjax.PRNGKey(seed)


### PR DESCRIPTION
For the flattening/reshaping/batching of samples we need to know how many batch dims the samples have.

Since I can't figure out how to automatically increase that number for the output of a jax.lax.scan, instead here I keep around the number of non-batch dims and compute it from that.

That information is also present in hilbert, so in principle it would be possible to move all the tree maps etc from the wrapper class to netket, and support pytrees directly.

Example:
```python
import netket as nk
import jax
import jax.numpy as jnp

g1 = nk.graph.Chain(4)
g2 = nk.graph.Chain(1, pbc=False)
hi1 = nk.hilbert.Fock(n_max=8, N=g1.n_nodes)
hi2 = nk.hilbert.Spin(s=1/2, N=g2.n_nodes)
hi = hi1*hi2

k = jax.random.key(123)
x = hi.random_state(k, (23,))
print(jax.tree.map(lambda x: x.shape, x))

ma1 = nk.models.RBM
ma2 = nk.models.RBM

from netket.utils.samples_pytree import SampleWrapperExample
from flax import linen as nn
class ProdModel(nn.Module):
    models: tuple[nn.Module]
    @nn.compact
    def __call__(self, x):
        assert isinstance (x, SampleWrapperExample)
        assert len(x.sub_states) == len(self.models)
        return sum(mi()(xi) for mi, xi in zip(self.models, x.sub_states))

ma = ProdModel((ma1, ma2))

sa = nk.sampler.MetropolisLocal(hi)
vs = nk.vqs.MCState(sa, ma)
vs.sample()

S = vs.quantum_geometric_tensor()
S@vs.parameters
```
```
SampleWrapperExample(sub_states=((23, 4), (23, 1)), _structure=(ShapeDtypeStruct(shape=(4,), dtype=int8), ShapeDtypeStruct(shape=(1,), dtype=int8)))
```
@gcarleo 