### PR TITLE
Generalise the jax>=0.11 forward-reference import fix (+ TC010 lint)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 
 ## NetKet 3.23 (In development)
 
-...
+### Bug Fixes
+* Importing NetKet no longer crashes with `TypeError: unsupported operand type(s) for |: 'str' and 'types.UnionType'` under `jax>=0.11`, where `jax.typing.ArrayLike` became a PEP 604 union: a partially-quoted forward reference in an `online_statistics` overload is now fully quoted [PR #2269](https://github.com/netket/netket/pull/2269), a second latent occurrence in {class}`netket.utils.HashableArray` was fixed the same way, and the `TC010` ruff lint is now enabled to prevent regressions [PR #2270](https://github.com/netket/netket/pull/2270).
 
 ## NetKet 3.22.4 (17 August 2026)
 

--- a/netket/utils/array.py
+++ b/netket/utils/array.py
@@ -28,7 +28,7 @@ class HashableArray:
     The underlying array can also be accessed using :code:`numpy.asarray(self)`.
     """
 
-    def __init__(self, wrapped: Array | "HashableArray"):
+    def __init__(self, wrapped: "Array | HashableArray"):
         """
         Wraps an array into an object that is hashable, and that can be
         converted again into an array.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,7 +171,7 @@ line-length = 88
 exclude = ["Examples", "docs/conf.py", "*.ipynb"]
 
 [tool.ruff.lint]
-select = ["E", "F", "W", "D410", "UP", "TID252"]
+select = ["E", "F", "W", "D410", "UP", "TID252", "TC010"]
 fixable = ["E", "F", "W", "D", "UP"]
 ignore = ["E501", "E731", "E721", "E701", "E741", "UP007", "UP035"]
 #ignore = ["E266"]


### PR DESCRIPTION
Follow-up to #2269 (thanks @tzerweck!).

#2269 fixed the partially-quoted union annotation in the `online_statistics`
overload that crashed `import netket` under `jax>=0.11`, where
`jax.typing.ArrayLike` became a PEP 604 `types.UnionType` whose `__ror__`
rejects a `str` operand (overload annotations are evaluated eagerly on
Python ≤3.13).

### There's one more

A `grep` over the whole package finds exactly one other string-in-union
annotation:

```python
# netket/utils/array.py
def __init__(self, wrapped: Array | "HashableArray"):
```

This is a **latent** version of the same bug. It's harmless *today* only
because `netket.utils.types.Array` is still `Union[np.ndarray, jax.Array]`
(a `typing.Union`, whose `__or__` tolerates a `str`). The moment that alias
is modernised to `np.ndarray | jax.Array` (PEP 604) — exactly the sort of
change ruff's `UP` rules push toward — it breaks identically. Verified:

```python
>>> (np.ndarray | jax.Array) | "HashableArray"
TypeError: unsupported operand type(s) for |: 'types.UnionType' and 'str'
```

Fully quoted here (`"Array | HashableArray"`), matching the style already
used elsewhere in the file.

### A general guard

Rather than rely on `grep`, this enables ruff's **`TC010`** lint ("Invalid
string member in `X | Y`-style union type"). It flags exactly these two
lines across the tree today (both now fixed) with zero false positives, so
any future partially-quoted union annotation fails CI instead of shipping.

### Testing

* `TC010` across `netket/` → clean after the fix.
* Full configured lint on the touched files → clean.
* `import netket` succeeds under jax 0.11.1 / CPython 3.12 (this combination
  reproduced the original crash before #2269).