### PR TITLE
Allow different probabilities for different moves in `ExchangeRule`

### DIFF
--- a/netket/sampler/metropolis.py
+++ b/netket/sampler/metropolis.py
@@ -571,7 +571,7 @@ def MetropolisLocal(hilbert, **kwargs) -> MetropolisSampler:
 
 
 def MetropolisExchange(
-    hilbert, *, clusters=None, graph=None, d_max=1, **kwargs
+    hilbert, *, clusters=None, graph=None, d_max=1, probabilities=None, **kwargs
 ) -> MetropolisSampler:
     r"""
     This sampler acts locally only on two local degree of freedom :math:`s_i` and :math:`s_j`,
@@ -623,7 +623,16 @@ def MetropolisExchange(
 
     Args:
         hilbert: The Hilbert space to sample.
+        clusters: The list of clusters that can be exchanged. This should be
+            a list of 2-tuples containing two integers. Every tuple is an edge,
+            or cluster of sites to be exchanged.
+        graph: The graph for determining the clusters that can be exchanged.
+            Do not specify together with `clusters`.
         d_max: The maximum graph distance allowed for exchanges.
+            Only used if `graph` is specified.
+        probabilities: Relative probability of trying each cluster
+            (if `clusters` is given) or clusters with each graph distance
+            (if `graph` is given). Defaults to equal probability for all clusters.
         n_chains: The total number of independent Markov chains across all devices.
             Either specify this or `n_chains_per_rank`.
         n_chains_per_rank: Number of independent chains on every device (default = 16).
@@ -668,7 +677,9 @@ def MetropolisExchange(
                 stacklevel=2,
             )
 
-    rule = ExchangeRule(clusters=clusters, graph=graph, d_max=d_max)
+    rule = ExchangeRule(
+        clusters=clusters, graph=graph, d_max=d_max, probabilities=probabilities
+    )
     return MetropolisSampler(hilbert, rule, **kwargs)
 
 

--- a/netket/sampler/rules/exchange.py
+++ b/netket/sampler/rules/exchange.py
@@ -83,6 +83,11 @@ class ExchangeRule(MetropolisRule):
     The Exchange rule will swap the two sites of a random row of this
     matrix at every Metropolis step.
     """
+    probabilities: jax.Array
+    r"""1-Dimensional array :math:`p_{i}` of length :math:`N_\text{clusters}`
+    containing the relative probability of choosing each particular cluster
+    for the exchange update.
+    """
 
     def __init__(
         self,
@@ -90,6 +95,7 @@ class ExchangeRule(MetropolisRule):
         clusters: list[tuple[int, int]] | None = None,
         graph: AbstractGraph | None = None,
         d_max: int = 1,
+        probabilities: list[float] | None = None,
     ):
         r"""
         Constructs the Exchange Rule.
@@ -101,13 +107,20 @@ class ExchangeRule(MetropolisRule):
             clusters: The list of clusters that can be exchanged. This should be
                 a list of 2-tuples containing two integers. Every tuple is an edge,
                 or cluster of sites to be exchanged.
-            graph: A graph, from which the edges determine the clusters
-                that can be exchanged.
-            d_max: Only valid if a graph is passed in. The maximum distance
-                between two sites
+            graph: The graph for determining the clusters that can be exchanged.
+                Do not specify together with `clusters`.
+            d_max: The maximum graph distance allowed for exchanges.
+                Only used if `graph` is specified.
+            probabilities: Relative probability of trying each cluster
+                (if `clusters` is given) or clusters with each graph distance
+                (if `graph` is given). Defaults to equal probability for all clusters.
         """
+        if probabilities is not None:
+            probabilities = np.atleast_1d(probabilities)
+            if not np.all(probabilities > 0):
+                raise ValueError("Probabilities must be positive")
         if clusters is None and graph is not None:
