### PR TITLE
Constrained autoregressive sampling and ARNNs

### DIFF
--- a/netket/models/__init__.py
+++ b/netket/models/__init__.py
@@ -40,6 +40,14 @@ from .slater import Slater2nd, MultiSlater2nd
 
 from .utils import update_GCNN_parity
 
+from .constrained_autoreg import (
+    ConstrainedARNNDense,
+    ConstrainedFastARNNDense,
+    ConstrainedARNNConv1D,
+    ConstrainedFastARNNConv1D,
+    ConstrainedARNNConv2D,
+    ConstrainedFastARNNConv2D,
+)
 
 from netket.utils import _hide_submodules
 

--- a/netket/models/constrained_autoreg.py
+++ b/netket/models/constrained_autoreg.py
@@ -1,0 +1,412 @@
+"""
+Constraint-aware autoregressive neural networks.
+
+This module provides the constrained variants of the dense autoregressive models:
+
+    - :class:`~netket.models.ConstrainedARNNDense`
+    - :class:`~netket.models.ConstrainedFastARNNDense`
+
+Both classes support:
+    1. :class:`~netket.hilbert.constraint.SumConstraint`, and
+    2. :class:`~netket.hilbert.constraint.SumOnPartitionConstraint`.
+
+The constrained conditionals are constructed directly by masking infeasible local
+values at each site and renormalizing. Deterministic closure is used on dependent
+sites (last site for :code:`SumConstraint`, one dependent per partition for
+:code:`SumOnPartitionConstraint`).
+"""
+
+import numpy as np
+
+import jax
+from jax import numpy as jnp
+
+from netket.hilbert.constraint import SumConstraint, SumOnPartitionConstraint
+
+from .autoreg import ARNNDense, ARNNConv1D, ARNNConv2D
+from .fast_autoreg import FastARNNDense, FastARNNConv1D, FastARNNConv2D
+
+
+def _is_uniform_spacing(local_states, atol: float = 1.0e-12) -> tuple[bool, float]:
+    """
+    Check whether local states form a uniform arithmetic progression.
+
+    The constrained masking logic for sum/partition constraints uses range and
+    lattice checks, which require uniformly spaced local-state values.
+    """
+    xs = np.sort(np.asarray(local_states, dtype=np.float64))
+
+    if xs.size <= 1:
+        return True, 1.0
+
+    diffs = np.diff(xs)
+    step = float(diffs[0])
+    ok = bool(np.all(np.abs(diffs - step) <= atol))
+    return ok, step
+
+
+def _normalise_masked(probabilities: jax.Array, mask: jax.Array) -> jax.Array:
+    """
+    Normalize categorical probabilities after applying a boolean feasibility mask.
+
+    If a row has no feasible entries, the unmasked probabilities are returned for
+    numerical safety.
+    """
+    masked = jnp.where(mask, probabilities, 0.0)
+    z = jnp.sum(masked, axis=-1, keepdims=True)
+    return jnp.where(z > 0.0, masked / z, probabilities)
+
+
+def _value_to_local_mask(
+    *,
+    values: jax.Array,
+    local_states: jax.Array,
+    tol: float = 1.0e-6,
+) -> jax.Array:
+    """
+    Convert target local-state values into one-hot masks over `local_states`.
+
+    Rows that are not representable within tolerance are mapped to all-False.
+    """
+    diff = jnp.abs(local_states[None, :] - values[:, None])
+    idx = jnp.argmin(diff, axis=-1)
+    dmin = jnp.take_along_axis(diff, idx[:, None], axis=-1)[:, 0]
+    exact = dmin <= tol
+    onehot = jax.nn.one_hot(idx, local_states.shape[0], dtype=jnp.bool_)
+    return onehot & exact[:, None]
+
+
+def _prefix_sum_before(inputs: jax.Array, index: jax.Array) -> jax.Array:
+    """
+    Return prefix sums `sum(inputs[:, :index], axis=1)` for dynamic JAX indices.
+    """
+    prefix = jnp.cumsum(inputs, axis=1)
+    idx_prev = jnp.maximum(index - 1, 0)
+    prev = jax.lax.dynamic_index_in_dim(prefix, idx_prev, axis=1, keepdims=False)
+    return jnp.where(index > 0, prev, jnp.zeros((inputs.shape[0],), dtype=inputs.dtype))
+
+
+def _build_partition_topology(
+    sizes: tuple[int, ...],
+) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Build:
+      - site -> partition map
+      - dependent site index for each partition
+    """
+    part_of_site: list[int] = []
+    slaves: list[int] = []
+    off = 0
+    for p, sz in enumerate(sizes):
+        part_of_site.extend([p] * sz)
+        slaves.append(off + sz - 1)
+        off += sz
+    return np.asarray(part_of_site, dtype=np.int32), np.asarray(slaves, dtype=np.int32)
+
+
+class _ConstrainedARNNMixin:
+    """
+    Shared constrained-AR logic for dense and fast dense autoregressive models.
+
+    Subclasses inherit all base model hyperparameters and architecture.
+    """
+
+    _constraint_aware_autoregressive: bool = True
+    """Marker consumed by constrained samplers to enable model-direct exact sampling."""
+
+    def __post_init__(self):
+        super().__post_init__()
+
+        constraint = getattr(self.hilbert, "constraint", None)
+        if not isinstance(constraint, (SumConstraint, SumOnPartitionConstraint)):
+            raise ValueError(
+                "Constrained ARNN models currently support only "
+                "SumConstraint and SumOnPartitionConstraint."
+            )
+
+        spacing_ok, _ = _is_uniform_spacing(self.hilbert.local_states)
+        if not spacing_ok:
+            raise ValueError(
+                "Constrained ARNN models require uniformly spaced local_states."
+            )
+
+    def _sum_mask(
+        self, inputs: jax.Array, index: jax.Array, base_p: jax.Array
+    ) -> jax.Array:
+        """
+        Apply exact sum-constraint feasibility mask to one site conditional.
+        """
+        constraint = self.hilbert.constraint
+        target = jnp.asarray(constraint.sum_value, dtype=jnp.float32)
+        local_states = jnp.asarray(self.hilbert.local_states, dtype=jnp.float32)
+        local_min = jnp.min(local_states)
+        local_max = jnp.max(local_states)
+        _, local_step = _is_uniform_spacing(self.hilbert.local_states)
+        local_step = jnp.asarray(local_step, dtype=jnp.float32)
+
+        slave_site = jnp.asarray(self.hilbert.size - 1, dtype=jnp.int32)
+        index = jnp.asarray(index, dtype=jnp.int32)
+
+        x = inputs.astype(jnp.float32)
+        prefix_sum = _prefix_sum_before(x, index)
+
+        # Remaining sites after choosing current value, including the slave site.
+        n_remaining = (slave_site - index).astype(jnp.float32)
+        need = target - (prefix_sum[:, None] + local_states[None, :])
+
+        lo = n_remaining * local_min
+        hi = n_remaining * local_max
+        in_range = (need >= lo - 1.0e-6) & (need <= hi + 1.0e-6)
+
+        k = (need - lo) / jnp.where(jnp.abs(local_step) > 1.0e-12, local_step, 1.0)
+        on_lattice = jnp.abs(k - jnp.round(k)) <= 1.0e-6
+        feasible = jnp.where(
+            jnp.abs(local_step) > 1.0e-12, in_range & on_lattice, in_range
+        )
+
+        slave_value = target - prefix_sum
+        slave_mask = _value_to_local_mask(values=slave_value, local_states=local_states)
+
+        is_slave = index == slave_site
+        mask = jnp.where(is_slave, slave_mask, feasible)
+        return _normalise_masked(base_p, mask)
+
+    def _partition_mask(
+        self,
+        inputs: jax.Array,
+        index: jax.Array,
+        base_p: jax.Array,
+    ) -> jax.Array:
+        """
+        Apply exact partition-sum feasibility mask to one site conditional.
+        """
+        constraint = self.hilbert.constraint
+        sizes = tuple(int(s) for s in constraint.sizes)
+        targets = tuple(float(t) for t in constraint.sum_values)
+        part_of_site_np, slaves_np = _build_partition_topology(sizes)
+
+        pnum = len(sizes)
+        index = jnp.asarray(index, dtype=jnp.int32)
+
+        local_states = jnp.asarray(self.hilbert.local_states, dtype=jnp.float32)
+        local_min = jnp.min(local_states)
+        local_max = jnp.max(local_states)
+        _, local_step = _is_uniform_spacing(self.hilbert.local_states)
+        local_step = jnp.asarray(local_step, dtype=jnp.float32)
+
+        part_of_site = jnp.asarray(part_of_site_np, dtype=jnp.int32)
+        slaves = jnp.asarray(slaves_np, dtype=jnp.int32)
+        sizes_arr = jnp.asarray(sizes, dtype=jnp.float32)
+        targets_arr = jnp.asarray(targets, dtype=jnp.float32)
+
+        part = part_of_site[index]
+        onehot_part = jax.nn.one_hot(part, pnum, dtype=jnp.float32)
+
+        x = inputs.astype(jnp.float32)
+
+        site_part = jax.nn.one_hot(part_of_site, pnum, dtype=jnp.float32)
+        sums_by_site = x[:, :, None] * site_part[None, :, :]
+        csum = jnp.cumsum(sums_by_site, axis=1)
+        idx_prev = jnp.maximum(index - 1, 0)
+        prefix_sums_prev = jax.lax.dynamic_index_in_dim(
+            csum, idx_prev, axis=1, keepdims=False
+        )
+        prefix_sums = jnp.where(
+            index > 0,
+            prefix_sums_prev,
+            jnp.zeros((inputs.shape[0], pnum), dtype=jnp.float32),
+        )
+
+        count_csum = jnp.cumsum(site_part, axis=0)
+        done_counts_prev = jax.lax.dynamic_index_in_dim(
+            count_csum, idx_prev, axis=0, keepdims=False
+        )
+        done_counts = jnp.where(
+            index > 0, done_counts_prev, jnp.zeros((pnum,), dtype=jnp.float32)
+        )
+
+        sums_new = (
+            prefix_sums[:, None, :]
+            + onehot_part[None, None, :] * local_states[None, :, None]
+        )
+        done_new = done_counts[None, :] + onehot_part[None, :]
+        rem = sizes_arr[None, :] - done_new
+
+        need = targets_arr[None, None, :] - sums_new
+        lo = rem[:, None, :] * local_min
+        hi = rem[:, None, :] * local_max
+        in_range = (need >= lo - 1.0e-6) & (need <= hi + 1.0e-6)
+
+        k = (need - lo) / jnp.where(jnp.abs(local_step) > 1.0e-12, local_step, 1.0)
+        on_lattice = jnp.abs(k - jnp.round(k)) <= 1.0e-6
+        feasible = jnp.where(
+            jnp.abs(local_step) > 1.0e-12,
+            jnp.all(in_range & on_lattice, axis=-1),
+            jnp.all(in_range, axis=-1),
+        )
+
+        slave_value = targets_arr[part] - prefix_sums[:, part]
+        slave_mask = _value_to_local_mask(values=slave_value, local_states=local_states)
+        is_slave = jnp.any(slaves == index)
+        mask = jnp.where(is_slave, slave_mask, feasible)
+        return _normalise_masked(base_p, mask)
+
+    def _apply_constraint_mask(
+        self,
+        inputs: jax.Array,
+        index: jax.Array,
+        base_p: jax.Array,
+    ) -> jax.Array:
+        """
+        Dispatch per-site masking based on the Hilbert-space constraint type.
+        """
+        constraint = self.hilbert.constraint
+        if isinstance(constraint, SumConstraint):
+            return self._sum_mask(inputs, index, base_p)
+        return self._partition_mask(inputs, index, base_p)
+
+    def conditional(self, inputs, index):
+        """
+        Constraint-aware single-site conditional used by autoregressive samplers.
+        """
+        if inputs.ndim == 1:
+            inputs = jnp.expand_dims(inputs, axis=0)
+
+        base_p = super().conditional(inputs, index)
+        return self._apply_constraint_mask(
+            inputs, jnp.asarray(index, dtype=jnp.int32), base_p
+        )
+
+    def conditionals(self, inputs):
+        """
+        Constraint-aware conditionals over all sites.
+        """
+        if inputs.ndim == 1:
+            inputs = jnp.expand_dims(inputs, axis=0)
+
+        base_all = super().conditionals(inputs)
+        indices = jnp.arange(self.hilbert.size, dtype=jnp.int32)
+        base_t = jnp.swapaxes(base_all, 0, 1)
+        masked_t = jax.vmap(
+            lambda site_i, p_i: self._apply_constraint_mask(inputs, site_i, p_i)
+        )(indices, base_t)
+        return jnp.swapaxes(masked_t, 0, 1)
+
+    def __call__(self, inputs):
+        """
+        Log-wavefunction consistent with constrained conditionals.
+
+        For representable constrained states:
+            exp(machine_pow * Re(logpsi)) = product_i p_i^constrained(x_i | x_<i).
+        For non-representable states under deterministic closures:
+            one or more factors become zero and logpsi is -inf.
+        """
+        squeeze = False
+        if inputs.ndim == 1:
+            inputs = jnp.expand_dims(inputs, axis=0)
+            squeeze = True
+
+        probs = self.conditionals(inputs)
+        idx = self.hilbert.states_to_local_indices(inputs)
+        p_sel = jnp.take_along_axis(probs, idx[..., None], axis=-1)[..., 0]
+
+        log_prob = jnp.sum(jnp.log(p_sel), axis=-1)
+        log_psi = log_prob / float(self.machine_pow)
+        return log_psi[0] if squeeze else log_psi
+
+
+class ConstrainedARNNDense(_ConstrainedARNNMixin, ARNNDense):
+    """
+    Dense autoregressive wavefunction with exact built-in constraint handling.
+
+    This model represents probability mass only on configurations that satisfy the
+    Hilbert-space constraint. At each autoregressive step, infeasible local values
+    are masked out and the conditional distribution is renormalized on the feasible
+    support.
+
+    Use this model when the Hilbert space is constrained by
+    :class:`~netket.hilbert.constraint.SumConstraint` (single global fixed-sum sector)
+    or :class:`~netket.hilbert.constraint.SumOnPartitionConstraint`
+    (independent fixed-sum sectors over site partitions).
+
+    For such fixed-sum constraints, one dependent site is closed deterministically so the
+    final configuration satisfies the target exactly. The resulting log-amplitude is
+    consistent with the constrained conditionals used during sampling, so
+    `conditionals`, `conditional`, and `__call__` all describe the same constrained
+    distribution.
+
+    Assumptions:
+        Local state values must lie on a uniformly spaced lattice.
+    """
+
+
+class ConstrainedFastARNNDense(_ConstrainedARNNMixin, FastARNNDense):
+    """
+    Fast autoregressive neural network with dense layers.
+
+    See :class:`netket.models.FastARNNSequential` for a brief explanation
+    of fast autoregressive sampling.
+
+    This model represents probability mass only on configurations that satisfy the
+    Hilbert-space constraint. At each autoregressive step, infeasible local values
+    are masked out and the conditional distribution is renormalized on the feasible
+    support.
+
+    Use this model when the Hilbert space is constrained by
+    :class:`~netket.hilbert.constraint.SumConstraint` (single global fixed-sum sector)
+    or :class:`~netket.hilbert.constraint.SumOnPartitionConstraint`
+    (independent fixed-sum sectors over site partitions).
+
+    For such fixed-sum constraints, one dependent site is closed deterministically so the
+    final configuration satisfies the target exactly. The resulting log-amplitude is
+    consistent with the constrained conditionals used during sampling, so
+    `conditionals`, `conditional`, and `__call__` all describe the same constrained
+    distribution.
+
+    Assumptions:
+        Local state values must lie on a uniformly spaced lattice.
+    """
+
+
+class ConstrainedARNNConv1D(_ConstrainedARNNMixin, ARNNConv1D):
+    """
+    Constraint-aware 1D convolutional autoregressive neural network.
+
+    This class keeps the same architecture and hyperparameters as
+    :class:`~netket.models.ARNNConv1D` and enforces supported Hilbert constraints
+    directly inside autoregressive conditionals.
+    """
+
+
+class ConstrainedFastARNNConv1D(_ConstrainedARNNMixin, FastARNNConv1D):
+    """
+    Constraint-aware fast 1D convolutional autoregressive neural network.
+
+    This class keeps the same architecture and hyperparameters as
+    :class:`~netket.models.FastARNNConv1D` and enforces supported Hilbert
+    constraints directly inside autoregressive conditionals.
+
+    See :class:`netket.models.FastARNNSequential` for a brief explanation of fast autoregressive sampling.
+    """
+
+
+class ConstrainedARNNConv2D(_ConstrainedARNNMixin, ARNNConv2D):
+    """
+    Constraint-aware 2D convolutional autoregressive neural network.
+
+    This class keeps the same architecture and hyperparameters as
+    :class:`~netket.models.ARNNConv2D` and enforces supported Hilbert constraints
+    directly inside autoregressive conditionals.
+    """
+
+
+class ConstrainedFastARNNConv2D(_ConstrainedARNNMixin, FastARNNConv2D):
+    """
+    Constraint-aware fast 2D convolutional autoregressive neural network.
+
+    This class keeps the same architecture and hyperparameters as
+    :class:`~netket.models.FastARNNConv2D` and enforces supported Hilbert
+    constraints directly inside autoregressive conditionals.
+
+    See :class:`netket.models.FastARNNSequential` for a brief explanation of fast autoregressive sampling.
+    """

--- a/netket/sampler/__init__.py
+++ b/netket/sampler/__init__.py
@@ -45,7 +45,13 @@ from .metropolis_numpy import (
     MetropolisCustomNumpy,
 )
 
-from .autoreg import ARDirectSampler
+from .autoreg import (
+    ARDirectSampler,
+    UnconstrainedARDirectSampler,
+    SumConstrainedARDirectSampler,
+    PartitionConstrainedARDirectSampler,
+    GenericConstrainedARDirectSampler,
+)
 
 from . import rules
 

--- a/netket/sampler/autoreg.py
+++ b/netket/sampler/autoreg.py
@@ -19,11 +19,324 @@ import jax
 from jax import numpy as jnp
 from jax.sharding import NamedSharding, PartitionSpec as P
 
+import netket as nk
 from netket import jax as nkjax
 from netket import config
 from netket.hilbert import DiscreteHilbert
 from netket.sampler import Sampler, SamplerState
 from netket.utils.types import PRNGKeyT, DType
+
+from netket.utils import struct
+from netket.hilbert.constraint import SumConstraint, SumOnPartitionConstraint
+
+#
+#   Internal utils
+
+
+def _pop_cache(variables: dict):
+    """
+    Split a Flax variable tree into non-cache variables and the optional cache.
+
+    Args:
+        variables: Model variables dictionary, potentially containing a :code:`"cache"` entry.
+
+    Returns a tuple :code:`(variables_no_cache, cache_or_None)` where:
+        - ``variables_no_cache`` is safe to pass repeatedly to ``model.apply``.
+        - ``cache_or_None`` is the mutable recurrent/attention cache when present.
+    """
+    if "cache" in variables:
+        variables, cache = flax.core.pop(variables, "cache")
+        return variables, cache
+    return variables, None
+
+
+def _with_cache(variables_no_cache: dict, cache):
+    """
+    Reassemble a variable tree expected by ``model.apply``.
+
+    This helper keeps cache handling centralized and avoids repeating
+    ``{**variables, "cache": cache}`` in every sampling branch.
+    """
+    if cache is not None:
+        return {**variables_no_cache, "cache": cache}
+    return variables_no_cache
+
+
+def _as_static_tuple(x) -> tuple:
+    """Convert an array-like to a plain Python tuple (for pytree_node=False fields)."""
+    return tuple(float(v) for v in jnp.asarray(x).reshape(-1).tolist())
+
+
+def _as_static_int_tuple(x) -> tuple[int, ...]:
+    """Convert an array-like to a plain Python int tuple."""
+    return tuple(int(v) for v in jnp.asarray(x).reshape(-1).tolist())
+
+
+def _log_prob_dtype():
+    """Floating dtype used for log-probability accumulation buffers."""
+    return jnp.float64 if jax.config.jax_enable_x64 else jnp.float32
+
+
+def _ordered_site_tuple(
+    model, variables, site_indices: tuple[int, ...]
+) -> tuple[int, ...]:
+    """
+    Compute site order as a hashable Python tuple for static-index JIT kernels.
+    """
+    idx = jnp.asarray(site_indices, dtype=jnp.int32)
+    try:
+        ordered = model.apply(variables, idx, method=model.reorder)
+        return tuple(int(v) for v in jnp.asarray(ordered).reshape(-1).tolist())
+    except (AttributeError, TypeError):
+        return tuple(int(v) for v in site_indices)
+
+
+def _is_uniform_spacing(local_states, atol: float = 1.0e-12) -> tuple[bool, float]:
+    """
+    Check whether local states from a Hilbert space form a uniform arithmetic progression.
+
+    For such alphabets, feasibility of remaining-sum constraints can be checked
+    by range + lattice tests, which is the key to fast exact prefix masking.
+    """
+    # Sort to compute consecutive spacings robustly.
+    xs = jnp.sort(jnp.asarray(local_states, dtype=jnp.float64))
+
+    if xs.size <= 1:
+        return True, 1.0
+
+    diffs = jnp.diff(xs)
+    step = diffs[0]
+    ok = jnp.all(jnp.abs(diffs - step) <= atol)
+    return bool(ok), float(step)
+
+
+def _normalise_masked(
+    probabilities: jnp.ndarray, mask: jnp.ndarray
+) -> tuple[jnp.ndarray, jnp.ndarray]:
+    """
+    Apply a boolean mask to categorical probabilities and renormalize row-wise.
+
+    Args:
+        p_norm: Row-normalized masked probabilities.
+        feasible: Per-row boolean indicating whether at least one masked entry existed.
+    """
+    # Zero out infeasible candidates.
+    masked = jnp.where(mask, probabilities, 0.0)
+
+    # Partition function per row.
+    z = jnp.sum(masked, axis=-1, keepdims=True)
+
+    # Row feasibility flag (at least one feasible candidate).
+    feasible = z[:, 0] > 0.0
+
+    # Keep numerical path finite even for infeasible rows, the caller tracks `feasible`.
+    p_norm = jnp.where(z > 0.0, masked / z, probabilities)
+    return p_norm, feasible
+
+
+def _sum_feasible_mask(
+    *,
+    prefix_sum: jax.Array,
+    candidate_vals: jax.Array,
+    n_remaining: int,
+    target: float,
+    local_min: float,
+    local_max: float,
+    step: float,
+    tol: float = 1.0e-12,
+) -> jax.Array:
+    """
+    Feasibility oracle for one sum-constrained update with uniform local spacing.
+
+    For every sample row and candidate local state value, this function checks
+    whether the remaining number of sites can still satisfy the global target.
+    The check consists of:
+        1. Interval feasibility ``[lo, hi]`` from remaining min/max contributions.
+        2. Lattice feasibility (if ``step != 0``) from uniform local spacing.
+    """
+    # Remaining amount required after choosing each candidate value.
+    need = target - (prefix_sum[:, None] + candidate_vals[None, :])
+
+    # Reachable interval using remaining sites.
+    lo = n_remaining * local_min
+    hi = n_remaining * local_max
+    in_range = (need >= lo - tol) & (need <= hi + tol)
+
+    # Degenerate step: interval test is sufficient.
+    if abs(step) <= tol:
+        return in_range
+
+    # Arithmetic-lattice compatibility for uniform discrete alphabets.
+    k = (need - lo) / step
+    on_lattice = jnp.abs(k - jnp.round(k)) <= tol
+    return in_range & on_lattice
+
+
+#
+#   Constraint plan builders
+
+
+def _plan_sum_constraint(hilbert):
+    """
+    Build exact prefix-mask data for :class:`~netket.hilbert.constraint.SumConstraint`.
+
+    The last site is treated as a deterministic dependent, but free-site sampling
+    is constrained by an exact feasibility mask at each auto-regressive step. This guarantees
+    the final dependent is representable in the Hilbert space's :code:`local_states` and preserves exactness.
+
+    Returns None when local states are not uniformly spaced, otherwise a fully static/hashable tuple payload:
+        (free_indices_tuple, target, local_min, local_max, local_step, slave_site)
+    """
+    N = hilbert.size
+    target = float(hilbert.constraint.sum_value)
+    local_states = jnp.asarray(hilbert.local_states, dtype=jnp.float32)
+
+    # Prefix feasibility mask currently assumes a uniformly spaced local alphabet.
+    spacing_ok, step = _is_uniform_spacing(local_states)
+    if not spacing_ok:
+        return None
+
+    # All independent sites are free.
+    free_indices = jnp.arange(N - 1, dtype=jnp.int32)
+
+    # Return all constants required by the sampling kernel.
+    return (
+        tuple(int(v) for v in free_indices.tolist()),
+        float(target),
+        float(jnp.min(local_states)),
+        float(jnp.max(local_states)),
+        float(step),
+        int(N - 1),
+    )
+
+
+def _plan_partition_constraint(hilbert):
+    """
+    Build exact prefix-mask data for NetKet :class:`~netket.hilbert.constraint.SumOnPartitionConstraint`.
+
+    For each partition, the last site is the dependent and all earlier partition
+    sites are free. Free-site updates are masked by partition-wise feasibility
+    checks, yielding exact constrained sampling with zero rejection.
+
+    Returns None when local states are not uniformly spaced. Otherwise a fully static/hashable tuple payload:
+        (
+          free_indices_tuple,
+          partition_of_site_tuple,
+          partition_sizes_tuple,
+          partition_targets_tuple,
+          partition_slaves_tuple,
+          local_min,
+          local_max,
+          local_step,
+        )
+    """
+    constraint = hilbert.constraint
+    sizes = [int(s) for s in constraint.sizes]
+    targets = [float(t) for t in constraint.sum_values]
+    local_states = jnp.asarray(hilbert.local_states, dtype=jnp.float32)
+
+    # Prefix feasibility mask currently assumes a uniformly spaced local alphabet.
+    spacing_ok, step = _is_uniform_spacing(local_states)
+    if not spacing_ok:
+        return None
+
+    free_list: list[int] = []
+    partition_of_site: list[int] = []
+    partition_slaves: list[int] = []
+    off = 0
+    for p, sz in enumerate(sizes):
+        # Record partition index for each site in this partition.
+        partition_of_site.extend([p] * sz)
+
+        # Last site is a dependent, others are free.
+        free_len = sz - 1
+        free_list.extend(range(off, off + free_len))
+        partition_slaves.append(off + free_len)
+        off += sz
+
+    # Return all constants required by the sampling kernel.
+    return (
+        tuple(int(v) for v in free_list),
+        tuple(int(v) for v in partition_of_site),
+        tuple(int(v) for v in sizes),
+        tuple(float(v) for v in targets),
+        tuple(int(v) for v in partition_slaves),
+        float(jnp.min(local_states)),
+        float(jnp.max(local_states)),
+        float(step),
+    )
+
+
+#
+#   Plan dispatch
+
+_TWO_PHASE = "two_phase"
+_SUM_PREFIX = "sum"
+_PARTITION_PREFIX = "partition"
+_REJECTION = "rejection"
+
+
+def _build_plan(hilbert):
+    """
+    Inspect :code:`hilbert` and return the optimal sampling plan based on its constraint. For
+    current NetKet constraints, there exists a concrete fast-path plan. For generic constraints,
+    the fallback is rejection sampling, which will be slow.
+
+    Returns
+
+        For NetKet prefix-masked exact sampling::
+
+            ("sum_prefix", data: tuple)
+            ("partition_prefix", data: tuple)
+
+        For rejection-based sampling::
+
+            ("rejection", constraint_fn: callable)
+    """
+
+    constraint = getattr(hilbert, "constraint", None)
+
+    #
+    # SumConstraint
+    # Use exact prefix masking when local states allow uniform-lattice tests.
+    # Otherwise fall back to rejection for correctness.
+    if isinstance(constraint, SumConstraint):
+        data = _plan_sum_constraint(hilbert)
+        if data is not None:
+            return _SUM_PREFIX, data
+        # Fallback to rejection sampling, should never happen for this constraint.
+        return _REJECTION, constraint
+
+    #
+    # SumOnPartitionConstraint
+    # Same strategy as SumConstraint: exact prefix masking when feasible,
+    # otherwise rejection fallback.
+    if isinstance(constraint, SumOnPartitionConstraint):
+        data = _plan_partition_constraint(hilbert)
+        if data is not None:
+            return _PARTITION_PREFIX, data
+        return _REJECTION, constraint
+
+    #
+    # Unconstrained Hilbert spaces
+    if not getattr(hilbert, "constrained", False):
+        N = hilbert.size
+        return _TWO_PHASE, tuple(range(N)), lambda s: s
+
+    # Any remaining callable generic constraint falls-back to rejection
+    if constraint is not None and callable(constraint):
+        return _REJECTION, constraint
+
+    raise ValueError(
+        f"ConstrainedARDirectSampler: cannot build a sampling plan for\n"
+        f"  Hilbert type : {type(hilbert).__name__}\n"
+        f"  Constraint   : {type(constraint).__name__ if constraint is not None else 'None'}\n\n"
+        "To enable zero-rejection sampling, do ONE of the following:\n"
+        "  1. For NetKet SumConstraint / SumOnPartitionConstraint, ensure\n"
+        "     local states are uniformly spaced to enable fast exact prefix masking.\n"
+        "  2. For any other constraint, make it a JAX-callable (B,N) -> (B,)bool,\n"
+        "     the sampler will fall back to a compiled rejection while_loop.\n"
+    )
 
 
 class ARDirectSamplerState(SamplerState):
@@ -35,7 +348,7 @@ class ARDirectSamplerState(SamplerState):
         super().__init__()
 
 
-class ARDirectSampler(Sampler):
+class UnconstrainedARDirectSampler(Sampler):
     r"""
     Direct sampler for autoregressive neural networks.
 
