### PR TITLE
Fix multi-process HDF5Log collective deadlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ## NetKet 3.23 (In development)
 
 ### Bug Fixes
+* {class}`netket.logging.HDF5Log` no longer deadlocks multi-process (sharded) runs: it reduced the logged {class}`netket.stats.Stats` inside its master-only gate, so the host-side reduction collective ran on rank 0 alone and hung every other rank. The reduction now runs on all ranks and only the write is gated to the master [PR #2272](https://github.com/netket/netket/pull/2272).
 * Importing NetKet no longer crashes with `TypeError: unsupported operand type(s) for |: 'str' and 'types.UnionType'` under `jax>=0.11`, where `jax.typing.ArrayLike` became a PEP 604 union: a partially-quoted forward reference in an `online_statistics` overload is now fully quoted [PR #2269](https://github.com/netket/netket/pull/2269), a second latent occurrence in {class}`netket.utils.HashableArray` was fixed the same way, and the `TC010` ruff lint is now enabled to prevent regressions [PR #2270](https://github.com/netket/netket/pull/2270).
 
 ## NetKet 3.22.4 (17 August 2026)

--- a/netket/_src/logging/hdf5_log.py
+++ b/netket/_src/logging/hdf5_log.py
@@ -41,7 +41,13 @@ def _compute_chunk_shape(value: np.ndarray, chunk_size: int | None) -> tuple[int
 
 
 def _append_dataset(root, value, data, *, chunk_size: int | None = None):
+    # ``np.asarray`` materialises ``value`` to host -- a collective when it is a
+    # sharded array, so every rank must reach it. ``data`` is ``None`` on
+    # non-master ranks (they hold no writer): they still materialise (to join
+    # the collective) but do not write. See HDF5Log.__call__.
     value = np.asarray(value)
+    if data is None:
+        return
     if root in data:
         f_value = data[root]
         f_value.resize(f_value.shape[0] + 1, axis=0)
@@ -263,14 +269,13 @@ class HDF5Log(AbstractCallback):
         if self._writer is None:
             self._init_output_file()
 
-        if self._is_master_process:
-            tree_log(
-                log_data,
-                "data",
-                self._writer,
-                iter=step,
-                chunk_size=self._chunk_size,
-            )
+        tree_log(
+            log_data,
+            "data",
+            self._writer,
+            iter=step,
+            chunk_size=self._chunk_size,
+        )
 
         self._steps_notflushed_write += 1
         if self._steps_notflushed_write >= self._write_every:


### PR DESCRIPTION
HDF5Log reduced the (possibly sharded) `Stats` inside its `if self._is_master_process:` gate. The host-side reduction — `np.asarray(value)` materialising a sharded array — is a collective that **every** rank must join, so running it on rank 0 only deadlocks every other rank under multi-process sharding (multi-GPU VMC hangs at step 0).

## Fix

Run the tree walk on all ranks and gate only the I/O:

- `HDF5Log.__call__` now calls `tree_log(...)` unconditionally instead of behind `if self._is_master_process`.
- Only the master holds an `h5py` writer, so `data` (the writer) is `None` on the other ranks. `_append_dataset` now materialises `value` (joining the collective) and then returns early when `data is None`, so non-master ranks participate in the reduction but do not write.

This mirrors `RuntimeLog`'s contract: reduce on every rank, gate only the write. All writer dereferences already route through `_append_dataset`, so the single early-return covers every path.

## Test plan

Reproduced the step-0 hang under `djaxrun -np 2` on CPU (sharded `Stats` in the logged data); with this change the run proceeds and rank 0 writes the HDF5 file while the other rank participates in the reduction without writing.