### PR TITLE
Fix constraint validation bug in SumConstrainedHilbertIndex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ## NetKet 3.19.1
 
 * Fix a bug where using non-differentiable parameters with chunking would lead to tracer leaks and errors when using `nk.optimizer.qgt.QGTOnTheFly`. This was due to incorrect capturing of the 'model_state' in some shard_maps.
+* Fix constraint validation bug in `SumConstrainedHilbertIndex` where `all_states()` returned invalid states for edge cases with single valid configurations (e.g., `Spin(s=1, N=4, total_sz=4)`). (#XX)
 
 ## NetKet 3.19 (In development)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 ## NetKet 3.19.1
 
 * Fix a bug where using non-differentiable parameters with chunking would lead to tracer leaks and errors when using `nk.optimizer.qgt.QGTOnTheFly`. This was due to incorrect capturing of the 'model_state' in some shard_maps.
-* Fix constraint validation bug in `SumConstrainedHilbertIndex` where `all_states()` returned invalid states for edge cases with single valid configurations (e.g., `Spin(s=1, N=4, total_sz=4)`). (#XX)
+* Fix constraint validation bug in `SumConstrainedHilbertIndex` where `all_states()` returned invalid states for edge cases with single valid configurations (e.g., `Spin(s=1, N=4, total_sz=4)`). Fixes [#2126](https://github.com/netket/netket/issues/2126).
 
 ## NetKet 3.19 (In development)
 

--- a/netket/hilbert/index/constrained_sum.py
+++ b/netket/hilbert/index/constrained_sum.py
@@ -78,7 +78,8 @@ class SumConstrainedHilbertIndex(HilbertIndex):
     @jax.jit
     def _compute_all_states(self):
         if self.n_particles == 0:
-            return jnp.zeros((1, self.size), dtype=self.range.dtype)
+            all_states_fock = jnp.zeros((1, self.size), dtype=self.range.dtype)
+            return self.range.numbers_to_states(all_states_fock, dtype=self.range.dtype)
         with jax.ensure_compile_time_eval():
             c = jnp.repeat(
                 jnp.eye(self.size, dtype=self.range.dtype),

--- a/test/hilbert/test_hilbert.py
+++ b/test/hilbert/test_hilbert.py
@@ -867,3 +867,11 @@ def test_hilbert_dtype_int8():
     assert hi.all_states().dtype == np.int8
     hi = nk.hilbert.SpinOrbitalFermions(4, s=1 / 2, n_fermions_per_spin=(2, 2))
     assert hi.all_states().dtype == np.int8
+
+
+def test_spin_constraint_bug_single_valid_state():
+    """Test for issue #2126: constraint validation bug with single valid configurations"""
+    hilbert_space = nk.hilbert.Spin(s=1, N=4, total_sz=4)
+    all_states = hilbert_space.all_states()
+    constraints = hilbert_space.constraint(all_states)
+    assert np.all(constraints), "All states should satisfy constraints"


### PR DESCRIPTION
## Summary
Fixes a bug where `all_states()` returned invalid states that failed constraint checks in edge cases with single valid configurations.

## Problem
The issue occurred in `SumConstrainedHilbertIndex._compute_all_states()` when `n_particles=0`, causing states to be returned in index space instead of physical spin space.

**Example bug case:**
```python
hilbert_space = nk.hilbert.Spin(s=1, N=4, total_sz=4)
print(hilbert_space.all_states())  # [[0 0 0 0]] ❌ 
print(hilbert_space.constraint(hilbert_space.all_states()))  # [False] ❌ 
```

**After fix:**
```python
hilbert_space = nk.hilbert.Spin(s=1, N=4, total_sz=4)  
print(hilbert_space.all_states())  # [[2 2 2 2]] ✅
print(hilbert_space.constraint(hilbert_space.all_states()))  # [True] ✅
```

## Solution
Apply proper conversion from fock index space to physical spin space when `n_particles=0`.

## Test plan
- [x] Reproduced original bug case
- [x] Fixed bug with minimal code change  
- [x] All existing hilbert tests pass
- [x] Tested various edge cases and spin configurations

Closes #2126

🤖 Generated with [Claude Code](https://claude.ai/code)