@@ -193,3 +506,1518 @@ class ARDirectSampler(Sampler):
             return (σ, log_prob), new_state
         else:
             return σ, new_state
+
+
+class ConstrainedARDirectSampler(Sampler):
+    r"""
+    Base class for constrained direct samplers for autoregressive neural networks.
+
+    This sampler family only works with Flax models exposing
+    ``model.conditional``. Given a batch of partial samples and an index
+    ``i ∈ [0, self.hilbert.size)``, ``model.conditional`` must return the
+    conditional probabilities over local states at site ``i``.
+
+    In short, if your model admits a factorization
+
+    .. math::
+
+        p(x) = p_1(x_1) p_2(x_2|x_1)\dots p_N(x_N|x_{N-1}, \dots, x_1),
+
+    then ``model.conditional(x, i)`` should return :math:`p_i(x)`.
+
+    Subclasses implement concrete constrained strategies:
+    - exact prefix-feasibility masking for known NetKet constraints,
+    - exact rejection sampling fallback for generic callable constraints.
+    """
+
+    max_resampling_attempts: int = struct.field(pytree_node=False, default=4096)
+    """Maximum number of rejection-loop iterations before raising a RuntimeError."""
+
+    _local_states: tuple = struct.field(pytree_node=False, default=())
+    """The allowed local states in the Hilbert space being sampled."""
+
+    def __init__(
+        self,
+        hilbert,
+        machine_pow=None,
+        dtype=None,
+        *,
+        max_resampling_attempts: int = 4096,
+    ):
+        """
+        Construct a constrained autoregressive sampler.
+
+        Args:
+            hilbert: The Hilbert space to sample.
+            dtype: The dtype of the states sampled (default = np.float64).
+            max_resampling_attempts: Maximum number of rejection-loop iterations before raising
+              ``RuntimeError`` (applies only to the fallback rejection path).
+        """
+        if machine_pow is not None:
+            raise ValueError(
+                "ARDirectSampler.machine_pow should not be used. Modify the model `machine_pow` directly."
+            )
+
+        super().__init__(hilbert, machine_pow=2, dtype=dtype)
+
+        # ensure machine_pow is a float, as it can be sometimes used around...
+        self.machine_pow = float(self.machine_pow)
+
+        self.max_resampling_attempts = int(max_resampling_attempts)
+        self._local_states = _as_static_tuple(
+            jnp.asarray(self.hilbert.local_states, dtype=self.dtype)
+        )
+
+    @property
+    def is_exact(self) -> bool:
+        """
+        Returns `True` because the sampler is exact.
+
+        The sampler is exact if all the samples are exactly distributed according to the
+        chosen power of the variational state, and there is no correlation among them.
+        """
+        return True
+
+    def _local_states_array(self) -> jnp.ndarray:
+        """Returns the local states of the Hilbert space being sampled."""
+        return jnp.asarray(self._local_states, dtype=self.dtype)
+
+    def _init_cache(self, model, σ, key):
+        variables = model.init(key, σ, 0, method=model.conditional)
+        cache = variables.get("cache")
+        return cache
+
+    def _init_state(self, model, variables, key) -> ARDirectSamplerState:
+        return ARDirectSamplerState(key=key)
+
+    def _reset(self, model, variables, state) -> ARDirectSamplerState:
+        return state
+
+    @partial(
+        jax.jit,
+        static_argnames=("model", "chain_length", "return_log_probabilities"),
+    )
+    def _sampling_kernel_model_direct(
+        self,
+        model,
+        variables,
+        state,
+        chain_length: int,
+        return_log_probabilities: bool = False,
+    ):
+        """
+        Generic direct AR kernel that follows model conditionals over all sites.
+        """
+        variables_no_cache, _ = _pop_cache(variables)
+
+        total = self.n_batches * chain_length
+        n_sites = self.hilbert.size
+        local_states = self._local_states_array()
+
+        new_key, key_init, key_scan = jax.random.split(state.key, 3)
+        sigma0 = jnp.zeros((total, n_sites), dtype=self.dtype)
+        cache0 = self._init_cache(model, sigma0, key_init)
+
+        try:
+            site_order = model.apply(
+                _with_cache(variables_no_cache, cache0),
+                jnp.arange(n_sites, dtype=jnp.int32),
+                method=model.reorder,
+            ).astype(jnp.int32)
+        except (AttributeError, TypeError):
+            site_order = jnp.arange(n_sites, dtype=jnp.int32)
+
+        if return_log_probabilities:
+            logp0 = jnp.zeros((total,), dtype=_log_prob_dtype())
+
+            def _step(carry, site_i):
+                sigma, cache, key, logp = carry
+                key, key_draw = jax.random.split(key)
+                p, mutables = model.apply(
+                    _with_cache(variables_no_cache, cache),
+                    sigma,
+                    site_i,
+                    method=model.conditional,
+                    mutable=["cache"],
+                )
+                cache = mutables.get("cache", None)
+                new_col, new_p = nkjax.batch_choice(
+                    key_draw, local_states, p, return_prob=True
+                )
+                sigma = sigma.at[:, site_i].set(new_col)
+                logp = logp + jnp.log(new_p).astype(logp.dtype)
+                return (sigma, cache, key, logp), None
+
+            (sigma, _cache, _key, logp), _ = jax.lax.scan(
+                _step,
+                (sigma0, cache0, key_scan, logp0),
+                site_order,
+            )
+        else:
+            logp = None
+
+            def _step(carry, site_i):
+                sigma, cache, key = carry
+                key, key_draw = jax.random.split(key)
+                p, mutables = model.apply(
+                    _with_cache(variables_no_cache, cache),
+                    sigma,
+                    site_i,
+                    method=model.conditional,
+                    mutable=["cache"],
+                )
+                cache = mutables.get("cache", None)
+                new_col = nkjax.batch_choice(key_draw, local_states, p)
+                sigma = sigma.at[:, site_i].set(new_col)
+                return (sigma, cache, key), None
+
+            (sigma, _cache, _key), _ = jax.lax.scan(
+                _step,
+                (sigma0, cache0, key_scan),
+                site_order,
+            )
+
+        sigma = sigma.reshape((self.n_batches, chain_length, n_sites))
+        valid = self.hilbert.constraint(sigma.reshape(total, n_sites)).reshape(
+            (self.n_batches, chain_length)
+        )
+        all_accepted = jnp.all(valid)
+        new_state = state.replace(key=new_key)
+
+        if return_log_probabilities:
+            return (
+                (sigma, logp.reshape(self.n_batches, chain_length)),
+                new_state,
+                all_accepted,
+            )
+        return sigma, new_state, all_accepted
+
+    @partial(
+        jax.jit,
+        static_argnames=(
+            "model",
+            "chain_length",
+            "site_order",
+            "return_log_probabilities",
+        ),
+    )
+    def _sampling_kernel_model_direct_static(
+        self,
+        model,
+        variables,
+        state,
+        chain_length: int,
+        *,
+        site_order: tuple[int, ...],
+        return_log_probabilities: bool = False,
+    ):
+        """
+        Static-index variant of `_sampling_kernel_model_direct` for FastARNN models.
+        """
+        variables_no_cache, _ = _pop_cache(variables)
+
+        total = self.n_batches * chain_length
+        n_sites = self.hilbert.size
+        local_states = self._local_states_array()
+
+        new_key, key_init, key_scan = jax.random.split(state.key, 3)
+        sigma = jnp.zeros((total, n_sites), dtype=self.dtype)
+        cache = self._init_cache(model, sigma, key_init)
+
+        key = key_scan
+        if return_log_probabilities:
+            logp = jnp.zeros((total,), dtype=_log_prob_dtype())
+            for site_i in site_order:
+                key, key_draw = jax.random.split(key)
+                p, mutables = model.apply(
+                    _with_cache(variables_no_cache, cache),
+                    sigma,
+                    site_i,
+                    method=model.conditional,
+                    mutable=["cache"],
+                )
+                cache = mutables.get("cache", None)
+                new_col, new_p = nkjax.batch_choice(
+                    key_draw, local_states, p, return_prob=True
+                )
+                sigma = sigma.at[:, site_i].set(new_col)
+                logp = logp + jnp.log(new_p).astype(logp.dtype)
+        else:
+            logp = None
+            for site_i in site_order:
+                key, key_draw = jax.random.split(key)
+                p, mutables = model.apply(
+                    _with_cache(variables_no_cache, cache),
+                    sigma,
+                    site_i,
+                    method=model.conditional,
+                    mutable=["cache"],
+                )
+                cache = mutables.get("cache", None)
+                new_col = nkjax.batch_choice(key_draw, local_states, p)
+                sigma = sigma.at[:, site_i].set(new_col)
+
+        sigma = sigma.reshape((self.n_batches, chain_length, n_sites))
+        valid = self.hilbert.constraint(sigma.reshape(total, n_sites)).reshape(
+            (self.n_batches, chain_length)
+        )
+        all_accepted = jnp.all(valid)
+        new_state = state.replace(key=new_key)
+
+        if return_log_probabilities:
+            return (
+                (sigma, logp.reshape(self.n_batches, chain_length)),
+                new_state,
+                all_accepted,
+            )
+        return sigma, new_state, all_accepted
+
+    def _sample_chain_model_direct(
+        self,
+        model,
+        variables,
+        state,
+        chain_length: int,
+        return_log_probabilities: bool = False,
+    ):
+        """
+        Host-side dispatcher for model-direct kernels with FastARNN handling.
+        """
+        if isinstance(model, nk.models.FastARNNSequential):
+            variables_no_cache, _ = _pop_cache(variables)
+            site_order = _ordered_site_tuple(
+                model,
+                variables_no_cache,
+                tuple(range(self.hilbert.size)),
+            )
+            out, new_state, all_accepted = self._sampling_kernel_model_direct_static(
+                model,
+                variables,
+                state,
+                chain_length,
+                site_order=site_order,
+                return_log_probabilities=return_log_probabilities,
+            )
+        else:
+            out, new_state, all_accepted = self._sampling_kernel_model_direct(
+                model,
+                variables,
+                state,
+                chain_length,
+                return_log_probabilities=return_log_probabilities,
+            )
+        self._raise_if_not_all_accepted(all_accepted)
+        return out, new_state
+
+    def _raise_if_not_all_accepted(self, all_accepted):
+        """
+        Raise a clear host-side error when rejection-based paths did not fill all rows.
+        """
+        if not bool(all_accepted):
+            raise RuntimeError(
+                "ConstrainedARDirectSampler: rejection sampling failed to accept "
+                f"all samples after {self.max_resampling_attempts} attempts. "
+                "Consider increasing max_resampling_attempts."
+            )
+
+    def _sample_chain(
+        self,
+        model,
+        variables,
+        state,
+        chain_length: int,
+        return_log_probabilities: bool = False,
+    ):
+        """
+        A wrapper around subclass JIT kernels.
+
+        The wrapper intentionally performs only one host-side action, converting the scalar acceptance
+        flag to bool and raising a clear error if fallback rejection failed to fill all sample slots.
+        """
+        out, new_state, all_accepted = self._sampling_kernel(
+            model,
+            variables,
+            state,
+            chain_length,
+            return_log_probabilities=return_log_probabilities,
+        )
+
+        self._raise_if_not_all_accepted(all_accepted)
+
+        return out, new_state
+
+
+class SumConstrainedARDirectSampler(ConstrainedARDirectSampler):
+    r"""
+    Direct sampler for autoregressive models on Hilbert spaces constrained with a
+    :class:`~netket.hilbert.constraint.SumConstraint` constraint.
+
+    This sampler uses an exact prefix-feasibility masking strategy.
+    For each autoregressive site update, candidate local values that cannot be
+    completed to the target sum are masked out before sampling. After all free
+    sites are sampled, one dependent site is set deterministically to enforce
+    the exact final sum. The method is rejection-free (for supported local-state values).
+    """
+
+    _free_indices: tuple[int, ...] = struct.field(pytree_node=False, default=())
+    """Indices sampled autoregressively before deterministic sum closure."""
+
+    _target: float = struct.field(pytree_node=False, default=0.0)
+    """Target total sum enforced by ``SumConstraint``."""
+
+    _local_min: float = struct.field(pytree_node=False, default=0.0)
+    """Minimum value in the local state alphabet (used for feasibility bounds)."""
+
+    _local_max: float = struct.field(pytree_node=False, default=0.0)
+    """Maximum value in the local state alphabet (used for feasibility bounds)."""
+
+    _local_step: float = struct.field(pytree_node=False, default=1.0)
+    """Uniform spacing step of local states for lattice-feasibility checks."""
+
+    _slave_site: int = struct.field(pytree_node=False, default=0)
+    """Index of the deterministic dependent site set after free-site sampling."""
+
+    def __init__(
+        self,
+        hilbert,
+        payload,
+        machine_pow=None,
+        dtype=None,
+        *,
+        max_resampling_attempts: int = 4096,
+    ):
+        # Shared sampler initialization.
+        super().__init__(
+            hilbert,
+            machine_pow=machine_pow,
+            dtype=dtype,
+            max_resampling_attempts=max_resampling_attempts,
+        )
+
+        # Unpack static payload produced by the plan builder.
+        (
+            free_indices,
+            target,
+            local_min,
+            local_max,
+            local_step,
+            slave_site,
+        ) = payload
+
+        # Store all payload items as Python scalars/tuples for stable metadata.
+        self._free_indices = tuple(int(v) for v in free_indices)
+        self._target = float(target)
+        self._local_min = float(local_min)
+        self._local_max = float(local_max)
+        self._local_step = float(local_step)
+        self._slave_site = int(slave_site)
+
+    def _sample_chain(
+        self,
+        model,
+        variables,
+        state,
+        chain_length: int,
+        return_log_probabilities: bool = False,
+    ):
+        """
+        Dispatch to a static-index kernel for FastARNN models.
+        """
+        if getattr(model, "_constraint_aware_autoregressive", False):
+            return self._sample_chain_model_direct(
+                model,
+                variables,
+                state,
+                chain_length,
+                return_log_probabilities=return_log_probabilities,
+            )
+
+        if isinstance(model, nk.models.FastARNNSequential):
+            variables_no_cache, _ = _pop_cache(variables)
+            site_order = _ordered_site_tuple(
+                model, variables_no_cache, self._free_indices
+            )
+            out, new_state, all_accepted = self._sampling_kernel_static(
+                model,
+                variables,
+                state,
+                chain_length,
+                site_order=site_order,
+                return_log_probabilities=return_log_probabilities,
+            )
+            self._raise_if_not_all_accepted(all_accepted)
+            return out, new_state
+
+        return super()._sample_chain(
+            model,
+            variables,
+            state,
+            chain_length,
+            return_log_probabilities=return_log_probabilities,
+        )
+
+    @partial(
+        jax.jit,
+        static_argnames=(
+            "model",
+            "chain_length",
+            "site_order",
+            "return_log_probabilities",
+        ),
+    )
+    def _sampling_kernel_static(
+        self,
+        model,
+        variables,
+        state,
+        chain_length: int,
+        *,
+        site_order: tuple[int, ...],
+        return_log_probabilities: bool = False,
+    ):
+        """
+        Static-index constrained sum kernel, compatible with FastARNN conditionals.
+        """
+        variables_no_cache, _ = _pop_cache(variables)
+
+        total = self.n_batches * chain_length
+        n_sites = self.hilbert.size
+        local_states = self._local_states_array()
+        local_states_f32 = local_states.astype(jnp.float32)
+
+        new_key, key_init, key_ar = jax.random.split(state.key, 3)
+        sigma = jnp.zeros((total, n_sites), dtype=self.dtype)
+        cache = self._init_cache(model, sigma, key_init)
+
+        prefix_sum = jnp.zeros((total,), dtype=jnp.float32)
+        feasible = jnp.ones((total,), dtype=jnp.bool_)
+        key = key_ar
+
+        if return_log_probabilities:
+            logp = jnp.zeros((total,), dtype=_log_prob_dtype())
+            for step_i, site_i in enumerate(site_order):
+                key, key_draw = jax.random.split(key)
+                p, mutables = model.apply(
+                    _with_cache(variables_no_cache, cache),
+                    sigma,
+                    site_i,
+                    method=model.conditional,
+                    mutable=["cache"],
+                )
+                cache = mutables.get("cache", None)
+                n_remaining = len(site_order) - step_i
+                mask = _sum_feasible_mask(
+                    prefix_sum=prefix_sum,
+                    candidate_vals=local_states_f32,
+                    n_remaining=n_remaining,
+                    target=self._target,
+                    local_min=self._local_min,
+                    local_max=self._local_max,
+                    step=self._local_step,
+                )
+                p_masked, row_feasible = _normalise_masked(p, mask)
+                feasible = feasible & row_feasible
+                new_col, new_p = nkjax.batch_choice(
+                    key_draw,
+                    local_states,
+                    p_masked,
+                    return_prob=True,
+                )
+                sigma = sigma.at[:, site_i].set(new_col)
+                prefix_sum = prefix_sum + new_col.astype(jnp.float32)
+                logp = logp + jnp.log(new_p).astype(logp.dtype)
+        else:
+            logp = None
+            for step_i, site_i in enumerate(site_order):
+                key, key_draw = jax.random.split(key)
+                p, mutables = model.apply(
+                    _with_cache(variables_no_cache, cache),
+                    sigma,
+                    site_i,
+                    method=model.conditional,
+                    mutable=["cache"],
+                )
+                cache = mutables.get("cache", None)
+                n_remaining = len(site_order) - step_i
+                mask = _sum_feasible_mask(
+                    prefix_sum=prefix_sum,
+                    candidate_vals=local_states_f32,
+                    n_remaining=n_remaining,
+                    target=self._target,
+                    local_min=self._local_min,
+                    local_max=self._local_max,
+                    step=self._local_step,
+                )
+                p_masked, row_feasible = _normalise_masked(p, mask)
+                feasible = feasible & row_feasible
+                new_col = nkjax.batch_choice(key_draw, local_states, p_masked)
+                sigma = sigma.at[:, site_i].set(new_col)
+                prefix_sum = prefix_sum + new_col.astype(jnp.float32)
+
+        slave = self._target - prefix_sum
+        dists = jnp.abs(slave[:, None] - local_states_f32[None, :])
+        idx = jnp.argmin(dists, axis=-1)
+        slave_vals = local_states_f32[idx]
+        sigma = sigma.at[:, self._slave_site].set(slave_vals.astype(self.dtype))
+        slave_exact = jnp.abs(slave_vals - slave) <= 1.0e-6
+        all_accepted = jnp.all(feasible & slave_exact)
+
+        sigma = sigma.reshape(self.n_batches, chain_length, n_sites)
+        new_state = state.replace(key=new_key)
+        if return_log_probabilities:
+            return (
+                (sigma, logp.reshape(self.n_batches, chain_length)),
+                new_state,
+                all_accepted,
+            )
+        return sigma, new_state, all_accepted
+
+    @partial(
+        jax.jit, static_argnames=("model", "chain_length", "return_log_probabilities")
+    )
+    def _sampling_kernel(
+        self,
+        model,
+        variables,
+        state,
+        chain_length: int,
+        return_log_probabilities: bool = False,
+    ):
+        # Split model variables and isolate mutable cache handling.
+        variables_no_cache, _ = _pop_cache(variables)
+
+        # Flattened sample count and static local alphabet.
+        total = self.n_batches * chain_length
+        n_sites = self.hilbert.size
+        local_states = self._local_states_array()
+
+        # PRNG split for output state, cache init, and AR draws.
+        new_key, key_init, key_ar = jax.random.split(state.key, 3)
+        sigma_seed = jnp.zeros((total, n_sites), dtype=self.dtype)
+
+        # Initialize model cache once for the target batch shape.
+        cache0 = self._init_cache(model, sigma_seed, key_init)
+        free_indices = jnp.asarray(self._free_indices, dtype=jnp.int32)
+
+        # Allow model-specific site reordering.
+        try:
+            ordered_free = model.apply(
+                _with_cache(variables_no_cache, cache0),
+                free_indices,
+                method=model.reorder,
+            ).astype(jnp.int32)
+        except (AttributeError, TypeError):
+            ordered_free = free_indices
+
+        # Scan input carries both the step index (for remaining-site arithmetic)
+        # and the actual site index to sample.
+        scan_steps = (
+            jnp.arange(free_indices.shape[0], dtype=jnp.int32),
+            ordered_free,
+        )
+
+        # Feasibility arithmetic is done in float32 for speed and consistency.
+        local_states_f32 = local_states.astype(jnp.float32)
+
+        if return_log_probabilities:
+            # Per-sample running state:
+            # - logp: accumulated log conditional probability
+            # - prefix_sum: running sum of already sampled free sites
+            # - feasible: whether at least one feasible candidate remained at each step
+            logp0 = jnp.zeros((total,), dtype=_log_prob_dtype())
+            prefix_sum0 = jnp.zeros((total,), dtype=jnp.float32)
+            feasible0 = jnp.ones((total,), dtype=jnp.bool_)
+
+            def _step_sum_logp(carry, scan_in):
+                sigma, cache, key, logp, prefix_sum, feasible = carry
+                step_i, site_i = scan_in
+
+                # Query unconstrained conditional probabilities.
+                key, key_draw = jax.random.split(key)
+                p, mutables = model.apply(
+                    _with_cache(variables_no_cache, cache),
+                    sigma,
+                    site_i,
+                    method=model.conditional,
+                    mutable=["cache"],
+                )
+                cache = mutables.get("cache", None)
+                n_remaining = free_indices.shape[0] - step_i
+
+                # Build exact feasibility mask for every candidate local value.
+                mask = _sum_feasible_mask(
+                    prefix_sum=prefix_sum,
+                    candidate_vals=local_states_f32,
+                    n_remaining=n_remaining,
+                    target=self._target,
+                    local_min=self._local_min,
+                    local_max=self._local_max,
+                    step=self._local_step,
+                )
+
+                # Renormalize categorical probabilities over feasible support only.
+                p_masked, row_feasible = _normalise_masked(p, mask)
+                feasible = feasible & row_feasible
+
+                # Sample constrained conditional and update running statistics.
+                new_col, new_p = nkjax.batch_choice(
+                    key_draw,
+                    local_states,
+                    p_masked,
+                    return_prob=True,
+                )
+                sigma = sigma.at[:, site_i].set(new_col)
+                prefix_sum = prefix_sum + new_col.astype(jnp.float32)
+                logp = logp + jnp.log(new_p).astype(logp.dtype)
+                return (sigma, cache, key, logp, prefix_sum, feasible), None
+
+            # One fused scan over all free sites.
+            (sigma, _cache, _key, logp, prefix_sum, feasible), _ = jax.lax.scan(
+                _step_sum_logp,
+                (sigma_seed, cache0, key_ar, logp0, prefix_sum0, feasible0),
+                scan_steps,
+            )
+        else:
+            # Same state as above without explicit log-probability tracking.
+            prefix_sum0 = jnp.zeros((total,), dtype=jnp.float32)
+            feasible0 = jnp.ones((total,), dtype=jnp.bool_)
+
+            def _step_sum(carry, scan_in):
+                sigma, cache, key, prefix_sum, feasible = carry
+                step_i, site_i = scan_in
+
+                # Query unconstrained conditional probabilities.
+                key, key_draw = jax.random.split(key)
+                p, mutables = model.apply(
+                    _with_cache(variables_no_cache, cache),
+                    sigma,
+                    site_i,
+                    method=model.conditional,
+                    mutable=["cache"],
+                )
+                cache = mutables.get("cache", None)
+                n_remaining = free_indices.shape[0] - step_i
+
+                # Mask infeasible values and renormalize on feasible support.
+                mask = _sum_feasible_mask(
+                    prefix_sum=prefix_sum,
+                    candidate_vals=local_states_f32,
+                    n_remaining=n_remaining,
+                    target=self._target,
+                    local_min=self._local_min,
+                    local_max=self._local_max,
+                    step=self._local_step,
+                )
+                p_masked, row_feasible = _normalise_masked(p, mask)
+                feasible = feasible & row_feasible
+
+                # Draw constrained sample and update prefix sum.
+                new_col = nkjax.batch_choice(key_draw, local_states, p_masked)
+                sigma = sigma.at[:, site_i].set(new_col)
+                prefix_sum = prefix_sum + new_col.astype(jnp.float32)
+                return (sigma, cache, key, prefix_sum, feasible), None
+
+            # One fused scan over all free sites.
+            (sigma, _cache, _key, prefix_sum, feasible), _ = jax.lax.scan(
+                _step_sum,
+                (sigma_seed, cache0, key_ar, prefix_sum0, feasible0),
+                scan_steps,
+            )
+            logp = None  # type: ignore[assignment]
+
+        # Final deterministic slave-site closure to satisfy exact sum target.
+        slave = self._target - prefix_sum
+        dists = jnp.abs(slave[:, None] - local_states_f32[None, :])
+        idx = jnp.argmin(dists, axis=-1)
+        slave_vals = local_states_f32[idx]
+        sigma = sigma.at[:, self._slave_site].set(slave_vals.astype(self.dtype))
+
+        # Accept only if all rows stayed feasible and slave was exactly representable.
+        slave_exact = jnp.abs(slave_vals - slave) <= 1.0e-6
+        all_accepted = jnp.all(feasible & slave_exact)
+
+        # Restore NetKet sample shape and return new sampler key.
+        sigma = sigma.reshape(self.n_batches, chain_length, n_sites)
+        new_state = state.replace(key=new_key)
+
+        if return_log_probabilities:
+            return (
+                (sigma, logp.reshape(self.n_batches, chain_length)),
+                new_state,
+                all_accepted,
+            )
+        return sigma, new_state, all_accepted
+
+
+class PartitionConstrainedARDirectSampler(ConstrainedARDirectSampler):
+    r"""
+    Direct sampler for autoregressive models with Hilbert spaces constrained with a
+    :class:`~netket.hilbert.constraint.SumOnPartitionConstraint` constraint.
+
+    This sampler generalizes the sum-prefix strategy to multiple partitions.
+    During autoregressive updates, candidate values are masked using partition-
+    wise feasibility checks so that every partition target remains reachable.
+    After all free sites are sampled, one dependent site per partition is set
+    deterministically to close each partition sum exactly. For supported local-state
+    values this path is rejection-free and exact.
+    """
+
+    _free_indices: tuple[int, ...] = struct.field(pytree_node=False, default=())
+    """Global indices of all free sites across partitions."""
+
+    _partition_of_site: tuple[int, ...] = struct.field(pytree_node=False, default=())
+    """Map from global site index to partition id."""
+
+    _partition_sizes: tuple[int, ...] = struct.field(pytree_node=False, default=())
+    """Number of sites in each partition."""
+
+    _partition_targets: tuple[float, ...] = struct.field(pytree_node=False, default=())
+    """Target sum for each partition."""
+
+    _partition_slaves: tuple[int, ...] = struct.field(pytree_node=False, default=())
+    """Dependent site index used to close each partition sum exactly."""
+
+    _local_min: float = struct.field(pytree_node=False, default=0.0)
+    """Minimum value in the local state alphabet."""
+
+    _local_max: float = struct.field(pytree_node=False, default=0.0)
+    """Maximum value in the local state alphabet."""
+
+    _local_step: float = struct.field(pytree_node=False, default=1.0)
+    """Uniform spacing step of local states for lattice-feasibility checks."""
+
+    def __init__(
+        self,
+        hilbert,
+        payload,
+        machine_pow=None,
+        dtype=None,
+        *,
+        max_resampling_attempts: int = 4096,
+    ):
+        # Shared sampler initialization.
+        super().__init__(
+            hilbert,
+            machine_pow=machine_pow,
+            dtype=dtype,
+            max_resampling_attempts=max_resampling_attempts,
+        )
+        # Unpack static payload from the planner.
+        (
+            free_indices,
+            partition_of_site,
+            partition_sizes,
+            partition_targets,
+            partition_slaves,
+            local_min,
+            local_max,
+            local_step,
+        ) = payload
+        # Keep payload metadata as Python tuples/scalars for stable JAX metadata.
+        self._free_indices = tuple(int(v) for v in free_indices)
+        self._partition_of_site = tuple(int(v) for v in partition_of_site)
+        self._partition_sizes = tuple(int(v) for v in partition_sizes)
+        self._partition_targets = tuple(float(v) for v in partition_targets)
+        self._partition_slaves = tuple(int(v) for v in partition_slaves)
+        self._local_min = float(local_min)
+        self._local_max = float(local_max)
+        self._local_step = float(local_step)
+
+    def _sample_chain(
+        self,
+        model,
+        variables,
+        state,
+        chain_length: int,
+        return_log_probabilities: bool = False,
+    ):
+        """
+        Dispatch to a static-index kernel for FastARNN models.
+        """
+        if getattr(model, "_constraint_aware_autoregressive", False):
+            return self._sample_chain_model_direct(
+                model,
+                variables,
+                state,
+                chain_length,
+                return_log_probabilities=return_log_probabilities,
+            )
+
+        if isinstance(model, nk.models.FastARNNSequential):
+            variables_no_cache, _ = _pop_cache(variables)
+            site_order = _ordered_site_tuple(
+                model, variables_no_cache, self._free_indices
+            )
+            out, new_state, all_accepted = self._sampling_kernel_static(
+                model,
+                variables,
+                state,
+                chain_length,
+                site_order=site_order,
+                return_log_probabilities=return_log_probabilities,
+            )
+            self._raise_if_not_all_accepted(all_accepted)
+            return out, new_state
+
+        return super()._sample_chain(
+            model,
+            variables,
+            state,
+            chain_length,
+            return_log_probabilities=return_log_probabilities,
+        )
+
+    @partial(
+        jax.jit,
+        static_argnames=(
+            "model",
+            "chain_length",
+            "site_order",
+            "return_log_probabilities",
+        ),
+    )
+    def _sampling_kernel_static(
+        self,
+        model,
+        variables,
+        state,
+        chain_length: int,
+        *,
+        site_order: tuple[int, ...],
+        return_log_probabilities: bool = False,
+    ):
+        """
+        Static-index constrained partition kernel, compatible with FastARNN.
+        """
+        variables_no_cache, _ = _pop_cache(variables)
+
+        total = self.n_batches * chain_length
+        n_sites = self.hilbert.size
+        local_states = self._local_states_array()
+        local_states_f32 = local_states.astype(jnp.float32)
+
+        new_key, key_init, key_ar = jax.random.split(state.key, 3)
+        sigma = jnp.zeros((total, n_sites), dtype=self.dtype)
+        cache = self._init_cache(model, sigma, key_init)
+
+        pnum = len(self._partition_sizes)
+        partition_of_site = jnp.asarray(self._partition_of_site, dtype=jnp.int32)
+        partition_sizes = jnp.asarray(self._partition_sizes, dtype=jnp.int32)
+        partition_targets = jnp.asarray(self._partition_targets, dtype=jnp.float32)
+        partition_slaves = tuple(int(v) for v in self._partition_slaves)
+        step_is_zero = abs(self._local_step) <= 1.0e-12
+
+        prefix_sums = jnp.zeros((total, pnum), dtype=jnp.float32)
+        done_counts = jnp.zeros((pnum,), dtype=jnp.int32)
+        feasible = jnp.ones((total,), dtype=jnp.bool_)
+        key = key_ar
+
+        if return_log_probabilities:
+            logp = jnp.zeros((total,), dtype=_log_prob_dtype())
+            for site_i in site_order:
+                key, key_draw = jax.random.split(key)
+                p, mutables = model.apply(
+                    _with_cache(variables_no_cache, cache),
+                    sigma,
+                    site_i,
+                    method=model.conditional,
+                    mutable=["cache"],
+                )
+                cache = mutables.get("cache", None)
+                part = partition_of_site[site_i]
+                onehot_p = jax.nn.one_hot(part, pnum, dtype=jnp.float32)[None, None, :]
+                sums_new = (
+                    prefix_sums[:, None, :] + onehot_p * local_states_f32[None, :, None]
+                )
+                done_new = done_counts + jax.nn.one_hot(part, pnum, dtype=jnp.int32)
+                rem = partition_sizes - done_new
+                lo = rem[None, None, :] * self._local_min
+                hi = rem[None, None, :] * self._local_max
+                need = partition_targets[None, None, :] - sums_new
+                in_range = (need >= lo - 1.0e-12) & (need <= hi + 1.0e-12)
+                if step_is_zero:
+                    mask = jnp.all(in_range, axis=-1)
+                else:
+                    k = (need - lo) / self._local_step
+                    on_lattice = jnp.abs(k - jnp.round(k)) <= 1.0e-12
+                    mask = jnp.all(in_range & on_lattice, axis=-1)
+                p_masked, row_feasible = _normalise_masked(p, mask)
+                feasible = feasible & row_feasible
+                new_col, new_p = nkjax.batch_choice(
+                    key_draw,
+                    local_states,
+                    p_masked,
+                    return_prob=True,
+                )
+                sigma = sigma.at[:, site_i].set(new_col)
+                prefix_sums = prefix_sums.at[:, part].add(new_col.astype(jnp.float32))
+                done_counts = done_new
+                logp = logp + jnp.log(new_p).astype(logp.dtype)
+        else:
+            logp = None
+            for site_i in site_order:
+                key, key_draw = jax.random.split(key)
+                p, mutables = model.apply(
+                    _with_cache(variables_no_cache, cache),
+                    sigma,
+                    site_i,
+                    method=model.conditional,
+                    mutable=["cache"],
+                )
+                cache = mutables.get("cache", None)
+                part = partition_of_site[site_i]
+                onehot_p = jax.nn.one_hot(part, pnum, dtype=jnp.float32)[None, None, :]
+                sums_new = (
+                    prefix_sums[:, None, :] + onehot_p * local_states_f32[None, :, None]
+                )
+                done_new = done_counts + jax.nn.one_hot(part, pnum, dtype=jnp.int32)
+                rem = partition_sizes - done_new
+                lo = rem[None, None, :] * self._local_min
+                hi = rem[None, None, :] * self._local_max
+                need = partition_targets[None, None, :] - sums_new
+                in_range = (need >= lo - 1.0e-12) & (need <= hi + 1.0e-12)
+                if step_is_zero:
+                    mask = jnp.all(in_range, axis=-1)
+                else:
+                    k = (need - lo) / self._local_step
+                    on_lattice = jnp.abs(k - jnp.round(k)) <= 1.0e-12
+                    mask = jnp.all(in_range & on_lattice, axis=-1)
+                p_masked, row_feasible = _normalise_masked(p, mask)
+                feasible = feasible & row_feasible
+                new_col = nkjax.batch_choice(key_draw, local_states, p_masked)
+                sigma = sigma.at[:, site_i].set(new_col)
+                prefix_sums = prefix_sums.at[:, part].add(new_col.astype(jnp.float32))
+                done_counts = done_new
+
+        slave_exact = jnp.ones((total,), dtype=jnp.bool_)
+        for p, slave_site in enumerate(partition_slaves):
+            slave = partition_targets[p] - prefix_sums[:, p]
+            dists = jnp.abs(slave[:, None] - local_states_f32[None, :])
+            idx = jnp.argmin(dists, axis=-1)
+            slave_vals = local_states_f32[idx]
+            sigma = sigma.at[:, slave_site].set(slave_vals.astype(self.dtype))
+            slave_exact = slave_exact & (jnp.abs(slave_vals - slave) <= 1.0e-6)
+
+        all_accepted = jnp.all(feasible & slave_exact)
+        sigma = sigma.reshape(self.n_batches, chain_length, n_sites)
+        new_state = state.replace(key=new_key)
+        if return_log_probabilities:
+            return (
+                (sigma, logp.reshape(self.n_batches, chain_length)),
+                new_state,
+                all_accepted,
+            )
+        return sigma, new_state, all_accepted
+
+    @partial(
+        jax.jit, static_argnames=("model", "chain_length", "return_log_probabilities")
+    )
+    def _sampling_kernel(
+        self,
+        model,
+        variables,
+        state,
+        chain_length: int,
+        return_log_probabilities: bool = False,
+    ):
+        # Split immutable variable tree and mutable cache usage.
+        variables_no_cache, _ = _pop_cache(variables)
+
+        # Flattened sample axis and static local alphabet.
+        total = self.n_batches * chain_length
+        n_sites = self.hilbert.size
+        local_states = self._local_states_array()
+
+        # PRNG split for outgoing state key, cache init, and AR draw stream.
+        new_key, key_init, key_ar = jax.random.split(state.key, 3)
+        sigma_seed = jnp.zeros((total, n_sites), dtype=self.dtype)
+
+        # Initialize model cache once at the target batch shape.
+        cache0 = self._init_cache(model, sigma_seed, key_init)
+        free_indices = jnp.asarray(self._free_indices, dtype=jnp.int32)
+
+        # Respect model-defined ordering over free sites when exposed.
+        try:
+            ordered_free = model.apply(
+                _with_cache(variables_no_cache, cache0),
+                free_indices,
+                method=model.reorder,
+            ).astype(jnp.int32)
+        except (AttributeError, TypeError):
+            ordered_free = free_indices
+
+        # Partition metadata used by vectorized feasibility logic.
+        pnum = len(self._partition_sizes)
+        partition_of_site = jnp.asarray(self._partition_of_site, dtype=jnp.int32)
+        partition_sizes = jnp.asarray(self._partition_sizes, dtype=jnp.int32)
+        partition_targets = jnp.asarray(self._partition_targets, dtype=jnp.float32)
+        partition_slaves = tuple(int(v) for v in self._partition_slaves)
+        local_states_f32 = local_states.astype(jnp.float32)
+        step_is_zero = abs(self._local_step) <= 1.0e-12
+
+        if return_log_probabilities:
+            # Running state per sample row and per partition.
+            logp0 = jnp.zeros((total,), dtype=_log_prob_dtype())
+            prefix_sums0 = jnp.zeros((total, pnum), dtype=jnp.float32)
+            done_counts0 = jnp.zeros((pnum,), dtype=jnp.int32)
+            feasible0 = jnp.ones((total,), dtype=jnp.bool_)
+
+            def _step_part_logp(carry, site_i):
+                sigma, cache, key, logp, prefix_sums, done_counts, feasible = carry
+
+                # Query unconstrained conditional probabilities.
+                key, key_draw = jax.random.split(key)
+                p, mutables = model.apply(
+                    _with_cache(variables_no_cache, cache),
+                    sigma,
+                    site_i,
+                    method=model.conditional,
+                    mutable=["cache"],
+                )
+                cache = mutables.get("cache", None)
+                part = partition_of_site[site_i]
+
+                # Candidate-wise partition sums for each possible local value.
+                onehot_p = jax.nn.one_hot(part, pnum, dtype=jnp.float32)[None, None, :]
+                sums_new = (
+                    prefix_sums[:, None, :] + onehot_p * local_states_f32[None, :, None]
+                )
+                done_new = done_counts + jax.nn.one_hot(part, pnum, dtype=jnp.int32)
+                rem = partition_sizes - done_new
+
+                # Partition feasibility: interval bounds + optional lattice test.
+                lo = rem[None, None, :] * self._local_min
+                hi = rem[None, None, :] * self._local_max
+                need = partition_targets[None, None, :] - sums_new
+                in_range = (need >= lo - 1.0e-12) & (need <= hi + 1.0e-12)
+                if step_is_zero:
+                    mask = jnp.all(in_range, axis=-1)
+                else:
+                    k = (need - lo) / self._local_step
+                    on_lattice = jnp.abs(k - jnp.round(k)) <= 1.0e-12
+                    mask = jnp.all(in_range & on_lattice, axis=-1)
+
+                # Restrict support to feasible candidates and renormalize.
+                p_masked, row_feasible = _normalise_masked(p, mask)
+                feasible = feasible & row_feasible
+
+                # Draw constrained sample and update running partition state.
+                new_col, new_p = nkjax.batch_choice(
+                    key_draw,
+                    local_states,
+                    p_masked,
+                    return_prob=True,
+                )
+                sigma = sigma.at[:, site_i].set(new_col)
+                prefix_sums = prefix_sums.at[:, part].add(new_col.astype(jnp.float32))
+                done_counts = done_new
+                logp = logp + jnp.log(new_p).astype(logp.dtype)
+                return (
+                    sigma,
+                    cache,
+                    key,
+                    logp,
+                    prefix_sums,
+                    done_counts,
+                    feasible,
+                ), None
+
+            # Fused scan over all free sites.
+            (sigma, _cache, _key, logp, prefix_sums, _done, feasible), _ = jax.lax.scan(
+                _step_part_logp,
+                (
+                    sigma_seed,
+                    cache0,
+                    key_ar,
+                    logp0,
+                    prefix_sums0,
+                    done_counts0,
+                    feasible0,
+                ),
+                ordered_free,
+            )
+        else:
+            # Same state without log-probability accumulation.
+            prefix_sums0 = jnp.zeros((total, pnum), dtype=jnp.float32)
+            done_counts0 = jnp.zeros((pnum,), dtype=jnp.int32)
+            feasible0 = jnp.ones((total,), dtype=jnp.bool_)
+
+            def _step_part(carry, site_i):
+                sigma, cache, key, prefix_sums, done_counts, feasible = carry
+
+                # Query unconstrained conditional probabilities.
+                key, key_draw = jax.random.split(key)
+                p, mutables = model.apply(
+                    _with_cache(variables_no_cache, cache),
+                    sigma,
+                    site_i,
+                    method=model.conditional,
+                    mutable=["cache"],
+                )
+                cache = mutables.get("cache", None)
+                part = partition_of_site[site_i]
+
+                # Candidate-wise partition sums for each possible local value.
+                onehot_p = jax.nn.one_hot(part, pnum, dtype=jnp.float32)[None, None, :]
+                sums_new = (
+                    prefix_sums[:, None, :] + onehot_p * local_states_f32[None, :, None]
+                )
+                done_new = done_counts + jax.nn.one_hot(part, pnum, dtype=jnp.int32)
+                rem = partition_sizes - done_new
+
+                # Partition feasibility: interval bounds + optional lattice test.
+                lo = rem[None, None, :] * self._local_min
+                hi = rem[None, None, :] * self._local_max
+                need = partition_targets[None, None, :] - sums_new
+                in_range = (need >= lo - 1.0e-12) & (need <= hi + 1.0e-12)
+                if step_is_zero:
+                    mask = jnp.all(in_range, axis=-1)
+                else:
+                    k = (need - lo) / self._local_step
+                    on_lattice = jnp.abs(k - jnp.round(k)) <= 1.0e-12
+                    mask = jnp.all(in_range & on_lattice, axis=-1)
+
+                # Restrict support to feasible candidates and renormalize.
+                p_masked, row_feasible = _normalise_masked(p, mask)
+                feasible = feasible & row_feasible
+
+                # Draw constrained sample and update running partition state.
+                new_col = nkjax.batch_choice(key_draw, local_states, p_masked)
+                sigma = sigma.at[:, site_i].set(new_col)
+                prefix_sums = prefix_sums.at[:, part].add(new_col.astype(jnp.float32))
+                done_counts = done_new
+                return (sigma, cache, key, prefix_sums, done_counts, feasible), None
+
+            # Fused scan over all free sites.
+            (sigma, _cache, _key, prefix_sums, _done, feasible), _ = jax.lax.scan(
+                _step_part,
+                (sigma_seed, cache0, key_ar, prefix_sums0, done_counts0, feasible0),
+                ordered_free,
+            )
+            logp = None  # type: ignore[assignment]
+
+        # Deterministically set one slave site per partition.
+        slave_exact = jnp.ones((total,), dtype=jnp.bool_)
+        for p, slave_site in enumerate(partition_slaves):
+            slave = partition_targets[p] - prefix_sums[:, p]
+            dists = jnp.abs(slave[:, None] - local_states_f32[None, :])
+            idx = jnp.argmin(dists, axis=-1)
+            slave_vals = local_states_f32[idx]
+            sigma = sigma.at[:, slave_site].set(slave_vals.astype(self.dtype))
+            slave_exact = slave_exact & (jnp.abs(slave_vals - slave) <= 1.0e-6)
+
+        # Final acceptance requires feasible prefix path and exact slave closure.
+        all_accepted = jnp.all(feasible & slave_exact)
+
+        # Restore NetKet sample shape and return updated sampler key.
+        sigma = sigma.reshape(self.n_batches, chain_length, n_sites)
+        new_state = state.replace(key=new_key)
+
+        if return_log_probabilities:
+            return (
+                (sigma, logp.reshape(self.n_batches, chain_length)),
+                new_state,
+                all_accepted,
+            )
+        return sigma, new_state, all_accepted
+
+
+class GenericConstrainedARDirectSampler(ConstrainedARDirectSampler):
+    r"""
+    Direct sampler for autoregressive models with Hilbert spaces using generic
+    callable constraints.
+
+    This sampler is the universal constrained fallback. It repeatedly proposes
+    full autoregressive samples and accepts those satisfying the user-provided
+    batched constraint callable ``(B, N) -> (B,) bool``.
+
+    The rejection loop is compiled with ``jax.lax.while_loop`` and runs fully
+    on device. The method is exact, but throughput depends on acceptance rate and
+    is much slower than the autoregressive samplers implemented for the native
+    NetKet constraints.
+    """
+
+    _check_fn: object = struct.field(pytree_node=False, default=None)
+    """Callable constraint validator used in compiled rejection sampling."""
+
+    def __init__(
+        self,
+        hilbert,
+        check_fn,
+        machine_pow=None,
+        dtype=None,
+        *,
+        max_resampling_attempts: int = 4096,
+    ):
+        # Shared sampler initialization.
+        super().__init__(
+            hilbert,
+            machine_pow=machine_pow,
+            dtype=dtype,
+            max_resampling_attempts=max_resampling_attempts,
+        )
+        # Constraint callable must be batched and JAX-compatible.
+        self._check_fn = check_fn
+
+    @partial(
+        jax.jit, static_argnames=("model", "chain_length", "return_log_probabilities")
+    )
+    def _sampling_kernel(
+        self,
+        model,
+        variables,
+        state,
+        chain_length: int,
+        return_log_probabilities: bool = False,
+    ):
+        # Split immutable variables and mutable cache path.
+        variables_no_cache, _ = _pop_cache(variables)
+
+        # Flattened sampling axis and local alphabet.
+        total = self.n_batches * chain_length
+        n_sites = self.hilbert.size
+        local_states = self._local_states_array()
+
+        # Key split for outgoing state, cache initialization, and AR stream.
+        new_key, key_init, key_ar = jax.random.split(state.key, 3)
+        sigma_seed = jnp.zeros((total, n_sites), dtype=self.dtype)
+
+        # Initialize mutable cache once per sampling call.
+        cache0 = self._init_cache(model, sigma_seed, key_init)
+        check_fn = self._check_fn
+
+        # Model-provided AR ordering when available.
+        try:
+            site_order = model.apply(
+                _with_cache(variables_no_cache, cache0),
+                jnp.arange(n_sites, dtype=jnp.int32),
+                method=model.reorder,
+            ).astype(jnp.int32)
+        except (AttributeError, TypeError):
+            site_order = jnp.arange(n_sites, dtype=jnp.int32)
+
+        if return_log_probabilities:
+            # One complete unconstrained AR proposal with log-probability.
+            def _one_ar_pass(key):
+                logp0 = jnp.zeros((total,), dtype=_log_prob_dtype())
+
+                def _step(carry, site_i):
+                    sigma, cache, k, logp = carry
+                    k, k_draw = jax.random.split(k)
+                    p, mutables = model.apply(
+                        _with_cache(variables_no_cache, cache),
+                        sigma,
+                        site_i,
+                        method=model.conditional,
+                        mutable=["cache"],
+                    )
+                    cache = mutables.get("cache", None)
+                    new_col, new_p = nkjax.batch_choice(
+                        k_draw, local_states, p, return_prob=True
+                    )
+                    logp = logp + jnp.log(new_p).astype(logp.dtype)
+                    return (sigma.at[:, site_i].set(new_col), cache, k, logp), None
+
+                sigma0 = jnp.zeros((total, n_sites), dtype=self.dtype)
+                (sigma, _, key_out, logp), _ = jax.lax.scan(
+                    _step, (sigma0, cache0, key, logp0), site_order
+                )
+                return sigma, logp, key_out
+
+            # Accumulators for accepted rows across rejection attempts.
+            accepted0 = jnp.zeros((self.n_batches, chain_length), dtype=jnp.bool_)
+            sigma_acc0 = jnp.zeros(
+                (self.n_batches, chain_length, n_sites), dtype=self.dtype
+            )
+            logp_acc0 = jnp.zeros(
+                (self.n_batches, chain_length), dtype=_log_prob_dtype()
+            )
+
+            def cond_fn(carry):
+                # Keep iterating until all rows accepted or attempts exhausted.
+                i, _k, accepted, _s, _lp = carry
+                return (i < self.max_resampling_attempts) & (~jnp.all(accepted))
+
+            def body_fn(carry):
+                # Propose a full fresh batch and fill unresolved accepted rows.
+                i, k, accepted, sigma_acc, logp_acc = carry
+                k, k_use = jax.random.split(k)
+                sigma_new, logp_new, k_next = _one_ar_pass(k_use)
+                valid = check_fn(sigma_new).reshape(self.n_batches, chain_length)
+                take = (~accepted) & valid
+                sigma_new_r = sigma_new.reshape(self.n_batches, chain_length, n_sites)
+                logp_new_r = logp_new.reshape(self.n_batches, chain_length)
+                sigma_acc = jnp.where(take[:, :, None], sigma_new_r, sigma_acc)
+                logp_acc = jnp.where(take, logp_new_r, logp_acc)
+                return i + 1, k_next, accepted | valid, sigma_acc, logp_acc
+
+            # Device-side rejection loop.
+            _, key_out, accepted, sigma_acc, logp_acc = jax.lax.while_loop(
+                cond_fn,
+                body_fn,
+                (
+                    jnp.zeros((), dtype=jnp.int32),
+                    key_ar,
+                    accepted0,
+                    sigma_acc0,
+                    logp_acc0,
+                ),
+            )
+        else:
+            # Same proposal path without log-probability accumulation.
+            def _one_ar_pass(key):
+                def _step(carry, site_i):
+                    sigma, cache, k = carry
+                    k, k_draw = jax.random.split(k)
+                    p, mutables = model.apply(
+                        _with_cache(variables_no_cache, cache),
+                        sigma,
+                        site_i,
+                        method=model.conditional,
+                        mutable=["cache"],
+                    )
+                    cache = mutables.get("cache", None)
+                    new_col = nkjax.batch_choice(k_draw, local_states, p)
+                    return (sigma.at[:, site_i].set(new_col), cache, k), None
+
+                sigma0 = jnp.zeros((total, n_sites), dtype=self.dtype)
+                (sigma, _, key_out), _ = jax.lax.scan(
+                    _step, (sigma0, cache0, key), site_order
+                )
+                return sigma, key_out
+
+            # Accumulators for accepted rows across rejection attempts.
+            accepted0 = jnp.zeros((self.n_batches, chain_length), dtype=jnp.bool_)
+            sigma_acc0 = jnp.zeros(
+                (self.n_batches, chain_length, n_sites), dtype=self.dtype
+            )
+
+            def cond_fn(carry):
+                # Keep iterating until all rows accepted or attempts exhausted.
+                i, _k, accepted, _s = carry
+                return (i < self.max_resampling_attempts) & (~jnp.all(accepted))
+
+            def body_fn(carry):
+                # Propose a full fresh batch and fill unresolved accepted rows.
+                i, k, accepted, sigma_acc = carry
+                k, k_use = jax.random.split(k)
+                sigma_new, k_next = _one_ar_pass(k_use)
+                valid = check_fn(sigma_new).reshape(self.n_batches, chain_length)
+                take = (~accepted) & valid
+                sigma_new_r = sigma_new.reshape(self.n_batches, chain_length, n_sites)
+                sigma_acc = jnp.where(take[:, :, None], sigma_new_r, sigma_acc)
+                return i + 1, k_next, accepted | valid, sigma_acc
+
+            _, key_out, accepted, sigma_acc = jax.lax.while_loop(
+                cond_fn,
+                body_fn,
+                (
+                    jnp.zeros((), dtype=jnp.int32),
+                    key_ar,
+                    accepted0,
+                    sigma_acc0,
+                ),
+            )
+            logp_acc = None  # type: ignore[assignment]
+
+        # Emit updated sampler key and aggregate acceptance flag.
+        new_state = state.replace(key=key_out)
+        all_accepted = jnp.all(accepted)
+
+        if return_log_probabilities:
+            return (sigma_acc, logp_acc), new_state, all_accepted
+        return sigma_acc, new_state, all_accepted
+
+
+def ARDirectSampler(
+    hilbert,
+    machine_pow=None,
+    dtype=None,
+    *,
+    max_resampling_attempts: int = 4096,
+):
+    r"""
+    Direct sampler for autoregressive neural networks on unconstrained and constrained Hilbert spaces.
+
+    This sampler expects a Flax model exposing ``model.conditional``. Given a
+    batch of partial samples and a site index ``i``, ``model.conditional`` must
+    return the conditional distribution over local states at ``i``.
+
+    In short, for a model factorization
+
+    .. math::
+
+        p(x) = p_1(x_1) p_2(x_2|x_1) \dots p_N(x_N|x_{N-1}, \dots, x_1),
+
+    ``model.conditional(x, i)`` should return :math:`p_i(x)`.
+
+
+    This sampler supports both unconstrained and constrained spaces.
+
+    - For unconstrained Hilbert spaces, sampling is exact autoregressive direct
+      sampling with no rejection.
+    - For :class:`~netket.hilbert.constraint.SumConstraint` and
+      :class:`~netket.hilbert.constraint.SumOnPartitionConstraint` with uniformly
+      spaced local states, sampling uses exact prefix-feasibility masking and
+      deterministic dependent-site closure (zero rejection).
+    - For generic callable constraints ``(B, N) -> (B,) bool`` (e.g. custom constraints
+      which subclass :class:`~netket.hilbert.constraint.DiscreteHilbertConstraint`),
+      sampling uses a JAX-compiled rejection loop. This remains exact but will be slower when
+      acceptance rates are low.
+
+    Args:
+        hilbert: The Hilbert space to sample.
+        machine_pow: Optional model power argument for unconstrained usage.
+            Constrained samplers internally use ``machine_pow=2`` semantics.
+        dtype: The dtype of sampled states.
+        max_resampling_attempts: Maximum number of proposal rounds used by the
+            generic rejection path.
+
+    Returns:
+        A sampler instance compatible with the provided Hilbert space and
+        constraint type.
+    """
+
+    # Unconstrained spaces use the legacy ARDirectSampler directly.
+    if not getattr(hilbert, "constrained", False):
+        if machine_pow is None:
+            return UnconstrainedARDirectSampler(hilbert=hilbert, dtype=dtype)
+        return UnconstrainedARDirectSampler(
+            hilbert=hilbert, machine_pow=machine_pow, dtype=dtype
+        )
+
+    # Build a static plan once and dispatch to the matching concrete sampler.
+    plan = _build_plan(hilbert)
+    kind = plan[0]
+
+    if kind == _SUM_PREFIX:
+        # SumConstraint path.
+        _, payload = plan
+        return SumConstrainedARDirectSampler(
+            hilbert=hilbert,
+            payload=payload,
+            dtype=dtype,
+            max_resampling_attempts=max_resampling_attempts,
+        )
+
+    if kind == _PARTITION_PREFIX:
+        # SumOnPartitionConstraint path.
+        _, payload = plan
+        return PartitionConstrainedARDirectSampler(
+            hilbert=hilbert,
+            payload=payload,
+            dtype=dtype,
+            max_resampling_attempts=max_resampling_attempts,
+        )
+
+    if kind == _REJECTION:
+        # Generic callable-constraint rejection path.
+        _, check_fn = plan
+        return GenericConstrainedARDirectSampler(
+            hilbert=hilbert,
+            check_fn=check_fn,
+            dtype=dtype,
+            max_resampling_attempts=max_resampling_attempts,
+        )
+
+    raise RuntimeError(f"Unknown autoregressive sampler plan kind: {kind}")

