### PR TITLE
Transform vstate chunks

### DIFF
--- a/netket/_src/vqs/transformed_vstate.py
+++ b/netket/_src/vqs/transformed_vstate.py
@@ -9,6 +9,7 @@ from netket._src.operator.hpsi_utils import make_logpsi_op_afun
 # Eventually, we should have classes TransformedMCState and TransformedFullSumState that allow access to the underlying operator and model.
 # In this implementation, we have access to the operator in the new variables, but not to the original model/apply_fun.
 
+
 def apply_operator(operator, vstate, *, seed=None):
     """
     Apply an operator to a variational state.
@@ -21,9 +22,9 @@ def apply_operator(operator, vstate, *, seed=None):
         operator: The operator to apply.
         vstate: The variational state.
 
-    
-    Note that is the vstate's chunk size is specified, the chunk size of the transformed vstate will 
-    be set to `vstate.chunk_size // operator.max_conn_size` to account for the increased memory usage. 
+
+    Note that is the vstate's chunk size is specified, the chunk size of the transformed vstate will
+    be set to `vstate.chunk_size // operator.max_conn_size` to account for the increased memory usage.
     """
 
     if not isinstance(vstate, (FullSumState, MCState)):
@@ -33,11 +34,11 @@ def apply_operator(operator, vstate, *, seed=None):
         vstate._apply_fun, operator, vstate.variables
     )
 
-    if vstate.chunk_size is None: 
+    if vstate.chunk_size is None:
         chunk_size = None
