### PR TITLE
Implement momentum support in SR (Stochastic Reconfiguration)

### DIFF
--- a/netket/_src/ngd/sr.py
+++ b/netket/_src/ngd/sr.py
@@ -63,7 +63,6 @@ def _compute_sr_update(
     else:
         info = {}
 
-    # Update old_updates for momentum (store in flat form before complex repacking)
     if momentum is not None:
         old_updates = updates
 

--- a/netket/_src/ngd/sr.py
+++ b/netket/_src/ngd/sr.py
@@ -42,7 +42,7 @@ def _compute_sr_update(
     # (np, #ns) x (#ns) -> (np) - where the sum over #ns is done automatically
     F = O_L.T @ dv
 
-    # Add momentum term to F: F + λμdtheta_{i-1}
+    # Add momentum term to F: F + λ μ dθ_{i-1}
     if momentum is not None:
         F = F + diag_shift * momentum * old_updates
 

--- a/netket/_src/ngd/sr.py
+++ b/netket/_src/ngd/sr.py
@@ -36,11 +36,15 @@ def _compute_sr_update(
     # Typically solvers only accept the matrix and the right-hand side.
     solver_fn = ensure_accepts_kwargs(solver_fn, "dv")
 
-    if (momentum is not None) or (old_updates is not None) or (proj_reg is not None):
-        raise ValueError("Not implemented")
+    if proj_reg is not None:
+        raise ValueError("proj_reg not implemented for SR")
 
     # (np, #ns) x (#ns) -> (np) - where the sum over #ns is done automatically
     F = O_L.T @ dv
+
+    # Add momentum term to F: F + λμdtheta_{i-1}
+    if momentum is not None:
+        F = F + diag_shift * momentum * old_updates
 
     # This does the contraction (np, #ns) x (#ns, np) -> (np, np).
     matrix = O_L.T @ O_L
@@ -58,6 +62,10 @@ def _compute_sr_update(
             info = {}
     else:
         info = {}
+
+    # Update old_updates for momentum (store in flat form before complex repacking)
+    if momentum is not None:
+        old_updates = updates
 
     # If complex mode and we have complex parameters, we need
     # To repack the real coefficients in order to get complex updates

--- a/test/driver/test_vmc_ngd.py
+++ b/test/driver/test_vmc_ngd.py
@@ -168,7 +168,10 @@ def test_advd_vs_nk_vmc(model, use_ntk, onthefly):
 
 @pytest.mark.parametrize("model", machines)
 @pytest.mark.parametrize("onthefly", onthefly_vals)
-def test_SRt_vs_SR(model, onthefly):
+@pytest.mark.parametrize(
+    "momentum", [pytest.param(None, id=""), pytest.param(0.5, id="momentum")]
+)
+def test_SRt_vs_SR(model, onthefly, momentum):
     """
     nk.driver.VMC_kernelSR must give **exactly** the same dynamics as nk.driver.VMC with nk.optimizer.SR
     """
@@ -181,8 +184,7 @@ def test_SRt_vs_SR(model, onthefly):
         opt,
         variational_state=vstate_srt,
         diag_shift=0.1,
-        # proj_reg=0.5,
-        # momentum=0.0,
+        momentum=momentum,
         use_ntk=True,
         on_the_fly=onthefly,
     )
@@ -195,6 +197,7 @@ def test_SRt_vs_SR(model, onthefly):
         opt,
         variational_state=vstate_sr,
         diag_shift=0.1,
+        momentum=momentum,
         use_ntk=False,
         on_the_fly=False,
     )


### PR DESCRIPTION
## Summary

This PR implements momentum support for the SR (Stochastic Reconfiguration) method following the mathematical equation:

```
dtheta_i = (S+λI)^-1(F + λμdtheta_{i-1})
```

where:
- `theta_i` are the parameter vectors at iteration i
- `dtheta_i` is the update returned by the function
- `S` is the QGT matrix
- `λ` is the diagonal shift
- `μ` is the momentum coefficient  
- `F` is the force vector

## Changes

- **SR Implementation**: Add momentum term to the right-hand side F with diagonal shift factor
- **Shape Handling**: Store `old_updates` in flat form before complex parameter repacking to ensure shape consistency
- **Test Coverage**: Update `test_SRt_vs_SR` with momentum parameter cases (None, 0.5)
- **Backward Compatibility**: Maintain existing behavior when `momentum=None`

## Technical Details

### Key Implementation Points:
1. **Momentum Application**: The momentum term `λμdtheta_{i-1}` is added to F before solving the linear system
2. **Complex Parameter Handling**: `old_updates` is stored before the complex repacking to maintain consistent shapes across iterations
3. **Mathematical Consistency**: Follows the same momentum equation structure as the SRT implementation but applies it correctly to the SR formulation

### Files Modified:
- `netket/_src/ngd/sr.py`: Core momentum implementation
- `test/driver/test_vmc_ngd.py`: Added momentum test parametrization

## Test Results

All existing tests pass, including:
- ✅ All momentum parameter combinations (None, 0.5)
- ✅ Both real and complex parameter modes
- ✅ Both on-the-fly and Jacobian computation modes
- ✅ All existing SR vs SRT comparison tests

The implementation correctly handles shape mismatches that can occur with complex parameters and maintains numerical accuracy across all test cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)