### PR TITLE
Fix crash at import on multi-node allocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ## NetKet 3.23 (In development)
 
 ### Bug Fixes
+* Importing NetKet no longer crashes on multi-node (multi-slice) allocations: the default sharding mesh is now built directly with {class}`jax.sharding.Mesh` instead of `jax.make_mesh`, which refuses to build meshes spanning several slices [issue #2260](https://github.com/netket/netket/issues/2260).
 * {class}`netket.logging.TensorBoardLog` no longer silently drops metrics that arrive as `jax`/`numpy` scalar arrays (such as `acceptance`); scalar (0-dim or single-element) arrays are now logged, with complex scalars split into `/re` and `/im` tags [issue #2244](https://github.com/netket/netket/issues/2244).
 
 ...

--- a/netket/tools/djaxrun.py
+++ b/netket/tools/djaxrun.py
@@ -26,6 +26,32 @@ def find_free_port():
         return s.getsockname()[1]
 
 
+def check_hostname_resolvable():
+    """
+    Warns if the hostname of this machine cannot be resolved to an address.
+
+    jax binds gloo's TCP device (used for cpu collectives in multi-process runs)
+    to the address of the local hostname, so if the hostname is not resolvable
+    every process crashes at jax startup with `Unable to find address for:
+    <hostname>`. This happens on macOS, where the hostname is often only
+    resolvable through mDNS, as `<hostname>.local`.
+    """
+    hostname = socket.gethostname()
+    try:
+        socket.getaddrinfo(hostname, None)
+    except socket.gaierror:
+        print(
+            f"[djaxrun] WARNING: the hostname of this machine, '{hostname}', cannot be "
+            "resolved to an ip address.\n"
+            "  jax will most likely fail to initialize its cpu collectives with\n"
+            f"  `Unable to find address for: {hostname}`.\n"
+            "  To fix this, make the hostname resolvable, for example by running\n"
+            f"    sudo scutil --set HostName {hostname}.local     # macOS\n"
+            f"    echo '127.0.0.1 {hostname}' | sudo tee -a /etc/hosts   # anywhere",
+            file=sys.stderr,
+        )
+
+
 def render_panels(buffers):
     panels = []
     for rank, content in enumerate(buffers):
@@ -80,6 +106,8 @@ def main():
     procs = []
     log_files = []
     ansi_escape = re.compile(r"\x1b\[[0-9;?]*[a-zA-Z]")
+
+    check_hostname_resolvable()
 
     def start_proc(rank):
         env = os.environ.copy()

--- a/netket/utils/config_flags.py
+++ b/netket/utils/config_flags.py
@@ -345,6 +345,7 @@ config.define(
 
 def _setup_experimental_sharding(val, explicit=False):
     if val:
+        import numpy as np
         import jax
         from jax.sharding import AxisType
 
@@ -353,10 +354,10 @@ def _setup_experimental_sharding(val, explicit=False):
         else:
             axis_types = AxisType.Auto
 
-        mesh = jax.make_mesh(
-            (len(jax.devices()),),
-            ("S"),
-            axis_types=axis_types,
+        mesh = jax.sharding.Mesh(
+            np.asarray(jax.devices()),
+            ("S",),
+            axis_types=(axis_types,),
         )
         jax.sharding.set_mesh(mesh)
 


### PR DESCRIPTION
Fixes #2260.

On allocations spanning 2+ nodes, `import netket` crashed for every process: the default sharding mesh was built with `jax.make_mesh`, which explicitly rejects meshes spanning multiple slices (a >1-node allocation is a multi-slice topology). We now build the mesh directly with `jax.sharding.Mesh`. The only thing `jax.make_mesh` adds is topology-aware device reordering, which is irrelevant for a single axis spanning all devices, over which we only ever reduce.

Also makes `djaxrun` warn when the machine's hostname is not resolvable, which otherwise makes jax fail to initialize its gloo cpu collectives with a confusing error.

Tested with `djaxrun -np 2` (2 processes x 4 cpu devices): 42 passed, 6 skipped.

---
*Pi.Claude (Filippo's agent)*