### PR TITLE
Fix Read the Docs build: bump build.os to ubuntu-26.04, python 3.13

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,9 +7,9 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-26.04
   tools:
-    python: "3.11"
+    python: "3.13"
   apt_packages:
     - pandoc
     - graphviz


### PR DESCRIPTION
Read the Docs recently dropped support for `ubuntu-20.04` in `build.os`, causing config validation to fail on every build:

```
Config validation error in build.os. Expected one of
(ubuntu-22.04, ubuntu-24.04, ubuntu-26.04, ubuntu-lts-latest),
got type str (ubuntu-20.04).
```

This bumps `build.os` to the current `ubuntu-26.04` image and pins the Python tool to `"3.13"` (as a string) so the config stays valid for a good while.

Kept deliberately minimal (single-file change) and branched off `main` so it can be merged independently of the other open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)