### PR TITLE
(Minor redundancy) operators list initialized twice in Representation.projector

### DIFF
--- a/netket/_src/symmetry/representation.py
+++ b/netket/_src/symmetry/representation.py
@@ -141,7 +141,6 @@ class Representation:
 
         # Filter out the characters that vanish (do before normalizing to avoid even smaller values)
         mask = ~np.isclose(np.conj(character_table[character_index]), 0.0, atol=atol)
-        operators = np.array([self[g] for g in self.group], dtype=object)
         coefficients = prefactor * np.conj(character_table[character_index])
 
         operators = operators[mask]


### PR DESCRIPTION
Hi,

I noticed a minor redundancy in `netket/_src/symmetry/representation.py`. The `operators` list is initialized twice (see line 140 and line 144):

https://github.com/netket/netket/blob/a8675bdc6f457b922262b0acfc5916183fc6c2c1/netket/_src/symmetry/representation.py#L137-L146

line 144 seems redundant.