--- a/test/models/test_autoreg.py
+++ b/test/models/test_autoreg.py
@@ -450,3 +450,407 @@ def test_construct_rnn():
             inv_reorder_idx=inv_reorder_idx,
             prev_neighbors=HashableArray(np.array([[1, -1], [0, -1], [0, 3], [1, -1]])),
         )
+
+
+#
+# Constrained autoregressive model tests
+
+
+def _get_constrained_arnn_cls_or_skip(name: str):
+    if not hasattr(nk.models, name):
+        pytest.skip(f"nk.models.{name} is required by constrained ARNN tests.")
+    return getattr(nk.models, name)
+
+
+def _build_supported_constrained_hilbert(kind: str):
+    if kind == "sum":
+        return nk.hilbert.Spin(
+            s=0.5,
+            N=6,
+            constraint=nk.hilbert.constraint.SumConstraint(0),
+        )
+    if kind == "partition":
+        return nk.hilbert.Spin(
+            s=0.5,
+            N=8,
+            constraint=nk.hilbert.constraint.SumOnPartitionConstraint(
+                sum_values=(0, 0),
+                sizes=(4, 4),
+            ),
+        )
+    raise ValueError(f"Unknown constrained Hilbert kind: {kind}")
+
+
+@pytest.mark.parametrize(
+    "model_name", ["ConstrainedARNNDense", "ConstrainedFastARNNDense"]
+)
+@pytest.mark.parametrize("constraint_kind", ["sum", "partition"])
+@pytest.mark.parametrize("machine_pow", [1, 2])
+def test_constrained_arnn_logpsi_matches_conditionals(
+    model_name, constraint_kind, machine_pow
+):
+    model_cls = _get_constrained_arnn_cls_or_skip(model_name)
+    hilbert = _build_supported_constrained_hilbert(constraint_kind)
+
+    model = model_cls(
+        hilbert=hilbert,
+        layers=2,
+        features=6,
+        machine_pow=machine_pow,
+        param_dtype=jnp.float64,
+    )
+
+    states = jnp.asarray(hilbert.all_states())
+    variables = model.init(jax.random.PRNGKey(0), states[:1])
+
+    conds = model.apply(variables, states, method=model.conditionals)
+    np.testing.assert_allclose(
+        np.asarray(jnp.sum(conds, axis=-1)),
+        1.0,
+        atol=1e-12,
+        rtol=1e-12,
+    )
+
+    idx = hilbert.states_to_local_indices(states)
+    p_selected = jnp.take_along_axis(conds, idx[..., None], axis=-1)[..., 0]
+    log_prob_from_conditionals = jnp.sum(jnp.log(p_selected), axis=-1)
+
+    log_psi = model.apply(variables, states)
+    log_prob_from_model = machine_pow * jnp.real(log_psi)
+
+    np.testing.assert_allclose(
+        np.asarray(log_prob_from_model),
+        np.asarray(log_prob_from_conditionals),
+        atol=1e-10,
+        rtol=1e-10,
+    )
+
+
+@pytest.mark.parametrize("constraint_kind", ["sum", "partition"])
+@pytest.mark.parametrize("machine_pow", [1, 2])
+def test_constrained_dense_and_fast_match(constraint_kind, machine_pow):
+    dense_cls = _get_constrained_arnn_cls_or_skip("ConstrainedARNNDense")
+    fast_cls = _get_constrained_arnn_cls_or_skip("ConstrainedFastARNNDense")
+    hilbert = _build_supported_constrained_hilbert(constraint_kind)
+
+    dense = dense_cls(
+        hilbert=hilbert,
+        layers=3,
+        features=5,
+        machine_pow=machine_pow,
+        param_dtype=jnp.float64,
+    )
+    fast = fast_cls(
+        hilbert=hilbert,
+        layers=3,
+        features=5,
+        machine_pow=machine_pow,
+        param_dtype=jnp.float64,
+    )
+
+    key_spins, key_model = jax.random.split(jax.random.PRNGKey(11))
+    spins = hilbert.random_state(key_spins, size=5)
+
+    variables = fast.init(key_model, spins, 0, method=fast.conditional)
+
+    p_dense = dense.apply(variables, spins, method=dense.conditionals)
+    p_fast = fast.apply(variables, spins, method=fast.conditionals)
+    np.testing.assert_allclose(
+        np.asarray(p_fast), np.asarray(p_dense), atol=1e-10, rtol=1e-10
+    )
+
+    logpsi_dense = dense.apply(variables, spins)
+    logpsi_fast = fast.apply(variables, spins)
+    np.testing.assert_allclose(
+        np.asarray(logpsi_fast),
+        np.asarray(logpsi_dense),
+        atol=1e-10,
+        rtol=1e-10,
+    )
+
+
+@pytest.mark.parametrize(
+    "model_name", ["ConstrainedARNNDense", "ConstrainedFastARNNDense"]
+)
+@pytest.mark.parametrize("constraint_kind", ["sum", "partition"])
+def test_constrained_arnn_slave_sites_are_deterministic(model_name, constraint_kind):
+    model_cls = _get_constrained_arnn_cls_or_skip(model_name)
+    hilbert = _build_supported_constrained_hilbert(constraint_kind)
+
+    model = model_cls(
+        hilbert=hilbert,
+        layers=2,
+        features=6,
+        machine_pow=2,
+        param_dtype=jnp.float64,
+    )
+    states = jnp.asarray(hilbert.all_states())
+    variables = model.init(jax.random.PRNGKey(7), states[:1])
+    conds = model.apply(variables, states, method=model.conditionals)
+
+    if constraint_kind == "sum":
+        slave_sites = [hilbert.size - 1]
+    else:
+        sizes = tuple(int(v) for v in hilbert.constraint.sizes)
+        slave_sites = list(np.cumsum(sizes) - 1)
+
+    for slave_site in slave_sites:
+        p_site = conds[:, slave_site, :]
+        np.testing.assert_allclose(
+            np.asarray(jnp.sum(p_site, axis=-1)),
+            1.0,
+            atol=1e-12,
+            rtol=1e-12,
+        )
+
+        # Dependent-site closure must produce one exact local value per prefix.
+        n_nonzero = np.sum(np.asarray(p_site) > 1.0e-12, axis=-1)
+        assert np.all(n_nonzero == 1)
+
+
+@pytest.mark.parametrize(
+    "model_name", ["ConstrainedARNNDense", "ConstrainedFastARNNDense"]
+)
+def test_constrained_arnn_raises_on_unsupported_constraint(model_name):
+    model_cls = _get_constrained_arnn_cls_or_skip(model_name)
+
+    class PairBalanceConstraint(nk.hilbert.constraint.DiscreteHilbertConstraint):
+        @jax.jit
+        def __call__(self, x):
+            return jnp.sum(x[..., ::2], axis=-1) == jnp.sum(x[..., 1::2], axis=-1)
+
+        def __hash__(self):
+            return hash("PairBalanceConstraint")
+
+        def __eq__(self, other):
+            return isinstance(other, PairBalanceConstraint)
+
+    hilbert = nk.hilbert.Spin(s=0.5, N=6, constraint=PairBalanceConstraint())
+
+    with pytest.raises(ValueError, match="support only"):
+        model_cls(hilbert=hilbert, layers=2, features=6, machine_pow=2)
+
+
+#
+# Constrained convolutional autoregressive model tests
+
+
+def _is_conv2d_model_name(model_name: str) -> bool:
+    return "Conv2D" in model_name
+
+
+def _build_supported_constrained_hilbert_for_conv(
+    constraint_kind: str, model_name: str
+):
+    # 2D convolutions require a square number of sites.
+    if _is_conv2d_model_name(model_name):
+        if constraint_kind == "sum":
+            return nk.hilbert.Spin(
+                s=0.5,
+                N=4,
+                constraint=nk.hilbert.constraint.SumConstraint(0),
+            )
+        if constraint_kind == "partition":
+            return nk.hilbert.Spin(
+                s=0.5,
+                N=4,
+                constraint=nk.hilbert.constraint.SumOnPartitionConstraint(
+                    sum_values=(0, 0),
+                    sizes=(2, 2),
+                ),
+            )
+        raise ValueError(f"Unknown constrained Hilbert kind: {constraint_kind}")
+
+    if constraint_kind == "sum":
+        return nk.hilbert.Spin(
+            s=0.5,
+            N=8,
+            constraint=nk.hilbert.constraint.SumConstraint(0),
+        )
+    if constraint_kind == "partition":
+        return nk.hilbert.Spin(
+            s=0.5,
+            N=8,
+            constraint=nk.hilbert.constraint.SumOnPartitionConstraint(
+                sum_values=(0, 0),
+                sizes=(4, 4),
+            ),
+        )
+    raise ValueError(f"Unknown constrained Hilbert kind: {constraint_kind}")
+
+
+def _build_constrained_conv_model(model_name: str, hilbert, machine_pow: int):
+    model_cls = _get_constrained_arnn_cls_or_skip(model_name)
+    kwargs = dict(
+        hilbert=hilbert,
+        layers=2,
+        features=6,
+        machine_pow=machine_pow,
+        param_dtype=jnp.float64,
+    )
+    if _is_conv2d_model_name(model_name):
+        kwargs["kernel_size"] = (2, 2)
+    else:
+        kwargs["kernel_size"] = 2
+    return model_cls(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "ConstrainedARNNConv1D",
+        "ConstrainedFastARNNConv1D",
+        "ConstrainedARNNConv2D",
+        "ConstrainedFastARNNConv2D",
+    ],
+)
+@pytest.mark.parametrize("constraint_kind", ["sum", "partition"])
+@pytest.mark.parametrize("machine_pow", [1, 2])
+def test_constrained_conv_logpsi_matches_conditionals(
+    model_name, constraint_kind, machine_pow
+):
+    hilbert = _build_supported_constrained_hilbert_for_conv(constraint_kind, model_name)
+    model = _build_constrained_conv_model(model_name, hilbert, machine_pow)
+
+    states = jnp.asarray(hilbert.all_states())
+    variables = model.init(jax.random.PRNGKey(101), states[:1])
+
+    conds = model.apply(variables, states, method=model.conditionals)
+    np.testing.assert_allclose(
+        np.asarray(jnp.sum(conds, axis=-1)),
+        1.0,
+        atol=1e-12,
+        rtol=1e-12,
+    )
+
+    idx = hilbert.states_to_local_indices(states)
+    p_selected = jnp.take_along_axis(conds, idx[..., None], axis=-1)[..., 0]
+    log_prob_from_conditionals = jnp.sum(jnp.log(p_selected), axis=-1)
+
+    log_psi = model.apply(variables, states)
+    log_prob_from_model = machine_pow * jnp.real(log_psi)
+
+    np.testing.assert_allclose(
+        np.asarray(log_prob_from_model),
+        np.asarray(log_prob_from_conditionals),
+        atol=1e-10,
+        rtol=1e-10,
+    )
+
+
+@pytest.mark.parametrize("constraint_kind", ["sum", "partition"])
+@pytest.mark.parametrize("machine_pow", [1, 2])
+@pytest.mark.parametrize(
+    "dense_name, fast_name",
+    [
+        ("ConstrainedARNNConv1D", "ConstrainedFastARNNConv1D"),
+        ("ConstrainedARNNConv2D", "ConstrainedFastARNNConv2D"),
+    ],
+)
+def test_constrained_conv_dense_fast_match(
+    constraint_kind, machine_pow, dense_name, fast_name
+):
+    hilbert = _build_supported_constrained_hilbert_for_conv(constraint_kind, dense_name)
+    dense = _build_constrained_conv_model(dense_name, hilbert, machine_pow)
+    fast = _build_constrained_conv_model(fast_name, hilbert, machine_pow)
+
+    key_spins, key_model = jax.random.split(jax.random.PRNGKey(137))
+    spins = hilbert.random_state(key_spins, size=4)
+
+    variables = fast.init(key_model, spins, 0, method=fast.conditional)
+
+    p_dense = dense.apply(variables, spins, method=dense.conditionals)
+    p_fast = fast.apply(variables, spins, method=fast.conditionals)
+    np.testing.assert_allclose(
+        np.asarray(p_fast),
+        np.asarray(p_dense),
+        atol=1e-10,
+        rtol=1e-10,
+    )
+
+    logpsi_dense = dense.apply(variables, spins)
+    logpsi_fast = fast.apply(variables, spins)
+    np.testing.assert_allclose(
+        np.asarray(logpsi_fast),
+        np.asarray(logpsi_dense),
+        atol=1e-10,
+        rtol=1e-10,
+    )
+
+
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "ConstrainedARNNConv1D",
+        "ConstrainedFastARNNConv1D",
+        "ConstrainedARNNConv2D",
+        "ConstrainedFastARNNConv2D",
+    ],
+)
+@pytest.mark.parametrize("constraint_kind", ["sum", "partition"])
+def test_constrained_conv_slave_sites_are_deterministic(model_name, constraint_kind):
+    hilbert = _build_supported_constrained_hilbert_for_conv(constraint_kind, model_name)
+    model = _build_constrained_conv_model(model_name, hilbert, machine_pow=2)
+
+    states = jnp.asarray(hilbert.all_states())
+    variables = model.init(jax.random.PRNGKey(149), states[:1])
+    conds = model.apply(variables, states, method=model.conditionals)
+
+    if constraint_kind == "sum":
+        slave_sites = [hilbert.size - 1]
+    else:
+        sizes = tuple(int(v) for v in hilbert.constraint.sizes)
+        slave_sites = list(np.cumsum(sizes) - 1)
+
+    for slave_site in slave_sites:
+        p_site = conds[:, slave_site, :]
+        np.testing.assert_allclose(
+            np.asarray(jnp.sum(p_site, axis=-1)),
+            1.0,
+            atol=1e-12,
+            rtol=1e-12,
+        )
+
+        n_nonzero = np.sum(np.asarray(p_site) > 1.0e-12, axis=-1)
+        assert np.all(n_nonzero == 1)
+
+
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "ConstrainedARNNConv1D",
+        "ConstrainedFastARNNConv1D",
+        "ConstrainedARNNConv2D",
+        "ConstrainedFastARNNConv2D",
+    ],
+)
+def test_constrained_conv_raises_on_unsupported_constraint(model_name):
+    model_cls = _get_constrained_arnn_cls_or_skip(model_name)
+
+    class PairBalanceConstraint(nk.hilbert.constraint.DiscreteHilbertConstraint):
+        @jax.jit
+        def __call__(self, x):
+            return jnp.sum(x[..., ::2], axis=-1) == jnp.sum(x[..., 1::2], axis=-1)
+
+        def __hash__(self):
+            return hash("PairBalanceConstraint")
+
+        def __eq__(self, other):
+            return isinstance(other, PairBalanceConstraint)
+
+    hilbert = nk.hilbert.Spin(s=0.5, N=8, constraint=PairBalanceConstraint())
+
+    kwargs = dict(
+        hilbert=hilbert,
+        layers=2,
+        features=6,
+        machine_pow=2,
+        param_dtype=jnp.float64,
+    )
+    if _is_conv2d_model_name(model_name):
+        kwargs["kernel_size"] = (2, 2)
+    else:
+        kwargs["kernel_size"] = 2
+
+    with pytest.raises(ValueError, match="support only"):
+        model_cls(**kwargs)

