### PR TITLE
Fix JAX-MG potrs sharding spec

### DIFF
--- a/netket/optimizer/solver/solvers.py
+++ b/netket/optimizer/solver/solvers.py
@@ -470,7 +470,7 @@ def cholesky_distributed(A, b, *, local_tile_size=None, x0=None):
         b,
         T_A=local_tile_size,
         mesh=jax.sharding.get_abstract_mesh(),
-        in_specs=(P("S", None), P(None, None)),
+        in_specs=P("S", None),
     )
 
     if squeeze_output:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
 [project.optional-dependencies]
 cuda = ["jax[cuda12]; sys_platform == 'linux'"]
 pyscf = ["pyscf>=2.0"]
-extra = ["tensorboardx>=2.0.0", "openfermion>=1.0.0", "h5py>=3.7.0", "qutip>=4", "mlflow>=2.0.0"]
+extra = ["tensorboardx>=2.0.0", "openfermion>=1.0.0", "h5py>=3.7.0", "qutip>=4", "mlflow>=2.0.0", "jaxmg>=0.0.9"]
 dev = [
     "networkx>=2.4",
     "matplotlib>=3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
 [project.optional-dependencies]
 cuda = ["jax[cuda12]; sys_platform == 'linux'"]
 pyscf = ["pyscf>=2.0"]
-extra = ["tensorboardx>=2.0.0", "openfermion>=1.0.0", "h5py>=3.7.0", "qutip>=4", "mlflow>=2.0.0", "jaxmg>=0.0.9"]
+extra = ["tensorboardx>=2.0.0", "openfermion>=1.0.0", "h5py>=3.7.0", "qutip>=4", "mlflow>=2.0.0", "jaxmg>=0.0.9; sys_platform == 'linux'"]
 dev = [
     "networkx>=2.4",
     "matplotlib>=3",

--- a/test/optimizer/test_solver_distributed.py
+++ b/test/optimizer/test_solver_distributed.py
@@ -23,6 +23,15 @@ import netket as nk
 
 from test import common  # noqa: F401
 
+# jaxmg's FFI handlers (potrs_mg, syevd_mg) are only registered for the CUDA
+# platform. Even when jaxmg is installed (e.g. on Linux CI), the kernels cannot
+# run on a CPU/Host backend, so these tests must be skipped unless a GPU is
+# available.
+pytestmark = pytest.mark.skipif(
+    jax.default_backend() != "gpu",
+    reason="jaxmg distributed solvers require a GPU backend",
+)
+
 
 def test_cholesky_distributed_basic():
     """Test cholesky_distributed solver on a small system."""


### PR DESCRIPTION
Fixes #2251.

## Summary

Pass the single matrix `PartitionSpec` expected by current JAX-MG versions to `potrs`.

## Validation

- Four-GPU distributed solve of `A = 2I`, `b = 1`
- Maximum solution error: `1.11e-16`
- `git diff --check`