### PR TITLE
Fix get_local_estimator not hitting the flattening of leading axes

### DIFF
--- a/netket/experimental/observable/infidelity/expect.py
+++ b/netket/experimental/observable/infidelity/expect.py
@@ -34,6 +34,9 @@ def get_kernels(afun, afun_t, params, params_t, σ, σ_t, model_state, model_sta
     W = {"params": params, **model_state}
     W_t = {"params": params_t, **model_state_t}
 
+    σ = σ.reshape(-1, σ.shape[-1])
+    σ_t = σ_t.reshape(-1, σ_t.shape[-1])
+
     log_val = afun_t(W_t, σ) - afun(W, σ)
     log_val_t = afun(W, σ_t) - afun_t(W_t, σ_t)
 
@@ -73,13 +76,8 @@ def infidelity_sampling_inner(
     sigma_t,
     cv_coeff,
 ):
-    N = sigma.shape[-1]
-
-    σ = sigma.reshape(-1, N)
-    σ_t = sigma_t.reshape(-1, N)
-
     log_val, log_val_t = get_kernels(
-        afun, afun_t, params, params_t, σ, σ_t, model_state, model_state_t
+        afun, afun_t, params, params_t, sigma, sigma_t, model_state, model_state_t
     )
 
     if cv_coeff is not None:


### PR DESCRIPTION
Minimal fix. The function `get_kernels` takes samples flattened over the leading dimensions. While in `infidelity_sampling_inner` this reshaping was carried out before calling `get_kernels`, `get_local_estimator` would not do it, leading to an obscure ValueError message. This moves the reshaping directly into `get_kernels`.