--- a/test/sampler/test_pt.py
+++ b/test/sampler/test_pt.py
@@ -154,7 +154,7 @@ def test_sampler_statistics():
 @pytest.fixture
 def model_and_weights(request):
     def build_model(hilb, sampler=None):
-        if isinstance(sampler, nk.sampler.ARDirectSampler):
+        if isinstance(sampler, nk.sampler.UnconstrainedARDirectSampler):
             ma = nk.models.ARNNDense(
                 hilbert=hilb, machine_pow=sampler.machine_pow, layers=3, features=5
             )

--- a/test/sampler/test_sampler.py
+++ b/test/sampler/test_sampler.py
@@ -199,7 +199,7 @@ if not config.netket_experimental_sharding:
 @pytest.fixture
 def model_and_weights(request):
     def build_model(hilb, sampler=None):
-        if isinstance(sampler, nk.sampler.ARDirectSampler):
+        if isinstance(sampler, nk.sampler.UnconstrainedARDirectSampler):
             ma = nk.models.ARNNDense(
                 hilbert=hilb, machine_pow=sampler.machine_pow, layers=3, features=5
             )
@@ -218,9 +218,9 @@ def model_and_weights(request):
         w = ma.init(jax.random.PRNGKey(WEIGHT_SEED), jnp.zeros((1, hilb.size)))
 
         # Create more featureful weights for better convergence testing
