### PR TITLE
do not crash when logging a complex number to a 'real' history

### DIFF
--- a/netket/_src/callbacks/save_state.py
+++ b/netket/_src/callbacks/save_state.py
@@ -100,7 +100,11 @@ class SaveVariationalState(AbstractCallback, mutable=True):
             if jax.process_index() == 0:
                 pattern = re.compile(rf"^{re.escape(self._file_name_root)}_(\d+)\.nk$")
                 saved = sorted(
-                    (p for p in self._path.glob(f"{self._file_name_root}_*.nk") if pattern.match(p.name)),
+                    (
+                        p
+                        for p in self._path.glob(f"{self._file_name_root}_*.nk")
+                        if pattern.match(p.name)
+                    ),
                     key=lambda p: int(pattern.match(p.name).group(1)),
                 )
                 for old in saved[: -self._max_to_keep]:

--- a/netket/_src/logging/mlflow_log.py
+++ b/netket/_src/logging/mlflow_log.py
@@ -217,7 +217,9 @@ class MLFlowLog(AbstractCallback):
         data: list[tuple[str, Any]] = []
         if self._ignore:
             item = {k: v for k, v in item.items() if k not in self._ignore}
-        walk_tree_with_path(item, "", visit_leaf=_visit_leaf, expand_node=_expand_node, data=data)
+        walk_tree_with_path(
+            item, "", visit_leaf=_visit_leaf, expand_node=_expand_node, data=data
+        )
 
         metrics = {}
         for key, val in data:

--- a/netket/_src/vqs/expect_to_precision.py
+++ b/netket/_src/vqs/expect_to_precision.py
@@ -195,7 +195,9 @@ def expect_to_precision(
                 active = [
                     i
                     for i in active
-                    if _check_not_converged(stats_list[i], atol_leaves[i], rtol_leaves[i])
+                    if _check_not_converged(
+                        stats_list[i], atol_leaves[i], rtol_leaves[i]
+                    )
                 ]
 
                 pbar.set_postfix(

--- a/netket/utils/history/history.py
+++ b/netket/utils/history/history.py
@@ -15,6 +15,7 @@
 from typing import Any, Union, TYPE_CHECKING
 from collections.abc import Iterable
 from numbers import Number
+import warnings
 
 import numpy as np
 
@@ -427,12 +428,34 @@ def append(self: History, values: dict, it: Any):  # noqa: E0102, F811
         elif isinstance(_vals, np.ndarray):
             new_shape = (len(_vals) + 1,) + _vals.shape[1:]
             # try to resize in place the buffer so that we don't reallocate
-            # and if we fail, resize tby reallocating to a new buffer.
+            # and if we fail, resize by reallocating to a new buffer.
             try:
                 _vals.resize(new_shape)
             except ValueError:
                 _vals = np.resize(_vals, new_shape)
                 self._value_dict[key] = _vals
+
+            # If the incoming value does not fit the stored dtype (for example
+            # a complex value -- such as a complex NaN/inf produced by a
+            # diverging run -- logged into a real-valued history) truncate it
+            # to the stored dtype and warn, rather than raising a cryptic
+            # "float() argument must not be 'complex'" TypeError or silently
+            # promoting the whole history to a wider dtype.
+            if np.result_type(_vals.dtype, np.asarray(val).dtype) != _vals.dtype:
+                warnings.warn(
+                    f"Logging a value of dtype {np.asarray(val).dtype} into the "
+                    f"history key '{key}' which stores dtype {_vals.dtype}. The "
+                    f"value will be truncated to {_vals.dtype}. This usually "
+                    f"indicates a diverging run producing complex NaN/inf "
+                    f"values.",
+                    category=UserWarning,
+                    stacklevel=2,
+                )
+                # numpy emits its own ComplexWarning when discarding the
+                # imaginary part; we already warned above, so silence it.
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore")
+                    val = np.asarray(val).astype(_vals.dtype)
 
             _vals[-1] = val
         else:

--- a/test/utils/test_history.py
+++ b/test/utils/test_history.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 import numpy as np
 import jax
 import jax.numpy as jnp
@@ -118,6 +119,31 @@ def test_append():
     # test that repr does not fail
     repr(a1)
     repr(a2)
+
+
+def test_append_complex_into_real_truncates_and_warns():
+    # A history initialised with a real value must not crash with a cryptic
+    # TypeError when a later complex value is appended (e.g. a complex NaN
+    # produced by a diverging run). Instead the value is truncated to the
+    # stored dtype and a warning is emitted, keeping the history dtype stable.
+    h = nk.utils.History(1.18, iters=0)
+    assert np.issubdtype(h["value"].dtype, np.floating)
+
+    with pytest.warns(UserWarning, match="truncated"):
+        h.append(complex(np.nan, np.nan), it=1)
+
+    # dtype is preserved (not promoted to complex)
+    assert np.issubdtype(h["value"].dtype, np.floating)
+    np.testing.assert_allclose(h["value"][0], 1.18)
+    # complex(nan, nan) truncated to real -> nan
+    assert np.isnan(h["value"][1])
+    np.testing.assert_array_equal(h.iters, np.array([0, 1]))
+
+    # a finite complex value keeps only its real part, and previously-stored
+    # data is preserved
+    with pytest.warns(UserWarning, match="truncated"):
+        h.append(2.0 + 3.0j, it=2)
+    np.testing.assert_allclose(h["value"][2], 2.0)
 
 
 def test_construct_from_dict():

--- a/test/variational/test_continuous_expect.py
+++ b/test/variational/test_continuous_expect.py
@@ -123,9 +123,7 @@ def test_continuous_kinetic_param_gather_chunked():
     kin = nk.operator.KineticEnergy(hilb, mass=1.0)
     sab = nk.sampler.MetropolisGaussian(hilb, sigma=1.0, n_chains=16, sweep_size=1)
 
-    vs = nk.vqs.MCState(
-        sab, GatherModel(), n_samples=512, sampler_seed=1234, seed=1234
-    )
+    vs = nk.vqs.MCState(sab, GatherModel(), n_samples=512, sampler_seed=1234, seed=1234)
 
     assert vs.chunk_size is None
     sol_nc = vs.expect(kin)

--- a/test/variational/test_exact_state.py
+++ b/test/variational/test_exact_state.py
@@ -91,7 +91,6 @@ QGT_objects["OnTheFly"] = nk.optimizer.qgt.QGTOnTheFly
 QGT_objects["JacobianPyTree"] = nk.optimizer.qgt.QGTJacobianPyTree
 
 
-@common.skipif_mpi
 @pytest.fixture(params=[pytest.param(ma, id=name) for name, ma in machines.items()])
 def vstate(request):
     ma = request.param


### PR DESCRIPTION
This creeps up in some exotic cases when cholesky gives NaN, but regardless it's good to have it