-            clusters = compute_clusters(graph, d_max)
+            clusters, probabilities = compute_clusters(graph, d_max, probabilities)
         elif not (clusters is not None and graph is None):
             raise ValueError(
                 """You must either provide the list of exchange-clusters or a netket graph, from
@@ -115,6 +128,17 @@ class ExchangeRule(MetropolisRule):
             )
 
         self.clusters = jnp.array(clusters)
+
+        if probabilities is None:
+            self.probabilities = jnp.ones(len(clusters))
+        else:
+            if len(probabilities) != len(clusters):
+                # shouldn't get here if both are computed from graphs
+                raise TypeError(
+                    "Number of clusters and probabilities don't match: "
+                    f"{len(clusters)} != {len(probabilities)}"
+                )
+            self.probabilities = jnp.asarray(probabilities)
 
     def transition(rule, sampler, machine, parameters, state, key, σ):
         n_chains = σ.shape[0]
@@ -131,7 +155,7 @@ class ExchangeRule(MetropolisRule):
             cluster = jax.random.choice(
                 key,
                 a=jnp.arange(rule.clusters.shape[0]),
-                p=hoppable_clusters,
+                p=hoppable_clusters * rule.probabilities,
                 replace=True,
             )
 
@@ -156,26 +180,22 @@ class ExchangeRule(MetropolisRule):
         return f"ExchangeRule(# of clusters: {len(self.clusters)})"
 
 
-def compute_clusters(graph: AbstractGraph, d_max: int):
+def compute_clusters(graph: AbstractGraph, d_max: int, prob: np.ndarray):
     """
     Given a netket graph and a maximum distance, computes all clusters.
     If `d_max = 1` this is equivalent to taking the edges of the graph.
     Then adds next-nearest neighbors and so on.
     """
-    clusters = []
     distances = np.asarray(graph.distances())
-    size = distances.shape[0]
-    for i in range(size):
-        for j in range(i + 1, size):
-            if distances[i][j] <= d_max:
-                clusters.append((i, j))
+    clusters = np.argwhere(distances <= d_max)
+    # keep one copy of i != j clusters
+    clusters = clusters[clusters[:, 0] < clusters[:, 1]]
 
-    res_clusters = np.empty((len(clusters), 2), dtype=np.int64)
+    if prob is not None:
+        assert prob.shape == (d_max,), f"Expected {d_max = } probabilities, got {prob}"
+        prob = prob[distances[clusters[:, 0], clusters[:, 1]] - 1]
 
-    for i, cluster in enumerate(clusters):
-        res_clusters[i] = np.asarray(cluster)
-
-    return res_clusters
+    return clusters, prob
 
 
 @jax.jit

--- a/netket/sampler/rules/exchange.py
+++ b/netket/sampler/rules/exchange.py
@@ -151,7 +151,7 @@ class ExchangeRule(MetropolisRule):
         @jax.vmap
         def _update_samples(key, σ, hoppable_clusters):
             # pick a random cluster, taking into account the mask
-            n_conn = hoppable_clusters.sum(axis=-1)
+            n_conn = hoppable_clusters @ rule.probabilities
             cluster = jax.random.choice(
                 key,
                 a=jnp.arange(rule.clusters.shape[0]),
@@ -170,7 +170,7 @@ class ExchangeRule(MetropolisRule):
             hoppable_clusters_proposed = _compute_different_clusters_mask(
                 rule.clusters, σp
             )
-            n_conn_proposed = hoppable_clusters_proposed.sum(axis=-1)
+            n_conn_proposed = hoppable_clusters_proposed @ rule.probabilities
             log_prob_corr = jnp.log(n_conn) - jnp.log(n_conn_proposed)
             return σp, log_prob_corr
 

--- a/netket/sampler/rules/exchange.py
+++ b/netket/sampler/rules/exchange.py
@@ -148,16 +148,21 @@ class ExchangeRule(MetropolisRule):
 
         keys = jnp.asarray(jax.random.split(key, n_chains))
 
-        probs = jnp.ones(rule.clusters.shape[0]) if rule.probabilities is None else rule.probabilities
+        # when probabilities is None, mask itself is the (uniform) weight
+        def _weighted_mask(mask):
+            if rule.probabilities is None:
+                return mask
+            else:
+                return mask * rule.probabilities
 
         @jax.vmap
         def _update_samples(key, σ, hoppable_clusters):
             # pick a random cluster, taking into account the mask
-            n_conn = hoppable_clusters @ probs
+            p = _weighted_mask(hoppable_clusters)
             cluster = jax.random.choice(
                 key,
                 a=jnp.arange(rule.clusters.shape[0]),
-                p=hoppable_clusters * probs,
+                p=p,
                 replace=True,
             )
 
@@ -172,8 +177,8 @@ class ExchangeRule(MetropolisRule):
             hoppable_clusters_proposed = _compute_different_clusters_mask(
                 rule.clusters, σp
             )
-            n_conn_proposed = hoppable_clusters_proposed @ probs
-            log_prob_corr = jnp.log(n_conn) - jnp.log(n_conn_proposed)
+            p_proposed = _weighted_mask(hoppable_clusters_proposed)
+            log_prob_corr = jnp.log(p.sum()) - jnp.log(p_proposed.sum())
             return σp, log_prob_corr
 
         return _update_samples(keys, σ, hoppable_clusters)

--- a/netket/sampler/rules/exchange.py
+++ b/netket/sampler/rules/exchange.py
@@ -83,10 +83,10 @@ class ExchangeRule(MetropolisRule):
     The Exchange rule will swap the two sites of a random row of this
     matrix at every Metropolis step.
     """
-    probabilities: jax.Array
+    probabilities: jax.Array | None
     r"""1-Dimensional array :math:`p_{i}` of length :math:`N_\text{clusters}`
     containing the relative probability of choosing each particular cluster
-    for the exchange update.
+    for the exchange update. If None, all clusters are chosen with equal probability.
     """
 
     def __init__(
@@ -130,7 +130,7 @@ class ExchangeRule(MetropolisRule):
         self.clusters = jnp.array(clusters)
 
         if probabilities is None:
-            self.probabilities = jnp.ones(len(clusters))
+            self.probabilities = None
         else:
             if len(probabilities) != len(clusters):
                 # shouldn't get here if both are computed from graphs
@@ -148,14 +148,16 @@ class ExchangeRule(MetropolisRule):
 
         keys = jnp.asarray(jax.random.split(key, n_chains))
 
+        probs = jnp.ones(rule.clusters.shape[0]) if rule.probabilities is None else rule.probabilities
+
         @jax.vmap
         def _update_samples(key, σ, hoppable_clusters):
             # pick a random cluster, taking into account the mask
-            n_conn = hoppable_clusters @ rule.probabilities
+            n_conn = hoppable_clusters @ probs
             cluster = jax.random.choice(
                 key,
                 a=jnp.arange(rule.clusters.shape[0]),
-                p=hoppable_clusters * rule.probabilities,
+                p=hoppable_clusters * probs,
                 replace=True,
             )
 
@@ -170,7 +172,7 @@ class ExchangeRule(MetropolisRule):
             hoppable_clusters_proposed = _compute_different_clusters_mask(
                 rule.clusters, σp
             )
-            n_conn_proposed = hoppable_clusters_proposed @ rule.probabilities
+            n_conn_proposed = hoppable_clusters_proposed @ probs
             log_prob_corr = jnp.log(n_conn) - jnp.log(n_conn_proposed)
             return σp, log_prob_corr
 

--- a/test/sampler/test_sampler.py
+++ b/test/sampler/test_sampler.py
@@ -91,6 +91,9 @@ samplers["MetropolisPT(Local): Fock"] = nk.sampler.ParallelTemperingLocal(
 samplers["Metropolis(Exchange): Fock-1particle"] = nk.sampler.MetropolisExchange(
     hib, graph=g
 )
+samplers["Metropolis(Exchange, Prob): Fock-1particle"] = nk.sampler.MetropolisExchange(
+    hib, graph=g, d_max=2, probabilities=[1.0, 0.5]
+)
 
 if not config.netket_experimental_sharding:
     samplers["Metropolis(Hamiltonian,numba operator): Spin"] = (


### PR DESCRIPTION
There are situations where allowing further-range exchanges in Monte Carlo is useful, but you don't normally want to use all of them at the same probability. This PR is therefore to allow weighting the different proposals allowed by `ExchangeRule`

**Usage 1:** if `clusters` are specified manually, `probabilities` specifies the relative probability of proposing each one of them:
```python
sampler = nk.sampler.MetropolisExchange(hilbert, clusters=[(1,2),(2,3),(3,4)], probabilities=[1,2,3])
```

**Usage 2:** if `graph` and `d_max` are specified, `probabilities` specifies the relative probabilities of clusters with graph distance 1,2,...
```python
sampler = nk.sampler.MetropolisExchange(hilbert, graph=graph, d_max=2, probabilities=[1.0, 0.5])
```

**Miscellaneous improvements:**
* lowered the `compute_clusters` function to numpy instead of big nested loops
* expanded the documentation of `MetropolisExchange` to cover every argument