-        if not isinstance(sampler, nk.sampler.ARDirectSampler) and not isinstance(
-            hilb, Particle
-        ):
+        if not isinstance(
+            sampler, nk.sampler.UnconstrainedARDirectSampler
+        ) and not isinstance(hilb, Particle):
             # Create structured weights that lead to a more peaked distribution
             # This creates correlations between spins and non-trivial structure
             key = jax.random.PRNGKey(WEIGHT_SEED + 1)
@@ -305,7 +305,10 @@ def set_pdf_power(request):
         elif int(cmdline_mpow) != request.param:
             pytest.skip(f"Running only --mpow={cmdline_mpow}.")
 
-        if isinstance(sampler, nk.sampler.ARDirectSampler) and request.param != 2:
+        if (
+            isinstance(sampler, nk.sampler.UnconstrainedARDirectSampler)
+            and request.param != 2
+        ):
             pytest.skip("ARDirectSampler only supports machine_pow = 2.")
 
         return sampler.replace(machine_pow=request.param)
@@ -673,7 +676,10 @@ def test_setup_throwing_multiplerules():
 
 @common.skipif_distributed
 def test_exact_sampler(sampler):
-    known_exact_samplers = (nk.sampler.ExactSampler, nk.sampler.ARDirectSampler)
+    known_exact_samplers = (
+        nk.sampler.ExactSampler,
+        nk.sampler.UnconstrainedARDirectSampler,
+    )
     if isinstance(sampler, known_exact_samplers):
         assert sampler.is_exact is True
         assert sampler.n_chains_per_rank == 1
