### PR TITLE
Allow HistoryDict to load NaNs from JSON

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,4 +2,4 @@
 
 Those have been moved to our website. Please visit
 
-https://netket.readthedocs.io/en/latest/docs/contributing.html
+https://netket.readthedocs.io/en/latest/developer-guides/contributing.html

--- a/netket/utils/history/history_dict.py
+++ b/netket/utils/history/history_dict.py
@@ -261,10 +261,19 @@ def _is_complex_leaf(subtree):
     ) or _is_number_list(subtree)
 
 
+def _replace_none_with_nan(x):
+    if isinstance(x, list):
+        return [_replace_none_with_nan(v) for v in x]
+    return np.nan if x is None else x
+
+
 def _convert_complex(subtree):
     if isinstance(subtree, dict) and "real" in subtree and "imag" in subtree:
-        return np.array(subtree["real"]) + 1j * np.array(subtree["imag"])
-    return np.array(subtree)
+        real = _replace_none_with_nan(subtree["real"])
+        imag = _replace_none_with_nan(subtree["imag"])
+        return np.array(real) + 1j * np.array(imag)
+    else:
+        return np.array(_replace_none_with_nan(subtree))
 
 
 def histdict_to_nparray(hist_dict):

--- a/test/utils/test_history.py
+++ b/test/utils/test_history.py
@@ -188,3 +188,19 @@ def test_historydict_push():
             assert set(v1.keys()) == set(
                 v2.keys()
             ), f"HistoryDict keys differ for '{key}'"
+
+
+def test_historydict_from_file_complex_nan(tmp_path):
+    # See #2220 - can't reload log file with complex NaNs.
+    log = nk.logging.RuntimeLog()
+    log(0, {"Energy": 1.0 + 1j})
+    log(1, {"Energy": 2.0 + 1j * np.nan})
+    log.serialize(tmp_path / "history.json")
+
+    hist = nk.utils.history.HistoryDict.from_file(tmp_path / "history.json")
+    np.testing.assert_array_equal(hist["Energy"].iters, np.array([0, 1]))
+
+    value = hist["Energy"]["value"]
+    np.testing.assert_allclose(value[0], 1.0 + 1j)
+    assert np.isnan(np.real(value[1]))
+    assert np.isnan(np.imag(value[1]))


### PR DESCRIPTION
I encountered a small bug when loading complex arrays that contain nans from JSON files.
It looks like NaNs are getting written to `null` in the JSON logger, but loading those files gives an error.

A MRE:

File example.json
```json
{"Energy": {"iters":[0,1], "Mean": {"real":[1.000001, null],"imag":[0.00013,null]}}}
```

```python
from netket.utils.history import HistoryDict

hd = HistoryDict()
hd = hd.from_file("example.json")
```
 which gives

```bash
Traceback (most recent call last):
  File "/Users/rwiersema/Documents/netket/bugs/history_dict/bug.py", line 4, in <module>
    hd = hd.from_file("example.json")
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rwiersema/Documents/netket/.venv/lib/python3.11/site-packages/netket/utils/history/history_dict.py", line 179, in from_file
    data = histdict_to_nparray(data)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rwiersema/Documents/netket/.venv/lib/python3.11/site-packages/netket/utils/history/history_dict.py", line 274, in histdict_to_nparray
    return jax.tree.map(_convert_complex, hist_dict, is_leaf=_is_complex_leaf)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rwiersema/Documents/netket/.venv/lib/python3.11/site-packages/jax/_src/tree.py", line 156, in map
    return tree_util.tree_map(f, tree, *rest, is_leaf=is_leaf)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rwiersema/Documents/netket/.venv/lib/python3.11/site-packages/jax/_src/tree_util.py", line 373, in tree_map
    return treedef.unflatten(f(*xs) for xs in zip(*all_leaves))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rwiersema/Documents/netket/.venv/lib/python3.11/site-packages/jax/_src/tree_util.py", line 373, in <genexpr>
    return treedef.unflatten(f(*xs) for xs in zip(*all_leaves))
                             ^^^^^^
  File "/Users/rwiersema/Documents/netket/.venv/lib/python3.11/site-packages/netket/utils/history/history_dict.py", line 266, in _convert_complex
    return np.array(subtree["real"]) + 1j * np.array(subtree["imag"])
                                       ~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
TypeError: unsupported operand type(s) for *: 'complex' and 'NoneType'
```
The problem is that the subtree is a list containing both actual values and `None`, resulting in the above error.

This fix should enable you to load these files by first filtering `None` from the subtrees.

(I also fixed the link to the contributing docs on the website)