### PR TITLE
Update automorphism

### DIFF
--- a/netket/graph/graph.py
+++ b/netket/graph/graph.py
@@ -181,7 +181,7 @@ class Graph(AbstractGraph):
 
     def _compute_automorphisms(self):
         """
-        Compute the graph autmorphisms of this graph.
+        Compute the graph automorphisms of this graph.
         """
         colors = self.edge_colors
         result = self._igraph.get_isomorphisms_vf2(
@@ -190,7 +190,10 @@ class Graph(AbstractGraph):
 
         # sort them s.t. the identity comes first
         result = np.unique(result, axis=0).tolist()
-        result = PermutationGroup([Permutation(i) for i in result], self.n_nodes)
+        result = PermutationGroup(
+            [Permutation(inverse_permutation_array=perm) for perm in result],
+            self.n_nodes,
+        )
         return result
 
     # TODO turn into a struct.property_cached?


### PR DESCRIPTION
Very minor change to `graph._compute_automorphisms` to remove the deprecation warning due to the updated `Permutation` class.

I retained the previous behaviour so nothing changes, but technically it was sending each permutation as an inverse permutation. It doesn't change anything when constructing the full group though.

(I messed with the other branch update_automorphism with an underscore, it can be deleted)