@@ -813,3 +819,167 @@ def test_chunking_invariant(model_and_weights, sampler_type):
     )
 
     np.testing.assert_allclose(samples, samples_ch)
+
+
+class PairBalanceConstraint(nk.hilbert.constraint.DiscreteHilbertConstraint):
+    """Generic custom constraint used to test the rejection-based constrained AR path."""
+
+    @jax.jit
+    def __call__(self, x):
+        return jnp.sum(x[..., ::2], axis=-1) == jnp.sum(x[..., 1::2], axis=-1)
+
+    def __hash__(self):
+        return hash("PairBalanceConstraint")
+
+    def __eq__(self, other):
+        return isinstance(other, PairBalanceConstraint)
+
+
+def _build_constrained_case(case: str):
+    if case == "sum":
+        hi = nk.hilbert.Spin(
+            s=0.5, N=8, constraint=nk.hilbert.constraint.SumConstraint(0)
+        )
+        model_name = "ConstrainedARNNDense"
+    elif case == "sum_fast":
+        hi = nk.hilbert.Spin(
+            s=0.5, N=8, constraint=nk.hilbert.constraint.SumConstraint(0)
+        )
+        model_name = "ConstrainedFastARNNDense"
+    elif case == "partition":
+        hi = nk.hilbert.Spin(
+            s=0.5,
+            N=8,
+            constraint=nk.hilbert.constraint.SumOnPartitionConstraint(
+                sum_values=(0, 0), sizes=(4, 4)
+            ),
+        )
+        model_name = "ConstrainedARNNDense"
+    elif case == "generic":
+        hi = nk.hilbert.Spin(s=0.5, N=8, constraint=PairBalanceConstraint())
+        # For generic constraints we intentionally keep using regular ARNN.
+        model_name = "ARNNDense"
+    else:
+        raise ValueError(f"Unknown constrained test case: {case}")
+    return hi, model_name
+
+
+def _build_ard_model(hilb, model_name: str):
+    if not hasattr(nk.models, model_name):
+        pytest.skip(
+            f"Model nk.models.{model_name} is required by constrained AR sampler tests."
+        )
+    model_cls = getattr(nk.models, model_name)
+    return model_cls(hilbert=hilb, machine_pow=2, layers=3, features=5)
+
+
+def _make_constrained_sampler_or_skip(hilb):
+    try:
+        return nk.sampler.ARDirectSampler(hilb)
+    except Exception as exc:
+        pytest.skip(
+            "Constrained ARDirectSampler support is required for this test "
+            f"(got: {type(exc).__name__}: {exc})."
+        )
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        pytest.param("sum", id="sum"),
+        pytest.param("sum_fast", id="sum-fast"),
+        pytest.param("partition", id="partition"),
+        pytest.param("generic", id="generic"),
+    ],
+)
+@common.skipif_distributed
+def test_constrained_ardirect_states_in_hilbert(case):
+    hi, model_name = _build_constrained_case(case)
+    sa = _make_constrained_sampler_or_skip(hi)
+    ma = _build_ard_model(hi, model_name)
+    w = ma.init(jax.random.PRNGKey(WEIGHT_SEED), jnp.zeros((1, hi.size)))
+
+    samples, _ = sa.sample(ma, w, chain_length=64)
+    assert samples.shape == (sa.n_chains, 64, hi.size)
+
+    valid = hi.constraint(np.asarray(samples).reshape(-1, hi.size))
+    assert bool(np.all(np.asarray(valid)))
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        pytest.param("sum", id="sum"),
+        pytest.param("sum_fast", id="sum-fast"),
+        pytest.param("partition", id="partition"),
+        pytest.param("generic", id="generic"),
+    ],
+)
+@common.skipif_distributed
+def test_constrained_ardirect_return_log_probabilities(case):
+    hi, model_name = _build_constrained_case(case)
+    sa = _make_constrained_sampler_or_skip(hi)
+    ma = _build_ard_model(hi, model_name)
+    w = ma.init(jax.random.PRNGKey(WEIGHT_SEED), jnp.zeros((1, hi.size)))
+
+    (samples, log_probs), _ = sa.sample(
+        ma, w, chain_length=4, return_log_probabilities=True
+    )
+
+    log_probs_computed = jax.vmap(ma.apply, in_axes=(None, 0))(w, samples)
+    log_probs_computed = sa.machine_pow * log_probs_computed.real
+
+    assert log_probs.shape == samples.shape[:-1]
+    np.testing.assert_allclose(log_probs, log_probs_computed)
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        pytest.param("sum", id="sum"),
+        pytest.param("sum_fast", id="sum-fast"),
+        pytest.param("partition", id="partition"),
+        pytest.param("generic", id="generic"),
+    ],
+)
+@common.skipif_distributed
+def test_constrained_ardirect_correct_sampling(case):
+    """
+    Distribution-level correctness test for constrained autoregressive sampling (repeated
+    chi-square tests + Fisher combination of p-values).
+    """
+    hi, model_name = _build_constrained_case(case)
+    sa = _make_constrained_sampler_or_skip(hi)
+    ma = _build_ard_model(hi, model_name)
+    w = ma.init(jax.random.PRNGKey(WEIGHT_SEED), jnp.zeros((1, hi.size)))
+
+    n_states = hi.n_states
+    n_samples = max(40 * n_states, 100)
+
+    ps = np.absolute(nk.nn.to_array(hi, ma, w, normalize=False)) ** sa.machine_pow
+    ps /= ps.sum()
+
+    n_rep = 6
+    pvalues = np.zeros(n_rep)
+
+    sampler_state = sa.init_state(ma, w, seed=SAMPLER_SEED)
+    for jrep in range(n_rep):
+        sampler_state = sa.reset(ma, w, state=sampler_state)
+        samples, sampler_state = sa.sample(
+            ma, w, state=sampler_state, chain_length=n_samples
+        )
+        assert samples.shape == (sa.n_chains, n_samples, hi.size)
+
+        sttn = hi.states_to_numbers(np.asarray(samples.reshape(-1, hi.size)))
+        n_s = sttn.size
+
+        unique, counts = np.unique(sttn, return_counts=True)
+        hist_samp = np.zeros(n_states)
+        hist_samp[unique] = counts
+
+        f_exp = n_s * ps
+        f_exp = f_exp * (n_s / np.sum(f_exp))
+        _, pvalues[jrep] = chisquare(hist_samp, f_exp=f_exp)
+
+    _, pval = combine_pvalues(pvalues, method="fisher")
+    assert pval > 0.01 or np.max(pvalues) > 0.01


