### PR TITLE
Fix pyscf Boys doctest for pyscf>=2.14

### DIFF
--- a/netket/_src/operator/pyscf_api.py
+++ b/netket/_src/operator/pyscf_api.py
@@ -108,7 +108,7 @@ def from_pyscf_molecule(
         >>>
         >>> # compute the boys orbitals
         >>> mf = scf.RHF(mol).run(verbose=0)  # doctest:+ELLIPSIS
-        >>> mo_coeff = lo.Boys(mol).kernel(mf.mo_coeff)
+        >>> mo_coeff = lo.Boys(mol, mf.mo_coeff).kernel()
         >>> # use the boys orbitals to construct the netket hamiltonian
         >>> ha = nkx.operator.from_pyscf_molecule(mol, mo_coeff=mo_coeff)
 

--- a/netket/_src/operator/pyscf_utils.py
+++ b/netket/_src/operator/pyscf_utils.py
@@ -225,7 +225,7 @@ def TV_from_pyscf_molecule(
         >>>
         >>> # compute the boys orbitals
         >>> mf = scf.RHF(mol).run(verbose=0)  # doctest:+ELLIPSIS
-        >>> mo_coeff = lo.Boys(mol).kernel(mf.mo_coeff)
+        >>> mo_coeff = lo.Boys(mol, mf.mo_coeff).kernel()
         >>> ha = nkx.operator.pyscf.TV_from_pyscf_molecule(mol, mo_coeff)
 
     Args:


### PR DESCRIPTION
## Summary

pyscf 2.14.0 made `mo_coeff` a **required positional argument** of `OrbitalLocalizer.__init__` (the base class of `pyscf.lo.Boys`). This breaks the `from_pyscf_molecule` / `TV_from_pyscf_molecule` doctests, which now fail with:

```
TypeError: OrbitalLocalizer.__init__() missing 1 required positional argument: 'mo_coeff'
```

This surfaced in CI (e.g. #2252's Doctests job) once pyscf 2.14.0 started being resolved.

## Fix

Pass the MO coefficients to the `lo.Boys(...)` constructor instead of to `.kernel(...)`:

```python
- mo_coeff = lo.Boys(mol).kernel(mf.mo_coeff)
+ mo_coeff = lo.Boys(mol, mf.mo_coeff).kernel()
```

This form works on both older (`mo_coeff` optional) and newer (`mo_coeff` required) pyscf versions. Verified locally that the doctests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)