### PR TITLE
Fix ill-conditioned QGT test fixtures failing on macOS CI

### DIFF
--- a/test/optimizer/test_qgt_itersolve.py
+++ b/test/optimizer/test_qgt_itersolve.py
@@ -117,7 +117,10 @@ def model(request):
 
 @pytest.fixture
 def vstate(request, model, chunk_size):
-    N = 5
+    # The tests below invert S, so S must be invertible: rank(QGT) is at most
+    # `n_states - 1`, so keep n_states well above n_parameters, and initialise at
+    # a finite scale, as at ~0 parameters the RBM log-derivatives get collinear.
+    N = 8
     hi = nk.hilbert.Spin(1 / 2, N)
 
     k = jax.random.PRNGKey(123)
@@ -131,7 +134,7 @@ def vstate(request, model, chunk_size):
     )
 
     # initialize the same parameters on every rank
-    vstate.init_parameters(normal(stddev=0.001), seed=k2)
+    vstate.init_parameters(normal(stddev=0.1), seed=k2)
 
     vstate.sample()
 

--- a/test/optimizer/test_qgt_logic.py
+++ b/test/optimizer/test_qgt_logic.py
@@ -515,7 +515,10 @@ def test_qgt_jacobian_imaginary(dense):
     ma = nk.models.RBM(alpha=1, param_dtype=complex)
 
     sa = nk.sampler.MetropolisLocal(hi, n_chains=16)
-    vs = nk.vqs.MCState(sa, ma, n_samples=1008, n_discard_per_chain=10)
+    vs = nk.vqs.MCState(sa, ma, n_samples=1008, n_discard_per_chain=10, seed=123)
+    # At the default, tiny initialisation the QGT is numerically singular (cond
+    # ~1e13) and `pinv` truncates it differently in the two modes compared below.
+    vs.init_parameters(jax.nn.initializers.normal(stddev=0.1), seed=123)
 
     E, F = vs.expect_and_grad(ha)
 


### PR DESCRIPTION
## Summary

The macOS CI job has been failing consistently for a long time on 4 tests, and intermittently on a 5th:

```
test/optimizer/test_qgt_itersolve.py::test_qgt_solve[RBM[dtype=float32]-chunk={None,16}-cholesky-Jacobian{PyTree,Dense}(diag_scale=0.01)]
test/optimizer/test_qgt_logic.py::test_qgt_jacobian_imaginary[dense=True]
```

Neither is a netket bug. Both tests assert that a solver inverts a matrix that is **singular**, so whether the assertion passes is decided by rounding, and therefore by the BLAS of the platform the test runs on. They pass on linux and fail on the macOS runner.

## `test_qgt_solve` (the 4 permanent failures)

The `vstate` fixture used 5 spins with parameters initialised at `normal(stddev=0.001)`, which is rank-deficient twice over:

* the QGT is the covariance of the `n_parameters` log-derivatives over the sampled configurations, so its rank is at most `n_states - 1 = 31`, while the RBM has 35 parameters;
* at near-zero parameters the log-derivatives of an RBM become nearly collinear (`d log psi / d W_ij -> sigma_i * b_j`), which by itself reduces the numerical rank of the 35x35 QGT to **15** (all 32 configurations are sampled, so this is not a sampling artifact).

The QGT objects regularised with `diag_scale` and `diag_shift=0` do not lift the smallest eigenvalues, so the matrix handed to the solver had a condition number of **6.1e7**. In single precision (eps ~ 1.2e-7) that leaves no correct digit at all: the returned solution has a norm 1e7 times larger than the right-hand side, and the residual `S @ x - y` is whatever rounding makes it. Measured against the test tolerance (`rtol=1e-2, atol=1e-4`), the worst residual came out at **0.79x** the tolerance on one mac and **4.6x** on the CI mac.

Fixed by making the test matrix invertible in single precision: 8 spins (80 parameters, 255 states) and initialisation at `stddev=0.1`.

| | before | after |
|---|---|---|
| numerical rank / n_parameters | 15 / 35 | 80 / 80 |
| condition number | 6.1e7 | 7.2e3 |
| worst residual vs. test tolerance | 0.80x | **0.06x** |

The "after" numbers are the worst case over 5 seeds x both Jacobian implementations, so there is a factor ~17 of margin where there used to be a coin flip. No tolerance was touched.

## `test_qgt_jacobian_imaginary` (the intermittent failure)

Same root cause: it solves a `diag_shift=0` QGT with `pinv` at the default (tiny) initialisation scale, where the QGT has a condition number of ~1e13. `pinv` truncates the smallest singular values, and truncates differently in the `complex` and `imag` modes it compares, so the element-wise comparison of the two solutions fails for roughly **one seed in ten** (3 out of 24 measured draws). The state was also unseeded, which is why this one failed only occasionally.

Re-initialising the parameters at a finite scale brings the condition number to ~1e7 and the two solutions into agreement ~200x inside the tolerance (0 out of 16 draws fail), and the state is now seeded so the test is reproducible. Note that the parameters are re-initialised on the state rather than passed as `*_init` arguments to the `RBM`: the init functions are part of the module's static configuration, so changing them makes this test stop sharing jit cache entries with `test_qgt_jacobian_imaginary_match` next to it, which costs ~1.5s of recompilation.

## Testing

In an environment matching the CI job (Python 3.13, jax 0.11.0, macOS arm64):

* `test/optimizer`: 1311 passed, 9 skipped;
* both files also pass under 2-CPU sharding (`NETKET_EXPERIMENTAL_SHARDING_CPU=2`);
* `ruff` and `black` clean.

Runtime cost of the larger system, interleaving A/B runs and taking minima (this machine is noisy): `test_qgt_itersolve.py` 18.4s -> 20.2s, and no measurable change for `test_qgt_logic.py`.

Test-only change, so no CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)