### PR DESCRIPTION
# Summary

This PR adds exact constrained autoregressive support for Hilbert spaces with `SumConstraint` and `SumOnPartitionConstraint` and a generic callable-constraint fallback. It also adds constrained autoregressive model variants (dense and convolutional, fast and non-fast) plus added tests for correctness and distributional behaviour.

# Motivation

The current AR sampler targets unconstrained spaces. For constrained sectors, users had to rely on alternative samplers. This PR introduces a unified constrained AR path that is:
- exact for native NetKet sum constraints via prefix-feasibility masking,
- generic for custom constraints via compiled rejection fallback,
- consistent with constrained model log-prob semantics.

# Implementation details

1. Added constrained sampler architecture in `netket/sampler/autoreg.py`:
   - `ConstrainedARDirectSampler` base for all constrained AR samplers
   - `SumConstrainedARDirectSampler` (exact prefix mask, deterministic closure) for NetKet's `SumConstraint`.
   - `PartitionConstrainedARDirectSampler` (partition-wise exact prefix mask, deterministic closure) for NetKet's `SumOnPartitionConstraint`.
   - `GenericConstrainedARDirectSampler`, using a compiled rejection-based sampling fallback, for custom constraints inheriting from `DiscreteHilbertConstraint` for example, **which will be slow** especially compared to the above.
   - Rename existing `ARDirectSampler` to `UnconstrainedARDirectSampler`
   - Create a `ARDirectSampler` function which dispatches to the correct sampler based on the Hilbert space (constrained or not, type of constraint).

