### PR TITLE
Speed up CI by caching XLA compilations and using all cores

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -62,11 +62,12 @@ jobs:
             sharding_script: "run_test_sharding_distributed.sh"
 
     env:
-      # Reuse XLA compiled executables across xdist workers and across CI runs.
-      # The test suite is dominated by compilation, not execution, so this is
-      # worth roughly a 2x reduction in CPU time. The cache key is derived from
-      # the HLO, so a cache hit is only ever an identical computation and this
-      # cannot mask a change in netket.
+      # Reuse XLA compiled executables. The test suite is dominated by
+      # compilation, not execution, so this pays off twice: the xdist workers of
+      # a single run stop compiling the same kernels independently, and on macOS
+      # the cache is also carried between runs (see the restore/save steps).
+      # A cache key is derived from the HLO, so a hit is only ever an identical
+      # computation and this cannot mask a change in netket.
       JAX_COMPILATION_CACHE_DIR: ${{ github.workspace }}/.jax-cache
       # Default is 1s, which skips the many small compilations that make up most
       # of the suite's time.
@@ -87,13 +88,26 @@ jobs:
         run: |
           uv sync --extra dev --extra extra ${{ matrix.test_type != 'sharding' && '--extra pyscf' || '' }}
 
-      # Restored on every run, but only written on pushes to main (see below), so
-      # that PRs share one stable cache instead of each writing their own entry.
-      # Note uv.lock is gitignored, so pyproject.toml is the dependency-pinning
-      # file actually present in the checkout. Rotating on it is a convenience
-      # only: jax embeds its own version and the backend in its cache keys, so a
-      # stale entry from another jax version can never be hit.
+      # macOS only. Measured on #2264: carrying the cache between runs takes the
+      # macOS job from ~46 min to ~21 min, and its stored cache stays at a steady
+      # 169MB, i.e. entries are genuinely being reused. On ubuntu-latest the very
+      # same setup got no cross-run benefit at all and the stored cache doubled
+      # every run (184MB -> 367MB), which means nothing was hit and everything was
+      # recompiled and appended. Root cause not yet understood -- it is NOT CPU
+      # heterogeneity across the runner fleet, since jax reports platform_version
+      # 'cpu' and does not put host CPU features in the key. Until that is
+      # explained, persisting the linux caches only buys unbounded growth, so the
+      # linux jobs keep the cache directory (which is where their within-run
+      # cross-worker win comes from) without pushing it to the Actions cache.
+      #
+      # Restored on every run, written only on pushes to main (see below), so PRs
+      # share one stable cache instead of each writing their own entry. Note
+      # uv.lock is gitignored, so pyproject.toml is the dependency-pinning file
+      # actually present in the checkout. Rotating on it is a convenience only:
+      # jax embeds its own version and the backend in its cache keys, so a stale
+      # entry from another jax version can never be hit.
       - name: Restore JAX compilation cache
+        if: ${{ runner.os == 'macOS' }}
         uses: actions/cache/restore@v4
         with:
           path: ${{ github.workspace }}/.jax-cache
@@ -107,12 +121,13 @@ jobs:
           export NETKET_EXPERIMENTAL=1
           # Deliberately left on `-n auto` from pyproject.toml, i.e. 2 workers on
           # the 4-vCPU ubuntu runner (2 physical cores + SMT). `-n logical` does
-          # give 4 workers and cuts this job to ~13 min, but two runs in a row
-          # died with "the runner has received a shutdown signal" at 81% and 93%
-          # with no failing test and no crashed worker, which is how an
-          # OOM-killed runner presents. It also buys nothing: the macOS job runs
-          # on a 3-core runner that is already saturated, so it sets the critical
-          # path at ~22 min either way. See #2264.
+          # give 4 workers and had this job pacing for ~31 min, but two runs in a
+          # row died with "the runner has received a shutdown signal" at 81% and
+          # 93% with no failing test and no crashed worker, which is how an
+          # OOM-killed runner presents. If someone wants to retry it, the angle is
+          # `--clear-cache-every`: it exists to bound memory on Actions and 200 was
+          # tuned for 2 workers, and clearing is now cheap because a recompile is a
+          # cache hit rather than a full XLA compile. See #2264.
           uv run pytest --cov=netket --cov-append --jax-cpu-disable-async-dispatch --clear-cache-every 200 -m "not slow" test
 
       - name: Docstring tests
