### PR TITLE
Fix import failure on jax>=0.11: unquoted forward reference in `online_statistics` overload

### DIFF
--- a/netket/_src/stats/online_stats/operations.py
+++ b/netket/_src/stats/online_stats/operations.py
@@ -42,7 +42,7 @@ def online_statistics(
 
 @overload
 def online_statistics(
-    data: "LocalEstimators" | jax.typing.ArrayLike,
+    data: "LocalEstimators | jax.typing.ArrayLike",
     old_estimator: OnlineStats | None = None,
     *,
     decay: float | None = None,


### PR DESCRIPTION
`import netket` fails on Python 3.13 with the current release of jax:

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
    import netket
  File ".../site-packages/netket/__init__.py", line 40, in <module>
    from .utils import config
  ...
  File ".../site-packages/netket/_src/stats/online_stats/operations.py", line 45, in <module>
    data: "LocalEstimators" | jax.typing.ArrayLike,
          ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
TypeError: unsupported operand type(s) for |: 'str' and 'types.UnionType'
```

Reproduced with netket 3.22.4 (latest on PyPI) and jax/jaxlib 0.11.1 (latest) on CPython
3.13.11, in a fresh environment. `pyproject.toml` declares `jax>=0.7.0` with no upper bound,
so this combination is one `pip install netket` away. The same line is still present on `main`.

### Root cause

The annotation on the second `@overload` is only *partially* quoted:

```python
data: "LocalEstimators" | jax.typing.ArrayLike,
```

Overload annotations are evaluated eagerly at `def` time on Python <= 3.13, so this really does
compute `str.__or__(ArrayLike)`, then `type(ArrayLike).__ror__(str)`. That used to succeed only
because `jax.typing.ArrayLike` was a `typing.Union`, whose `__ror__` accepts arbitrary operands
and wraps a `str` into a `ForwardRef`. It is now a PEP 604 `types.UnionType`, whose `__ror__`
rejects a `str`. Minimal, jax-free reproducer:

```console
$ python3.13 -c 'def f(x: "Foo" | (int | str)): ...'
TypeError: unsupported operand type(s) for |: 'str' and 'types.UnionType'
```

Two reasons this may not have shown up in CI: it needs a recent enough jax, and it disappears
on Python 3.14, where PEP 649 makes annotations lazy (verified on 3.14.5 — same expression
evaluates fine).

### Fix

Quote the whole union, matching the style already used on the implementation signature two
definitions below (line 55) and on the first overload:

```diff
-    data: "LocalEstimators" | jax.typing.ArrayLike,
+    data: "LocalEstimators | jax.typing.ArrayLike",
```

One character moved; no runtime behaviour changes, and static type checkers read the two forms
identically. `from __future__ import annotations` would also work, but it changes annotation
semantics for the whole module, and nothing else in the file needs it — this is the only
eagerly-evaluated annotation there that mixes a string with a runtime object. It is also the
only occurrence in the package (`grep` over all of `netket/` finds exactly one other
string-in-union annotation, `netket/utils/array.py:31`, `wrapped: Array | "HashableArray"`;
that one is currently harmless because `netket.utils.types.Array` is still a `typing.Union`,
but it would break the same way if that alias ever moved to `|` syntax — happy to fix it in
this PR too if you want).

### Testing

With the patch applied on top of 3.22.4 under jax 0.11.1 / CPython 3.13.11:

* `import netket` succeeds.
* `online_statistics` on a `(4, 500)` array returns a mean matching numpy to 15 digits, and
  merging a second batch into the returned estimator works.

(`typing.get_type_hints(online_statistics)` still raises `NameError: name 'LocalEstimatorsBatch'
is not defined` both before and after the patch, since those names are `TYPE_CHECKING`-only — that is
unchanged, pre-existing, and presumably intended.)

### Suggested CHANGELOG entry

Under `## NetKet 3.23 (In development)` -> `### Bug Fixes` (fill in the PR number once opened):

```markdown
* Importing NetKet no longer crashes with `TypeError: unsupported operand type(s) for |: 'str'
  and 'types.UnionType'` under `jax>=0.11`, where `jax.typing.ArrayLike` became a PEP 604
  union: a partially-quoted forward reference in an `online_statistics` overload is now fully
  quoted [PR #2269](https://github.com/netket/netket/pull/2269).
```