-    
-    else: 
-        chunk_size = vstate.chunk_size//operator.max_conn_size
+
+    else:
+        chunk_size = vstate.chunk_size // operator.max_conn_size
 
     if isinstance(vstate, FullSumState):
         transformed_vstate = FullSumState(

--- a/netket/_src/vqs/transformed_vstate.py
+++ b/netket/_src/vqs/transformed_vstate.py
@@ -42,8 +42,10 @@ def apply_operator(operator, vstate, *, seed=None, adapt_chunk_size: bool=True):
         chunk_size = None
 
     if adapt_chunk_size and vstate.chunk_size is not None:
-        chunk_size_temp = vstate.chunk_size // operator.max_conn_size
-        chunk_size = chunk_size_divisor(chunk_size_temp, vstate.n_samples_per_rank)
+
+        chunk_size = vstate.chunk_size // operator.max_conn_size
+        if isinstance(vstate, MCState):
+            chunk_size = chunk_size_divisor(chunk_size, vstate.n_samples_per_rank)
 
     else: 
         chunk_size = vstate.chunk_size

--- a/netket/_src/vqs/transformed_vstate.py
+++ b/netket/_src/vqs/transformed_vstate.py
@@ -18,13 +18,14 @@ def apply_operator(operator, vstate, *, seed=None):
     that simulates the application of the operator. The operator can still be
     accessed in the resulting variational state as `op_vstate.variables['operator']`.
 
+    .. note::
+
+        Note that is the vstate's chunk size is specified, the chunk size of the transformed vstate will
+        be set to `vstate.chunk_size // operator.max_conn_size` to account for the increased memory usage.
+
     Args:
-        operator: The operator to apply.
-        vstate: The variational state.
-
-
-    Note that is the vstate's chunk size is specified, the chunk size of the transformed vstate will
-    be set to `vstate.chunk_size // operator.max_conn_size` to account for the increased memory usage.
+        operator: The operator to apply in front of the variational state ket
+        vstate: The variational state (or ket)
     """
 
     if not isinstance(vstate, (FullSumState, MCState)):

--- a/netket/_src/vqs/transformed_vstate.py
+++ b/netket/_src/vqs/transformed_vstate.py
@@ -24,10 +24,11 @@ def apply_operator(operator, vstate, *, seed=None, adapt_chunk_size: bool=True):
     accessed in the resulting variational state as `op_vstate.variables['operator']`.
 
     Args:
-        operator: the operator to apply
-        vstate: variational state
-        adapt_chunk_size: whether to adapt the chunk size of the new state. 
-        This is based on the max connectivity of the operator and the number of samples per rank.
+        operator: The operator to apply.
+        vstate: The variational state.
+        adapt_chunk_size: Whether to adapt the chunk size of the new state. Since the number of calls to the 
+            model is multiplied by operator.max_conn_size, the chunk size is divided by operator.max_conn_size.
+            Then, it needs to be adjusted to be a divisor of the number of samples per rank.
     """
 
     if not isinstance(vstate, (FullSumState, MCState)):

--- a/netket/_src/vqs/transformed_vstate.py
+++ b/netket/_src/vqs/transformed_vstate.py
@@ -39,7 +39,7 @@ def apply_operator(operator, vstate, *, seed=None):
         chunk_size = None
 
     else:
-        chunk_size = vstate.chunk_size // operator.max_conn_size
+        chunk_size = max(vstate.chunk_size // operator.max_conn_size, 1)
 
     if isinstance(vstate, FullSumState):
         transformed_vstate = FullSumState(

--- a/netket/jax/sharding/fixed_sharding_decorator.py
+++ b/netket/jax/sharding/fixed_sharding_decorator.py
@@ -252,18 +252,22 @@ def sharding_decorator(
             _not = lambda t: tuple(not x for x in t)
             _sele2 = lambda cond, x, y: tuple(x if c else y for c in cond)
 
+            # workaround for shard_map not supporting non-array args part 1/2
+            # Compute nonarray_args BEFORE PRNGKey treatment to maintain structure consistency
+            nonarray_args = tuple(
+                not hasattr(a, "dtype") for a in args
+            )
+
             # PRNGKey treatment 1/2
             args = tuple(
                 jax.random.split(a, jax.device_count()) if c == "key" else a
                 for a, c in safe_zip(args, sharded_args)
             )
 
-            # workaround for shard_map not supporting non-array args part 1/2
-            nonarray_args = jax.tree.map(lambda a: not hasattr(a, "dtype"), args)
-            args = jax.tree.map(
-                lambda c, a: Partial(partial(lambda x: x, a)) if c else a,
-                nonarray_args,
-                args,
+            # Apply the nonarray transformation after PRNGKey treatment
+            args = tuple(
+                Partial(partial(lambda x: x, a)) if c else a
+                for c, a in safe_zip(nonarray_args, args)
             )
 
             mesh = jax.sharding.get_abstract_mesh()

--- a/netket/jax/sharding/fixed_sharding_decorator.py
+++ b/netket/jax/sharding/fixed_sharding_decorator.py
@@ -254,9 +254,7 @@ def sharding_decorator(
 
             # workaround for shard_map not supporting non-array args part 1/2
             # Compute nonarray_args BEFORE PRNGKey treatment to maintain structure consistency
-            nonarray_args = tuple(
-                not hasattr(a, "dtype") for a in args
-            )
+            nonarray_args = tuple(not hasattr(a, "dtype") for a in args)
 
             # PRNGKey treatment 1/2
             args = tuple(

--- a/test/operator/test_apply_operator.py
+++ b/test/operator/test_apply_operator.py
@@ -54,9 +54,8 @@ def test_apply_operator(operator, vstate):
         assert transformed_vstate.n_samples_per_rank == vstate.n_samples_per_rank
         assert transformed_vstate.n_discard_per_chain == vstate.n_discard_per_chain
 
-
-    #change the chunk size and check that it has been adapted correctly. 
+    # change the chunk size and check that it has been adapted correctly.
     vstate.chunk_size = 2**10
     transformed_vstate = nk.vqs.apply_operator(operator, vstate)
 
-    assert transformed_vstate.chunk_size == vstate.chunk_size//operator.max_conn_size
+    assert transformed_vstate.chunk_size == vstate.chunk_size // operator.max_conn_size


### PR DESCRIPTION
This PR (with @Adrien-Kahn) aims to adjust the chunk size in `netket.vqs.apply_operator` so that it always divides `vstate.n_samples_per_rank` and is less than or equal to `chunk_size / operator.max_conn_size`. We added a flag that disables the automatic adjustment of the `chunk_size`. 