@@ -126,10 +141,15 @@ jobs:
           uv run ./test_sharding/"${{ matrix.sharding_script }}" -m 'not slow'
 
       # Written only on pushes to main, so PRs restore a stable cache rather than
-      # each pushing a ~250MB entry of their own. run_id in the key makes every
+      # each pushing a ~170MB entry of their own. run_id in the key makes every
       # push store a new entry, which the restore-keys prefix above then picks up.
+      #
+      # always(), because a compiled executable is valid whether or not the test
+      # asserting on it passed. Without it a single failing test anywhere in the
+      # suite skips the save and the cache never advances -- on #2264 one flaky
+      # test did exactly that to two jobs at once.
       - name: Prune JAX compilation cache
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        if: ${{ always() && runner.os == 'macOS' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         run: |
           # jax never evicts from its own cache, so drop entries that no run has
           # written for a week to stop the archive growing without bound.
@@ -137,7 +157,7 @@ jobs:
           du -sh "$JAX_COMPILATION_CACHE_DIR" || true
 
       - name: Save JAX compilation cache
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        if: ${{ always() && runner.os == 'macOS' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         uses: actions/cache/save@v4
         with:
           path: ${{ github.workspace }}/.jax-cache

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -64,10 +64,10 @@ jobs:
     env:
       # Reuse XLA compiled executables. The test suite is dominated by
       # compilation, not execution, so this pays off twice: the xdist workers of
-      # a single run stop compiling the same kernels independently, and on macOS
-      # the cache is also carried between runs (see the restore/save steps).
-      # A cache key is derived from the HLO, so a hit is only ever an identical
-      # computation and this cannot mask a change in netket.
+      # a single run stop compiling the same kernels independently, and the cache
+      # is carried between runs (see the restore/save steps below).
+      # A cache key covers the HLO and the compilation target, so a hit is only
+      # ever an identical computation and this cannot mask a change in netket.
       JAX_COMPILATION_CACHE_DIR: ${{ github.workspace }}/.jax-cache
       # Default is 1s, which skips the many small compilations that make up most
       # of the suite's time.
@@ -88,32 +88,46 @@ jobs:
         run: |
           uv sync --extra dev --extra extra ${{ matrix.test_type != 'sharding' && '--extra pyscf' || '' }}
 
-      # macOS only. Measured on #2264: carrying the cache between runs takes the
-      # macOS job from ~46 min to ~21 min, and its stored cache stays at a steady
-      # 169MB, i.e. entries are genuinely being reused. On ubuntu-latest the very
-      # same setup got no cross-run benefit at all and the stored cache doubled
-      # every run (184MB -> 367MB), which means nothing was hit and everything was
-      # recompiled and appended. Root cause not yet understood -- it is NOT CPU
-      # heterogeneity across the runner fleet, since jax reports platform_version
-      # 'cpu' and does not put host CPU features in the key. Until that is
-      # explained, persisting the linux caches only buys unbounded growth, so the
-      # linux jobs keep the cache directory (which is where their within-run
-      # cross-worker win comes from) without pushing it to the Actions cache.
+      # A jax cache key depends on the host CPU target, not just on the HLO, and
+      # the ubuntu-latest fleet is not homogeneous -- a single workflow run has
+      # been served by both an EPYC 7763 (zen3) and an EPYC 9V74 at the same time.
+      # So a cache built on one runner is worthless on a differently-specced one:
+      # the linux caches used to hit nothing and simply double in size every run
+      # (184MB -> 367MB) as the whole key set got recompiled and appended. Capping
+      # the ISA with --xla_cpu_max_isa does not help, the key tracks the full
+      # target. Keys are however perfectly stable *per* CPU model, so the fix is
+      # to give each distinct compilation environment its own cache.
       #
+      # Rather than guess which properties matter, fingerprint them: compile one
+      # trivial jit into a throwaway cache and hash the filenames it produces.
+      # Those filenames *are* jax's cache keys, so the hash captures everything
+      # that affects them -- jax version, CPU target, XLA flags -- and rotates
+      # automatically when any of it changes. This also subsumes the pyproject
+      # hash that used to be in the key. See #2264.
+      - name: Fingerprint the compilation environment
+        id: jaxfp
+        run: |
+          probe=$(mktemp -d)
+          JAX_COMPILATION_CACHE_DIR="$probe" \
+          JAX_PERSISTENT_CACHE_MIN_COMPILE_TIME_SECS=0 \
+            uv run python -c "
+          import jax, jax.numpy as jnp
+          jax.block_until_ready(jax.jit(lambda x: (x * 2.0 + 1.0).sum())(jnp.ones((8, 8))))
+          "
+          fp=$(ls "$probe" | sort | { command -v sha256sum >/dev/null && sha256sum || shasum -a 256; } | cut -c1-16)
+          echo "Compilation environment fingerprint: $fp"
+          echo "fp=$fp" >> "$GITHUB_OUTPUT"
+          rm -rf "$probe"
+
       # Restored on every run, written only on pushes to main (see below), so PRs
-      # share one stable cache instead of each writing their own entry. Note
-      # uv.lock is gitignored, so pyproject.toml is the dependency-pinning file
-      # actually present in the checkout. Rotating on it is a convenience only:
-      # jax embeds its own version and the backend in its cache keys, so a stale
-      # entry from another jax version can never be hit.
+      # share one stable cache instead of each writing their own entry.
       - name: Restore JAX compilation cache
-        if: ${{ runner.os == 'macOS' }}
         uses: actions/cache/restore@v4
         with:
           path: ${{ github.workspace }}/.jax-cache
-          key: jax-cache-${{ matrix.os }}-${{ matrix.test_type }}-${{ matrix.sharding_script }}-${{ hashFiles('pyproject.toml') }}-
+          key: jax-cache-${{ matrix.os }}-${{ matrix.test_type }}-${{ matrix.sharding_script }}-${{ steps.jaxfp.outputs.fp }}-
           restore-keys: |
-            jax-cache-${{ matrix.os }}-${{ matrix.test_type }}-${{ matrix.sharding_script }}-
+            jax-cache-${{ matrix.os }}-${{ matrix.test_type }}-${{ matrix.sharding_script }}-${{ steps.jaxfp.outputs.fp }}-
 
       - name: Main tests
         if: ${{ matrix.test_type == 'main' }}
@@ -149,7 +163,7 @@ jobs:
       # suite skips the save and the cache never advances -- on #2264 one flaky
       # test did exactly that to two jobs at once.
       - name: Prune JAX compilation cache
-        if: ${{ always() && runner.os == 'macOS' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         run: |
           # jax never evicts from its own cache, so drop entries that no run has
           # written for a week to stop the archive growing without bound.
@@ -157,11 +171,11 @@ jobs:
           du -sh "$JAX_COMPILATION_CACHE_DIR" || true
 
       - name: Save JAX compilation cache
-        if: ${{ always() && runner.os == 'macOS' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         uses: actions/cache/save@v4
         with:
           path: ${{ github.workspace }}/.jax-cache
-          key: jax-cache-${{ matrix.os }}-${{ matrix.test_type }}-${{ matrix.sharding_script }}-${{ hashFiles('pyproject.toml') }}-${{ github.run_id }}
+          key: jax-cache-${{ matrix.os }}-${{ matrix.test_type }}-${{ matrix.sharding_script }}-${{ steps.jaxfp.outputs.fp }}-${{ github.run_id }}
 
       - name: Generate coverage report
         if: always()

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -62,15 +62,10 @@ jobs:
             sharding_script: "run_test_sharding_distributed.sh"
 
     env:
-      # Reuse XLA compiled executables. The test suite is dominated by
-      # compilation, not execution, so this pays off twice: the xdist workers of
-      # a single run stop compiling the same kernels independently, and the cache
-      # is carried between runs (see the restore/save steps below).
-      # A cache key covers the HLO and the compilation target, so a hit is only
-      # ever an identical computation and this cannot mask a change in netket.
+      # The suite is compilation-bound; reuse XLA executables across xdist workers
+      # and across runs. Keys cover HLO + target, so a hit is identical work.
       JAX_COMPILATION_CACHE_DIR: ${{ github.workspace }}/.jax-cache
-      # Default is 1s, which skips the many small compilations that make up most
-      # of the suite's time.
+      # Default 1s would skip most of this suite's many small compilations.
       JAX_PERSISTENT_CACHE_MIN_COMPILE_TIME_SECS: "0"
 
     steps:
@@ -88,22 +83,10 @@ jobs:
         run: |
           uv sync --extra dev --extra extra ${{ matrix.test_type != 'sharding' && '--extra pyscf' || '' }}
 
-      # A jax cache key depends on the host CPU target, not just on the HLO, and
-      # the ubuntu-latest fleet is not homogeneous -- a single workflow run has
-      # been served by both an EPYC 7763 (zen3) and an EPYC 9V74 at the same time.
-      # So a cache built on one runner is worthless on a differently-specced one:
-      # the linux caches used to hit nothing and simply double in size every run
-      # (184MB -> 367MB) as the whole key set got recompiled and appended. Capping
-      # the ISA with --xla_cpu_max_isa does not help, the key tracks the full
-      # target. Keys are however perfectly stable *per* CPU model, so the fix is
-      # to give each distinct compilation environment its own cache.
-      #
-      # Rather than guess which properties matter, fingerprint them: compile one
-      # trivial jit into a throwaway cache and hash the filenames it produces.
-      # Those filenames *are* jax's cache keys, so the hash captures everything
-      # that affects them -- jax version, CPU target, XLA flags -- and rotates
-      # automatically when any of it changes. This also subsumes the pyproject
-      # hash that used to be in the key. See #2264.
+      # Keys track the host CPU target and ubuntu-latest is a mixed fleet, so one
+      # shared cache hit nothing and doubled each run (--xla_cpu_max_isa does not
+      # help). Keys are stable per CPU, so cache per environment, fingerprinted by
+      # hashing the filenames one trivial jit emits -- those are jax's keys. See #2264.
       - name: Fingerprint the compilation environment
         id: jaxfp
         run: |
@@ -119,8 +102,7 @@ jobs:
           echo "fp=$fp" >> "$GITHUB_OUTPUT"
           rm -rf "$probe"
 
-      # Restored on every run, written only on pushes to main (see below), so PRs
-      # share one stable cache instead of each writing their own entry.
+      # Restored always, written only on main, so PRs share one stable cache.
       - name: Restore JAX compilation cache
         uses: actions/cache/restore@v4
         with:
@@ -133,15 +115,9 @@ jobs:
         if: ${{ matrix.test_type == 'main' }}
         run: |
           export NETKET_EXPERIMENTAL=1
-          # Deliberately left on `-n auto` from pyproject.toml, i.e. 2 workers on
-          # the 4-vCPU ubuntu runner (2 physical cores + SMT). `-n logical` does
-          # give 4 workers and had this job pacing for ~31 min, but two runs in a
-          # row died with "the runner has received a shutdown signal" at 81% and
-          # 93% with no failing test and no crashed worker, which is how an
-          # OOM-killed runner presents. If someone wants to retry it, the angle is
-          # `--clear-cache-every`: it exists to bound memory on Actions and 200 was
-          # tuned for 2 workers, and clearing is now cheap because a recompile is a
-          # cache hit rather than a full XLA compile. See #2264.
+          # Left on `-n auto` (2 workers here) on purpose: `-n logical` gives 4 and
+          # is faster, but killed the runner twice with a shutdown signal and no
+          # failing test, i.e. OOM. To retry, lower --clear-cache-every. See #2264.
           uv run pytest --cov=netket --cov-append --jax-cpu-disable-async-dispatch --clear-cache-every 200 -m "not slow" test
 
       - name: Docstring tests
@@ -154,19 +130,12 @@ jobs:
         run: |
           uv run ./test_sharding/"${{ matrix.sharding_script }}" -m 'not slow'
 
-      # Written only on pushes to main, so PRs restore a stable cache rather than
-      # each pushing a ~170MB entry of their own. run_id in the key makes every
-      # push store a new entry, which the restore-keys prefix above then picks up.
-      #
-      # always(), because a compiled executable is valid whether or not the test
-      # asserting on it passed. Without it a single failing test anywhere in the
-      # suite skips the save and the cache never advances -- on #2264 one flaky
-      # test did exactly that to two jobs at once.
+      # run_id stores a fresh entry per push, found by the prefix above. always():
+      # an executable is valid even if the test asserting on it failed.
       - name: Prune JAX compilation cache
         if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         run: |
-          # jax never evicts from its own cache, so drop entries that no run has
-          # written for a week to stop the archive growing without bound.
+          # jax never evicts, so drop entries unwritten for a week.
           find "$JAX_COMPILATION_CACHE_DIR" -type f -mtime +7 -delete 2>/dev/null || true
           du -sh "$JAX_COMPILATION_CACHE_DIR" || true
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -61,6 +61,17 @@ jobs:
             test_type: "sharding"
             sharding_script: "run_test_sharding_distributed.sh"
 
+    env:
+      # Reuse XLA compiled executables across xdist workers and across CI runs.
+      # The test suite is dominated by compilation, not execution, so this is
+      # worth roughly a 2x reduction in CPU time. The cache key is derived from
+      # the HLO, so a cache hit is only ever an identical computation and this
+      # cannot mask a change in netket.
+      JAX_COMPILATION_CACHE_DIR: ${{ github.workspace }}/.jax-cache
+      # Default is 1s, which skips the many small compilations that make up most
+      # of the suite's time.
+      JAX_PERSISTENT_CACHE_MIN_COMPILE_TIME_SECS: "0"
+
     steps:
       - uses: actions/checkout@v4
         with:
@@ -76,11 +87,28 @@ jobs:
         run: |
           uv sync --extra dev --extra extra ${{ matrix.test_type != 'sharding' && '--extra pyscf' || '' }}
 
+      # Restored on every run, but only written on pushes to main (see below), so
+      # that PRs share one stable cache instead of each writing their own entry.
+      # Note uv.lock is gitignored, so pyproject.toml is the dependency-pinning
+      # file actually present in the checkout. Rotating on it is a convenience
+      # only: jax embeds its own version and the backend in its cache keys, so a
+      # stale entry from another jax version can never be hit.
+      - name: Restore JAX compilation cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ github.workspace }}/.jax-cache
+          key: jax-cache-${{ matrix.os }}-${{ matrix.test_type }}-${{ matrix.sharding_script }}-${{ hashFiles('pyproject.toml') }}-
+          restore-keys: |
+            jax-cache-${{ matrix.os }}-${{ matrix.test_type }}-${{ matrix.sharding_script }}-
+
       - name: Main tests
         if: ${{ matrix.test_type == 'main' }}
         run: |
           export NETKET_EXPERIMENTAL=1
-          uv run pytest --cov=netket --cov-append --jax-cpu-disable-async-dispatch --clear-cache-every 200 -m "not slow" test
+          # -n logical, not the `-n auto` from pyproject.toml: `auto` counts
+          # physical cores, so the 4-vCPU ubuntu runner (2 cores + SMT) only got
+          # 2 workers. No-op on the macOS runners, which have no SMT.
+          uv run pytest --cov=netket --cov-append --jax-cpu-disable-async-dispatch --clear-cache-every 200 -n logical -m "not slow" test
 
       - name: Docstring tests
         if: ${{ matrix.test_type == 'doctest' }}
@@ -91,6 +119,24 @@ jobs:
         if: ${{ matrix.test_type == 'sharding' }}
         run: |
           uv run ./test_sharding/"${{ matrix.sharding_script }}" -m 'not slow'
+
+      # Written only on pushes to main, so PRs restore a stable cache rather than
+      # each pushing a ~250MB entry of their own. run_id in the key makes every
+      # push store a new entry, which the restore-keys prefix above then picks up.
+      - name: Prune JAX compilation cache
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        run: |
+          # jax never evicts from its own cache, so drop entries that no run has
+          # written for a week to stop the archive growing without bound.
+          find "$JAX_COMPILATION_CACHE_DIR" -type f -mtime +7 -delete 2>/dev/null || true
+          du -sh "$JAX_COMPILATION_CACHE_DIR" || true
+
+      - name: Save JAX compilation cache
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ github.workspace }}/.jax-cache
+          key: jax-cache-${{ matrix.os }}-${{ matrix.test_type }}-${{ matrix.sharding_script }}-${{ hashFiles('pyproject.toml') }}-${{ github.run_id }}
 
       - name: Generate coverage report
         if: always()

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -105,10 +105,15 @@ jobs:
         if: ${{ matrix.test_type == 'main' }}
         run: |
           export NETKET_EXPERIMENTAL=1
-          # -n logical, not the `-n auto` from pyproject.toml: `auto` counts
-          # physical cores, so the 4-vCPU ubuntu runner (2 cores + SMT) only got
-          # 2 workers. No-op on the macOS runners, which have no SMT.
-          uv run pytest --cov=netket --cov-append --jax-cpu-disable-async-dispatch --clear-cache-every 200 -n logical -m "not slow" test
+          # Deliberately left on `-n auto` from pyproject.toml, i.e. 2 workers on
+          # the 4-vCPU ubuntu runner (2 physical cores + SMT). `-n logical` does
+          # give 4 workers and cuts this job to ~13 min, but two runs in a row
+          # died with "the runner has received a shutdown signal" at 81% and 93%
+          # with no failing test and no crashed worker, which is how an
+          # OOM-killed runner presents. It also buys nothing: the macOS job runs
+          # on a 3-core runner that is already saturated, so it sets the critical
+          # path at ~22 min either way. See #2264.
+          uv run pytest --cov=netket --cov-append --jax-cpu-disable-async-dispatch --clear-cache-every 200 -m "not slow" test
 
       - name: Docstring tests
         if: ${{ matrix.test_type == 'doctest' }}

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ pip-wheel-metadata
 .ipynb_checkpoints
 .pytest_cache
 .benchmarks
+.jax-cache
 .mypy_cache
 .virtual_documents
 .ruff_cache

--- a/test_sharding/run_standard_tests_with_sharding.sh
+++ b/test_sharding/run_standard_tests_with_sharding.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
 export NETKET_EXPERIMENTAL_SHARDING_CPU=2
 export JAX_PLATFORM_NAME=cpu
-python3 -m pytest --cov=netket --cov-append -n 0 "$@" test
+# Each xdist worker is its own process and gets its own pair of CPU devices, so
+# this parallelises safely. 2 workers rather than `auto`/`logical` because every
+# worker already spreads itself over NETKET_EXPERIMENTAL_SHARDING_CPU devices.
+# Override by passing another -n after the script name.
+python3 -m pytest --cov=netket --cov-append -n 2 "$@" test


### PR DESCRIPTION
The test suite is compilation-bound, and that compilation was being repeated both across xdist workers within a run and across every CI run.

- Enable jax's persistent compilation cache, stored in the Actions cache and keyed on a fingerprint of the compilation environment (the ubuntu fleet is mixed-CPU and keys track the CPU target — see comments below). Written on pushes to `main`, saved with `always()`.
- Run the standard-tests-under-sharding script with 2 xdist workers instead of serially.
- `-n logical` was tried and reverted: 4 workers is faster but OOM-killed the runner twice.

| Job | baseline (median of 8 runs on main) | warm cache |
|---|---|---|
| Ubuntu | 47.6 min | **19.9 min** |
| macOS | 46.4 min | **18.0 min** |
| Sharding (Standard) | 43.9 min | 21.7 min (cold) |

Critical path **~47 → ~20 min**. A hit requires identical HLO and target, so this cannot mask a change in netket.