2. Added constrained model implementations for autoregressive NNs in `netket/models/constrained_autoreg.py` to enforce feasibility at conditional level and keep `conditionals`, `conditional` and `__call__` probabilistically consistent with the constrained AR samplers. Those are:
   - `ConstrainedARNNDense`
   - `ConstrainedFastARNNDense`
   - `ConstrainedARNNConv1D`
   - `ConstrainedFastARNN1D`
   - `ConstrainedARNNConv2D`
   - `ConstrainedFastARNNConv2D`


# Tests

Added targeted constrained tests in sampler (`tests/sampler/test_sampler.py`) and model (`tests/models/test_autoreg.py`):

1. Sampler tests:
   - Constrained state validity
   - `return_log_probabilities` consistency
   - distribution goodness of fit vs. exact reference for the constrained samplers.

2. Model tests:
   - logpsi/conditional consistency.
   - dense vs. flat parity.
   - deterministic dependent-site closure.
   - unsupported constraint error behavior.
   - same set for constrained convolutional variants.

## Note:
Some minor edits in test files have been made to refer to `UnconstrainedARDirectSampler` (previously `ARDirectSampler`) in `isinstance(...)` checks for example. 

# Notes

- Fast exact zero-rejection constrained sampling is provided for native NetKet sum constraints with uniformly spaced local states.
- Generic constraints remain exact via rejection fallback, with throughput depending on acceptance rate. **This will be slow**, especially compared to the zero-rejection constrained sampling.
- There are a lot of "helper" functions in the files, but I did not know how you want to organize them and I did not want to change the package structure based on my discretion. 
- The `Constrained*` ARNN models are meant to be used with AR samplers with Hilbert spaces which have `SumConstraint` or `SumOnPartitionConstraint` because if not, the model conditionals and sampler distribution won't be aligned. 
- For generic callable constraints, use a regular AR model with the rejection fallback AR sampler, the constrained ARNNs intentionally raise on unsupported constraints because the encode the sum/partition feasibility logic.