### PR TITLE
Add ladder operators to PauliStrings

### DIFF
--- a/netket/operator/_pauli_strings/base.py
+++ b/netket/operator/_pauli_strings/base.py
@@ -31,7 +31,7 @@ from netket.utils.numbers import dtype as _dtype, is_scalar
 from .._abstract_operator import AbstractOperator
 from .._discrete_operator import DiscreteOperator
 
-valid_pauli_regex = re.compile(r"^[XYZI]+$")
+valid_pauli_regex = re.compile(r"^[XYZI+-]+$")
 
 
 def _standardize_matrix_input_type(op):
@@ -97,7 +97,7 @@ def canonicalize_input(hilbert: AbstractHilbert, operators, weights, *, dtype=No
     if not consistent:
         raise ValueError(
             """Operators in string must be one of
-            the Pauli operators X,Y,Z, or the identity I"""
+            the Pauli operators X,Y,Z, ladder operators +,-, or the identity I"""
         )
 
     weights = _standardize_matrix_input_type(weights)
@@ -538,7 +538,6 @@ def _split_string(s):
     return [x for x in str(s)]
 
 
-@jit(nopython=True)
 def _make_new_pauli_string(op1, w1, op2, w2):
     """Compute the (symbolic) tensor product of two pauli strings with weights
     Args:
@@ -546,19 +545,39 @@ def _make_new_pauli_string(op1, w1, op2, w2):
         w1, w2 (complex): The corresponding weights
 
     Returns:
-        new_op (str): the new pauli string (result of the tensor product)
-        new_weight (complex): the weight of the pauli string
+        new_ops (list(str)): the new pauli strings (result of the tensor product)
+        new_weights (list(complex)): the weights of the pauli strings
 
     """
     assert len(op1) == len(op2)
     op1 = _split_string(op1)
     op2 = _split_string(op2)
-    o_w = [_apply_pauli_op_reduction(a, b) for a, b in zip(op1, op2)]
-    new_op = [o[0] for o in o_w]
-    new_weights = np.array([o[1] for o in o_w])
-    new_op = "".join(new_op)
-    new_weight = w1 * w2 * np.prod(new_weights)
-    return new_op, new_weight
+    local_terms = [_apply_op_reduction(a, b) for a, b in zip(op1, op2)]
+    new_ops = []
+    new_weights = []
+    for term_product in product(*local_terms):
+        new_op = "".join(o[0] for o in term_product)
+        new_weight = w1 * w2 * np.prod(np.array([o[1] for o in term_product]))
+        new_ops.append(new_op)
+        new_weights.append(new_weight)
+    return new_ops, new_weights
+
+
+def _pauli_expansion(op):
+    if op == "+":
+        return (("X", 0.5), ("Y", 0.5j))
+    if op == "-":
+        return (("X", 0.5), ("Y", -0.5j))
+    return ((op, 1),)
+
+
+def _apply_op_reduction(op1, op2):
+    terms = []
+    for pauli1, weight1 in _pauli_expansion(op1):
+        for pauli2, weight2 in _pauli_expansion(op2):
+            pauli, weight = _apply_pauli_op_reduction(pauli1, pauli2)
+            terms.append((pauli, weight1 * weight2 * weight))
+    return terms
 
 
 def _remove_zero_weights(op_arr, w_arr):
@@ -598,7 +617,6 @@ def _reduce_pauli_string(op_arr, w_arr):
     return operators, weights
 
 
-@jit(nopython=True)
 def _will_matmul_produce_complex_coefficients(op_arr1, op_arr2):
     """Check if multiplication will produce complex coefficients.
 
@@ -606,6 +624,8 @@ def _will_matmul_produce_complex_coefficients(op_arr1, op_arr2):
     """
     for op1 in op_arr1:
         for op2 in op_arr2:
+            if "+" in op1 or "-" in op1 or "+" in op2 or "-" in op2:
+                return True
             y_count = 0
             for i in range(len(op1)):
                 p1, p2 = op1[i], op2[i]
@@ -640,9 +660,9 @@ def _matmul(op_arr1, w_arr1, op_arr2, w_arr2, *, dtype):
     weights = []
     for (op1, w1), (op2, w2) in product(zip(op_arr1, w_arr1), zip(op_arr2, w_arr2)):
         # warning: numba always returns complex values, even if we are expecting float.
-        op, w = _make_new_pauli_string(op1, w1, op2, w2)
-        operators.append(op)
-        weights.append(w)
+        new_ops, new_weights = _make_new_pauli_string(op1, w1, op2, w2)
+        operators.extend(new_ops)
+        weights.extend(new_weights)
     # so here we recast to the desired dtype
     operators, weights = np.array(operators), np.array(weights)
     # explicit real part to avoid warning

--- a/netket/operator/_pauli_strings/jax.py
+++ b/netket/operator/_pauli_strings/jax.py
@@ -75,7 +75,7 @@ def pack_internals(operators, weights, cutoff=0):
 
     def append(key, k):
         # convert list to tuple
-        key = tuple(sorted(key))  # order of X and Y does not matter
+        key = tuple(sorted(key))  # order of X, Y, + and - does not matter
         if key in acting:
             acting[key].append(k)
         else:
@@ -99,6 +99,14 @@ def pack_internals(operators, weights, cutoff=0):
             b_weight *= (-1.0j) ** (len(y_ops))  # absorb the -i into weights
             b_z_check += y_ops
 
+        plus_ops = find_char(op, "+")  # ladder operator: flips 0 -> 1
+        if len(plus_ops):
+            b_to_change += plus_ops
+
+        minus_ops = find_char(op, "-")  # ladder operator: flips 1 -> 0
+        if len(minus_ops):
+            b_to_change += minus_ops
+
         z_ops = find_char(op, "Z")  # find sites we act on with Z w/ op
         if len(z_ops):
             b_z_check += z_ops
@@ -113,7 +121,7 @@ def pack_internals(operators, weights, cutoff=0):
         if np.isreal(b_weight):
             b_weight = b_weight.real
 
-        append(b_to_change, (b_weight, b_z_check))
+        append(b_to_change, (b_weight, b_z_check, plus_ops, minus_ops))
     return acting
 
 
@@ -175,25 +183,43 @@ def pack_internals_jax(
     z_sign_masks = {}
     z_sign_indices = {}
     z_sign_indices_masks = {}
+    plus_masks = {}
+    plus_indices = {}
+    plus_indices_masks = {}
+    minus_masks = {}
+    minus_indices = {}
+    minus_indices_masks = {}
 
     for l, ops in acting_by_num_ops.items():
         x_flip_masks_l = []
         weights_l = []
         z_sign_masks_l = []  # if we decide to use masks
         z_sign_indices_l = []  # if we decide to use indexing
+        plus_masks_l = []
+        plus_indices_l = []
+        minus_masks_l = []
+        minus_indices_l = []
 
         for sites_to_flip, rest in ops:
             w = [r[0] for r in rest]
             sites_for_sgn = [r[1] for r in rest]
+            plus_sites = [r[2] for r in rest]
+            minus_sites = [r[3] for r in rest]
             x_flip_mask = sites_to_mask(sites_to_flip, n_sites)
             z_sign_mask = list(
                 map(partial(sites_to_mask, n_sites=n_sites), sites_for_sgn)
             )
+            plus_mask = list(map(partial(sites_to_mask, n_sites=n_sites), plus_sites))
+            minus_mask = list(map(partial(sites_to_mask, n_sites=n_sites), minus_sites))
 
             x_flip_masks_l.append(x_flip_mask)
             weights_l.append(w)
             z_sign_masks_l.append(z_sign_mask)
             z_sign_indices_l.append(sites_for_sgn)
+            plus_masks_l.append(plus_mask)
+            plus_indices_l.append(plus_sites)
+            minus_masks_l.append(minus_mask)
+            minus_indices_l.append(minus_sites)
 
         # turn into arrays
         x_flip_masks[l] = jnp.array(x_flip_masks_l, dtype=mask_dtype)
@@ -203,24 +229,29 @@ def pack_internals_jax(
             weights[l] = jnp.array(weights_l)
 
         z_sign_masks[l] = jnp.array(z_sign_masks_l, dtype=mask_dtype)
+        plus_masks[l] = jnp.array(plus_masks_l, dtype=mask_dtype)
+        minus_masks[l] = jnp.array(minus_masks_l, dtype=mask_dtype)
 
         # prepare index arrays if we are indexing
-        num_z = [len(y) for x in z_sign_indices_l for y in x]
-        maxlen = max(num_z, default=0)
-        pad = maxlen != min(num_z, default=0)
-        if pad:
-            # arbitrarily fill with -1
-            tmp1 = np.full((len(z_sign_indices_l), l, maxlen), -1, dtype=index_dtype)
-            tmp2 = np.full((len(z_sign_indices_l), l, maxlen), False, dtype=mask_dtype)
-            for i, inds in enumerate(z_sign_indices_l):
-                for j, ind in enumerate(inds):
-                    tmp1[i, j, : len(ind)] = ind
-                    tmp2[i, j, : len(ind)] = True
-            z_sign_indices[l] = jnp.array(tmp1)
-            z_sign_indices_masks[l] = jnp.array(tmp2)
-        else:  # no padding needed, all have the same length
-            z_sign_indices[l] = jnp.array(z_sign_indices_l, dtype=index_dtype)
-            z_sign_indices_masks[l] = None
+        def pack_indices(indices_l):
+            num_indices = [len(y) for x in indices_l for y in x]
+            maxlen = max(num_indices, default=0)
+            pad = maxlen != min(num_indices, default=0)
+            if pad:
+                # arbitrarily fill with -1
+                tmp1 = np.full((len(indices_l), l, maxlen), -1, dtype=index_dtype)
+                tmp2 = np.full((len(indices_l), l, maxlen), False, dtype=mask_dtype)
+                for i, inds in enumerate(indices_l):
+                    for j, ind in enumerate(inds):
+                        tmp1[i, j, : len(ind)] = ind
+                        tmp2[i, j, : len(ind)] = True
+                return jnp.array(tmp1), jnp.array(tmp2)
+            else:  # no padding needed, all have the same length
+                return jnp.array(indices_l, dtype=index_dtype), None
+
+        z_sign_indices[l], z_sign_indices_masks[l] = pack_indices(z_sign_indices_l)
+        plus_indices[l], plus_indices_masks[l] = pack_indices(plus_indices_l)
+        minus_indices[l], minus_indices_masks[l] = pack_indices(minus_indices_l)
 
     # transform the arrays into lists so that we have consistent ordering
     # as we will concatenate the results in the operator
@@ -235,12 +266,33 @@ def pack_internals_jax(
     z_sign_indices_masks = [
         z_sign_indices_masks[k] if (mode == "index") else None for k in keys
     ]
+    plus_masks = [plus_masks[k] if (mode == "mask") else None for k in keys]
+    plus_indices = [plus_indices[k] if (mode == "index") else None for k in keys]
+    plus_indices_masks = [
+        plus_indices_masks[k] if (mode == "index") else None for k in keys
+    ]
+    minus_masks = [minus_masks[k] if (mode == "mask") else None for k in keys]
+    minus_indices = [minus_indices[k] if (mode == "index") else None for k in keys]
+    minus_indices_masks = [
+        minus_indices_masks[k] if (mode == "index") else None for k in keys
+    ]
 
     if len(x_flip_masks) > 0:
         x_flip_masks_stacked = jnp.concatenate(x_flip_masks, axis=0)
     else:  # empty / zero operator
         x_flip_masks_stacked = jnp.zeros((0, n_sites), dtype=mask_dtype)
-    z_data = (weights, z_sign_masks, z_sign_indices, z_sign_indices_masks)
+    z_data = (
+        weights,
+        z_sign_masks,
+        z_sign_indices,
+        z_sign_indices_masks,
+        plus_masks,
+        plus_indices,
+        plus_indices_masks,
+        minus_masks,
+        minus_indices,
+        minus_indices_masks,
+    )
     return x_flip_masks_stacked, z_data
 
 
@@ -252,7 +304,18 @@ def _pauli_strings_mels_jax(z_data, x):
     state1 = 1
     was_state_1 = x == state1
     mels = []
-    for w, z_sign_mask, z_sign_indices, z_sign_indexmask in zip(*z_data):
+    for (
+        w,
+        z_sign_mask,
+        z_sign_indices,
+        z_sign_indexmask,
+        plus_mask,
+        plus_indices,
+        plus_indexmask,
+        minus_mask,
+        minus_indices,
+        minus_indexmask,
+    ) in zip(*z_data):
         if z_sign_mask is not None:  # use masks
             was_state = was_state_1[..., None, None, :]
             mask = z_sign_mask
@@ -267,7 +330,26 @@ def _pauli_strings_mels_jax(z_data, x):
         sgn = (1 - 2 * (was_state * mask).astype(np.int8)).prod(
             axis=-1, promote_integers=False
         )
-        mels.append(jnp.einsum("...ab,ab->...a", sgn, w))
+
+        if plus_mask is not None:
+            plus_allowed = ~(was_state_1[..., None, None, :] & plus_mask).any(axis=-1)
+            minus_allowed = (was_state_1[..., None, None, :] | ~minus_mask).all(axis=-1)
+        else:
+            assert plus_indices is not None
+            plus_states = x[..., plus_indices] == state1
+            if plus_indexmask is not None:
+                plus_states = plus_states & plus_indexmask
+            plus_allowed = ~plus_states.any(axis=-1)
+
+            assert minus_indices is not None
+            minus_states = x[..., minus_indices] == state1
+            if minus_indexmask is None:
+                minus_allowed = minus_states.all(axis=-1)
+            else:
+                minus_allowed = (minus_states | ~minus_indexmask).all(axis=-1)
+
+        allowed = plus_allowed & minus_allowed
+        mels.append(jnp.einsum("...ab,ab->...a", sgn * allowed, w))
     if len(mels) > 0:
         return jnp.concatenate(mels, axis=-1)
     else:
@@ -400,7 +482,7 @@ class PauliStringsJax(PauliStringsBase, DiscreteJaxOperator):
                 self._x_flip_masks_stacked = jnp.zeros(
                     (0, self.hilbert.size), dtype=jnp.bool_
                 )
-                self._z_data = ([], [], [], [])
+                self._z_data = ([], [], [], [], [], [], [], [], [], [])
             else:
                 x_flip_masks_stacked, z_data = pack_internals_jax(
                     self.operators, weights, weight_dtype=self.dtype, mode=self._mode

--- a/netket/operator/_pauli_strings/numba.py
+++ b/netket/operator/_pauli_strings/numba.py
@@ -39,11 +39,15 @@ def pack_internals_numba(
 ):
     acting = pack_internals(operators, weights)
 
-    # the most Z we need to do anywhere
+    # the most Z / ladder constraints we need to check anywhere
     _n_z_check_max = 0
+    _n_plus_check_max = 0
+    _n_minus_check_max = 0
     for v in acting.values():
-        for _, b_z_check in v:
+        for _, b_z_check, b_plus_check, b_minus_check in v:
             _n_z_check_max = max(_n_z_check_max, len(b_z_check))
+            _n_plus_check_max = max(_n_plus_check_max, len(b_plus_check))
+            _n_minus_check_max = max(_n_minus_check_max, len(b_minus_check))
 
     n_operators = len(acting)
     # maximum number of strings which have the same sites to act on with X, but have different sites for Z
@@ -65,6 +69,12 @@ def pack_internals_numba(
     _nz_check = np.empty((n_operators, _n_op_max), dtype=np.intp)
     # sites to act on with Z for each operators of the X strings, padded
     _z_check = np.empty((n_operators, _n_op_max, _n_z_check_max), dtype=np.intp)
+    # sites with + ladder operators, which require the current state to be 0
+    _n_plus_check = np.empty((n_operators, _n_op_max), dtype=np.intp)
+    _plus_check = np.empty((n_operators, _n_op_max, _n_plus_check_max), dtype=np.intp)
+    # sites with - ladder operators, which require the current state to be 1
+    _n_minus_check = np.empty((n_operators, _n_op_max), dtype=np.intp)
+    _minus_check = np.empty((n_operators, _n_op_max, _n_minus_check_max), dtype=np.intp)
 
     for i, act in enumerate(acting.items()):
         sites = act[0]
@@ -77,6 +87,10 @@ def pack_internals_numba(
             _weights[i, j] = values[j][0]
             _nz_check[i, j] = len(values[j][1])
             _z_check[i, j, : _nz_check[i, j]] = values[j][1]
+            _n_plus_check[i, j] = len(values[j][2])
+            _plus_check[i, j, : _n_plus_check[i, j]] = values[j][2]
+            _n_minus_check[i, j] = len(values[j][3])
+            _minus_check[i, j, : _n_minus_check[i, j]] = values[j][3]
 
     return {
         "sites": _sites,
@@ -85,6 +99,10 @@ def pack_internals_numba(
         "weights_numba": _weights,
         "nz_check": _nz_check,
         "z_check": _z_check,
+        "n_plus_check": _n_plus_check,
+        "plus_check": _plus_check,
+        "n_minus_check": _n_minus_check,
+        "minus_check": _minus_check,
         "n_operators": n_operators,
         "mel_dtype": dtype,
     }
@@ -154,6 +172,10 @@ class PauliStringsNumba(PauliStringsBase):
             self._weights_numba = data["weights_numba"]
             self._nz_check = data["nz_check"]
             self._z_check = data["z_check"]
+            self._n_plus_check = data["n_plus_check"]
+            self._plus_check = data["plus_check"]
+            self._n_minus_check = data["n_minus_check"]
+            self._minus_check = data["minus_check"]
             self._n_operators = data["n_operators"]
 
             # caches for execution
@@ -179,6 +201,10 @@ class PauliStringsNumba(PauliStringsBase):
         weights,
         nz_check,
         z_check,
+        n_plus_check,
+        plus_check,
+        n_minus_check,
+        minus_check,
         cutoff,
         max_conn,
         pad=False,
@@ -197,6 +223,19 @@ class PauliStringsNumba(PauliStringsBase):
                 mel = 0.0
                 # iterate over the Z substrings
                 for j in range(n_op[i]):
+                    allowed = True
+                    for site in plus_check[i, j, : n_plus_check[i, j]]:
+                        if xb[site] == state_1:
+                            allowed = False
+                            break
+                    if allowed:
+                        for site in minus_check[i, j, : n_minus_check[i, j]]:
+                            if xb[site] != state_1:
+                                allowed = False
+                                break
+                    if not allowed:
+                        continue
+
                     # apply all the Z (check the qubits at all affected sites)
                     if nz_check[i, j] > 0:
                         to_check = z_check[i, j, : nz_check[i, j]]
@@ -266,6 +305,10 @@ class PauliStringsNumba(PauliStringsBase):
             self._weights_numba,
             self._nz_check,
             self._z_check,
+            self._n_plus_check,
+            self._plus_check,
+            self._n_minus_check,
+            self._minus_check,
             self._cutoff,
             self._n_operators,
             pad,

--- a/test/operator/test_pauli.py
+++ b/test/operator/test_pauli.py
@@ -306,6 +306,72 @@ def test_pauli_dense(Op):
 
 
 @pytest.mark.parametrize("Op", operators)
+def test_pauli_ladder_operators(Op):
+    hi = nk.hilbert.Qubit(2)
+
+    plus = Op(hi, "+I")
+    minus = Op(hi, "I-")
+    expected_plus = 0.5 * (
+        nk.operator.spin.sigmax(hi, 0, dtype=complex)
+        + 1j * nk.operator.spin.sigmay(hi, 0)
+    )
+    expected_minus = 0.5 * (
+        nk.operator.spin.sigmax(hi, 1, dtype=complex)
+        - 1j * nk.operator.spin.sigmay(hi, 1)
+    )
+
+    np.testing.assert_allclose(plus.to_dense(), expected_plus.to_dense())
+    np.testing.assert_allclose(minus.to_dense(), expected_minus.to_dense())
+
+    states = hi.all_states()
+    xp, mels = plus.get_conn_padded(states)
+    np.testing.assert_allclose(
+        xp[:, 0, :],
+        np.array(
+            [
+                [1, 0],
+                [1, 1],
+                [1, 0],
+                [1, 1],
+            ]
+        ),
+    )
+    np.testing.assert_allclose(mels[:, 0], np.array([1, 1, 0, 0]))
+
+
+@pytest.mark.parametrize("Op", operators)
+def test_pauli_ladder_strings_can_combine_with_z_phases(Op):
+    hi = nk.hilbert.Qubit(2)
+    op = Op(hi, "+Z")
+    expected = (
+        0.5
+        * (
+            nk.operator.spin.sigmax(hi, 0, dtype=complex)
+            + 1j * nk.operator.spin.sigmay(hi, 0)
+        )
+        @ nk.operator.spin.sigmaz(hi, 1)
+    )
+
+    np.testing.assert_allclose(op.to_dense(), expected.to_dense())
+
+
+@pytest.mark.parametrize("Op", operators)
+def test_pauli_ladder_matmul(Op):
+    hi = nk.hilbert.Qubit(1)
+    plus = Op(hi, "+")
+    minus = Op(hi, "-")
+    plus_expanded = 0.5 * (Op(hi, "X") + 1j * Op(hi, "Y"))
+    minus_expanded = 0.5 * (Op(hi, "X") - 1j * Op(hi, "Y"))
+
+    np.testing.assert_allclose(
+        (plus @ minus).to_dense(), (plus_expanded @ minus_expanded).to_dense()
+    )
+    np.testing.assert_allclose(
+        (minus @ plus).to_dense(), (minus_expanded @ plus_expanded).to_dense()
+    )
+
+
+@pytest.mark.parametrize("Op", operators)
 def test_pauli_zero(Op):
     op1 = Op(["IZ"], [1])
     op2 = Op(["IZ"], [-1])


### PR DESCRIPTION
## Summary

- Allow `PauliStrings` operator strings to contain `+` and `-` ladder operators.
- Treat ladder operators as state flips with zero matrix elements when the operator cannot act on the current local state.
- Support both JAX and Numba PauliStrings paths.
- Expand ladder operators into Pauli terms for symbolic `@` multiplication.
- Add focused regression coverage for dense matrices, Z phases, and ladder-operator multiplication.

Fixes #1206.

## Testing

- `git diff --check`

I could not run the Python test suite in this workspace because no usable Python interpreter is installed here. Opening as draft so repository CI can validate the patch before review.